### PR TITLE
feat(findings): bi-temporal valid_from/valid_until + investigation_as_of tool

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1496,6 +1496,50 @@ def _read_jsonl(path: Path) -> list[dict]:
     return out
 
 
+def _rewrite_jsonl_set_field(path: Path, target_ids: set, field: str, value) -> int:
+    """
+    Atomically rewrite a JSONL file, setting ``field`` = ``value`` on every
+    entry whose "id" is in ``target_ids``.
+
+    Returns the count of entries that were modified.  Fails open — if any I/O
+    or JSON error occurs the original file is left untouched.
+    """
+    if not path.exists():
+        return 0
+    try:
+        lines = path.read_text().splitlines()
+        new_lines = []
+        modified = 0
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                new_lines.append(line)
+                continue
+            try:
+                entry = json.loads(stripped)
+            except Exception:
+                new_lines.append(line)
+                continue
+            if str(entry.get("id", "")) in target_ids:
+                entry[field] = value
+                new_lines.append(json.dumps(entry))
+                modified += 1
+            else:
+                new_lines.append(line)
+        # Atomic replace via temp file in the same directory
+        dir_ = path.parent
+        with tempfile.NamedTemporaryFile("w", dir=dir_, delete=False, suffix=".tmp") as tf:
+            tf.write("\n".join(new_lines))
+            if new_lines:
+                tf.write("\n")
+            tmp_path = Path(tf.name)
+        tmp_path.replace(path)
+        return modified
+    except Exception as exc:
+        logger.debug("_rewrite_jsonl_set_field failed (fail-open): %r", exc)
+        return 0
+
+
 _REFLECTION_ERROR_RE = re.compile(r"\b(error|exception|traceback|failed|failure|timeout|conflict)\b", re.I)
 _REFLECTION_WARN_RE = re.compile(r"\b(warn|warning|degraded|fallback|retry)\b", re.I)
 _REFLECTION_HEX_RE = re.compile(r"\b[0-9a-f]{7,64}\b", re.I)
