### PR TITLE
fix(#12): Validate or flag unknown derived_from parent ids on store

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -2259,6 +2259,10 @@ def investigation_store(
     }
     derived = _normalize_derived_from(derived_from)
     if derived:
+        existing_ids = {f["id"] for f in _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl") if "id" in f}
+        unknown = [pid for pid in derived if pid not in existing_ids]
+        if unknown:
+            return json.dumps({"error": f"derived_from contains unknown parent id(s): {unknown}. Verify the parent findings exist before linking."})
         finding["derived_from"] = derived
     finding["entities"] = _extract_entities(text)
 


### PR DESCRIPTION
Closes #12

## Change
After normalizing derived_from at line 2260, validate that all parent IDs exist in the investigation's findings.jsonl file; return an error if any parent ID is not found, preventing dangling references that corrupt investigation_finding_provenance traversal and memory_retract lineage cleanup.

*Generated by loci-fix-sweep*