### PR TITLE
feat: progressive summary ladder (L0/L1/L2 fidelity)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -2333,6 +2333,8 @@ def investigation_start(
         "closed_summary": None,
         "owner": "",
         "acl": [],
+        "summary_l1": [],
+        "summary_l2": "",
     }
     _save_manifest(manifest)
     logger.info("Created investigation %s", investigation_id)
@@ -2347,6 +2349,7 @@ def investigation_load(
     last_n_findings: int = 20,
     include_retracted: bool = False,
     requesting_agent_id: Optional[str] = None,
+    fidelity: str = "full",
 ) -> str:
     """
     Retrieve manifest and recent findings for an investigation.
@@ -2367,10 +2370,19 @@ def investigation_load(
                              provided and the investigation has a non-empty ACL,
                              findings are filtered to those authored by agents
                              in the ACL or by the requesting agent itself.
+        fidelity: Controls how much detail is returned. One of:
+                  "full"    — existing behavior: returns manifest + all recent findings.
+                  "summary" — returns manifest + summary_l1 (bullets) + summary_l2
+                              (paragraph) instead of full findings list. Useful when
+                              context window is constrained.
+                  "brief"   — returns manifest + summary_l2 only (single paragraph).
+                              Most compact form; good for quick orientation.
 
     Returns:
         JSON with manifest, total finding count, recent findings, and
         ``excluded_retracted`` (count of findings filtered out).
+        When fidelity is "summary" or "brief", the ``recent_findings`` key is
+        omitted and replaced with ``summary_l1`` and/or ``summary_l2``.
     """
     manifest = _load_manifest(investigation_id)
     if not manifest:
@@ -2378,6 +2390,39 @@ def investigation_load(
             "error": f"Investigation '{investigation_id}' not found. Call investigation_start first."
         })
 
+    # Ensure summary fields exist (backwards-compatible with manifests created before this feature)
+    summary_l1 = manifest.get("summary_l1") or []
+    summary_l2 = manifest.get("summary_l2") or ""
+
+    if fidelity == "brief":
+        return json.dumps({
+            "manifest": manifest,
+            "fidelity": "brief",
+            "summary_l2": summary_l2,
+        }, indent=2)
+
+    if fidelity == "summary":
+        findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
+        all_retracted = _load_retracted_ids(investigation_id)
+        total_retracted = len(all_retracted)
+        retracted = set() if include_retracted else all_retracted
+        excluded_retracted = 0
+        if retracted:
+            kept = [f for f in findings if str(f.get("id", "")) not in retracted]
+            excluded_retracted = len(findings) - len(kept)
+            findings = kept
+        return json.dumps({
+            "manifest": manifest,
+            "fidelity": "summary",
+            "total_findings": len(findings),
+            "summary_l1": summary_l1,
+            "summary_l2": summary_l2,
+            "excluded_retracted": excluded_retracted,
+            "total_retracted": total_retracted,
+            "include_retracted": include_retracted,
+        }, indent=2)
+
+    # Default: fidelity == "full"
     findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
     all_retracted = _load_retracted_ids(investigation_id)
     total_retracted = len(all_retracted)
