### PR TITLE
fix(ci): install pytest in schema-consistency job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install pytest
+        run: pip install pytest
+
       - name: Run schema consistency tests
         run: pytest tests/test_schema_consistency.py -v --tb=short
 


### PR DESCRIPTION
The schema-consistency CI job was missing a `pip install pytest` step, causing exit code 127 (command not found). One-line fix.