### PR TITLE
feat: add memory_surface tool for proactive context surfacing

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -25,6 +25,7 @@ _ = memory_consolidate
 _ = memory_retract
 _ = memory_restore
 _ = memory_confidence
+_ = memory_surface
 _ = rag_context_search
 _ = reflection_loop_seed
 _ = reflection_loop_tick

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5271,6 +5271,152 @@ def rag_context_search(
 
 
 # ---------------------------------------------------------------------------
+# Tool: memory_surface — proactive context surfacing
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def memory_surface(
+    context: str,
+    investigation_id: Optional[str] = None,
+    top_k: int = 5,
+) -> str:
+    """
+    Proactively surface prior findings most relevant to the agent's current working context.
+
+    Unlike rag_context_search (which requires a precise query), memory_surface accepts
+    a free-form paragraph describing what the agent is doing and returns the most
+    tangentially-relevant prior findings using a lower similarity threshold (0.25 vs 0.5+).
+    This is designed for passive context injection — call it at the start of a task to
+    surface related memory without knowing exactly what to search for.
+
+    Args:
+        context:          A paragraph describing the agent's current working context.
+        investigation_id: Optional — if provided, restrict results to this investigation.
+        top_k:            How many surfaced results to return (default 5).
+
+    Returns:
+        JSON with {surfaced: [{finding_id, text, source, relevance_note, score,
+                               investigation_id}], context_used, count}
+    """
+    import math as _math
+
+    if not context or not context.strip():
+        return json.dumps({
+            "error": "context must not be empty",
+            "surfaced": [],
+            "context_used": context,
+            "count": 0,
+        })
+
+    try:
+        client, _col = _get_qdrant()
+        if client is None:
+            return json.dumps({
+                "error": "memory_surface requires Qdrant",
+                "surfaced": [],
+                "context_used": context,
+                "count": 0,
+            })
+
+        # Build investigation filter if requested
+        query_filter = None
+        if investigation_id:
+            try:
+                from qdrant_client.models import Filter, FieldCondition, MatchValue
+                query_filter = Filter(
+                    must=[FieldCondition(key="investigation_id", match=MatchValue(value=investigation_id))]
+                )
+            except Exception:
+                pass
+
+        # Fetch top_k * 3 candidates with a lower threshold via _qdrant_search_collection
+        fetch_limit = top_k * 3
+        try:
+            candidates = _qdrant_search_collection(
+                context,
+                collection_name=QDRANT_COLLECTION_PREFIX,
+                limit=fetch_limit,
+                query_filter=query_filter,
+            )
+        except RuntimeError as _rte:
+            _rte_msg = str(_rte)
+            if "qdrant_unavailable" in _rte_msg or "embedding_unavailable" in _rte_msg:
+                return json.dumps({
+                    "error": "memory_surface requires Qdrant",
+                    "surfaced": [],
+                    "context_used": context,
+                    "count": 0,
+                })
+            raise
+        except Exception as _exc:
+            return json.dumps({
+                "error": f"memory_surface search failed: {_exc}",
+                "surfaced": [],
+                "context_used": context,
+                "count": 0,
+            })
+
+        # Apply lower score threshold (0.25) to allow tangentially relevant findings
+        _SURFACE_SCORE_THRESHOLD = 0.25
+        filtered = [r for r in candidates if float(r.get("score") or 0.0) >= _SURFACE_SCORE_THRESHOLD]
+
+        # Apply Ebbinghaus decay if _MEMORY_DECAY_LAMBDA is defined on this module
+        _decay_lambda = globals().get("_MEMORY_DECAY_LAMBDA")
+        now_ts = time.time()
+        if _decay_lambda is not None:
+            try:
+                for r in filtered:
+                    created_ts = float(r.get("created_at_ts") or now_ts)
+                    age_days = (now_ts - created_ts) / 86400.0
+                    decay = _math.exp(-float(_decay_lambda) * age_days)
+                    r["score"] = round(float(r.get("score") or 0.0) * decay, 4)
+            except Exception:
+                pass  # decay is optional enhancement; never break the tool
+
+        # Re-sort after possible decay adjustment, then take top_k
+        filtered.sort(key=lambda r: float(r.get("score") or 0.0), reverse=True)
+        top_results = filtered[:top_k]
+
+        # Build short context prefix for relevance note fallback
+        _ctx_words = context.strip().split()
+        _ctx_prefix = " ".join(_ctx_words[:8])
+
+        surfaced = []
+        for r in top_results:
+            finding_id = r.get("id") or r.get("finding_id") or ""
+            text = str(r.get("text") or r.get("content") or "")
+            source = str(r.get("source") or r.get("origin") or "")
+            inv_id = r.get("investigation_id") or investigation_id or ""
+            score = round(float(r.get("score") or 0.0), 4)
+
+            # Generate relevance_note: simple label based on context prefix
+            relevance_note = f"Related to: {_ctx_prefix}"
+
+            surfaced.append({
+                "finding_id": finding_id,
+                "text": text[:300] if len(text) > 300 else text,
+                "source": source,
+                "relevance_note": relevance_note,
+                "score": score,
+                "investigation_id": inv_id,
+            })
+
+        return json.dumps({
+            "surfaced": surfaced,
+            "context_used": context[:200] if len(context) > 200 else context,
+            "count": len(surfaced),
+        }, indent=2)
+
+    except Exception as _top_exc:
+        return json.dumps({
+            "error": f"memory_surface error: {_top_exc}",
+            "surfaced": [],
+            "context_used": context[:200] if len(context) > 200 else context,
+            "count": 0,
+        })
+
+
+# ---------------------------------------------------------------------------
 # Mnemosyne sleep / consolidation
 # ---------------------------------------------------------------------------
 

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -257,6 +257,61 @@ class TestAuditLog(unittest.TestCase):
         self.assertNotIn("error", result)
 
 
+class TestMemorySurface(unittest.TestCase):
+    """memory_surface returns valid JSON in all cases, including when Qdrant is unavailable."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = server.MEMORY_DIR
+        server.MEMORY_DIR = Path(self._tmp.name)
+
+    def tearDown(self):
+        server.MEMORY_DIR = self._orig
+        self._tmp.cleanup()
+
+    def test_memory_surface_returns_valid_json(self):
+        """Without Qdrant, memory_surface must return valid JSON with error key."""
+        result = _json(server.memory_surface(context="Working on authentication token expiry bug"))
+        self.assertIsInstance(result, dict)
+        # Either surfaced results (if Qdrant available) or a graceful error
+        self.assertTrue(
+            "surfaced" in result or "error" in result,
+            f"memory_surface missing 'surfaced' or 'error' key: {result}",
+        )
+
+    def test_memory_surface_no_qdrant_has_surfaced_list(self):
+        """When Qdrant is unavailable, surfaced must be an empty list, not missing."""
+        result = _json(server.memory_surface(context="Investigating retry logic in sync service"))
+        self.assertIn("surfaced", result)
+        self.assertIsInstance(result["surfaced"], list)
+
+    def test_memory_surface_empty_context_returns_error(self):
+        """Empty context string should return an error dict, not raise."""
+        result = _json(server.memory_surface(context=""))
+        self.assertIn("error", result)
+        self.assertIn("surfaced", result)
+        self.assertEqual(result["surfaced"], [])
+
+    def test_memory_surface_has_required_output_keys(self):
+        """Output must always include context_used and count keys."""
+        result = _json(server.memory_surface(
+            context="Debugging database connection pool exhaustion",
+            top_k=3,
+        ))
+        self.assertIn("surfaced", result)
+        self.assertIn("count", result)
+        self.assertIn("context_used", result)
+
+    def test_memory_surface_with_investigation_id(self):
+        """Passing an investigation_id should not raise, must return valid JSON."""
+        result = _json(server.memory_surface(
+            context="Reviewing the auth service login flow",
+            investigation_id="test-inv-does-not-exist",
+        ))
+        self.assertIsInstance(result, dict)
+        self.assertIn("surfaced", result)
+
+
 class TestToolsSmokeReturnValidJSON(unittest.TestCase):
     """Smoke test: key tools return parseable JSON without raising."""
 


### PR DESCRIPTION
## Summary

- Adds new MCP tool `memory_surface(context, investigation_id, top_k)` positioned after `rag_context_search` in `mcp/server.py`
- Uses a lower Qdrant similarity threshold (0.25 vs the typical 0.5+) to surface tangentially relevant prior findings without requiring a precise query
- Supports optional `investigation_id` filtering, optional Ebbinghaus decay (activates when `_MEMORY_DECAY_LAMBDA` is defined on the module), and graceful fail-open on Qdrant unavailability
- Returns `{surfaced: [{finding_id, text, source, relevance_note, score, investigation_id}], context_used, count}`
- Added `memory_surface` to `.vulture_whitelist.py`
- Added 5 new integration tests in `TestMemorySurface` covering: valid JSON output, empty context error, required output keys, investigation_id scoping, and Qdrant-unavailable graceful degradation

## Test plan

- [ ] All 124 tests pass: `cd mcp && python3 -m pytest tests/ -v --tb=short`
- [ ] Lint clean: `ruff check mcp/server.py --select E9,F401,F811,F821,F841 --ignore E402`
- [ ] `memory_surface("")` returns `{"error": ..., "surfaced": [], ...}` (not a crash)
- [ ] `memory_surface("some context")` without Qdrant returns `{"error": "memory_surface requires Qdrant", "surfaced": [], ...}`
- [ ] With Qdrant available, returns up to `top_k` surfaced findings with `relevance_note` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)