### PR TITLE
fix(spider): fix 11 runtime bugs found by full-codebase audit

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -201,7 +201,7 @@ QDRANT_URL = os.environ.get('QDRANT_URL')
 QDRANT_KEY = os.environ.get('QDRANT_API_KEY', '')
 
 # Ollama embedding (same config as hooks/pre_llm_grounding.py + session_end_sync.py)
-OLLAMA_BASE           = os.environ.get('MNEMOSYNE_EMBEDDING_API_URL')
+OLLAMA_BASE           = os.environ.get('MNEMOSYNE_EMBEDDING_API_URL', 'http://localhost:11434/v1')
 EMBED_MODEL           = os.environ.get('MNEMOSYNE_EMBEDDING_MODEL',   'nomic-embed-text')
 EMBED_DIM             = int(os.environ.get('MNEMOSYNE_EMBEDDING_DIM', '768'))
 _EMBED_API_KEY        = os.environ.get('EMBED_API_KEY', '')
@@ -377,11 +377,21 @@ def _verify_totp(x_totp: Optional[str] = Header(default=None)):
 
 
 # ── helpers ─────────────────────────────────────────────────────────────────────
-def _db() -> sqlite3.Connection:
-    """Open Mnemosyne SQLite with row_factory."""
+from contextlib import contextmanager
+
+@contextmanager
+def _db():
+    """Open Mnemosyne SQLite with row_factory, commit on success, always close."""
     conn = sqlite3.connect(MNEMOSYNE_DB, timeout=10)
     conn.row_factory = sqlite3.Row
-    return conn
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
 
 def _embed_auth_headers() -> dict:
@@ -396,7 +406,7 @@ def _embed_auth_headers() -> dict:
 
 async def _embed(text: str) -> Optional[list]:
     """Embed via OpenAI-compat /v1/embeddings. Works with Ollama and cloud providers."""
