### PR TITLE
feat(investigation): conflict detection on investigation_store

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -34,6 +34,8 @@ _ = rag_context_search
 _ = reflection_loop_seed
 _ = reflection_loop_tick
 _ = reflection_loop_status
+_ = conflict_list
+_ = conflict_resolve
 
 # ── Public API exported by memcheck modules
 _ = run_contradiction

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -2456,6 +2456,125 @@ def investigation_load(
     }, indent=2)
 
 
+# ---------------------------------------------------------------------------
+# Conflict detection helpers
+# ---------------------------------------------------------------------------
+
+_NEGATION_MARKERS = frozenset(["not ", "no ", "never", "false"])
+
+
+def _has_negation(text: str) -> bool:
+    """Return True if text contains any negation marker (case-insensitive)."""
+    lower = text.lower()
+    return any(marker in lower for marker in _NEGATION_MARKERS)
+
+
+def _detect_conflicts(investigation_id: str, new_finding: dict) -> list[dict]:
+    """
+    Search Qdrant for near-neighbors of new_finding (same investigation, cosine
+    > 0.82, excluding the new finding itself) and apply simple conflict heuristics.
+
+    Returns a list of conflict dicts (may be empty). Fail-open — any exception
+    returns an empty list so investigation_store is never blocked.
+    """
+    try:
+        client, col = _get_qdrant()
+        if client is None:
+            return []
+
+        try:
+            from qdrant_client.models import Filter, FieldCondition, MatchValue
+        except ImportError:
+            return []
+
+        dense_vec = _embed(new_finding.get("text", ""))
+        if dense_vec is None:
+            return []
+
+        search_filter = Filter(must=[
+            FieldCondition(
+                key="investigation_id",
+                match=MatchValue(value=investigation_id),
+            )
+        ])
+
+        try:
+            from qdrant_client.models import SearchParams, QuantizationSearchParams
+            _sp = SearchParams(quantization=QuantizationSearchParams(rescore=True, oversampling=2.0))
+            result = client.search(
+                collection_name=col,
+                query_vector=dense_vec,
+                query_filter=search_filter,
+                limit=10,
+                score_threshold=0.82,
+                with_payload=True,
+                search_params=_sp,
+            )
+        except Exception:
+            # Some collection configurations use named vectors; fall back gracefully.
+            return []
+
+        new_id = new_finding.get("id", "")
+        new_type = new_finding.get("record_type", "")
+        new_text = new_finding.get("text", "")
+        new_neg = _has_negation(new_text)
+
+        conflicts = []
+        for hit in result:
+            payload = dict(hit.payload or {})
+            neighbor_id = str(payload.get("id", hit.id))
+            # Skip the finding itself (shouldn't appear since it may not yet be
+            # in the index, but guard anyway).
+            if neighbor_id == new_id:
+                continue
+
+            neighbor_type = payload.get("record_type") or payload.get("type", "")
+            neighbor_text = str(payload.get("text", ""))
+            neighbor_neg = _has_negation(neighbor_text)
+
+            is_conflict = False
+
+            # Heuristic 1: gap now filled by an observed finding
+            if neighbor_type == "gap" and new_type == "observed":
+                is_conflict = True
+
+            # Heuristic 2: assumption overridden by a non-assumed finding
+            elif neighbor_type == "assumed" and new_type != "assumed":
+                is_conflict = True
+
+            # Heuristic 3: opposing negation markers
+            elif new_neg != neighbor_neg:
+                is_conflict = True
+
+            if is_conflict:
+                conflicts.append({
+                    "neighbor_id": neighbor_id,
+                    "neighbor_type": neighbor_type,
+                    "score": round(float(hit.score), 4),
+                })
+
+        return conflicts
+    except Exception as exc:
+        logger.debug("_detect_conflicts: fail-open on exception: %s", exc)
+        return []
+
+
+def _write_conflict(investigation_id: str, finding_id_a: str, neighbor_id: str) -> str:
+    """Append a conflict record to conflicts.jsonl and return its id."""
+    conflict = {
+        "id": str(uuid.uuid4()),
+        "investigation_id": investigation_id,
+        "finding_id_a": finding_id_a,
+        "finding_id_b": neighbor_id,
+        "detected_at": _now(),
+        "status": "open",
+        "resolution": None,
+    }
+    path = _inv_dir(investigation_id) / "conflicts.jsonl"
+    _append_jsonl(path, conflict)
+    return conflict["id"]
+
+
 # ---- Tool: investigation_store ----
 
 @mcp.tool()
@@ -2612,12 +2731,32 @@ def investigation_store(
         "confidence": confidence,
     })
 
