### PR TITLE
Expose grounding as a warm ground MCP tool

### DIFF
--- a/.claude/workflows/loci-native.js
+++ b/.claude/workflows/loci-native.js
@@ -11,10 +11,14 @@ export const meta = {
 // -----------------------------------------------------------------------------
 // CONTRACT
 //   Workflow scripts cannot import local files or call MCP tools directly, so the
-//   grounding block is produced ONCE in the main loop and passed in via args:
+//   grounding block is produced ONCE in the main loop and passed in via args. Produce it
+//   with the warm `ground` MCP tool (keeps the cross-encoder loaded, so the RAG lane is
+//   reliable) — or the scripts/ground.py CLI when no server is running (cold-start may
+//   drop the RAG lane; fail-open, the case lanes still carry it):
 //
-//     block=$(python scripts/ground.py '{"title":"...","focus":"...","caseIds":[...]}')
-//     Workflow({ name: 'loci-native', args: { ground: block, tasks: [...] } })
+//     block = mcp__loci__ground({title, focus, case_ids:[...]}).block   // preferred (warm)
+//     block = $(python scripts/ground.py '{"title":"...","caseIds":[...]}')  // fallback
+//     Workflow({ scriptPath: '.../loci-native.js', args: { ground: block, tasks: [...] } })
 //
 //   args = {
 //     ground:  string   // grounding.ground().block — injected verbatim into every prompt

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6921,6 +6921,61 @@ def wiring_obligation_resolve(
 
 
 @mcp.tool()
+def ground(
+    title: str,
+    focus: str = "",
+    case_ids: Optional[list] = None,
+    entities: Optional[list] = None,
+    code_refs: Optional[list] = None,
+    budget_chars: int = 4000,
+    allow_keyword: bool = False,
+    graph_available: bool = False,
+) -> str:
+    """
+    Assemble a compact, provenance-tagged, char-budgeted GROUNDING block for a task —
+    run ONCE in an orchestrator before a fan-out and inject the block into every agent
+    prompt, so agents start with relevant prior context instead of each re-querying Loci
+    (the cost win). Structured-first, embedding-independent retrieval order: named cases
+    (investigation_load) -> exact entities (investigation_entity_lookup) -> code graph
+    (when graph_available) -> semantic RAG -> curated MEMORY.md -> keyword FTS (opt-in).
+    Every lane is fail-open: a dead source sets degraded=True rather than aborting.
+
+    Prefer this over calling the individual investigation_*/rag tools when preparing a
+    workflow — one warm call here beats N cold ones (and keeps the cross-encoder loaded,
+    which the ground.py CLI cannot). The block is tagged read-only reference, NOT ground
+    truth: consumers must verify against live code/data and cite the [tag] they rely on.
+
+    Args:
+        title: Short task title (drives retrieval).
+        focus: Optional longer task description.
+        case_ids: Named investigation IDs to load.
+        entities: Exact entity IDs to look up (O(1), no embedding).
+        code_refs: Symbol names for code-graph grounding (used only if graph_available).
+        budget_chars: Max characters of the assembled block (default 4000).
+        allow_keyword: Enable the noisy keyword/FTS fallback lane (default off).
+        graph_available: Enable the code-graph lane (default off; needs the Kuzu graph).
+
+    Returns:
+        JSON with {block, sources, chars, degraded}.
+    """
+    if not title or not title.strip():
+        return json.dumps({"error": "title must not be empty",
+                           "block": "", "sources": [], "chars": 0, "degraded": True})
+    import grounding
+    task = {
+        "title": title, "focus": focus or "",
+        "caseIds": case_ids or [], "entities": entities or [],
+        "codeRefs": code_refs or [],
+    }
+    opts = {
+        "budgetChars": budget_chars,
+        "allowKeyword": allow_keyword,
+        "graphAvailable": graph_available,
+    }
+    return json.dumps(grounding.ground(task, opts), indent=2)
+
+
+@mcp.tool()
 def rag_context_search(
     query: str,
     limit: int = 10,

--- a/mcp/tests/test_ground_tool.py
+++ b/mcp/tests/test_ground_tool.py
@@ -1,0 +1,55 @@
+"""Tests for the `ground` MCP tool — the warm-server wrapper over grounding.ground()."""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import server  # noqa: E402 — must follow the path setup above
+
+
+def test_ground_empty_title_guard():
+    out = json.loads(server.ground("   "))
+    assert out["degraded"] is True
+    assert out["chars"] == 0
+    assert out["sources"] == []
+    assert "error" in out
+
+
+def test_ground_delegates_and_serializes(monkeypatch):
+    captured = {}
+
+    def fake_ground(task, opts):
+        captured["task"] = task
+        captured["opts"] = opts
+        return {"block": "## X", "sources": ["case:c1"], "chars": 4, "degraded": False}
+
+    import grounding
+    monkeypatch.setattr(grounding, "ground", fake_ground)
+
+    out = json.loads(server.ground(
+        "decompose X", focus="split it", case_ids=["c1"], entities=["e1"],
+        code_refs=["foo"], budget_chars=1234, allow_keyword=True, graph_available=True,
+    ))
+    assert out == {"block": "## X", "sources": ["case:c1"], "chars": 4, "degraded": False}
+    # task/opts are mapped from the tool's snake_case params to grounding's camelCase keys
+    assert captured["task"] == {
+        "title": "decompose X", "focus": "split it",
+        "caseIds": ["c1"], "entities": ["e1"], "codeRefs": ["foo"],
+    }
+    assert captured["opts"] == {
+        "budgetChars": 1234, "allowKeyword": True, "graphAvailable": True,
+    }
+
+
+def test_ground_defaults_are_conservative(monkeypatch):
+    captured = {}
+    import grounding
+    monkeypatch.setattr(grounding, "ground",
+                        lambda task, opts: captured.update(task=task, opts=opts) or
+                        {"block": "", "sources": [], "chars": 0, "degraded": False})
+    server.ground("t")
+    # keyword + code-graph lanes default OFF; empty lists, not None
+    assert captured["opts"]["allowKeyword"] is False
+    assert captured["opts"]["graphAvailable"] is False
+    assert captured["task"]["caseIds"] == [] and captured["task"]["entities"] == []


### PR DESCRIPTION
## What
Adds an `@mcp.tool()` **`ground`** wrapper over `grounding.ground()` (from #113), so an orchestrator produces a grounding block from the **already-running server** rather than the `scripts/ground.py` CLI.

## Why
The CLI is a fresh process per invocation, so it cold-loads the cross-encoder (~15s) and re-inits Qdrant — which can make the **semantic RAG lane flakily drop on the first call** (fail-open, so the case lanes still carry it, but grounding quality varies run-to-run). The warm server keeps the model loaded.

**Verified:** two back-to-back `ground(...)` calls in one process both return the `rag` lane with `degraded=False` (2715 chars, consistent) — the cold-start drop is gone.

## Details
- `grounding.ground()` lazy-imports `server` from `sys.modules`, so calling it from within `server` creates **no import cycle**.
- Maps the tool's snake_case params → grounding's `task`/`opts` shape (`case_ids`→`caseIds`, etc.).
- Keyword + code-graph lanes default **OFF**; empty-title guard returns a well-formed `degraded` result.
- Template (`loci-native.js`) contract note now prefers the warm tool, with the CLI as the no-server fallback.

## Tests
3 new (`test_ground_tool.py`: guard, delegation/serialization, conservative defaults) — monkeypatched, no live services. **Full suite: 280 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45