### PR TITLE
fix(info): clean up 4 code smells from spider audit

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -1164,7 +1164,6 @@ async def skill_memory_prime(task: dict) -> dict:
         peer_urls = [u.strip() for u in peer_urls_raw.split(',') if u.strip()]
 
         import uuid as _uuid
-        import aiohttp
 
         async def _prime_peer(peer_url: str):
             base  = peer_url.rstrip('/a2a').rstrip('/')

--- a/mcp/memcheck/checks/contradiction_llm.py
+++ b/mcp/memcheck/checks/contradiction_llm.py
@@ -85,7 +85,7 @@ def _wire(embed_fn, llm_fn, cosine_fn):
     return embed_fn, llm_fn, cosine_fn
 
 
-def _extract_json(text: str) -> dict | None:
+def extract_json(text: str) -> dict | None:
     """Tolerant JSON extraction from a model reply (handles ``` fences)."""
     if not text:
         return None
@@ -173,7 +173,7 @@ def _gate_and_judge(
         except Exception as exc:  # noqa: BLE001 - fail-open per pair
             _log.debug("llm judge failed for pair (%s,%s): %r", id_a, id_b, exc)
             continue
-        parsed = _extract_json(reply or "")
+        parsed = extract_json(reply or "")
         if not parsed or not bool(parsed.get("contradict")):
             continue
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -94,8 +94,7 @@ try:
 except ImportError:
     pass
 
-import re as _re
-_EMAIL_RE = _re.compile(r'\b[\w._%+\-]+@[\w.\-]+\.[a-zA-Z]{2,}\b', _re.I)
+_EMAIL_RE = re.compile(r'\b[\w._%+\-]+@[\w.\-]+\.[a-zA-Z]{2,}\b', re.I)
 
 # ── Immutable event log (fail-open) ───────────────────────────────────────────
 # Appends a record before every memory mutation so the full operation history
@@ -111,12 +110,19 @@ def _event_log_append(event: dict) -> None:
         _el_append(event)
     except Exception:
         pass  # Never let event log failures block memory operations
-_HOST_RE = _re.compile(
+_HOST_RE = re.compile(
     r'\b[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?'
     r'(?:\.[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)*'
-    r'(?:\.(?:local|corp|internal|lan|dev|test|net|com|io|org))\b', _re.I
+    r'(?:\.(?:local|corp|internal|lan|dev|test|net|com|io|org))\b', re.I
 )
-_URL_RE = _re.compile(r'https?://[^\s"\' <>;]+', _re.I)
+_URL_RE = re.compile(r'https?://[^\s"\' <>;]+', re.I)
+
+
+def _safe_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _extract_entities(text: str) -> dict:
@@ -1983,13 +1989,6 @@ def _lexical_match_score(claim_tokens: set[str], evidence_tokens: set[str]) -> f
         return 0.0
     overlap = claim_tokens.intersection(evidence_tokens)
     return len(overlap) / max(1, len(claim_tokens))
-
-
-def _safe_float(value, default: float = 0.0) -> float:
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
 
 
 def _make_ref(record: dict, match_type: str, score: float | None = None) -> dict:
@@ -5347,7 +5346,7 @@ def investigation_reason(
                final_answer, persisted_finding_ids}.
     """
     from memcheck import llm as _llm
-    from memcheck.checks.contradiction_llm import _extract_json
+    from memcheck.checks.contradiction_llm import extract_json as _extract_json
 
     if not (investigation_id and (MEMORY_DIR / investigation_id).exists()):
         return json.dumps({"error": f"Investigation '{investigation_id}' not found."})


### PR DESCRIPTION
## Summary

Addresses the 4 remaining info-level items from the full-codebase spider audit (the 11 runtime bugs were fixed in #59).

- **Double `re` import** — `mcp/server.py` imported `re` at line 51 then `re as _re` at line 97 for the IOC regex constants. Removed the alias and replaced all `_re.compile`/`_re.I` references with `re.compile`/`re.I`.
- **`_safe_float` used before definition** — function was defined at line ~1972 but called starting at line ~288 in `_mnemo_recall`. Moved the definition to the module-level utility zone (near `_extract_entities`) and removed the duplicate at the old location.
- **`_extract_json` private API import** — `server.py` imported `_extract_json` from `memcheck.checks.contradiction_llm` by private name (underscore prefix). Renamed to `extract_json` in `contradiction_llm.py`, updated the one internal caller, and updated `server.py` to import the public name (aliased locally for minimal diff).
- **Redundant `import aiohttp` inside function** — `skill_memory_prime` in `a2a_server/server.py` re-imported `aiohttp` at line 1143 despite it being already imported at module top (line 176). Removed the inner import.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('mcp/server.py').read())"` — no syntax errors
- [ ] `python3 -c "from memcheck.checks.contradiction_llm import extract_json; print(extract_json('{}'))"` — returns `{}`
- [ ] MCP server tests pass
- [ ] A2A server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)