### PR TITLE
Semantic dedup + relevance on the local-GPU embedding path

### DIFF
--- a/mcp/embed_ops.py
+++ b/mcp/embed_ops.py
@@ -1,0 +1,116 @@
+"""Embedding-tier operations for Loci-native workflows — the offload that WORKS today.
+
+Generation on the local GPU is currently unreliable, but the embedding path (Ollama
+nomic-embed-text, 768-dim, warm on GPU) is solid. These are the cheap semantic ops that
+need only embeddings — no generation model — so they run on local GPU at ~zero token cost:
+
+- dedup(items):      cluster near-duplicate findings so an N-way fan-out doesn't
+                     triple-report the same issue (barrier-stage / synthesis dedup).
+- relevance(texts):  cosine of each text to a topic — a cheap gate/router that trims
+                     what reaches Claude, replacing a classifier agent.
+
+All fail-open: if embeddings are unavailable, dedup returns every item as its own cluster
+(i.e. no dedup) and relevance returns null scores, with degraded=True — never an exception.
+
+Embeddings come from OLLAMA_BASE_URL/EMBED_MODEL (same config the Loci server uses). The
+embed function is injectable so callers can reuse a warm client and tests can stub it.
+"""
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional
+
+_OLLAMA = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_URL") or ""
+_EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+
+
+def embed_texts(texts: list[str]) -> list[list[float]]:
+    """Batch-embed via Ollama /api/embed. Returns [] on any failure (fail-open)."""
+    texts = [t if isinstance(t, str) else str(t) for t in texts]
+    if not texts or not _OLLAMA:
+        return []
+    try:
+        import requests
+        r = requests.post(f"{_OLLAMA}/api/embed",
+                          json={"model": _EMBED_MODEL, "input": texts}, timeout=60)
+        r.raise_for_status()
+        embs = r.json().get("embeddings") or []
+        return embs if len(embs) == len(texts) else []
+    except Exception:
+        return []
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    import math
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def _text_of(item, key: Optional[str]) -> str:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        if key and key in item:
+            return str(item[key])
+        for k in ("text", "content", "summary", "title"):
+            if item.get(k):
+                return str(item[k])
+    return str(item)
+
+
+def dedup(items: list, threshold: float = 0.88, key: Optional[str] = None,
+          embed_fn: Optional[Callable[[list[str]], list[list[float]]]] = None) -> dict:
+    """Greedy near-duplicate clustering by cosine >= threshold.
+
+    Returns {clusters:[{rep_index, member_indices, text}], kept:[items], dropped:int,
+             degraded:bool}. `kept` is one representative (the first seen) per cluster —
+    feed it downstream in place of the raw list. Order-stable. Fail-open: with no
+    embeddings, every item is its own cluster (nothing dropped) and degraded=True.
+    """
+    items = list(items or [])
+    n = len(items)
+    if n <= 1:
+        return {"clusters": [{"rep_index": i, "member_indices": [i], "text": _text_of(items[i], key)}
+                             for i in range(n)],
+                "kept": items, "dropped": 0, "degraded": False}
+    ef = embed_fn or embed_texts
+    vecs = ef([_text_of(it, key) for it in items])
+    degraded = len(vecs) != n
+    clusters: list[dict] = []
+    if degraded:
+        # no embeddings -> no dedup, each its own cluster
+        for i, it in enumerate(items):
+            clusters.append({"rep_index": i, "member_indices": [i], "text": _text_of(it, key)})
+        return {"clusters": clusters, "kept": items, "dropped": 0, "degraded": True}
+    reps: list[int] = []  # representative index per cluster
+    for i in range(n):
+        placed = False
+        for ci, rep in enumerate(reps):
+            if _cosine(vecs[i], vecs[rep]) >= threshold:
+                clusters[ci]["member_indices"].append(i)
+                placed = True
+                break
+        if not placed:
+            reps.append(i)
+            clusters.append({"rep_index": i, "member_indices": [i], "text": _text_of(items[i], key)})
+    kept = [items[c["rep_index"]] for c in clusters]
+    return {"clusters": clusters, "kept": kept, "dropped": n - len(clusters), "degraded": False}
+
+
+def relevance(texts: list[str], topic: str,
+              embed_fn: Optional[Callable[[list[str]], list[list[float]]]] = None) -> dict:
+    """Cosine of each text to `topic`. Returns {scores:[float|None], degraded:bool}.
+    scores align with `texts`; None when embeddings are unavailable (degraded=True)."""
+    texts = list(texts or [])
+    if not texts or not topic:
+        return {"scores": [None] * len(texts), "degraded": not bool(topic)}
+    ef = embed_fn or embed_texts
+    vecs = ef([topic] + [str(t) for t in texts])
+    if len(vecs) != len(texts) + 1:
+        return {"scores": [None] * len(texts), "degraded": True}
+    tvec = vecs[0]
+    return {"scores": [round(_cosine(tvec, v), 4) for v in vecs[1:]], "degraded": False}

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6921,6 +6921,41 @@ def wiring_obligation_resolve(
 
 
 @mcp.tool()
+def semantic_dedup(items: list, threshold: float = 0.88, text_key: Optional[str] = None) -> str:
+    """
+    Cluster near-duplicate items by embedding cosine similarity on the local-GPU path —
+    no generation model, ~zero token cost. Use in a fan-out's synthesis step so an N-way
+    search doesn't triple-report the same finding: pass the aggregated items, feed the
+    returned `kept` (one representative per cluster) downstream.
+
+    items: list of strings OR dicts (text pulled from text_key, else text/content/summary/title).
+    threshold: cosine >= this counts as a duplicate (default 0.88; raise to be stricter).
+    Fail-open: if embeddings are unavailable, nothing is dropped and degraded=True.
+
+    Returns JSON {clusters:[{rep_index, member_indices, text}], kept:[...], dropped:int, degraded}.
+    """
+    import embed_ops
+    return json.dumps(embed_ops.dedup(items or [], threshold=threshold, key=text_key), indent=2)
+
+
+@mcp.tool()
+def semantic_relevance(texts: list, topic: str) -> str:
+    """
+    Cosine relevance of each text to `topic` on the local-GPU embedding path — a cheap
+    gate/router (keep texts above a score) that trims what reaches Claude, replacing a
+    classifier agent. No generation model.
+
+    Returns JSON {scores:[float|None], degraded}; scores align with `texts` (None when
+    embeddings are unavailable, degraded=True).
+    """
+    if not topic or not str(topic).strip():
+        return json.dumps({"scores": [None] * len(texts or []), "degraded": True,
+                           "error": "topic must not be empty"})
+    import embed_ops
+    return json.dumps(embed_ops.relevance(list(texts or []), topic), indent=2)
+
+
+@mcp.tool()
 def ground(
     title: str,
     focus: str = "",

--- a/mcp/tests/test_embed_ops.py
+++ b/mcp/tests/test_embed_ops.py
@@ -1,0 +1,68 @@
+"""Tests for embed_ops — the embedding-tier semantic ops. Embeddings are stubbed."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import embed_ops as E  # noqa: E402
+
+
+# Deterministic 2-D "embeddings": items in the same group point the same way.
+_VEC = {
+    "cat a": [1.0, 0.0], "cat a again": [0.999, 0.001],   # near-duplicates
+    "dog b": [0.0, 1.0], "dog b too": [0.001, 0.999],     # a different near-dup pair
+    "bird c": [0.7, 0.7],                                  # its own thing
+}
+
+
+def _stub(texts):
+    return [_VEC[t] for t in texts]
+
+
+def test_dedup_clusters_near_duplicates():
+    items = ["cat a", "dog b", "cat a again", "dog b too", "bird c"]
+    r = E.dedup(items, threshold=0.95, embed_fn=_stub)
+    assert r["degraded"] is False
+    assert len(r["clusters"]) == 3          # {cats}, {dogs}, {bird}
+    assert r["dropped"] == 2
+    assert set(r["kept"]) == {"cat a", "dog b", "bird c"}  # first-seen representative
+    cats = next(c for c in r["clusters"] if c["text"] == "cat a")
+    assert cats["member_indices"] == [0, 2]
+
+
+def test_dedup_high_threshold_keeps_everything():
+    items = ["cat a", "bird c", "dog b"]
+    r = E.dedup(items, threshold=0.999999, embed_fn=_stub)
+    assert r["dropped"] == 0 and len(r["clusters"]) == 3
+
+
+def test_dedup_dicts_use_text_key():
+    items = [{"id": 1, "msg": "cat a"}, {"id": 2, "msg": "cat a again"}]
+    r = E.dedup(items, threshold=0.95, key="msg", embed_fn=_stub)
+    assert r["dropped"] == 1
+    assert r["kept"] == [{"id": 1, "msg": "cat a"}]
+
+
+def test_dedup_fail_open_no_embeddings():
+    items = ["cat a", "cat a again"]
+    r = E.dedup(items, threshold=0.9, embed_fn=lambda t: [])  # embeddings unavailable
+    assert r["degraded"] is True
+    assert r["dropped"] == 0 and len(r["clusters"]) == 2  # nothing merged
+
+
+def test_dedup_singleton_and_empty():
+    assert E.dedup([], embed_fn=_stub)["kept"] == []
+    assert E.dedup(["cat a"], embed_fn=_stub)["dropped"] == 0
+
+
+def test_relevance_orders_by_topic():
+    r = E.relevance(["cat a", "dog b"], "cat a", embed_fn=_stub)
+    assert r["degraded"] is False
+    assert r["scores"][0] > r["scores"][1]   # 'cat a' more relevant to topic 'cat a'
+    assert abs(r["scores"][0] - 1.0) < 1e-6
+
+
+def test_relevance_fail_open():
+    r = E.relevance(["cat a"], "cat a", embed_fn=lambda t: [])
+    assert r["degraded"] is True and r["scores"] == [None]
+    assert E.relevance(["x"], "")["degraded"] is True  # empty topic

--- a/scripts/embed_ops.py
+++ b/scripts/embed_ops.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""CLI for embed_ops — cheap semantic ops on the local-GPU embedding path.
+
+Usage:
+  embed_ops.py dedup '<json list of items>' [threshold] [text_key]
+      -> {clusters, kept, dropped, degraded}   (near-duplicate clustering)
+  embed_ops.py relevance '<topic>' '<json list of texts>'
+      -> {scores, degraded}                    (cosine of each text to topic)
+
+Reads OLLAMA_BASE_URL / EMBED_MODEL from the environment (same as the Loci server).
+Fail-open: with no embeddings, dedup drops nothing and relevance returns null scores.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    import embed_ops as E
+    op = sys.argv[1]
+    if op == "dedup":
+        items = json.loads(sys.argv[2])
+        threshold = float(sys.argv[3]) if len(sys.argv) > 3 else 0.88
+        key = sys.argv[4] if len(sys.argv) > 4 else None
+        out = E.dedup(items, threshold=threshold, key=key)
+    elif op == "relevance":
+        topic = sys.argv[2]
+        texts = json.loads(sys.argv[3]) if len(sys.argv) > 3 else []
+        out = E.relevance(texts, topic)
+    else:
+        print(f"unknown op: {op}", file=sys.stderr)
+        return 2
+    print(json.dumps(out, indent=2))
+    if out.get("degraded"):
+        print("[embed_ops: DEGRADED — embeddings unavailable, result is a no-op fallback]",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
The **embedding tier** of the offload hierarchy — the part that runs on oxalis's GPU **today** (nomic-embed is warm; generation is cold-load-bound, see below). Generation-free, so ~zero token cost:

- **`embed_ops.dedup(items)`** — greedy near-duplicate clustering by cosine ≥ threshold. Drop into a fan-out's synthesis step so an N-way search doesn't triple-report the same finding; feed the returned `kept` (one representative per cluster) downstream.
- **`embed_ops.relevance(texts, topic)`** — cosine of each text to a topic; a cheap gate/router that trims what reaches Claude, replacing a classifier agent.

Both **fail-open**: no embeddings → dedup drops nothing, relevance returns null scores, `degraded=True`.

## Surface
- `mcp/embed_ops.py` — module (injectable `embed_fn` for reuse/tests).
- `scripts/embed_ops.py` — CLI (`dedup` / `relevance`).
- `server.py` — warm MCP tools **`semantic_dedup`** + **`semantic_relevance`**.

## Validated
- Live on the real nomic path: 4 findings (2 paraphrase pairs) → 2 clusters, 2 dropped, `degraded=False`.
- 7 unit tests (clustering, dict `text_key`, threshold, relevance ordering, fail-open) — stubbed embeddings, no live Ollama. **Full suite: 292 pass.**

## Substrate note (from live probing on oxalis)
Embeddings work warm on GPU. **Generation also works on GPU** (qwen2.5:3b verified: 111 tok/s warm, valid JSON) — the earlier "hang" was a ~70s **cold model load**, not broken generation. Keeping a small instruct model pinned (`keep_alive`) makes it sub-second. That unblocks the generation tier (query expansion, classification, `llm_local`) as a follow-up; this PR is the generation-free half that's ready now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45