-    url = OLLAMA_BASE.rstrip('/') + '/embeddings'
+    url = OLLAMA_BASE.rstrip('/').removesuffix('/v1') + '/v1/embeddings'
     try:
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as sess:
             async with sess.post(url, json={'model': EMBED_MODEL, 'input': text[:2000]},
@@ -978,7 +988,7 @@ async def skill_gpu_inference(task: dict) -> dict:
 
     try:
         async with aiohttp.ClientSession() as sess, sess.post(
-            f"{OLLAMA_BASE.rstrip('/v1')}/v1/chat/completions",
+            f"{OLLAMA_BASE.rstrip('/').removesuffix('/v1')}/v1/chat/completions",
             json={'model': model, 'messages': messages, 'max_tokens': max_t},
             timeout=aiohttp.ClientTimeout(total=120)
         ) as r:

--- a/deep_think_loci/grounding/ground_gate.py
+++ b/deep_think_loci/grounding/ground_gate.py
@@ -86,7 +86,11 @@ def main():
     ap.add_argument("--out", default=None)
     a = ap.parse_args()
 
-    raw = json.load(open(a.infile)) if a.infile else json.load(sys.stdin)
+    if a.infile:
+        with open(a.infile) as fh:
+            raw = json.load(fh)
+    else:
+        raw = json.load(sys.stdin)
     cands = raw.get("findings", raw) if isinstance(raw, dict) else raw
     # Cosine threshold is the default; the model is opt-in via --model until OOS validation favors it.
     model = a.model
@@ -98,7 +102,11 @@ def main():
         print(f"[ground_gate] model path failed ({exc}); falling back to cosine", file=sys.stderr)
         result = gate(a.query, cands, a.threshold, None)
     out = json.dumps(result, indent=1)
-    (open(a.out, "w").write(out + "\n")) if a.out else print(out)
+    if a.out:
+        with open(a.out, "w") as fh:
+            fh.write(out + "\n")
+    else:
+        print(out)
 
 
 if __name__ == "__main__":

--- a/mcp/memcheck/llm.py
+++ b/mcp/memcheck/llm.py
@@ -40,7 +40,7 @@ __all__ = [
 
 _log = logging.getLogger("memcheck.llm")
 
-_DEFAULT_OLLAMA = "http://100.73.200.19:11434"  # loci convention (matches ground_gate.py)
+_DEFAULT_OLLAMA = "http://localhost:11434"
 
 
 def _ollama_base() -> str:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -3146,16 +3146,16 @@ def investigation_pre_answer_check(
         claim_support_refs: list[dict] = []
         claim_contradiction_refs: list[dict] = []
 
-        for record in evidence_pool:
-            score = _lexical_match_score(claim_tokens, record.get("tokens", set()))
+        for evid in evidence_pool:
+            score = _lexical_match_score(claim_tokens, evid.get("tokens", set()))
             if score < 0.45:
                 continue
-            evidence_negated = bool(_NEGATION_RE.search(str(record.get("text", ""))))
+            evidence_negated = bool(_NEGATION_RE.search(str(evid.get("text", ""))))
             if claim_negated != evidence_negated and score >= 0.5:
-                ref = _make_ref(record, "contradiction", score=score)
+                ref = _make_ref(evid, "contradiction", score=score)
                 claim_contradiction_refs.append(ref)
             else:
-                ref = _make_ref(record, "support", score=score)
+                ref = _make_ref(evid, "support", score=score)
                 claim_support_refs.append(ref)
 
         qdrant_refs, qdrant_status = _search_qdrant_claim_evidence(claim, investigation_id, limit=5)
@@ -3737,7 +3737,25 @@ def _record_verdicts(verdicts: list) -> bool:
                 # vector is stored rather than the backend's fallback.
                 await engine.record(v, _embed(v.subject_excerpt))
 
-        asyncio.run(_record_all())
+        # FastMCP dispatches sync tools inline on a running event loop — asyncio.run()
+        # raises RuntimeError in that context. Delegate to a daemon thread when needed.
+        try:
+            asyncio.get_running_loop()
+            _exc: list[Exception] = []
+
+            def _run_thread() -> None:
+                try:
+                    asyncio.run(_record_all())
+                except Exception as e:
+                    _exc.append(e)
+
+            t = threading.Thread(target=_run_thread, daemon=True)
+            t.start()
+            t.join()
+            if _exc:
+                raise _exc[0]
+        except RuntimeError:
+            asyncio.run(_record_all())
         return True
     except Exception as exc:  # fail-open — recording must not fail the tool
         logger.debug("memcheck verdict recording failed, degrading: %r", exc)
@@ -4656,7 +4674,27 @@ def _forget_finding_verdicts(finding: dict) -> int:
             removed += await engine.forget(redact_excerpt(text), "memory")
             return removed
 
-        return asyncio.run(_forget_all())
+        # Same loop-detection guard as _record_claim_verdicts — asyncio.run() raises
+        # RuntimeError when FastMCP is dispatching inline on a running event loop.
+        try:
+            asyncio.get_running_loop()
+            _result: list[int] = []
+            _exc2: list[Exception] = []
+
+            def _run_forget() -> None:
+                try:
+                    _result.append(asyncio.run(_forget_all()))
+                except Exception as e:
+                    _exc2.append(e)
+
+            t2 = threading.Thread(target=_run_forget, daemon=True)
+            t2.start()
+            t2.join()
+            if _exc2:
+                raise _exc2[0]
+            return _result[0] if _result else 0
+        except RuntimeError:
+            return asyncio.run(_forget_all())
     except Exception as exc:  # fail-open — verdict cleanup is best-effort
         logger.debug("verdict forget failed, degrading to 0: %r", exc)
         return 0
@@ -5313,8 +5351,8 @@ def investigation_reason(
         if vecs and len(vecs) == len(findings) + 1:
             qv = vecs[0]
             scored = [(_llm.cosine(qv, vecs[i + 1]), f) for i, f in enumerate(findings)]
-            kept = [f for c, f in scored if c >= ground_threshold]
-            gated = sorted(kept, key=lambda f: 0)[:12] if kept else []
+            kept = [(c, f) for c, f in scored if c >= ground_threshold]
+            gated = [f for _, f in sorted(kept, key=lambda x: x[0], reverse=True)[:12]]
             gate_applied = True
 
     evidence = "\n".join(

--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -22,7 +22,7 @@ DB_PATH = os.environ.get(
     "MNEMOSYNE_DB",
     os.path.expanduser("~/.hermes/mnemosyne/data/mnemosyne.db"),
 )
-OLLAMA_URL = os.environ.get("OLLAMA_URL")
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 AMEM_LINK_THRESHOLD = float(os.environ.get("AMEM_LINK_THRESHOLD", "0.88"))
 AMEM_CONFLICT_THRESHOLD = float(os.environ.get("AMEM_CONFLICT_THRESHOLD", "0.96"))

--- a/scripts/glymphatic_sweep.py
+++ b/scripts/glymphatic_sweep.py
@@ -67,6 +67,9 @@ def _hdrs() -> dict:
 
 def _scroll_all(collection: str, with_vectors: bool = False) -> list[dict]:
     """Scroll all points in a collection. Returns list of {id, payload, vector?}."""
+    if not QDRANT_URL:
+        print("[glym] QDRANT_URL is not set — skipping Qdrant operations")
+        return []
     url  = f"{QDRANT_URL}/collections/{collection}/points/scroll"
     pts  = []
     offset = None
@@ -91,6 +94,8 @@ def _scroll_all(collection: str, with_vectors: bool = False) -> list[dict]:
 
 def _delete_points(collection: str, ids: list, dry_run: bool) -> int:
     if not ids:
+        return 0
+    if not QDRANT_URL:
         return 0
     if dry_run:
         print(f"[glym] DRY-RUN would delete {len(ids)} pts from {collection}")
@@ -166,8 +171,8 @@ def sweep_orphans(dry_run: bool) -> int:
     cur  = conn.cursor()
 
     try:
-        cur.execute("SELECT DISTINCT source_id FROM graph_edges")
-        has_edges = {str(row["source_id"]) for row in cur.fetchall()}
+        cur.execute("SELECT DISTINCT source FROM graph_edges")
+        has_edges = {str(row["source"]) for row in cur.fetchall()}
     except sqlite3.OperationalError:
         has_edges = set()
 
@@ -209,7 +214,7 @@ def sweep_orphans(dry_run: bool) -> int:
 # ── step 3: dangling graph edges ──────────────────────────────────────────────
 
 def sweep_edges(dry_run: bool) -> int:
-    """Remove graph_edges where source_id or target_id no longer exists."""
+    """Remove graph_edges where source or target no longer exists in working_memory."""
     if not os.path.exists(DB_PATH):
         print(f"[glym/edges] DB not found: {DB_PATH}")
         return 0
@@ -227,7 +232,7 @@ def sweep_edges(dry_run: bool) -> int:
         return 0
 
     try:
-        cur.execute("SELECT rowid, source_id, target_id FROM graph_edges")
+        cur.execute("SELECT rowid, source, target FROM graph_edges")
         edges = cur.fetchall()
     except sqlite3.OperationalError:
         conn.close()
@@ -236,7 +241,7 @@ def sweep_edges(dry_run: bool) -> int:
 
     dangling_rowids = [
         row["rowid"] for row in edges
-        if str(row["source_id"]) not in existing or str(row["target_id"]) not in existing
+        if str(row["source"]) not in existing or str(row["target"]) not in existing
     ]
 
     if dangling_rowids and not dry_run:

--- a/scripts/spreading_activation.py
+++ b/scripts/spreading_activation.py
@@ -181,8 +181,6 @@ def run_spreading_activation(
             for source, _target, _weight in edges:
                 out_degree[source] = out_degree.get(source, 0) + 1
 
-            newly_activated: list[str] = []
-
             for source, target, weight in edges:
                 # Rescale weight relative to the floor
                 w_prime = (weight - SA_EDGE_FLOOR) / (1.0 - SA_EDGE_FLOOR)
@@ -196,9 +194,6 @@ def run_spreading_activation(
 
                 prior = activation.get(target, 0.0)
                 activation[target] = min(1.0, prior + contribution)
-
-                if target not in activation or prior == 0.0:
-                    newly_activated.append(target)
 
             # Next frontier: targets that were not already in the frontier set
             frontier = [


### PR DESCRIPTION
## Summary

Spider-style audit of the entire Loci codebase found 17 issues (3 crashes, 8 wrong-behavior warnings, 6 info). This PR fixes the 11 most impactful.

**Crashes fixed:**
- `amem_consolidation.py` — `OLLAMA_URL` defaulted to `None`, causing `ValueError: unknown url type: 'None/v1/embeddings'` on every embedding call
- `a2a_server/server.py` — `MNEMOSYNE_EMBEDDING_API_URL` defaulted to `None`, causing `AttributeError: 'NoneType'.rstrip()` on all semantic recall paths
- `a2a_server/server.py` — `_embed()` constructed URL as `{BASE}/embeddings` instead of `{BASE}/v1/embeddings` (404 on all Ollama-compat endpoints)
- `a2a_server/server.py` — `skill_gpu_inference` used `OLLAMA_BASE.rstrip('/v1')` (character-strip) instead of `.removesuffix('/v1')`, corrupting any URL ending in `1`, `v`, or `/`

**Wrong behavior fixed:**
- `mcp/server.py:investigation_pre_answer_check` — inner loop variable `record` shadowed the `record: bool` parameter; `_make_ref(record, ...)` was passing a dict where callers passed `record=False`; renamed loop var to `evid`
- `mcp/server.py:investigation_reason` — `sorted(kept, key=lambda f: 0)` lost all grounding-gate relevance ranking, returning findings in JSONL order; now sorts by cosine score descending
- `mcp/server.py:_record_verdicts` and `_forget_finding_verdicts` — used bare `asyncio.run()` which raises `RuntimeError` when FastMCP dispatches inline on a running event loop; silently degraded to no-op; now uses same thread-delegation pattern as `_record_claim_verdicts`
- `scripts/glymphatic_sweep.py` — queried `source_id`/`target_id` columns that don't exist (schema uses `source`/`target`); all orphan-sweep and edge-sweep steps silently did nothing
- `scripts/glymphatic_sweep.py` — `QDRANT_URL=None` produced the URL string `"None/collections/..."`, causing silent 4xx failures on all Qdrant steps
- `scripts/spreading_activation.py` — `newly_activated` list was built but never read; append condition `target not in activation` was always `False` after `activation[target]` was set on the previous line
- `a2a_server/server.py:_db()` — `sqlite3.Connection.__exit__` commits/rolls back but does NOT close; every tool call leaked a file handle; converted to a proper `@contextmanager` that always closes

**Info fixed:**
- `mcp/memcheck/llm.py` — hardcoded private IP `100.73.200.19:11434` as Ollama fallback; replaced with `localhost:11434`
- `deep_think_loci/grounding/ground_gate.py` — two unclosed file handles (`open()` without `with`); converted to `with open() as fh:`

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('mcp/server.py').read())"` — no syntax errors
- [ ] Run MCP server tests: `pytest tests/test_mcp_server.py`
- [ ] Run A2A server tests: `pytest tests/test_a2a_server.py`
- [ ] `python3 scripts/amem_consolidation.py --help` — no crash when OLLAMA_URL unset
- [ ] `python3 scripts/glymphatic_sweep.py --dry-run` — edge sweep uses `source`/`target` columns
- [ ] `python3 scripts/spreading_activation.py --help` — no reference to newly_activated

🤖 Generated with [Claude Code](https://claude.com/claude-code)