### PR TITLE
fix(#43): Add `import sys` to a2a_server/server.py

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -156,7 +156,7 @@ JSON-RPC CALL SHAPE
   }
 """
 
-import os, uuid, json, sqlite3, logging, datetime
+import os, sys, uuid, json, sqlite3, logging, datetime
 from typing import Optional, Any
 
 # ── load .env before anything else ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #43

## Change
Add sys to the module-level import statement on line 159 to make sys.exit(1) at line 189 and sys.executable at line 1063 work without NameError.

*Generated by loci-fix-sweep*