@@ -2358,6 +2402,8 @@ def investigation_store(
     procedure_preconditions: Optional[str] = None,
     procedure_steps: Optional[str] = None,
     procedure_postconditions: Optional[str] = None,
+    valid_from: Optional[str] = None,
+    valid_until: Optional[str] = None,
 ) -> str:
     """
     Record a finding in the investigation.
@@ -2390,6 +2436,12 @@ def investigation_store(
                                  preconditions that must be true before running the procedure.
         procedure_steps: (procedure only) Numbered steps as a string.
         procedure_postconditions: (procedure only) Expected outcomes after the procedure.
+        valid_from: ISO8601 timestamp from which this finding is valid. Defaults
+                    to the current time when the finding is stored. Use to record
+                    a finding that was true at an earlier point in time.
+        valid_until: ISO8601 timestamp at which this finding ceased to be valid,
+                     or null (default) meaning it is currently believed to be true.
+                     Set when a finding has a known expiry or is superseded.
 
     Returns:
         JSON: {"stored": true, "finding_id": "<uuid>", "type": "<finding_type>",
@@ -2419,10 +2471,11 @@ def investigation_store(
         except (TypeError, ValueError):
             resolved_numeric_confidence = _confidence_to_numeric.get(confidence, 0.6)
 
+    _ts_now = _now()
     finding = {
         "id": str(uuid.uuid4()),
         "investigation_id": investigation_id,
-        "ts": _now(),
+        "ts": _ts_now,
         "created_at_ts": int(datetime.now(timezone.utc).timestamp()),
         "record_type": finding_type,   # "observed" | "inferred" | "assumed" | "gap"
         "type": finding_type,          # kept for backwards compat with existing JSONL
@@ -2433,6 +2486,8 @@ def investigation_store(
         "tags": [t.strip() for t in (
             ",".join(tags) if isinstance(tags, list) else (tags or "")
         ).split(",") if t.strip()],
+        "valid_from": valid_from if valid_from is not None else _ts_now,
+        "valid_until": valid_until,
     }
     derived = _normalize_derived_from(derived_from)
     if derived:
@@ -2695,6 +2750,90 @@ def procedure_search(
     except Exception as exc:
         logger.warning("procedure_search: unexpected error: %s", exc)
         return json.dumps({"error": str(exc), "procedures": [], "count": 0})
+
+
+# ---- Tool: investigation_as_of ----
+
+@mcp.tool()
+def investigation_as_of(
+    investigation_id: str,
+    as_of_timestamp: str,
+) -> str:
+    """
+    Return findings from an investigation as they were believed at a specific point in time.
+
+    A finding is included when BOTH of the following hold:
+      - created_at_ts <= as_of_epoch  (the finding existed by that moment)
+      - valid_until is null OR valid_until >= as_of_timestamp  (it was still believed valid)
+
+    This supports bi-temporal analysis: you can reconstruct the investigation's
+    knowledge state at any historical moment, even after findings have been
+    superseded or retracted.
+
+    Args:
+        investigation_id: Investigation identifier.
+        as_of_timestamp: ISO8601 timestamp (e.g. "2024-01-15T10:30:00+00:00").
+                         Findings created after this moment are excluded, and
+                         findings whose valid_until is before this moment are
+                         also excluded.
+
+    Returns:
+        JSON: {
+          "investigation_id": "<id>",
+          "as_of": "<as_of_timestamp>",
+          "findings": [...],
+          "count": <int>
+        }
+        On error: {"error": "<message>"}
+    """
+    try:
+        manifest = _load_manifest(investigation_id)
+        if not manifest:
+            return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
+
+        try:
+            as_of_dt = datetime.fromisoformat(as_of_timestamp)
+            # Make timezone-aware if naive (assume UTC)
+            if as_of_dt.tzinfo is None:
+                as_of_dt = as_of_dt.replace(tzinfo=timezone.utc)
+            as_of_epoch = int(as_of_dt.timestamp())
+        except (ValueError, TypeError) as exc:
+            return json.dumps({"error": f"Invalid as_of_timestamp: {exc}"})
+
+        findings_path = _inv_dir(investigation_id) / "findings.jsonl"
+        all_findings = _read_jsonl(findings_path)
+
+        result_findings = []
+        for f in all_findings:
+            created_at_ts = f.get("created_at_ts")
+            if created_at_ts is None:
+                # Older findings without created_at_ts: include them (fail-open)
+                pass
+            elif int(created_at_ts) > as_of_epoch:
+                continue
+
+            valid_until = f.get("valid_until")
+            if valid_until is not None:
+                try:
+                    vu_dt = datetime.fromisoformat(str(valid_until))
+                    if vu_dt.tzinfo is None:
+                        vu_dt = vu_dt.replace(tzinfo=timezone.utc)
+                    if vu_dt < as_of_dt:
+                        continue
+                except (ValueError, TypeError):
+                    pass  # fail-open: include if valid_until can't be parsed
+
+            result_findings.append(f)
+
+        return json.dumps({
+            "investigation_id": investigation_id,
+            "as_of": as_of_timestamp,
+            "findings": result_findings,
+            "count": len(result_findings),
+        }, indent=2)
+    except Exception as exc:
+        logger.exception("investigation_as_of failed")
+        return json.dumps({"error": f"investigation_as_of failed: {exc}"})
 
 
 # ---- Tool: investigation_note ----
@@ -5203,6 +5342,19 @@ def memory_retract(
                 "finding_id": fid,
                 "reasons": reasons.get(fid, []),
             })
+
+        # Bi-temporal hook: stamp valid_until on retracted findings so that
+        # investigation_as_of queries exclude them from any future as-of view.
+        try:
+            findings_path = _inv_dir(investigation_id) / "findings.jsonl"
+            _rewrite_jsonl_set_field(
+                findings_path,
+                set(contaminated_ids),
+                "valid_until",
+                ts,
+            )
+        except Exception as exc:  # fail-open
+            logger.debug("bi-temporal valid_until stamp failed, degrading: %r", exc)
 
         # Record a quarantine verdict to the store (fail-open) for recall.
         try:

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -178,6 +178,119 @@ class TestInvestigationLifecycle(unittest.TestCase):
         finding_ids = [f.get("id") for f in loaded.get("recent_findings", [])]
         self.assertIn(finding_id, finding_ids)
 
+    def test_investigation_store_accepts_valid_from(self):
+        """investigation_store should persist valid_from/valid_until in the finding."""
+        inv_id = _new_id("bitemporal-store")
+        server.investigation_start(investigation_id=inv_id, title="Bi-temporal store test")
+
+        past_ts = "2020-01-01T00:00:00+00:00"
+        future_ts = "2099-12-31T23:59:59+00:00"
+
+        stored = _json(server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="Auth service was returning HTTP 401 on all requests in Jan 2020.",
+            source="test:history",
+            confidence="high",
+            valid_from=past_ts,
+            valid_until=future_ts,
+        ))
+        self.assertNotIn("error", stored, f"Unexpected error: {stored}")
+        self.assertTrue(stored.get("stored"))
+
+        # Verify fields were persisted in the JSONL
+        loaded = _json(server.investigation_load(investigation_id=inv_id))
+        findings = loaded.get("recent_findings", [])
+        self.assertTrue(findings, "No findings returned from load")
+        finding = findings[0]
+        self.assertEqual(finding.get("valid_from"), past_ts,
+                         "valid_from not persisted correctly")
+        self.assertEqual(finding.get("valid_until"), future_ts,
+                         "valid_until not persisted correctly")
+
+    def test_investigation_as_of_returns_findings(self):
+        """investigation_as_of should return only findings valid at the given timestamp.
+
+        Strategy:
+        - Use a near-future checkpoint (2028) so all findings stored right now
+          have created_at_ts <= as_of_epoch.
+        - Distinguish findings via valid_until: finding A has no valid_until
+          (still believed), finding B has valid_until in 2023 (expired before checkpoint).
+        - A far-future query (2099) should include A but still exclude B.
+        - A past query (2000) should exclude all findings (created after 2000).
+        """
+        inv_id = _new_id("bitemporal-as-of")
+        server.investigation_start(investigation_id=inv_id, title="Bi-temporal as-of test")
+
+        # Near-future checkpoint: both findings are stored before this moment
+        checkpoint_ts = "2028-01-01T00:00:00+00:00"
+
+        # Finding A: no valid_until — currently believed, should appear at checkpoint
+        stored_a = _json(server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="Finding A — no valid_until, currently believed, should appear at checkpoint.",
+            source="test:a",
+            confidence="high",
+        ))
+        self.assertNotIn("error", stored_a)
+        fid_a = stored_a["finding_id"]
+
+        # Finding B: valid_until in the past (2023) — expired before checkpoint
+        stored_b = _json(server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="inferred",
+            text="Finding B — valid_until=2023, expired before checkpoint, should be excluded.",
+            source="test:b",
+            confidence="medium",
+            valid_until="2023-01-01T00:00:00+00:00",
+        ))
+        self.assertNotIn("error", stored_b)
+        fid_b = stored_b["finding_id"]
+
+        # Query as-of checkpoint (2028): should include A, exclude B (B expired 2023)
+        result = _json(server.investigation_as_of(
+            investigation_id=inv_id,
+            as_of_timestamp=checkpoint_ts,
+        ))
+        self.assertNotIn("error", result, f"Unexpected error: {result}")
+        self.assertEqual(result["investigation_id"], inv_id)
+        self.assertEqual(result["as_of"], checkpoint_ts)
+        self.assertIsInstance(result["findings"], list)
+
+        returned_ids = {f.get("id") for f in result["findings"]}
+        self.assertIn(fid_a, returned_ids, "Finding A (no valid_until) should appear at checkpoint")
+        self.assertNotIn(fid_b, returned_ids,
+                         "Finding B (valid_until=2023) should NOT appear at 2028 checkpoint")
+
+        # Far-future query (2099): A still included (no valid_until), B still excluded
+        future_ts = "2099-01-01T00:00:00+00:00"
+        result_future = _json(server.investigation_as_of(
+            investigation_id=inv_id,
+            as_of_timestamp=future_ts,
+        ))
+        self.assertNotIn("error", result_future)
+        future_ids = {f.get("id") for f in result_future["findings"]}
+        self.assertIn(fid_a, future_ids, "A should still appear with no valid_until in 2099")
+        self.assertNotIn(fid_b, future_ids, "B (expired 2023) should not appear in 2099 query")
+
+        # Past query (2000): no findings existed yet (created_at_ts > 2000 epoch)
+        past_ts = "2000-01-01T00:00:00+00:00"
+        result_past = _json(server.investigation_as_of(
+            investigation_id=inv_id,
+            as_of_timestamp=past_ts,
+        ))
+        self.assertNotIn("error", result_past)
+        self.assertEqual(result_past["count"], 0,
+                         "No findings should appear for a query set in year 2000")
+
+        # Error path: invalid investigation ID
+        err = _json(server.investigation_as_of(
+            investigation_id="no-such-investigation-xyz",
+            as_of_timestamp=checkpoint_ts,
+        ))
+        self.assertIn("error", err)
+
 
 class TestMemoryHealth(unittest.TestCase):
     """memory_health should always return valid JSON."""


### PR DESCRIPTION
## Summary

- **Schema**: Every finding written by `investigation_store` now carries two optional bi-temporal fields: `valid_from` (ISO8601, defaults to store time) and `valid_until` (ISO8601 or null, defaults to null meaning currently believed).
- **Tool update**: `investigation_store` accepts two new optional parameters (`valid_from`, `valid_until`) — fully backward-compatible; existing callers unchanged.
- **New tool**: `investigation_as_of(investigation_id, as_of_timestamp)` reconstructs the investigation's knowledge state at any point in time. A finding is included when `created_at_ts <= as_of_epoch` AND `(valid_until is null OR valid_until >= as_of_timestamp)`.
- **Retraction hook**: `memory_retract` now stamps `valid_until = _now()` on quarantined findings (atomic JSONL rewrite) so `investigation_as_of` queries automatically exclude retracted findings from any post-retraction as-of view.
- **Helper**: Added `_rewrite_jsonl_set_field(path, target_ids, field, value)` — atomic in-place JSONL field update via temp-file replace; fail-open.

## Test plan

- [x] All 119 pre-existing tests continue to pass
- [x] `test_investigation_store_accepts_valid_from` — verifies `valid_from`/`valid_until` are persisted in the JSONL finding
- [x] `test_investigation_as_of_returns_findings` — verifies temporal filtering (include current findings, exclude expired ones, exclude findings not yet created, and error on missing investigation)
- [x] Lint clean (`ruff check --select E9,F401,F811,F821,F841`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)