### PR TITLE
fix(#9): Apply similarity threshold to Qdrant hits in memory_recall

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -516,6 +516,8 @@ async def skill_memory_recall(task: dict) -> dict:
             for h in hits:
                 pl = h.get('payload', {})
                 mid = pl.get('memory_id', str(h.get('id', '')))
+                if float(h.get('score', 0)) < 0.59:
+                    continue
                 if mid not in seen_ids:
                     results.append({
                         'id': mid, 'content': pl.get('content', ''),


### PR DESCRIPTION
Closes #9

## Change
Add a similarity threshold filter (score >= 0.59) on line 519 before appending Qdrant mnemosyne hits to prevent low-relevance matches from contaminating results.

*Generated by loci-fix-sweep*