### PR TITLE
fix(#25): Remove dead always-false clause in spreading_activation

### DIFF
--- a/scripts/spreading_activation.py
+++ b/scripts/spreading_activation.py
@@ -199,7 +199,7 @@ def run_spreading_activation(
                 prior = activation.get(target, 0.0)
                 activation[target] = min(1.0, prior + contribution)
 
-                if target not in activation or prior == 0.0:
+                if prior == 0.0:
                     newly_activated.append(target)
 
             # Next frontier: targets that were not already in the frontier set


### PR DESCRIPTION
Closes #25

## Change
Remove the dead clause 'target not in activation or' from the condition, leaving only 'if prior == 0.0:' to clarify the actual logic.

*Generated by loci-fix-sweep*