### PR TITLE
Fix loci-native workflow template (meta literal + args coercion)

### DIFF
--- a/.claude/workflows/loci-native.js
+++ b/.claude/workflows/loci-native.js
@@ -1,8 +1,7 @@
 export const meta = {
   name: 'loci-native',
   description: 'Grounded, model/effort-tiered fan-out over a task list (Loci-native template)',
-  whenToUse: 'Fan out N planning/impl/verify agents that all share ONE injected grounding block ' +
-    '(produced up front by scripts/ground.py) instead of each re-querying Loci. Tier model/effort per task.',
+  whenToUse: 'Fan out N planning/impl/verify agents that all share ONE injected grounding block (produced up front by scripts/ground.py) instead of each re-querying Loci. Tier model/effort per task.',
   phases: [
     { title: 'Fanout', detail: 'one grounded agent per task, tiered by kind' },
     { title: 'Verify', detail: 'adversarial check of each non-trivial result' },
@@ -31,8 +30,10 @@ export const meta = {
 //   by parallel agents (that is what the _append_jsonl flock + single-writer rule buy us).
 // -----------------------------------------------------------------------------
 
-const GROUND = (args && args.ground) || ''
-const TASKS = (args && Array.isArray(args.tasks) && args.tasks) || []
+// args may arrive as an object OR a JSON string depending on how it was passed — coerce.
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const GROUND = A.ground || ''
+const TASKS = Array.isArray(A.tasks) ? A.tasks : []
 
 // Model/effort tiers. Omitting model => inherit the session model (right default).
 // Only the reasoning-heavy lane names a bigger model; mechanical work drops to low effort.
@@ -41,7 +42,7 @@ const DEFAULT_TIERS = {
   impl: { effort: 'high' },                       // default: implementation/planning
   reason: { model: 'opus', effort: 'high' },      // hardest analysis/synthesis
 }
-const TIERS = Object.assign({}, DEFAULT_TIERS, (args && args.tiers) || {})
+const TIERS = Object.assign({}, DEFAULT_TIERS, A.tiers || {})
 
 if (!GROUND) log('warning: args.ground is empty — agents run UNGROUNDED (did you run scripts/ground.py?)')
 if (!TASKS.length) { log('no tasks provided'); return { results: [] } }


### PR DESCRIPTION
Two defects surfaced running the `loci-native` template end-to-end (validating the grounding capability from #113):

1. **`meta.whenToUse` used string concatenation** (`'a' + 'b'`) — the workflow loader requires `meta` to be a pure literal and rejected the script (`meta must be a pure literal: BinaryExpression`). Collapsed to a single string.
2. **`args` can arrive as a JSON string**, not an object — so `Array.isArray(args.tasks)` was false and the run spawned **0 agents** (`results: []`). Now coerced: `const A = typeof args === 'string' ? JSON.parse(args) : (args || {})`.

**Verified:** with these fixes the template ran 4 agents (plan + adversarial verify, tests, callsites) — grounded via one injected block, model/effort-tiered, 0 errors — and produced a live-verified `investigation_store` decomposition plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45