-    return json.dumps({
+    # Conflict detection — fail-open; never blocks a successful store.
+    conflict_detected = False
+    conflicting_finding_id = None
+    conflict_id = None
+    try:
+        conflicts = _detect_conflicts(investigation_id, finding)
+        if conflicts:
+            first = conflicts[0]
+            conflict_id = _write_conflict(investigation_id, finding["id"], first["neighbor_id"])
+            conflict_detected = True
+            conflicting_finding_id = first["neighbor_id"]
+    except Exception as _cd_exc:
+        logger.debug("investigation_store: conflict detection failed (fail-open): %s", _cd_exc)
+
+    result = {
         "stored": True,
         "finding_id": finding["id"],
         "type": finding_type,
         "mnemo_stored": mnemo_stored,
-    }, indent=2)
+        "conflict_detected": conflict_detected,
+    }
+    if conflict_detected:
+        result["conflicting_finding_id"] = conflicting_finding_id
+        result["conflict_id"] = conflict_id
+
+    return json.dumps(result, indent=2)
 
 
 # ---- Tool: procedure_attempt ----
@@ -6379,6 +6518,116 @@ def investigation_reason(
         "final_answer": final_answer,
         "persisted_finding_ids": persisted,
     }, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Conflict management tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def conflict_list(investigation_id: str) -> str:
