### PR TITLE
fix(#10): pre_tool_grounding misses Claude Code 'file_path' writes, by

### DIFF
--- a/scripts/hooks/pre_tool_grounding.py
+++ b/scripts/hooks/pre_tool_grounding.py
@@ -266,8 +266,8 @@ def _extract_write_targets(tool_name: str, tool_input: dict) -> list[str]:
     paths: list[str] = []
     if not tool_input:
         return paths
-    # Hermes write_file / patch
-    for key in ("path",):
+    # Hermes write_file / patch; Claude Code Edit/Write tools use file_path
+    for key in ("path", "file_path"):
         v = tool_input.get(key)
         if v and isinstance(v, str):
             paths.append(v)


### PR DESCRIPTION
Closes #10

## Change
Add 'file_path' to the keys tuple checked in _extract_write_targets (line 270) so Claude Code's Edit/Write/MultiEdit tools are properly scanned for supply chain and agent config path violations.

*Generated by loci-fix-sweep*