### PR TITLE
feat: query->finding gate eval + trained model as gate default

### DIFF
--- a/deep_think_loci/README.md
+++ b/deep_think_loci/README.md
@@ -25,9 +25,9 @@ Every tier reasons **only over grounding-gated evidence** (see below). The opus 
 
 1. **Dedicated-writer persistence.** Workflow subagents unreliably execute an `investigation_store` MCP call when it's one step in a multi-step task (RAG → generate → store) — they silently skip it or *fabricate* a confirmation. Fix: generation agents return schema-validated output **only**; a single-purpose **writer** agent does all the stores and returns the real `finding_id`s. Took persistence from ~40% to 100%.
 
-2. **Cosine grounding gate (`grounding/ground_gate.py`).** RAG retrieval bleeds cross-target findings at cosine 0.35–0.59 — moderately similar, plausibly relevant, but *wrong topic* — and a non-verifying model will hallucinate over them. The gate embeds the query + each candidate (nomic, local) and keeps only those clearing a per-target threshold (**0.59**), dropping the bleed before any model reasons. Local, ~$0 marginal.
+2. **Grounding gate (`grounding/ground_gate.py`).** RAG retrieval bleeds cross-target findings at cosine 0.35–0.59 — moderately similar, plausibly relevant, but *wrong topic* — and a non-verifying model will hallucinate over them. The gate embeds the query + each candidate (nomic, local) and keeps only on-topic findings, dropping the bleed before any model reasons. Local, ~$0 marginal.
    - **Query per-target, never blended** — a blended multi-target query dilutes cosines and false-drops whole genuine targets (the v3 bug).
-   - Drop-in upgrade: a trained classifier (`grounding/grounding_bleed_clf.joblib`) once it beats the cosine threshold on a larger corpus.
+   - **Default = the trained classifier** (`grounding/grounding_bleed_clf.joblib`), now that `eval/grounding_gate_qf_eval.py` validated it beats the cosine threshold on the gate's real query→finding task (F1 0.94 vs 0.82, rejects all bleed at a small recall cost). Auto-loads when present + loadable; **falls back to the cosine threshold (0.59)** on any error or with `--no-model`.
 
 ## Usage
 
@@ -81,10 +81,10 @@ A full run ≈ **$5–8**, dominated by **cached context** (cache read/write), n
 | `grounding_bleed_clf.joblib` | trained bleed-detector (LR on nomic pair-features) |
 | `metrics.json` | latest CV AUC 0.994 / acc 0.965 vs tuned-cosine 0.910 (the finding-pair task) |
 
-Each run mints more labeled pairs as a byproduct; run `harvest.sh` to fold them back in (rebuild + retrain + eval). `eval/grounding_gate_eval.py` tracks separation quality longitudinally.
+Each run mints more labeled pairs as a byproduct; run `harvest.sh` to fold them back in (rebuild + retrain + eval). `eval/grounding_gate_eval.py` (pair task) and `eval/grounding_gate_qf_eval.py` (query→finding, cosine vs model) track quality longitudinally.
 
 ## Known limits
 
-- `mnemo_mirror` is down in Loci's venv → findings persist to qdrant `hermes_memory` (RAG works) but don't mirror to mnemosyne; `pip install mnemosyne-memory` into Loci's venv to enable.
-- The trained classifier now beats a tuned cosine threshold on the **finding-pair** task (CV acc 0.965 vs 0.910), but that's the classifier's *training* task — the live gate operates *query→finding*, so the cosine threshold remains the shipped default until a query→finding eval validates the swap.
+- `mnemo_mirror` is **active** — findings persist to both qdrant `hermes_memory` (RAG) and mnemosyne (3.4.0 in Loci's MCP venv).
+- The trained classifier is the gate **default**: it beats the cosine threshold on both the finding-pair task (CV acc 0.965 vs 0.910) and the gate's real **query→finding** task (F1 0.94 vs 0.82, rejects all bleed). Trade-off: it drops ~11% of genuine on-topic findings (recall 0.89 vs cosine 0.99) to reject *all* bleed; the opus load-gate backstops residual. The query→finding eval is currently **in-sample** (the model trained on these runs' findings), so the longitudinal harness eval is what guards future out-of-sample drift; use `--no-model` to force cosine.
 - Entailment-grounding (lineage/hallucination signals) is too sparse to train — accumulate deliberately.

--- a/deep_think_loci/grounding/ground_gate.py
+++ b/deep_think_loci/grounding/ground_gate.py
@@ -24,6 +24,10 @@ import numpy as np
 _BASE = (os.environ.get("OLLAMA_BASE_URL") or "http://100.73.200.19:11434").rstrip("/")
 OLLAMA = _BASE + "/v1/embeddings"
 EMB_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+# The trained bleed-detector, co-located. Validated to beat cosine on the gate's
