### PR TITLE
fix(#22): Early empty-query guard in memory_confidence

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -4924,6 +4924,12 @@ def memory_confidence(
     """
     import math as _math
 
+    if not query:
+        return json.dumps({
+            "confidence": 0.0, "basis": "empty_query",
+            "cues": {}, "top_hit_preview": "", "recommendation": "verify",
+        })
+
     client, col = _get_qdrant()
     if client is None:
         return json.dumps({


### PR DESCRIPTION
Closes #22

## Change
Add an early guard after imports (after line 4925) to check if query is empty/None and return immediately with confidence 0.0 before calling _get_qdrant() and _get_embed_fn().

*Generated by loci-fix-sweep*