@@ -2402,6 +2447,7 @@ def investigation_load(
 
     return json.dumps({
         "manifest": manifest,
+        "fidelity": "full",
         "total_findings": len(findings),
         "recent_findings": recent,
         "excluded_retracted": excluded_retracted,
@@ -3012,6 +3058,76 @@ def investigation_reflect(investigation_id: str) -> str:
         if freq
     }
 
+    # Progressive summary ladder — compute L1 (bullets) and L2 (paragraph) and
+    # persist them to the manifest so investigation_load can serve them without
+    # re-reading all findings. Fail-open: any failure falls back to a deterministic
+    # non-LLM summary and never blocks the rest of the reflect response.
+    summary_l1: list[str] = []
+    summary_l2: str = ""
+    try:
+        last_20 = findings[-20:]
+        _llm_summary_attempted = False
+        try:
+            from memcheck import llm as _llm
+            if _llm.llm_available() and last_20:
+                _llm_summary_attempted = True
+                context_bullets = "\n".join(
+                    f"- [{f.get('type', '?')}] {str(f.get('text', ''))[:300]}"
+                    for f in last_20
+                )
+                l1_prompt = (
+                    f"Investigation: {manifest['title']}\n"
+                    f"Recent findings (up to 20):\n{context_bullets}\n\n"
+                    "Produce exactly 5-7 concise key-point bullet strings that capture "
+                    "the most important things known so far. Each bullet should be a "
+                    "single sentence under 120 characters. Reply with ONLY a JSON array "
+                    "of strings, no other text. Example: [\"First point.\", \"Second point.\"]"
+                )
+                l1_raw = _llm.call_llm(l1_prompt, json_mode=True, timeout=60.0)
+                if l1_raw:
+                    try:
+                        parsed = json.loads(l1_raw)
+                        if isinstance(parsed, list):
+                            summary_l1 = [str(b) for b in parsed if str(b).strip()][:7]
+                    except Exception:
+                        pass
+
+                if summary_l1:
+                    l2_prompt = (
+                        f"Investigation: {manifest['title']}\n"
+                        f"Key points:\n" + "\n".join(f"- {b}" for b in summary_l1) + "\n\n"
+                        "Write a 2-3 sentence 'state of knowledge' paragraph summarising "
+                        "what is established, what is uncertain, and what remains to check. "
+                        "Be direct and concise. Reply with only the paragraph text."
+                    )
+                    l2_raw = _llm.call_llm(l2_prompt, timeout=60.0)
+                    if l2_raw:
+                        summary_l2 = l2_raw.strip()
+        except Exception:
+            _llm_summary_attempted = False
+
+        # Deterministic fallback when LLM is unavailable or failed to produce output
+        if not summary_l1:
+            summary_l1 = [
+                str(f.get("text", ""))[:100]
+                for f in findings[-5:]
+                if str(f.get("text", "")).strip()
+            ]
+        if not summary_l2:
+            n = len(findings)
+            latest_text = str(findings[-1].get("text", "")) if findings else ""
+            summary_l2 = (
+                f"Investigation with {n} finding{'s' if n != 1 else ''}."
+                + (f" Latest: {latest_text[:200]}" if latest_text else "")
+            )
+
+        # Persist to manifest (write-through cache via _save_manifest)
+        manifest["summary_l1"] = summary_l1
+        manifest["summary_l2"] = summary_l2
+        _save_manifest(manifest)
+    except Exception:
+        pass  # fail-open: summary generation never breaks reflect
+
     return json.dumps({
         "investigation_id": investigation_id,
         "title": manifest["title"],
@@ -3026,6 +3142,8 @@ def investigation_reflect(investigation_id: str) -> str:
         "key_entities": key_entities,
         "excluded_retracted": excluded_retracted,
         "self_check": self_check,
+        "summary_l1": summary_l1,
+        "summary_l2": summary_l2,
     }, indent=2)
 
 

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -999,3 +999,138 @@ class TestInvestigationACL(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestProgressiveSummaryFidelity(unittest.TestCase):
+    """Tests for the L0/L1/L2 progressive summary ladder (investigation_load fidelity param)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = server.MEMORY_DIR
+        server.MEMORY_DIR = Path(self._tmp.name)
+
+    def tearDown(self):
+        server.MEMORY_DIR = self._orig
+        self._tmp.cleanup()
+
+    def _setup_investigation_with_findings(self, inv_id):
+        """Create an investigation, add findings, then call reflect to populate summaries."""
+        server.investigation_start(investigation_id=inv_id, title="Fidelity test investigation")
+        for i in range(3):
+            server.investigation_store(
+                investigation_id=inv_id,
+                finding_type="observed",
+                text=f"Finding number {i + 1}: something important was observed here.",
+                source="test:manual",
+                confidence="high",
+            )
+        # Call reflect to compute and persist L1/L2 summaries
+        server.investigation_reflect(investigation_id=inv_id)
+
+    def test_investigation_load_fidelity_full_returns_recent_findings(self):
+        """fidelity='full' (default) returns recent_findings and manifest."""
+        inv_id = _new_id("fid-full")
+        self._setup_investigation_with_findings(inv_id)
+
+        result = _json(server.investigation_load(investigation_id=inv_id, fidelity="full"))
+        self.assertNotIn("error", result)
+        self.assertIn("manifest", result)
+        self.assertIn("recent_findings", result)
+        self.assertIsInstance(result["recent_findings"], list)
+        self.assertGreater(len(result["recent_findings"]), 0)
+
+    def test_investigation_load_fidelity_summary(self):
+        """fidelity='summary' returns summary_l1 bullets + summary_l2 paragraph, not full findings."""
+        inv_id = _new_id("fid-sum")
+        self._setup_investigation_with_findings(inv_id)
+
+        result = _json(server.investigation_load(investigation_id=inv_id, fidelity="summary"))
+        self.assertNotIn("error", result, f"Unexpected error: {result}")
+        self.assertIn("manifest", result)
+        self.assertEqual(result.get("fidelity"), "summary")
+        self.assertIn("summary_l1", result)
+        self.assertIn("summary_l2", result)
+        self.assertIsInstance(result["summary_l1"], list)
+        self.assertIsInstance(result["summary_l2"], str)
+        # Must NOT contain full findings list
+        self.assertNotIn("recent_findings", result)
+        # summary_l1 should have at least one bullet (fallback always populates it)
+        self.assertGreater(len(result["summary_l1"]), 0)
+        # summary_l2 should be a non-empty string
+        self.assertTrue(result["summary_l2"].strip())
+
+    def test_investigation_load_fidelity_brief(self):
+        """fidelity='brief' returns only manifest + summary_l2 paragraph."""
+        inv_id = _new_id("fid-brief")
+        self._setup_investigation_with_findings(inv_id)
+
+        result = _json(server.investigation_load(investigation_id=inv_id, fidelity="brief"))
+        self.assertNotIn("error", result, f"Unexpected error: {result}")
+        self.assertIn("manifest", result)
+        self.assertEqual(result.get("fidelity"), "brief")
+        self.assertIn("summary_l2", result)
+        self.assertIsInstance(result["summary_l2"], str)
+        # Must NOT contain full findings or L1 bullets
+        self.assertNotIn("recent_findings", result)
+        self.assertNotIn("summary_l1", result)
+
+    def test_investigation_reflect_populates_manifest_summaries(self):
+        """investigation_reflect persists summary_l1 and summary_l2 to the manifest."""
+        inv_id = _new_id("ref-sum")
+        server.investigation_start(investigation_id=inv_id, title="Reflect summary test")
+        server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="The database connection pool is exhausted under load.",
+            source="test:perf",
+            confidence="high",
+        )
+
+        reflect_result = _json(server.investigation_reflect(investigation_id=inv_id))
+        self.assertNotIn("error", reflect_result)
+        self.assertIn("summary_l1", reflect_result)
+        self.assertIn("summary_l2", reflect_result)
+        self.assertIsInstance(reflect_result["summary_l1"], list)
+        self.assertIsInstance(reflect_result["summary_l2"], str)
+
+        # Verify the summaries were persisted to the manifest
+        load_result = _json(server.investigation_load(investigation_id=inv_id))
+        manifest = load_result["manifest"]
+        self.assertIn("summary_l1", manifest)
+        self.assertIn("summary_l2", manifest)
+
+    def test_investigation_start_includes_summary_fields(self):
+        """Newly created investigations have summary_l1 and summary_l2 initialized."""
+        inv_id = _new_id("start-sum")
+        result = _json(server.investigation_start(investigation_id=inv_id, title="Summary init test"))
+        self.assertEqual(result["status"], "created")
+        manifest = result["manifest"]
+        self.assertIn("summary_l1", manifest)
+        self.assertIn("summary_l2", manifest)
+        self.assertEqual(manifest["summary_l1"], [])
+        self.assertEqual(manifest["summary_l2"], "")
+
+    def test_investigation_load_fidelity_summary_empty_investigation(self):
+        """fidelity='summary' on a fresh investigation with no findings does not error."""
+        inv_id = _new_id("fid-sum-empty")
+        server.investigation_start(investigation_id=inv_id, title="Empty summary test")
+
+        result = _json(server.investigation_load(investigation_id=inv_id, fidelity="summary"))
+        self.assertNotIn("error", result)
+        self.assertEqual(result.get("fidelity"), "summary")
+        self.assertIn("summary_l1", result)
+        self.assertIn("summary_l2", result)
+
+    def test_investigation_load_fidelity_brief_empty_investigation(self):
+        """fidelity='brief' on a fresh investigation with no findings does not error."""
+        inv_id = _new_id("fid-brief-empty")
+        server.investigation_start(investigation_id=inv_id, title="Empty brief test")
+
+        result = _json(server.investigation_load(investigation_id=inv_id, fidelity="brief"))
+        self.assertNotIn("error", result)
+        self.assertEqual(result.get("fidelity"), "brief")
+        self.assertIn("summary_l2", result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds `summary_l1` (list of key-point bullets) and `summary_l2` (state-of-knowledge paragraph) fields to investigation manifests, initialized to `[]` and `""` on `investigation_start`
- Enhances `investigation_reflect` to compute both summary levels after each reflection: tries an LLM call via `memcheck.llm` when available (5–7 bullets then a 2–3 sentence paragraph), falls back to a deterministic non-LLM version (last 5 finding texts + count sentence), and persists the result to the manifest via `_save_manifest`
- Adds `fidelity: str = "full"` parameter to `investigation_load` with three modes:
  - `"full"` — existing behavior (manifest + recent findings list)
  - `"summary"` — manifest + `summary_l1` bullets + `summary_l2` paragraph; no findings list
  - `"brief"` — manifest + `summary_l2` only; most compact form for quick orientation
- All new code is fail-open (wrapped in try/except); existing functionality is unchanged

## Test plan

- [x] All 126 existing tests pass (`python3 -m pytest tests/ -v --tb=short`)
- [x] 7 new tests added in `TestProgressiveSummaryFidelity`:
  - `test_investigation_load_fidelity_full_returns_recent_findings`
  - `test_investigation_load_fidelity_summary` (checks bullets + paragraph present, `recent_findings` absent)
  - `test_investigation_load_fidelity_brief` (checks only `summary_l2` returned)
  - `test_investigation_reflect_populates_manifest_summaries`
  - `test_investigation_start_includes_summary_fields`
  - `test_investigation_load_fidelity_summary_empty_investigation`
  - `test_investigation_load_fidelity_brief_empty_investigation`
- [x] Lint clean: `ruff check mcp/server.py --select E9,F401,F811,F821,F841 --ignore E402`

🤖 Generated with [Claude Code](https://claude.com/claude-code)