+# query->finding operation (eval/grounding_gate_qf_eval.py: f1 0.94 vs 0.82), so it
+# is the default when present + loadable; falls back to the cosine threshold otherwise.
+DEFAULT_MODEL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "grounding_bleed_clf.joblib")
 
 
 def embed(texts):
@@ -75,14 +79,23 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--query", required=True)
     ap.add_argument("--threshold", type=float, default=0.59)
-    ap.add_argument("--model", default=None, help="optional joblib pair-feature classifier (drop-in upgrade)")
+    ap.add_argument("--model", default=None, help="joblib pair-feature classifier (defaults to the co-located one)")
+    ap.add_argument("--no-model", action="store_true", help="force the cosine threshold even if the model is present")
     ap.add_argument("--in", dest="infile", default=None)
     ap.add_argument("--out", default=None)
     a = ap.parse_args()
 
     raw = json.load(open(a.infile)) if a.infile else json.load(sys.stdin)
     cands = raw.get("findings", raw) if isinstance(raw, dict) else raw
-    result = gate(a.query, cands, a.threshold, a.model)
+    # Default to the trained model when present + loadable; fall back to cosine on any error.
+    model = None if a.no_model else (a.model or (DEFAULT_MODEL if os.path.exists(DEFAULT_MODEL) else None))
+    try:
+        result = gate(a.query, cands, a.threshold, model)
+    except Exception as exc:
+        if model is None:
+            raise
+        print(f"[ground_gate] model path failed ({exc}); falling back to cosine", file=sys.stderr)
+        result = gate(a.query, cands, a.threshold, None)
     out = json.dumps(result, indent=1)
     (open(a.out, "w").write(out + "\n")) if a.out else print(out)
 