+    """
+    List all detected conflicts for an investigation.
+
+    Conflicts are recorded automatically by investigation_store when a new
+    finding appears to contradict an existing one (e.g. an observed finding
+    that contradicts an assumed or gap finding, or opposing negation markers).
+
+    Args:
+        investigation_id: Investigation identifier.
+
+    Returns:
+        JSON: {"conflicts": [{id, finding_id_a, finding_id_b, detected_at,
+               status, resolution}], "count": <int>}
+        On error: {"error": "<message>"}
+    """
+    try:
+        manifest = _load_manifest(investigation_id)
+        if not manifest:
+            return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
+
+        path = _inv_dir(investigation_id) / "conflicts.jsonl"
+        raw_conflicts = _read_jsonl(path)
+
+        conflicts = [
+            {
+                "id": c.get("id"),
+                "finding_id_a": c.get("finding_id_a"),
+                "finding_id_b": c.get("finding_id_b"),
+                "detected_at": c.get("detected_at"),
+                "status": c.get("status", "open"),
+                "resolution": c.get("resolution"),
+            }
+            for c in raw_conflicts
+        ]
+
+        return json.dumps({"conflicts": conflicts, "count": len(conflicts)}, indent=2)
+    except Exception as exc:
+        logger.exception("conflict_list failed: %s", exc)
+        return json.dumps({"error": str(exc)})
+
+
+_VALID_VERDICTS = frozenset(["a_wins", "b_wins", "both_valid", "false_positive"])
+
+
+@mcp.tool()
+def conflict_resolve(investigation_id: str, conflict_id: str, verdict: str) -> str:
+    """
+    Resolve a detected conflict by recording a verdict.
+
+    Args:
+        investigation_id: Investigation identifier.
+        conflict_id: The conflict id to resolve (from conflict_list or
+                     conflict_detected in investigation_store response).
+        verdict: One of: a_wins | b_wins | both_valid | false_positive
+                 a_wins        — finding_id_a (the newer finding) is correct.
+                 b_wins        — finding_id_b (the older finding) is correct.
+                 both_valid    — both findings are valid in different contexts.
+                 false_positive — the conflict detector was wrong; no real conflict.
+
+    Returns:
+        JSON: {"resolved": true, "conflict_id": "...", "verdict": "..."}
+        On error: {"error": "<message>"}
+    """
+    try:
+        if verdict not in _VALID_VERDICTS:
+            return json.dumps({
+                "error": f"verdict must be one of: {', '.join(sorted(_VALID_VERDICTS))}"
+            })
+
+        manifest = _load_manifest(investigation_id)
+        if not manifest:
+            return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
+
+        path = _inv_dir(investigation_id) / "conflicts.jsonl"
+        conflicts = _read_jsonl(path)
+
+        updated = False
+        new_rows = []
+        for c in conflicts:
+            if c.get("id") == conflict_id:
+                c = dict(c)
+                c["status"] = "resolved"
+                c["resolution"] = verdict
+                updated = True
+            new_rows.append(c)
+
+        if not updated:
+            return json.dumps({"error": f"Conflict '{conflict_id}' not found in investigation '{investigation_id}'."})
+
+        # Atomic rewrite using a temp file
+        import tempfile as _tmpmod
+        dir_ = _inv_dir(investigation_id)
+        with _tmpmod.NamedTemporaryFile("w", dir=dir_, delete=False, suffix=".tmp") as tf:
+            for row in new_rows:
+                tf.write(json.dumps(row) + "\n")
+            tmp_path = Path(tf.name)
+        tmp_path.replace(path)
+
+        return json.dumps({"resolved": True, "conflict_id": conflict_id, "verdict": verdict}, indent=2)
+    except Exception as exc:
+        logger.exception("conflict_resolve failed: %s", exc)
+        return json.dumps({"error": str(exc)})
 
 
 # ---------------------------------------------------------------------------

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -1134,3 +1134,175 @@ class TestProgressiveSummaryFidelity(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestConflictTools(unittest.TestCase):
+    """Tests for conflict_list and conflict_resolve tools."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = server.MEMORY_DIR
+        server.MEMORY_DIR = Path(self._tmp.name)
+
+    def tearDown(self):
+        server.MEMORY_DIR = self._orig
+        self._tmp.cleanup()
+
+    def test_conflict_list_returns_valid_json(self):
+        """conflict_list returns valid JSON with conflicts list for an investigation."""
+        inv_id = _new_id("clist")
+        server.investigation_start(investigation_id=inv_id, title="Conflict list test")
+
+        # Store a finding so the investigation dir exists with the right structure
+        server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="Auth service returns 200 on valid tokens.",
+            source="test:manual",
+            confidence="high",
+        )
+
+        result = _json(server.conflict_list(investigation_id=inv_id))
+        self.assertNotIn("error", result, f"Unexpected error: {result}")
+        self.assertIn("conflicts", result)
+        self.assertIn("count", result)
+        self.assertIsInstance(result["conflicts"], list)
+        self.assertEqual(result["count"], len(result["conflicts"]))
+
+    def test_conflict_list_missing_investigation_returns_error(self):
+        """conflict_list returns an error dict for a non-existent investigation."""
+        result = _json(server.conflict_list(investigation_id="does-not-exist-xyz"))
+        self.assertIn("error", result)
+
+    def test_conflict_list_reflects_manually_written_conflict(self):
+        """conflict_list reads conflicts.jsonl correctly when a conflict entry exists."""
+        import json as _json_mod
+        from pathlib import Path as _Path
+
+        inv_id = _new_id("clist-manual")
+        server.investigation_start(investigation_id=inv_id, title="Manual conflict test")
+        # Create the investigation directory by storing a finding
+        server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="gap",
+            text="We don't know if the token check is enforced.",
+            source="test",
+            confidence="low",
+        )
+
+        # Write a conflict record directly to conflicts.jsonl
+        conflict_entry = {
+            "id": "test-conflict-abc123",
+            "investigation_id": inv_id,
+            "finding_id_a": "finding-new",
+            "finding_id_b": "finding-old",
+            "detected_at": "2026-01-01T00:00:00+00:00",
+            "status": "open",
+            "resolution": None,
+        }
+        conflicts_path = _Path(self._tmp.name) / inv_id / "conflicts.jsonl"
+        with open(conflicts_path, "a") as fh:
+            fh.write(_json_mod.dumps(conflict_entry) + "\n")
+
+        result = _json(server.conflict_list(investigation_id=inv_id))
+        self.assertNotIn("error", result)
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["conflicts"][0]["id"], "test-conflict-abc123")
+        self.assertEqual(result["conflicts"][0]["status"], "open")
+
+    def test_conflict_resolve_valid_verdicts(self):
+        """conflict_resolve accepts all four valid verdicts."""
+        import json as _json_mod
+        from pathlib import Path as _Path
+
+        for verdict in ("a_wins", "b_wins", "both_valid", "false_positive"):
+            with self.subTest(verdict=verdict):
+                inv_id = _new_id(f"cresolve-{verdict[:3]}")
+                server.investigation_start(investigation_id=inv_id, title=f"Resolve test {verdict}")
+                server.investigation_store(
+                    investigation_id=inv_id,
+                    finding_type="gap",
+                    text="Gap placeholder for conflict resolve test.",
+                    source="test",
+                    confidence="low",
+                )
+
+                conflict_id = f"conflict-{verdict}-abc"
+                conflict_entry = {
+                    "id": conflict_id,
+                    "investigation_id": inv_id,
+                    "finding_id_a": "fa",
+                    "finding_id_b": "fb",
+                    "detected_at": "2026-01-01T00:00:00+00:00",
+                    "status": "open",
+                    "resolution": None,
+                }
+                conflicts_path = _Path(self._tmp.name) / inv_id / "conflicts.jsonl"
+                with open(conflicts_path, "a") as fh:
+                    fh.write(_json_mod.dumps(conflict_entry) + "\n")
+
+                result = _json(server.conflict_resolve(
+                    investigation_id=inv_id,
+                    conflict_id=conflict_id,
+                    verdict=verdict,
+                ))
+                self.assertNotIn("error", result, f"Unexpected error for verdict {verdict!r}: {result}")
+                self.assertTrue(result.get("resolved"), f"resolved!=True for verdict {verdict!r}")
+                self.assertEqual(result.get("verdict"), verdict)
+                self.assertEqual(result.get("conflict_id"), conflict_id)
+
+                # Verify the file was updated
+                updated = _Path(self._tmp.name) / inv_id / "conflicts.jsonl"
+                rows = [_json_mod.loads(line) for line in updated.read_text().splitlines() if line.strip()]
+                row = next(r for r in rows if r["id"] == conflict_id)
+                self.assertEqual(row["status"], "resolved")
+                self.assertEqual(row["resolution"], verdict)
+
+    def test_conflict_resolve_rejects_invalid_verdict(self):
+        """conflict_resolve returns an error for unknown verdicts."""
+        inv_id = _new_id("cresolve-bad")
+        server.investigation_start(investigation_id=inv_id, title="Bad verdict test")
+        result = _json(server.conflict_resolve(
+            investigation_id=inv_id,
+            conflict_id="any-id",
+            verdict="WRONG_VERDICT",
+        ))
+        self.assertIn("error", result)
+
+    def test_conflict_resolve_unknown_conflict_id_returns_error(self):
+        """conflict_resolve returns error when conflict_id not found."""
+        inv_id = _new_id("cresolve-miss")
+        server.investigation_start(investigation_id=inv_id, title="Missing conflict test")
+        server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="gap",
+            text="placeholder",
+            source="test",
+            confidence="low",
+        )
+        result = _json(server.conflict_resolve(
+            investigation_id=inv_id,
+            conflict_id="no-such-conflict",
+            verdict="false_positive",
+        ))
+        self.assertIn("error", result)
+
+    def test_investigation_store_includes_conflict_detected_field(self):
+        """investigation_store response always includes conflict_detected field."""
+        inv_id = _new_id("store-conflict-field")
+        server.investigation_start(investigation_id=inv_id, title="Conflict field test")
+        result = _json(server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="Token validation uses RS256 algorithm.",
+            source="test:code-review",
+            confidence="medium",
+        ))
+        self.assertNotIn("error", result, f"Unexpected error: {result}")
+        self.assertIn("conflict_detected", result)
+        # Without Qdrant, conflict detection is skipped → always False in tests
+        self.assertFalse(result["conflict_detected"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- After `investigation_store` writes a finding, it searches Qdrant for near-neighbors (cosine similarity > 0.82, same `investigation_id`) and applies three heuristics to detect contradictions: (1) a `gap` finding overridden by an `observed` finding, (2) an `assumed` finding overridden by a non-assumed finding, and (3) opposing negation markers (`not`, `no`, `never`, `false`) on otherwise similar texts.
- Detected conflicts are appended to `conflicts.jsonl` in the investigation directory. The `investigation_store` response now always includes `conflict_detected: false` or `conflict_detected: true, conflicting_finding_id: "...", conflict_id: "..."`.
- Two new MCP tools: `conflict_list(investigation_id)` reads `conflicts.jsonl` and returns `{conflicts, count}`; `conflict_resolve(investigation_id, conflict_id, verdict)` atomically rewrites the file with the verdict (`a_wins | b_wins | both_valid | false_positive`).
- All conflict detection paths are fail-open — if Qdrant is unavailable or embedding fails, `conflict_detected` is simply `false` and `investigation_store` completes normally.

## Changed files

- `mcp/server.py` — `_detect_conflicts`, `_write_conflict`, `_has_negation` helpers; modified `investigation_store` return value; new `conflict_list` and `conflict_resolve` tools
- `mcp/tests/test_mcp_integration.py` — 7 new `TestConflictTools` tests
- `.vulture_whitelist.py` — added `conflict_list`, `conflict_resolve`

## Test plan

- [ ] All 126 existing + new tests pass: `cd mcp && python3 -m pytest tests/ -v --tb=short`
- [ ] Lint passes: `ruff check mcp/server.py --select E9,F401,F811,F821,F841 --ignore E402`
- [ ] `investigation_store` response includes `conflict_detected` field (test: `test_investigation_store_includes_conflict_detected_field`)
- [ ] `conflict_list` returns valid JSON with `conflicts` list and `count` (test: `test_conflict_list_returns_valid_json`)
- [ ] `conflict_resolve` accepts all four valid verdicts and atomically updates `conflicts.jsonl` (test: `test_conflict_resolve_valid_verdicts`)
- [ ] `conflict_resolve` rejects invalid verdicts with `{"error": ...}` (test: `test_conflict_resolve_rejects_invalid_verdict`)
- [ ] Manual smoke: start an investigation, store a `gap` finding, store an `observed` finding with a high-similarity embedding — verify `conflict_detected: true` in the second store response (requires Qdrant + embeddings running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)