--- a/eval/grounding_gate_qf_eval.py
+++ b/eval/grounding_gate_qf_eval.py
@@ -1,0 +1,146 @@
+"""
+Faithful query->finding eval for the deep-think-loci grounding gate.
+
+The deployed gate operates query->finding (a target's focus query vs each
+candidate finding), NOT finding<->finding (which is the classifier's training
+task, measured by grounding_gate_eval.py). This measures the gate's ACTUAL
+operation on the corpus and compares the cosine threshold against the trained
+classifier — the eval that decides whether to swap the trained model in as the
+gate default.
+
+For every (target focus query, finding) pair: cosine = sim(embed(focus),
+embed(finding)); label = 1 if the finding belongs to that target else 0 (bleed).
+Reports recall / bleed_rejection / f1 / accuracy / auc for the cosine threshold
+and (if present) the trained model, plus a swap verdict.
+
+Live-only (needs embeddings). Requires OLLAMA_URL. Persists scores
+dtl.gate_qf.{cosine,model}.{metric} unless HARNESS_DRY_RUN=1.
+"""
+import glob
+import json
+import math
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import harness
+from grounding_gate_eval import _metrics  # reuse metric computation
+
+THRESHOLD = float(os.environ.get("DTL_GROUND_THRESHOLD", "0.59"))
+CORPUS = os.environ.get("DTL_CORPUS_GLOB", os.path.expanduser("~/.hermes/memory-sessions/dt-loci-*/findings.jsonl"))
+MODEL = Path(__file__).resolve().parent.parent / "deep_think_loci/grounding/grounding_bleed_clf.joblib"
+
+# Built-in focus queries for the example dama-gotchi targets; override with
+# $DTL_TARGET_FOCUS (inline JSON or a path). Unknown targets fall back to the
+# target name as the query, so the eval generalizes to any corpus.
+DEFAULT_FOCUS = {
+    "rooted-canary": "training/rooted_canary_e2e.py rooted-device telemetry canary + DGC-26 gate",
+    "governance-gate": "training/governance_gate.py DGC checks, shadow-eval, fail-closed logic",
+    "telemetry-ingest": "realtime ingest + gotchi_mqtt_bridge.py telemetry path and schema",
+    "ant-training": "training/ant_trainer_base.py candidate export, publish, shadow-eval hook",
+    "sensor-fusion": "android EskfFusion + sensors/tdoa_triangulation.py fusion correctness",
+}
+
+
+def _focus_map():
+    raw = os.environ.get("DTL_TARGET_FOCUS")
+    if raw:
+        try:
+            return json.loads(raw if raw.strip().startswith("{") else Path(raw).read_text())
+        except Exception:
+            pass
+    return DEFAULT_FOCUS
+
+
+def _target(rec):
+    return next((t.split(":", 1)[1] for t in (rec.get("tags") or []) if t.startswith("dt_target:")), "")
+
+
+def _unit(v):
+    n = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [x / n for x in v]
+
+
+def run():
+    run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if not harness.OLLAMA_URL:
+        print("[gate-qf-eval] OLLAMA_URL unset — this eval needs embeddings; skipping.")
+        return
+
+    focus = _focus_map()
+    findings = []
+    for f in glob.glob(CORPUS):
+        for line in open(f, errors="ignore"):
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            t = _target(r)
+            if t:
+                findings.append({"text": (r.get("text") or "")[:2000], "target": t})
+    targets = sorted({x["target"] for x in findings})
+    if not findings or not targets:
+        print(f"[gate-qf-eval] no targeted findings in {CORPUS}")
+        return
+
+    harness.ensure_collection() if not harness.DRY_RUN else None
+    qvec = {t: _unit(harness.embed(focus.get(t, t))) for t in targets}
+    texts = sorted({x["text"] for x in findings})
+    fvec = {tx: _unit(harness.embed(tx)) for tx in texts}
+
+    labels, cosv, feats = [], [], []
+    for t in targets:
+        q = qvec[t]
+        for x in findings:
+            cv = fvec[x["text"]]
+            cos = sum(a * b for a, b in zip(q, cv))
+            labels.append(1 if x["target"] == t else 0)
+            cosv.append(cos)
+            feats.append((q, cv, cos))
+
+    print(f"[gate-qf-eval] run_date={run_date} targets={len(targets)} findings={len(findings)} "
+          f"pairs={len(labels)} (pos={sum(labels)}) thr={THRESHOLD} dry_run={harness.DRY_RUN}")
+    cos_m = _metrics(labels, cosv, THRESHOLD)
+    print("  COSINE @%.2f :" % THRESHOLD, {k: round(v, 3) for k, v in cos_m.items()})
+
+    mdl_m = None
+    if MODEL.exists():
+        try:
+            import joblib
+            import numpy as np
+            clf = joblib.load(str(MODEL))
+            X = np.array([np.concatenate([np.abs(np.array(q) - np.array(cv)), np.array(q) * np.array(cv), [cos]])
+                          for q, cv, cos in feats])
+            proba = clf.predict_proba(X)[:, 1].tolist()
+            mdl_m = _metrics(labels, proba, 0.5)
+            print("  MODEL  @0.5 :", {k: round(v, 3) for k, v in mdl_m.items()})
+        except Exception as e:
+            print("  [model skipped]", e)
+
+    if mdl_m:
+        better = mdl_m["f1"] > cos_m["f1"] and mdl_m["accuracy"] >= cos_m["accuracy"]
+        print(f"  VERDICT: trained model {'BEATS' if better else 'does NOT beat'} cosine on query->finding "
+              f"(f1 {mdl_m['f1']:.3f} vs {cos_m['f1']:.3f}, acc {mdl_m['accuracy']:.3f} vs {cos_m['accuracy']:.3f})"
+              f" -> {'SWAP IN the trained model' if better else 'keep cosine default'}")
+
+    if not harness.DRY_RUN:
+        vec = harness.embed("deep_think_loci grounding gate query->finding eval")
+        for tag, m in (("cosine", cos_m), ("model", mdl_m)):
+            if not m:
+                continue
+            for name, val in m.items():
+                if val == val:
+                    harness.upsert_score(
+                        task_id=f"dtl.gate_qf.{tag}.{name}",
+                        task_name=f"gate query->finding {tag} {name}",
+                        category="deep_think_loci",
+                        score=float(val),
+                        run_date=run_date,
+                        context_preview=f"{len(findings)} findings x {len(targets)} targets",
+                        vector=vec,
+                    )
+        print(f"[gate-qf-eval] persisted to {harness.EVAL_COLLECTION}")
+
+
+if __name__ == "__main__":
+    run()

--- a/eval/run_eval.sh
+++ b/eval/run_eval.sh
@@ -6,3 +6,4 @@ EVAL_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 "$HERMES_PY" "$EVAL_DIR/harness.py" "$@"
 "$HERMES_PY" "$EVAL_DIR/grounding_gate_eval.py" "$@"
+"$HERMES_PY" "$EVAL_DIR/grounding_gate_qf_eval.py" "$@"


### PR DESCRIPTION
Adds the faithful query->finding gate eval (`eval/grounding_gate_qf_eval.py`) — measures the gate's real operation (target focus vs candidate finding) and compares the cosine threshold against the trained classifier.

**Result (132 findings x 5 targets):** trained model F1 **0.94** vs cosine 0.82, accuracy 0.977 vs 0.914, rejects **all** bleed (vs cosine ~10% leak) at a small recall cost. So `ground_gate.py` now **defaults to the trained model** (auto-load when present; `--no-model` or any error falls back to cosine 0.59). Wired into `run_eval.sh`.

Caveat: the qf-eval is currently in-sample (model trained on these runs' findings); the longitudinal harness eval guards future out-of-sample drift. Unit tests unchanged + green.