### PR TITLE
GPU-acceleration tier + unified placement with the DAMA trainer

### DIFF
--- a/mcp/batched_gen.py
+++ b/mcp/batched_gen.py
@@ -1,0 +1,207 @@
+"""Batched-serving generation client — concurrent fan-out generation with Ollama fallback.
+
+For high-concurrency workflow fan-out (N planning/research agents, per-prompt gates,
+map-stage classification), the Ollama tier serializes: `llm_local.generate` issues one
+POST per prompt and Ollama processes them essentially one-at-a-time. A batched,
+OpenAI-compatible server (vLLM / TGI) can serve many small requests *concurrently* with
+continuous batching, which is a large throughput win when you have dozens of short prompts.
+
+Substrate facts this is built against (session grounding):
+  - [gen] The local generation tier (mcp/llm_local.py) already exists and speaks to Ollama
+    (qwen2.5:3b, pinned via keep_alive). This module's FALLBACK path lazily reuses it.
+  - [hardware] Oxalis exposes TWO GPUs shared with the DAMA ant-trainer. GPU placement is
+    governed by ONE authoritative policy (dama-gotchi/training/GPU_PACKING_POLICY.md): the
+    2080 Ti is the ant-TRAINER GPU, the 4070 Ti hosts persistent inference. A batched-gen
+    server must therefore NOT squat the 2080 Ti persistently (it would collide with training
+    bursts) — it shares the 4070 Ti inference GPU or runs opportunistically and yields to
+    training. See scripts/gpu_placement.md for the reconciled placement.
+  - [pattern:fail-open] Every op fails open: on missing config / HTTP error / timeout /
+    parse failure we return a well-formed degraded result and NEVER raise. A failed prompt
+    yields {"text": "", "ok": False}, so the output list ALWAYS aligns 1:1 with `prompts`.
+  - [pattern:injectable] The HTTP client is injected via `client_fn` (defaulting to None ->
+    lazily resolved at call time), so importing this module never hard-requires `requests`,
+    a live vLLM server, or the sibling llm_local module. Tests stub both paths.
+
+Grounding is SILENT on: whether a vLLM/TGI server is actually deployed, its model name, and
+the exact VLLM_BASE_URL value. This module therefore treats VLLM_BASE_URL as the sole switch:
+unset -> go straight to the Ollama fallback; set -> try the batched path first, fall back on
+any failure. The concrete deploy plan lives in scripts/vllm_serve.md (not yet executed).
+
+Contract:
+    generate_batch(prompts, model=None, max_tokens=256, fmt=None, client_fn=None)
+        -> list[dict]   # each {"text": str, "ok": bool}, aligned to `prompts`
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+from typing import Callable, Optional
+
+# Max in-flight requests to the batched server. Continuous batching only engages when the
+# server sees multiple concurrent requests, so we dispatch the batch across a thread pool.
+_MAX_CONCURRENCY = int(os.environ.get("VLLM_MAX_CONCURRENCY", "16"))
+
+# [hardware] The batched server's OpenAI-compatible base URL, e.g. http://100.73.200.19:8000
+# Unset -> we never touch the network for the primary path and degrade to Ollama immediately.
+_VLLM = os.environ.get("VLLM_BASE_URL") or ""
+
+# Model the batched server serves. Grounding is silent on the exact tag; default matches the
+# small instruct model recommended in scripts/vllm_serve.md. Override via VLLM_MODEL or arg.
+_DEFAULT_MODEL = os.environ.get("VLLM_MODEL", "Qwen2.5-3B-Instruct")
+
+# Generous timeout: a batched server may queue many concurrent requests behind continuous
+# batching. Grounding is silent on an exact value; 120s mirrors llm_local's cold-load budget.
+_TIMEOUT = float(os.environ.get("VLLM_TIMEOUT", "120"))
+
+
+def _fail(n: int) -> list[dict]:
+    """A fully-degraded, correctly-aligned result: n copies of {'text':'','ok':False}."""
+    return [{"text": "", "ok": False} for _ in range(n)]
+
+
+def _ok_text(text: str, fmt: Optional[str]) -> dict:
+    """Wrap a generated string, validating JSON when fmt=='json' (mirrors llm_local)."""
+    text = text or ""
+    if fmt == "json":
+        try:
+            json.loads(text)
+        except Exception:
+            return {"text": text, "ok": False}
+    return {"text": text, "ok": True}
+
+
+def _via_ollama(prompts: list[str], model: Optional[str], max_tokens: int,
+                fmt: Optional[str]) -> list[dict]:
+    """FALLBACK path: sequential mcp/llm_local.generate per prompt. Fail-open per prompt.
+
+    Lazily imports llm_local so this module never hard-requires it at import time
+    [pattern:injectable]. If the import itself fails, we degrade the whole batch.
+    """
+    try:
+        import llm_local  # lazy sibling import; may not be importable in all contexts
+    except Exception:
+        try:
+            from . import llm_local  # type: ignore
+        except Exception:
+            return _fail(len(prompts))
+
+    out: list[dict] = []
+    for p in prompts:
+        try:
+            # llm_local.generate defaults model to qwen2.5:3b when we pass None-equivalent;
+            # only forward `model` if the caller actually named one for the batched server.
+            if model:
+                res = llm_local.generate(p, model=model, fmt=fmt, max_tokens=max_tokens)
+            else:
+                res = llm_local.generate(p, fmt=fmt, max_tokens=max_tokens)
+            out.append({"text": res.get("text", ""), "ok": bool(res.get("ok"))})
+        except Exception:
+            # Per-prompt isolation: one bad prompt never poisons the rest [pattern:fail-open].
+            out.append({"text": "", "ok": False})
+    return out
+
+
+def _post_completions(client, url: str, model: str, prompt: str, max_tokens: int,
+                      fmt: Optional[str]) -> dict:
+    """POST one prompt to the OpenAI-compatible /v1/completions endpoint.
+
+    One request per prompt, but generate_batch() dispatches these CONCURRENTLY across a
+    thread pool so the server has multiple in-flight sequences to interleave — that is what
+    engages vLLM/TGI continuous batching (a single blocking loop would not). Per-prompt
+    requests (vs one list-prompt request) give clean per-prompt failure isolation and work
+    identically against TGI.
+    """
+    body = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0.2,
+        "stream": False,
+    }
+    if fmt == "json":
+        # vLLM supports OpenAI's response_format for JSON-guided decoding.
+        body["response_format"] = {"type": "json_object"}
+    r = client.post(f"{url}/v1/completions", json=body, timeout=_TIMEOUT)
+    r.raise_for_status()
+    data = r.json()
+    text = ((data.get("choices") or [{}])[0].get("text")) or ""
+    return _ok_text(text, fmt)
+
+
+def generate_batch(prompts: list[str],
+                   model: Optional[str] = None,
+                   max_tokens: int = 256,
+                   fmt: Optional[str] = None,
+                   client_fn: Optional[Callable[[], object]] = None) -> list[dict]:
+    """Generate for many prompts, batched on vLLM/TGI when available, else Ollama fallback.
+
+    Args:
+        prompts: list of prompt strings. The result is ALWAYS the same length and order.
+        model: model tag to serve. None -> VLLM_MODEL default on the batched path, and
+               llm_local's own default (qwen2.5:3b) on the fallback path.
+        max_tokens: max new tokens per prompt.
+        fmt: 'json' requests JSON-guided output AND validates each body parses as JSON;
+             a non-JSON body downgrades that prompt to ok=False (mirrors llm_local).
+        client_fn: injectable zero-arg factory returning an HTTP client exposing
+                   .post(url, json=..., timeout=...) -> response with .raise_for_status()
+                   and .json() (i.e. a `requests`-like Session). None -> lazily use
+                   `requests` [pattern:injectable]. Used ONLY for the batched path;
+                   the fallback path goes through llm_local.
+
+    Returns:
+        list[dict] aligned to `prompts`, each {"text": str, "ok": bool}. Never raises.
+    """
+    prompts = list(prompts or [])
+    if not prompts:
+        return []
+    # Normalize to strings so a stray non-str prompt can't blow up json serialization.
+    prompts = [p if isinstance(p, str) else str(p) for p in prompts]
+
+    # No batched server configured -> straight to the sequential Ollama fallback [gen].
+    if not _VLLM:
+        return _via_ollama(prompts, model, max_tokens, fmt)
+
+    # Resolve the HTTP client lazily/injectably. If even that fails, degrade to Ollama.
+    try:
+        if client_fn is not None:
+            client = client_fn()
+        else:
+            import requests  # lazy: importing this module must not require requests
+            client = requests
+    except Exception:
+        return _via_ollama(prompts, model, max_tokens, fmt)
+
+    served_model = model or _DEFAULT_MODEL
+
+    # Dispatch the batch CONCURRENTLY so the batched server has multiple in-flight requests
+    # to interleave — a plain blocking loop would serialize and never engage continuous
+    # batching. Results are written back by index to preserve 1:1 order [pattern:fail-open].
+    out: list[Optional[dict]] = [None] * len(prompts)
+    hard_fail = False
+
+    def _one(i: int, p: str):
+        try:
+            return i, _post_completions(client, _VLLM, served_model, p, max_tokens, fmt), False
+        except Exception:
+            # Per-prompt isolation on the batched path too [pattern:fail-open].
+            return i, {"text": "", "ok": False}, True
+
+    workers = max(1, min(len(prompts), _MAX_CONCURRENCY))
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+            for fut in concurrent.futures.as_completed(
+                    [ex.submit(_one, i, p) for i, p in enumerate(prompts)]):
+                i, res, failed = fut.result()
+                out[i] = res
+                hard_fail = hard_fail or failed
+    except Exception:
+        # Pool-level failure (never expected) -> degrade the whole batch to Ollama.
+        return _via_ollama(prompts, model, max_tokens, fmt)
+
+    any_ok = any(r and r["ok"] for r in out)
+    # If the batched server produced NOTHING usable (e.g. server down -> every request
+    # raised), fall back to Ollama for the whole batch rather than returning all-failed.
+    if hard_fail and not any_ok:
+        return _via_ollama(prompts, model, max_tokens, fmt)
+    return [r if r is not None else {"text": "", "ok": False} for r in out]

--- a/mcp/reranker.py
+++ b/mcp/reranker.py
@@ -1,0 +1,184 @@
+"""Pluggable GPU reranker — a reusable, model-pluggable two-stage reranking unit.
+
+This factors the cross-encoder reranking that currently lives inline in server.py
+(~588-609, the lazy `_get_cross_encoder` + `_cross_encoder` global) into one
+importable primitive. server.py should delegate to `rerank()` here instead of
+carrying its own CrossEncoder singleton.
+
+Two backends, chosen by env RERANK_MODEL:
+  - 'cross-encoder/ms-marco-MiniLM-L-6-v2'  (DEFAULT — reproduces current server.py
+    behavior exactly [rerank]: the 22M-param ms-marco MiniLM cross-encoder.)
+  - 'BAAI/bge-reranker-v2-m3'               (opt-in — a stronger reranker that lifts
+    retrieval precision [rerank]; heavier, multilingual.)
+Any other value is passed through verbatim to CrossEncoder, so operators can point at
+an arbitrary sentence-transformers cross-encoder without a code change.
+
+Substrate facts this is built against (session grounding):
+  - [hardware] torch in mcp/.venv sees cuda:0 (RTX 4070 Ti). We load the model on
+    'cuda' when torch.cuda.is_available(), else 'cpu' — mirroring the intent of the
+    server.py cross-encoder path.
+  - [rerank] server.py already reranks on GPU with a lazily-loaded, globally-cached
+    CrossEncoder. This module mirrors that: lazy-init, cache in a module global, and
+    on load failure set the cache to `False` PERMANENTLY so we never re-attempt a
+    known-broken load per call.
+  - [pattern:fail-open] EVERY op fails open (mirror embed_ops.py / llm_local.py): if
+    the model can't load (or no model_fn is injected and the real model is
+    unavailable), we return the docs in ORIGINAL order with score=None and set the
+    'degraded' marker. We NEVER raise.
+  - [pattern:injectable] `model_fn` is injectable — a callable (query, docs) -> list
+    of float scores. It defaults to None and is resolved lazily to the real
+    CrossEncoder at call time. Tests pass a stub so NO model is downloaded and no GPU
+    is touched.
+
+How server.py should delegate (do NOT edit server.py as part of this change):
+    from reranker import rerank
+    ranked = rerank(query, [hit.text for hit in hits], top_k=k)
+    # ranked -> [{"index": i, "score": s or None, "text": t}, ...] sorted desc.
+    # 'index' is the position in the INPUT docs list, so callers can re-associate
+    # each result with its original hit/payload. On degraded results score is None
+    # and order is preserved, so a caller can safely fall back to bi-encoder order.
+The existing server.py `_get_cross_encoder()` / `_cross_encoder` global and the inline
+`model.predict([[query, doc] ...])` call can then be deleted in favor of this module.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Callable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Default backend reproduces current server.py behavior [rerank].
+_DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# Module-global model cache, mirroring server.py's `_cross_encoder` singleton [rerank]:
+#   None  -> not yet attempted (lazy)
+#   False -> load failed permanently; never retry (fail-open)
+#   obj   -> a loaded CrossEncoder
+_model = None
+_model_lock = threading.Lock()
+# Which model name `_model` was loaded for, so a changed RERANK_MODEL forces a reload.
+_model_name: Optional[str] = None
+
+
+def _model_id() -> str:
+    """The configured backend, read from env each call so it can be overridden at runtime."""
+    return os.environ.get("RERANK_MODEL") or _DEFAULT_MODEL
+
+
+def _get_model():
+    """Lazy-init + globally cache a sentence_transformers.CrossEncoder on GPU if available.
+
+    Mirrors server.py ~588-609: double-checked locking, cache in a module global, and on
+    ANY load failure set the global to `False` permanently so we never re-attempt per call.
+    Returns the loaded model, or None if unavailable/failed (fail-open — never raises).
+    """
+    global _model, _model_name
+    wanted = _model_id()
+    # Fast path: already loaded for the currently-configured model.
+    if _model is not None and _model_name == wanted:
+        return _model if _model is not False else None
+    with _model_lock:
+        if _model is not None and _model_name == wanted:  # re-check under lock
+            return _model if _model is not False else None
+        _model_name = wanted
+        try:
+            # Resolve device lazily: cuda:0 (RTX 4070 Ti) when torch sees it, else cpu [hardware].
+            device = "cpu"
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    device = "cuda"
+            except Exception:
+                device = "cpu"
+            from sentence_transformers import CrossEncoder
+            _model = CrossEncoder(wanted, max_length=512, device=device)
+            logger.info("Reranker enabled (%s on %s)", wanted, device)
+        except ImportError:
+            logger.debug("sentence-transformers not installed — reranking disabled")
+            _model = False
+        except Exception as exc:
+            logger.warning("Reranker init failed — reranking disabled: %s", exc)
+            _model = False
+    return _model if _model is not False else None
+
+
+def get_model():
+    """Public accessor: the lazily-loaded, globally-cached CrossEncoder for the currently
+    configured RERANK_MODEL, or None if unavailable (fail-open). server.py delegates its
+    cross-encoder singleton to this so the backend is env-pluggable without touching call
+    sites (they keep calling `.predict(pairs)` on the returned model)."""
+    return _get_model()
+
+
+def _real_model_fn(query: str, docs: Sequence[str]) -> Optional[List[float]]:
+    """Default model_fn: score each doc with the cached CrossEncoder. None if unavailable."""
+    model = _get_model()
+    if model is None:
+        return None
+    try:
+        scores = model.predict([[query, d] for d in docs])
+        return [float(s) for s in scores]
+    except Exception as exc:
+        logger.warning("Reranker predict failed — falling back to original order: %s", exc)
+        return None
+
+
+def rerank(query: str,
+           docs: Sequence[str],
+           top_k: Optional[int] = None,
+           model_fn: Optional[Callable[[str, Sequence[str]], Optional[Sequence[float]]]] = None,
+           ) -> List[dict]:
+    """Rerank `docs` against `query`, best-first. Fail-open — never raises.
+
+    Args:
+        query: the query string.
+        docs: the candidate documents (strings) to reorder.
+        top_k: if set, cap the returned list to the top_k highest-scoring docs.
+        model_fn: injectable scorer, `fn(query, docs) -> sequence[float]` (one score per
+            doc). Defaults to None -> the lazily-resolved on-GPU CrossEncoder. Tests inject
+            a stub so NO model is downloaded [pattern:injectable].
+
+    Returns:
+        A list of {"index": int, "score": float|None, "text": str} sorted by score
+        descending. `index` is the position in the INPUT `docs` list.
+
+        Fail-open [pattern:fail-open]: if scoring is unavailable (no model_fn and the real
+        model can't load, or the model_fn returns None / a wrong-length list / raises), the
+        docs are returned in ORIGINAL order with score=None and each dict carries
+        "degraded": True. Empty docs -> [].
+    """
+    items = list(docs)
+    n = len(items)
+    if n == 0:
+        return []
+
+    def _passthrough() -> List[dict]:
+        out = [{"index": i, "score": None, "text": items[i], "degraded": True} for i in range(n)]
+        if top_k is not None:
+            out = out[: max(0, top_k)]
+        return out
+
+    scorer = model_fn if model_fn is not None else _real_model_fn
+
+    try:
+        scores = scorer(query, items)
+    except Exception as exc:
+        logger.warning("Reranker model_fn raised — falling back to original order: %s", exc)
+        return _passthrough()
+
+    # A None or malformed (wrong-length) score list means "unavailable" -> fail open.
+    if scores is None:
+        return _passthrough()
+    scores = list(scores)
+    if len(scores) != n:
+        logger.warning("Reranker returned %d scores for %d docs — falling back", len(scores), n)
+        return _passthrough()
+
+    ranked = [{"index": i, "score": float(scores[i]), "text": items[i]} for i in range(n)]
+    # Sort by score desc; stable sort keeps original order among ties.
+    ranked.sort(key=lambda r: r["score"], reverse=True)
+    if top_k is not None:
+        ranked = ranked[: max(0, top_k)]
+    return ranked

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -190,8 +190,6 @@ _CONFIDENCE_RANK: dict[str, int] = {"low": 0, "medium": 1, "high": 2}
 # ---------------------------------------------------------------------------
 
 _sparse_model = None
-_cross_encoder = None          # sentence_transformers.CrossEncoder | False (permanent failure)
-_cross_encoder_lock = threading.Lock()   # guards lazy init against concurrent first-callers
 _investigation_locks: dict[str, threading.Lock] = {}  # per-investigation lock for atomic JSONL appends
 _investigation_locks_lock = threading.Lock()          # guards _investigation_locks dict itself
 _qdrant_client: tuple | None = None    # (QdrantClient, collection_name) singleton
@@ -585,28 +583,23 @@ def _get_sparse_embedder():
 
 
 def _get_cross_encoder():
-    """Lazy-init a sentence-transformers CrossEncoder for two-stage reranking.
+    """The two-stage reranker's CrossEncoder, or None when unavailable (fail-open).
 
-    Uses ms-marco-MiniLM-L-6-v2 — a 22 M-param model trained on passage
-    ranking, CPU-capable at <100 ms per batch of 50. Gracefully disabled when
-    sentence-transformers is not installed so the rest of retrieval keeps
-    working with bi-encoder scores alone.
+    Delegates to reranker.get_model() so the backend is env-pluggable via RERANK_MODEL:
+    default 'cross-encoder/ms-marco-MiniLM-L-6-v2' reproduces the historical behavior; opt-in
+    'BAAI/bge-reranker-v2-m3' is a stronger reranker. Lazy-init, globally cached, loaded on
+    cuda:0 (the 4070 Ti) when available. Call sites keep calling `.predict(pairs)` unchanged.
+
+    NOTE: flipping RERANK_MODEL to bge is a retrieval-QUALITY change — shadow-eval / A-B it on
+    a held-out query set before making it the default (mirrors the DAMA shadow-eval + canary
+    gate; see scripts/gpu_placement.md and dama-gotchi/training/GPU_PACKING_POLICY.md).
     """
-    global _cross_encoder
-    if _cross_encoder is None:                        # fast path — no lock needed post-init
-        with _cross_encoder_lock:                     # slow path — guard concurrent first callers
-            if _cross_encoder is None:                # re-check after acquiring the lock
-                try:
-                    from sentence_transformers import CrossEncoder as _CE
-                    _cross_encoder = _CE("cross-encoder/ms-marco-MiniLM-L-6-v2", max_length=512)
-                    logger.info("Cross-encoder reranking enabled (ms-marco-MiniLM-L-6-v2)")
-                except ImportError:
-                    logger.debug("sentence-transformers not installed — reranking disabled")
-                    _cross_encoder = False
-                except Exception as exc:
-                    logger.warning("Cross-encoder init failed — reranking disabled: %s", exc)
-                    _cross_encoder = False
-    return _cross_encoder if _cross_encoder is not False else None
+    try:
+        import reranker
+        return reranker.get_model()
+    except Exception as exc:
+        logger.warning("Reranker unavailable — reranking disabled: %s", exc)
+        return None
 
 
 def _embed_sparse(text: str):
@@ -6936,6 +6929,21 @@ def llm_local(prompt: str, model: str = "qwen2.5:3b", fmt: Optional[str] = None,
     import llm_local as _llm
     return json.dumps(_llm.generate(prompt, model=model, fmt=fmt, max_tokens=max_tokens,
                                     temperature=temperature, keep_alive=keep_alive), indent=2)
+
+
+@mcp.tool()
+def generate_batch(prompts: list, model: Optional[str] = None, max_tokens: int = 256,
+                   fmt: Optional[str] = None) -> str:
+    """
+    Generate for MANY prompts at once — for high-concurrency fan-out (per-item classify/expand
+    gates, map stages). Uses a batched OpenAI-compatible server (vLLM/TGI at VLLM_BASE_URL,
+    dispatched concurrently so continuous batching engages) when configured, else fails open to
+    the sequential Ollama tier (llm_local). Returns JSON: a list of {text, ok} aligned 1:1 to
+    `prompts` (a failed prompt is {text:'', ok:False}; never raises).
+    """
+    import batched_gen
+    return json.dumps(batched_gen.generate_batch(list(prompts or []), model=model,
+                                                 max_tokens=max_tokens, fmt=fmt), indent=2)
 
 
 @mcp.tool()

--- a/mcp/tests/test_batched_gen.py
+++ b/mcp/tests/test_batched_gen.py
@@ -1,0 +1,205 @@
+"""Tests for batched_gen — the batched vLLM/TGI client with Ollama fallback.
+
+No live servers: the HTTP client is stubbed via `client_fn`, and the Ollama fallback is
+stubbed by monkeypatching the lazily-imported `llm_local` module. Mirrors test_embed_ops
+style: deterministic stubs, fail-open assertions, per-prompt isolation.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import batched_gen as B  # noqa: E402
+
+
+# ---- stub HTTP client emulating a requests.Session against /v1/completions -------------
+
+class _Resp:
+    def __init__(self, text="", *, status_ok=True, body=None):
+        self._text = text
+        self._status_ok = status_ok
+        self._body = body
+
+    def raise_for_status(self):
+        if not self._status_ok:
+            raise RuntimeError("HTTP 500")
+
+    def json(self):
+        if self._body is not None:
+            return self._body
+        return {"choices": [{"text": self._text}]}
+
+
+class _StubClient:
+    """Records posts; returns a canned completion per prompt. `fail_on` prompts raise."""
+    def __init__(self, fail_on=None, echo=True):
+        self.calls = []
+        self.fail_on = set(fail_on or ())
+        self.echo = echo
+
+    def post(self, url, json=None, timeout=None):
+        prompt = (json or {}).get("prompt", "")
+        self.calls.append({"url": url, "json": json})
+        if prompt in self.fail_on:
+            raise ConnectionError("simulated network failure")
+        return _Resp(text=f"echo:{prompt}" if self.echo else "")
+
+
+def _client_fn_for(client):
+    return lambda: client
+
+
+# ---- helpers to force VLLM_BASE_URL state ----------------------------------------------
+
+def _set_vllm(monkeypatch, url):
+    monkeypatch.setattr(B, "_VLLM", url)
+
+
+# ---- batched happy path ----------------------------------------------------------------
+
+def test_batched_happy_path(monkeypatch):
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+    client = _StubClient()
+    prompts = ["a", "b", "c"]
+    out = B.generate_batch(prompts, client_fn=_client_fn_for(client))
+    assert len(out) == len(prompts)
+    assert all(r["ok"] for r in out)
+    assert [r["text"] for r in out] == ["echo:a", "echo:b", "echo:c"]
+    # Hit the OpenAI-compatible completions endpoint, once per prompt.
+    assert all(c["url"].endswith("/v1/completions") for c in client.calls)
+    assert len(client.calls) == 3
+    assert client.calls[0]["json"]["model"] == B._DEFAULT_MODEL
+
+
+def test_batched_respects_model_and_max_tokens(monkeypatch):
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+    client = _StubClient()
+    B.generate_batch(["x"], model="my-model", max_tokens=99,
+                     client_fn=_client_fn_for(client))
+    body = client.calls[0]["json"]
+    assert body["model"] == "my-model"
+    assert body["max_tokens"] == 99
+
+
+def test_batched_json_format_validates(monkeypatch):
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+
+    class _JsonClient(_StubClient):
+        def post(self, url, json=None, timeout=None):
+            self.calls.append({"url": url, "json": json})
+            prompt = (json or {}).get("prompt")
+            text = '{"k": 1}' if prompt == "good" else "not json"
+            return _Resp(text=text)
+
+    client = _JsonClient()
+    out = B.generate_batch(["good", "bad"], fmt="json",
+                           client_fn=_client_fn_for(client))
+    assert out[0]["ok"] is True and out[1]["ok"] is False   # non-JSON downgraded
+    assert client.calls[0]["json"]["response_format"] == {"type": "json_object"}
+
+
+# ---- fallback to Ollama when VLLM_BASE_URL unset ---------------------------------------
+
+class _FakeLLMLocal:
+    """Stand-in for the sibling llm_local module (only .generate is used)."""
+    def __init__(self, fail_on=None):
+        self.calls = []
+        self.fail_on = set(fail_on or ())
+
+    def generate(self, prompt, model=None, fmt=None, max_tokens=256):
+        self.calls.append({"prompt": prompt, "model": model,
+                           "fmt": fmt, "max_tokens": max_tokens})
+        if prompt in self.fail_on:
+            return {"text": "", "ok": False, "model": model}
+        return {"text": f"ollama:{prompt}", "ok": True, "model": model or "qwen2.5:3b"}
+
+
+def _install_fake_llm_local(monkeypatch, fake):
+    # batched_gen does `import llm_local` lazily; put our fake on sys.modules so that
+    # import resolves to it without any real Ollama call.
+    monkeypatch.setitem(sys.modules, "llm_local", fake)
+
+
+def test_fallback_when_vllm_unset(monkeypatch):
+    _set_vllm(monkeypatch, "")            # no batched server configured
+    fake = _FakeLLMLocal()
+    _install_fake_llm_local(monkeypatch, fake)
+    # A client_fn is provided but must be IGNORED on the fallback path.
+    sentinel = _StubClient()
+    out = B.generate_batch(["a", "b"], client_fn=_client_fn_for(sentinel))
+    assert [r["text"] for r in out] == ["ollama:a", "ollama:b"]
+    assert all(r["ok"] for r in out)
+    assert len(fake.calls) == 2 and sentinel.calls == []   # went to Ollama, not HTTP
+
+
+def test_fallback_forwards_fmt_and_max_tokens(monkeypatch):
+    _set_vllm(monkeypatch, "")
+    fake = _FakeLLMLocal()
+    _install_fake_llm_local(monkeypatch, fake)
+    B.generate_batch(["p"], max_tokens=42, fmt="json",
+                     client_fn=None)
+    assert fake.calls[0]["fmt"] == "json"
+    assert fake.calls[0]["max_tokens"] == 42
+    assert fake.calls[0]["model"] is None   # no model named -> llm_local default used
+
+
+def test_fallback_when_batched_server_down(monkeypatch):
+    # VLLM set, but EVERY request raises -> whole batch degrades to Ollama, not all-failed.
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+    fake = _FakeLLMLocal()
+    _install_fake_llm_local(monkeypatch, fake)
+    client = _StubClient(fail_on={"a", "b"})   # server unreachable for all prompts
+    out = B.generate_batch(["a", "b"], client_fn=_client_fn_for(client))
+    assert [r["text"] for r in out] == ["ollama:a", "ollama:b"]
+    assert all(r["ok"] for r in out)
+
+
+# ---- per-prompt failure isolation ------------------------------------------------------
+
+def test_per_prompt_failure_isolation_batched(monkeypatch):
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+    client = _StubClient(fail_on={"b"})        # only middle prompt fails
+    out = B.generate_batch(["a", "b", "c"], client_fn=_client_fn_for(client))
+    assert len(out) == 3
+    assert out[0] == {"text": "echo:a", "ok": True}
+    assert out[1] == {"text": "", "ok": False}   # isolated failure
+    assert out[2] == {"text": "echo:c", "ok": True}
+
+
+def test_per_prompt_failure_isolation_fallback(monkeypatch):
+    _set_vllm(monkeypatch, "")
+    fake = _FakeLLMLocal(fail_on={"b"})
+    _install_fake_llm_local(monkeypatch, fake)
+    out = B.generate_batch(["a", "b", "c"])
+    assert out[0]["ok"] is True and out[0]["text"] == "ollama:a"
+    assert out[1] == {"text": "", "ok": False}
+    assert out[2]["ok"] is True
+
+
+def test_fallback_import_failure_degrades_whole_batch(monkeypatch):
+    # If llm_local cannot even be imported, fail-open: aligned all-failed result, no raise.
+    _set_vllm(monkeypatch, "")
+    monkeypatch.setitem(sys.modules, "llm_local", None)  # import llm_local -> ImportError
+    # also block the package-relative fallback import
+    out = B.generate_batch(["a", "b"])
+    assert out == [{"text": "", "ok": False}, {"text": "", "ok": False}]
+
+
+# ---- edge cases ------------------------------------------------------------------------
+
+def test_empty_prompts_returns_empty(monkeypatch):
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+    assert B.generate_batch([]) == []
+    assert B.generate_batch(None) == []
+
+
+def test_client_fn_construction_failure_degrades_to_ollama(monkeypatch):
+    _set_vllm(monkeypatch, "http://vllm.local:8000")
+    fake = _FakeLLMLocal()
+    _install_fake_llm_local(monkeypatch, fake)
+
+    def _boom():
+        raise RuntimeError("cannot build client")
+
+    out = B.generate_batch(["a"], client_fn=_boom)
+    assert out == [{"text": "ollama:a", "ok": True}]  # fell back cleanly

--- a/mcp/tests/test_gpu_warm.py
+++ b/mcp/tests/test_gpu_warm.py
@@ -1,0 +1,119 @@
+"""Tests for scripts/gpu_warm.py — the GPU warm-keeper. HTTP is stubbed; NO live Ollama.
+
+We inject a stub post_fn (the [pattern:injectable] contract) and assert:
+  - both hot models (qwen2.5:3b + nomic-embed-text) get pinned with keep_alive set,
+    hitting the right endpoints (/api/generate + /api/embed);
+  - the degraded path when Ollama is unreachable (poster raises) fails open, never raises.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# gpu_warm lives under scripts/, a sibling of mcp/.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+
+# gpu_warm reads OLLAMA_BASE_URL at import time; set it before import so the module is
+# "configured" and exercises the real request-building path against our stub.
+os.environ.setdefault("OLLAMA_BASE_URL", "http://stub-ollama:11434")
+
+import gpu_warm as G  # noqa: E402
+
+
+class _Resp:
+    """Minimal stand-in for a requests.Response."""
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _RecordingPoster:
+    """Stub post_fn that records calls and returns canned bodies keyed by URL."""
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, url, json=None, timeout=None):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        if url.endswith("/api/ps"):
+            return _Resp({"models": [
+                {"name": "qwen2.5:3b", "size_vram": 3200000000},
+                {"name": "nomic-embed-text", "size_vram": 280000000},
+            ]})
+        if url.endswith("/api/embed"):
+            return _Resp({"embeddings": [[0.0, 0.1]]})
+        # /api/generate
+        return _Resp({"response": "", "done": True})
+
+
+def _raising_poster(url, json=None, timeout=None):
+    raise ConnectionError("stub: ollama unreachable")
+
+
+def test_pin_gen_hits_generate_with_keep_alive():
+    poster = _RecordingPoster()
+    r = G.pin_model("qwen2.5:3b", "gen", keep_alive="-1", post_fn=poster)
+    assert r["ok"] is True
+    assert r["model"] == "qwen2.5:3b"
+    assert r["keep_alive"] == -1  # "-1" coerced to int -1 (indefinite)
+    call = poster.calls[-1]
+    assert call["url"].endswith("/api/generate")
+    assert call["json"]["keep_alive"] == -1
+    assert call["json"]["model"] == "qwen2.5:3b"
+    assert call["json"]["options"]["num_predict"] == 0  # load-only pin
+
+
+def test_pin_embed_hits_embed_with_keep_alive():
+    poster = _RecordingPoster()
+    r = G.pin_model("nomic-embed-text", "embed", keep_alive="30m", post_fn=poster)
+    assert r["ok"] is True
+    call = poster.calls[-1]
+    assert call["url"].endswith("/api/embed")
+    assert call["json"]["keep_alive"] == "30m"  # duration string passes through
+    assert call["json"]["model"] == "nomic-embed-text"
+
+
+def test_warm_once_pins_both_models():
+    poster = _RecordingPoster()
+    report = G.warm_once(keep_alive="-1", post_fn=poster, include_gpu=False)
+    assert report["degraded"] is False
+    pinned = {(p["model"], p["kind"]): p for p in report["pins"]}
+    # both hot models pinned, keep_alive set on each
+    assert ("qwen2.5:3b", "gen") in pinned
+    assert ("nomic-embed-text", "embed") in pinned
+    assert all(p["ok"] and p["keep_alive"] == -1 for p in report["pins"])
+    # /api/ps residency reported
+    names = {m["name"] for m in report["ps"]["models"]}
+    assert {"qwen2.5:3b", "nomic-embed-text"} <= names
+    # endpoints actually exercised
+    urls = [c["url"] for c in poster.calls]
+    assert any(u.endswith("/api/generate") for u in urls)
+    assert any(u.endswith("/api/embed") for u in urls)
+
+
+def test_pin_degraded_on_unreachable_ollama():
+    r = G.pin_model("qwen2.5:3b", "gen", post_fn=_raising_poster)
+    assert r["ok"] is False
+    assert "error" in r  # captured, not raised
+
+
+def test_warm_once_degraded_path_fails_open():
+    # Poster raises for every call -> pins fail, ps fails, but nothing propagates.
+    report = G.warm_once(keep_alive="-1", post_fn=_raising_poster, include_gpu=False)
+    assert report["degraded"] is True
+    assert all(p["ok"] is False for p in report["pins"])
+    assert report["ps"]["ok"] is False
+    # report is still well-formed (fail-open contract)
+    assert "pins" in report and "ps" in report and "ts" in report
+
+
+def test_main_oneshot_exits_zero_even_when_degraded(monkeypatch, capsys):
+    # Force the degraded path by making the lazy poster unresolvable.
+    monkeypatch.setattr(G, "_resolve_post", lambda pf: None)
+    rc = G.main(["--no-gpu"])  # one-shot
+    assert rc == 0  # fail-open: exit 0
+    out = capsys.readouterr().out
+    assert "DEGRADED" in out

--- a/mcp/tests/test_reembed_daemon.py
+++ b/mcp/tests/test_reembed_daemon.py
@@ -1,0 +1,229 @@
+"""Tests for scripts/reembed_daemon — batch GPU re-embed. Qdrant + embed are stubbed.
+
+No live Qdrant/Ollama/GPU: a fake client captures scroll/upsert and a stub embed_fn
+returns deterministic vectors. Proves the safety contract (dry-run mutates nothing),
+incremental targeting (only stale/missing points), batching, and per-batch fail-open.
+"""
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# The module under test lives in ../../scripts.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+
+import reembed_daemon as R  # noqa: E402
+
+MODEL = "nomic-embed-text"
+VERSION = "1"
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+class FakeQdrant:
+    """Captures scroll paging + upsert calls. scroll returns (points, next_offset)."""
+
+    def __init__(self, pages):
+        self.pages = pages          # list[list[point-dict]]
+        self.upserts = []           # list of the `points` lists passed to upsert
+        self.scroll_calls = 0
+
+    def scroll(self, collection_name, limit, offset, with_payload, with_vectors):
+        assert with_vectors is True and with_payload is True
+        self.scroll_calls += 1
+        idx = offset or 0
+        if idx >= len(self.pages):
+            return [], None
+        nxt = idx + 1 if idx + 1 < len(self.pages) else None
+        return self.pages[idx], nxt
+
+    def upsert(self, collection_name, points):
+        self.upserts.append(points)
+
+
+def _pt(pid, *, text="hello", model=MODEL, version=VERSION, vector=(0.1, 0.2)):
+    payload = {"text": text}
+    if model is not None:
+        payload["embed_model"] = model
+    if version is not None:
+        payload["embed_version"] = version
+    return {"id": pid, "payload": payload, "vector": list(vector) if vector else vector}
+
+
+def _fresh(pid):
+    return _pt(pid)                                  # has vector, model+version match
+
+
+def _stale_model(pid):
+    return _pt(pid, model="old-model")               # wrong model
+
+
+def _stale_version(pid):
+    return _pt(pid, version="0")                      # wrong version
+
+
+def _missing_vec(pid):
+    return _pt(pid, vector=None)                      # no vector at all
+
+
+def _stub_embed(texts):
+    """Deterministic 2-D vectors; one per text (correct count)."""
+    return [[float(len(t)), 1.0] for t in texts]
+
+
+def _upserted_ids(client):
+    ids = []
+    for batch in client.upserts:
+        for p in batch:
+            ids.append(p["id"] if isinstance(p, dict) else getattr(p, "id"))
+    return ids
+
+
+def _payload_of(p):
+    return p["payload"] if isinstance(p, dict) else getattr(p, "payload")
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+def test_dry_run_mutates_nothing():
+    pages = [[_fresh("a"), _stale_model("b"), _missing_vec("c")]]
+    client = FakeQdrant(pages)
+
+    called = {"n": 0}
+
+    def _boom_embed(texts):        # must NOT be called on a dry-run
+        called["n"] += 1
+        raise AssertionError("embed_fn called during dry-run")
+
+    r = R.reembed("hermes_memory", qdrant_client=client, embed_fn=_boom_embed,
+                  apply=False)
+
+    assert r["dry_run"] is True and r["applied"] is False
+    assert client.upserts == []            # wrote NOTHING
+    assert called["n"] == 0                 # GPU never touched
+    assert r["scanned"] == 3
+    assert r["missing_vector"] == 1
+    assert r["stale_meta"] == 1             # the wrong-model point
+    assert r["targeted"] == 2               # b + c would be re-embedded
+    assert r["reembedded"] == 0
+    assert r["degraded"] is False
+
+
+def test_apply_upserts_only_stale_and_missing():
+    pages = [[
+        _fresh("keep1"),
+        _stale_model("m"),
+        _stale_version("v"),
+        _missing_vec("x"),
+        _fresh("keep2"),
+    ]]
+    client = FakeQdrant(pages)
+
+    r = R.reembed("hermes_memory", qdrant_client=client, embed_fn=_stub_embed,
+                  apply=True, batch_size=64)
+
+    assert r["applied"] is True and r["dry_run"] is False
+    assert set(_upserted_ids(client)) == {"m", "v", "x"}   # fresh points untouched
+    assert r["targeted"] == 3
+    assert r["reembedded"] == 3
+    assert r["errors"] == []
+    # Re-embedded points get the current model/version stamped -> idempotent next run.
+    for batch in client.upserts:
+        for p in batch:
+            pl = _payload_of(p)
+            assert pl["embed_model"] == MODEL
+            assert pl["embed_version"] == VERSION
+
+
+def test_idempotent_second_run_targets_nothing():
+    # All points already fresh -> nothing targeted, nothing written.
+    pages = [[_fresh("a"), _fresh("b"), _fresh("c")]]
+    client = FakeQdrant(pages)
+    r = R.reembed("hermes_memory", qdrant_client=client, embed_fn=_stub_embed,
+                  apply=True)
+    assert r["targeted"] == 0 and r["reembedded"] == 0
+    assert client.upserts == []
+
+
+def test_batching_chunks_correctly():
+    # 10 stale points across 2 pages, batch_size 4 -> ceil(10/4) = 3 upsert calls.
+    n = 10
+    bs = 4
+    stale = [_stale_model(f"p{i}") for i in range(n)]
+    pages = [stale[:6], stale[6:]]         # paged
+    client = FakeQdrant(pages)
+
+    r = R.reembed("hermes_memory", qdrant_client=client, embed_fn=_stub_embed,
+                  apply=True, batch_size=bs, page_limit=6)
+
+    assert r["targeted"] == n and r["reembedded"] == n
+    assert len(client.upserts) == math.ceil(n / bs) == 3
+    sizes = [len(b) for b in client.upserts]
+    assert all(s <= bs for s in sizes)
+    assert sum(sizes) == n
+    assert sizes == [4, 4, 2]
+
+
+def test_fail_open_on_embed_error():
+    # First batch's embed raises; run must continue and upsert the rest, no exception.
+    stale = [_stale_model(f"p{i}") for i in range(6)]
+    pages = [stale]
+    client = FakeQdrant(pages)
+
+    calls = {"n": 0}
+
+    def _flaky_embed(texts):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("gpu hiccup")
+        return _stub_embed(texts)
+
+    r = R.reembed("hermes_memory", qdrant_client=client, embed_fn=_flaky_embed,
+                  apply=True, batch_size=3)
+
+    # 2 batches attempted; first failed (no upsert), second succeeded.
+    assert r["embed_batches"] == 2
+    assert len(client.upserts) == 1               # only the surviving batch
+    assert r["reembedded"] == 3
+    assert any("embed:" in e for e in r["errors"])
+    assert r["degraded"] is False                 # per-batch failure is NOT a hard degrade
+
+
+def test_fail_open_on_embed_count_mismatch():
+    stale = [_stale_model("a"), _stale_model("b")]
+    client = FakeQdrant([stale])
+
+    def _short_embed(texts):
+        return [[0.0, 1.0]]                        # wrong count (1 for 2 texts)
+
+    r = R.reembed("hermes_memory", qdrant_client=client, embed_fn=_short_embed,
+                  apply=True, batch_size=64)
+    assert client.upserts == []                   # nothing written on a bad batch
+    assert r["reembedded"] == 0
+    assert any("embed-count" in e for e in r["errors"])
+
+
+def test_scroll_error_is_fail_open_degraded():
+    class Boom(FakeQdrant):
+        def scroll(self, **kw):
+            raise RuntimeError("qdrant down")
+
+    r = R.reembed("hermes_memory", qdrant_client=Boom([]), embed_fn=_stub_embed,
+                  apply=True)
+    assert r["degraded"] is True
+    assert r["reembedded"] == 0
+    assert any("scroll:" in e for e in r["errors"])
+
+
+def test_named_vector_missing_detection():
+    # Named-vector collection: point missing the named vector is targeted.
+    p_ok = {"id": "ok", "payload": {"text": "x", "embed_model": MODEL,
+                                    "embed_version": VERSION},
+            "vector": {"dense": [0.1, 0.2]}}
+    p_missing = {"id": "miss", "payload": {"text": "y", "embed_model": MODEL,
+                                           "embed_version": VERSION},
+                 "vector": {"dense": None}}
+    client = FakeQdrant([[p_ok, p_missing]])
+    r = R.reembed("c", qdrant_client=client, embed_fn=_stub_embed, apply=False,
+                  vector_name="dense")
+    assert r["missing_vector"] == 1 and r["targeted"] == 1

--- a/mcp/tests/test_reranker.py
+++ b/mcp/tests/test_reranker.py
@@ -1,0 +1,83 @@
+"""Tests for reranker — the pluggable GPU reranking unit.
+
+Scores are stubbed via an injected model_fn; NO model is downloaded and no GPU/network
+is touched (mirrors test_embed_ops.py style + the [pattern:injectable] contract).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import reranker as R  # noqa: E402
+
+
+# A stub scorer: score = length of the doc string. Deterministic, no model.
+def _by_length(query, docs):
+    return [float(len(d)) for d in docs]
+
+
+def test_orders_by_score_desc():
+    docs = ["aa", "aaaa", "a", "aaa"]
+    r = R.rerank("q", docs, model_fn=_by_length)
+    # Highest length first.
+    assert [x["text"] for x in r] == ["aaaa", "aaa", "aa", "a"]
+    assert [x["index"] for x in r] == [1, 3, 0, 2]  # index into the INPUT list
+    assert r[0]["score"] == 4.0
+    assert all("degraded" not in x for x in r)
+
+
+def test_top_k_caps_results():
+    docs = ["a", "aaaa", "aa", "aaa"]
+    r = R.rerank("q", docs, top_k=2, model_fn=_by_length)
+    assert len(r) == 2
+    assert [x["text"] for x in r] == ["aaaa", "aaa"]
+
+
+def test_ties_keep_original_order():
+    docs = ["xx", "yy", "zz"]  # all length 2
+    r = R.rerank("q", docs, model_fn=_by_length)
+    assert [x["index"] for x in r] == [0, 1, 2]  # stable sort
+
+
+def test_fail_open_passthrough_when_unavailable(monkeypatch):
+    # No model_fn injected + force the real model to be unavailable -> original order, score=None.
+    monkeypatch.setattr(R, "_real_model_fn", lambda q, d: None)
+    docs = ["b", "cccc", "aa"]
+    r = R.rerank("q", docs)  # model_fn=None
+    assert [x["text"] for x in r] == ["b", "cccc", "aa"]  # unchanged
+    assert all(x["score"] is None for x in r)
+    assert all(x["degraded"] is True for x in r)
+
+
+def test_fail_open_respects_top_k():
+    r = R.rerank("q", ["a", "b", "c"], top_k=2, model_fn=lambda q, d: None)
+    assert len(r) == 2
+    assert all(x["score"] is None for x in r)
+    assert [x["text"] for x in r] == ["a", "b"]
+
+
+def test_fail_open_on_model_fn_raise():
+    def _boom(q, d):
+        raise RuntimeError("model exploded")
+    r = R.rerank("q", ["a", "bb"], model_fn=_boom)
+    assert [x["text"] for x in r] == ["a", "bb"]
+    assert all(x["score"] is None and x["degraded"] for x in r)
+
+
+def test_fail_open_on_wrong_length_scores():
+    # A scorer that returns the wrong number of scores is treated as unavailable.
+    r = R.rerank("q", ["a", "bb", "ccc"], model_fn=lambda q, d: [1.0])
+    assert [x["text"] for x in r] == ["a", "bb", "ccc"]
+    assert all(x["score"] is None for x in r)
+
+
+def test_empty_docs():
+    assert R.rerank("q", [], model_fn=_by_length) == []
+    assert R.rerank("q", []) == []
+
+
+def test_model_id_reads_env(monkeypatch):
+    monkeypatch.delenv("RERANK_MODEL", raising=False)
+    assert R._model_id() == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    monkeypatch.setenv("RERANK_MODEL", "BAAI/bge-reranker-v2-m3")
+    assert R._model_id() == "BAAI/bge-reranker-v2-m3"

--- a/scripts/gpu_placement.md
+++ b/scripts/gpu_placement.md
@@ -1,0 +1,132 @@
+# Dual-GPU placement for the Loci inference tiers
+
+> **This box is shared with the DAMA ant-trainer.** GPU placement is governed by ONE
+> authoritative policy — `dama-gotchi/training/GPU_PACKING_POLICY.md` — because it is a single
+> physical machine (WSL2 on `oxalis`). That policy assigns **GPU 0 = RTX 2080 Ti = ant-trainer
+> primary** and **GPU 1 = RTX 4070 Ti = persistent inference**. This doc EXTENDS it for the Loci
+> retrieval/generation tiers; it does not define a competing scheme. Where the two ever disagree,
+> the DAMA packing policy wins for the training GPU.
+
+## The hardware (session grounding)
+
+- **[hardware]** This box is WSL2 on the `oxalis` host.
+  - **RTX 4070 Ti** — visible to torch as `cuda:0` inside `mcp/.venv`
+    (`torch 2.12+cu130`, `cuda.is_available()=True`). Local compute.
+  - **RTX 2080 Ti (11 GB)** — the *second* GPU, exposed on the Windows/Ollama
+    side. Ollama is reached over the network at
+    `OLLAMA_BASE_URL=http://100.73.200.19:11434`.
+- **[rerank]** `mcp/server.py` already reranks on GPU: a lazy
+  `sentence_transformers.CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')`
+  (server.py ~588–601), loaded on **`cuda:0` (the 4070 Ti)**, used by
+  `rag_context_search`.
+- **[retrieval]** Qdrant is a **separate CPU-only k3s host** — no GPU there.
+  Embeddings are produced via **Ollama `nomic-embed-text` (768-dim)**, warm on GPU.
+- **[gen]** Local generation shipped: `mcp/llm_local.py` → **`qwen2.5:3b`**,
+  pinned via `keep_alive`.
+
+## The contention problem
+
+Two hot paths currently want GPU at the same time:
+
+1. **Retrieval-side, `cuda:0` / 4070 Ti** — the CrossEncoder reranker (torch, in-venv)
+   **and** whatever embedding calls resolve locally.
+2. **Generation-side, Ollama** — `qwen2.5:3b` gen + `nomic-embed-text` embeddings, both
+   served by the Ollama process (`100.73.200.19`).
+
+If a large / batched generation model and the interactive reranker land on the *same*
+GPU, a long gen occupies the SMs and VRAM and stalls rerank latency (and vice-versa).
+The goal of placement is to keep the **latency-sensitive retrieval tier** (embeddings +
+rerank) off the **throughput/heavy gen tier**.
+
+## Recommended layout (reconciled with the DAMA packing policy)
+
+| Tier | Workload | Target GPU | Priority rule |
+|------|----------|-----------|-----|
+| Training (bursty, DAMA) | `ant-trainer-*` k3s jobs | **2080 Ti (GPU 0)** | **owns this GPU** — highest priority per the packing policy |
+| Retrieval (latency-sensitive, Loci) | CrossEncoder rerank (torch) + warm Ollama embed/gen | **4070 Ti (`cuda:0`)** | already there; keep it there |
+| Generation (throughput / batched, Loci) | vLLM/TGI batched-gen server | **2080 Ti, opportunistic** | tenant only — **must yield to training**, never a persistent squatter |
+
+Rationale, corrected: rerank is a small model hit on the critical path of every
+`rag_context_search`; it stays on the 4070 Ti and must never queue behind a multi-second
+generation. A batched-gen server is heavier and *can* use the 2080 Ti's headroom — **but the
+2080 Ti is the ant-trainer's GPU**, so batched-gen runs there only opportunistically and
+preemptibly (telemetry-gated: don't launch/keep it resident while an `ant-trainer` job holds
+the card). Persistently squatting the 2080 Ti with a gen server — the earlier draft's plan —
+would collide with every training burst. When in doubt, batched-gen shares the 4070 Ti and
+accepts the contention rather than starving training.
+
+## Levers
+
+### torch side (the 4070 Ti reranker)
+- The reranker is pinned to `cuda:0` in code. To force the *whole venv process* onto a
+  specific physical GPU, launch it with `CUDA_VISIBLE_DEVICES` so `cuda:0` **is** the
+  4070 Ti:
+  ```bash
+  CUDA_VISIBLE_DEVICES=0 python -m mcp.server   # 4070 Ti only
+  ```
+  `CUDA_VISIBLE_DEVICES` remaps indices: the first listed device becomes `cuda:0`. Set it
+  at process launch (it is read once at CUDA init).
+  > Caveat: WSL2 ↔ Windows GPU enumeration ordering is not guaranteed to match
+  > `nvidia-smi` index order. **Verify** which physical card `cuda:0` is
+  > (`torch.cuda.get_device_name(0)`) before trusting the mapping — grounding only
+  > confirms the 4070 Ti is *currently* `cuda:0`, not that ordering is stable across hosts.
+
+### Ollama side (the gen / embed models)
+Ollama is a single server that schedules across the GPUs *it* can see. Relevant env vars,
+set **on the Ollama host** (`100.73.200.19`), not in this venv:
+
+- **`CUDA_VISIBLE_DEVICES`** — restrict which physical GPUs Ollama uses. To dedicate the
+  2080 Ti to a heavy/batched gen model, run that Ollama instance with
+  `CUDA_VISIBLE_DEVICES` pointing at just the 2080 Ti.
+- **`OLLAMA_SCHED_SPREAD=1`** — tells Ollama to **spread** a model across *all* visible
+  GPUs rather than packing onto one. Use it when you *want* a big model to shard across
+  both cards; **leave it unset (0)** when you want each model to stay pinned to one GPU so
+  gen and rerank/embeddings don't collide.
+- **`OLLAMA_MAX_LOADED_MODELS`** / **`OLLAMA_NUM_PARALLEL`** — cap concurrent resident
+  models / parallel requests so a batched gen server doesn't evict the warm
+  `nomic-embed-text`.
+- **`OLLAMA_KEEP_ALIVE`** (or per-request `keep_alive`, what `gpu_warm.py` sends) — keep
+  the hot models resident so a warm single-stream never re-eats the **~70s cold load**
+  (`mcp/llm_local.py` [substrate]).
+
+A clean split is **two Ollama endpoints**, each with its own
+`CUDA_VISIBLE_DEVICES`: one on the 4070 Ti for embeddings, one on the 2080 Ti for the
+heavy gen model. If you instead run a single Ollama over both cards, keep
+`OLLAMA_SCHED_SPREAD` **off** and rely on `keep_alive` pinning so the small
+embed/gen models stay put and the big model isn't forced to share.
+
+## Interaction with `gpu_warm.py`
+
+`scripts/gpu_warm.py` pins `qwen2.5:3b` and `nomic-embed-text` resident via
+`keep_alive=-1` and reports `/api/ps` residency. It pins **whatever GPU(s) the Ollama it
+talks to can see** — it does not itself choose a card. Placement is decided by the env
+vars above on the Ollama host; `gpu_warm.py` then keeps the chosen models warm so the cold
+load is paid once. Run the keeper (`--loop`) pointed at each Ollama endpoint you stand up.
+
+## Combined design philosophy (shared with the DAMA ant-trainer)
+
+The Loci GPU tiers and the DAMA training pipeline are the same box and should share one
+discipline, not two. The DAMA training system already codifies patterns the Loci offload
+tiers benefit from adopting:
+
+- **One telemetry-driven packing policy** — `GPU_PACKING_POLICY.md` places work by live
+  `nvidia-smi` headroom, not by hardcoded assumption. `gpu_warm.py` and any batched-gen
+  launcher should read GPU telemetry and **yield to training** rather than blindly pinning.
+- **Gated rollout for quality changes** — DAMA never ships a model to the fleet without
+  shadow-eval + an NIS canary. The reranker upgrade (`RERANK_MODEL` → `bge-reranker-v2-m3`)
+  is the retrieval analogue: it stays **default-OFF** until it's A/B'd on a held-out query
+  set. Same for `query_expand` (prove it lifts recall before wiring it into the live path).
+- **Fail-open, warm, cached** — the ant models degrade gracefully when a signal is missing;
+  the Loci tiers already mirror this (every op fail-open; models kept warm via `keep_alive`
+  / the cross-encoder singleton). Keep that symmetry.
+
+## What the grounding does NOT settle (do not assume)
+
+- Whether a **batched gen server** on the 2080 Ti actually exists yet — this doc proposes the
+  layout; grounding only states the 2080 Ti is *available* and is the ant-trainer's GPU, so
+  any gen server there must be preemptible w.r.t. training.
+- Whether the 2080 Ti's 11 GB fits your intended "larger gen model" — verify VRAM against
+  the specific model before committing.
+- Exact WSL2 GPU index ↔ physical card mapping stability (see the torch caveat above).
+- `OLLAMA_SCHED_SPREAD` / `CUDA_VISIBLE_DEVICES` semantics are Ollama/CUDA conventions, not
+  facts asserted by the session grounding — confirm against your installed Ollama version.

--- a/scripts/gpu_warm.py
+++ b/scripts/gpu_warm.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""GPU warm-keeper — pin the hot Ollama models resident so a warm single-stream
+never re-eats the ~70s cold load.
+
+Why this exists (session grounding):
+  - [gen] Local generation shipped on qwen2.5:3b (mcp/llm_local.py), pinned via keep_alive.
+  - [retrieval] Embeddings run via Ollama nomic-embed-text (768-dim), "warm on GPU".
+  - [substrate/llm_local] COLD-LOAD is ~70s; without keep_alive every call re-eats it.
+  - Ollama lives at OLLAMA_BASE_URL (fallback OLLAMA_URL) — same convention as
+    mcp/embed_ops.py and mcp/llm_local.py.
+
+What it does: issue a minimal /api/generate (qwen2.5:3b) and /api/embed (nomic-embed-text)
+call with keep_alive set to a long TTL (-1 = never unload, or a configurable duration),
+which forces Ollama to load + hold each model resident. Then report /api/ps residency and
+basic GPU state.
+
+Modes:
+  - one-shot (default): pin both models once, print residency + GPU state, exit.
+  - --loop: re-pin every N seconds forever (a lightweight keeper). With keep_alive=-1 a
+    re-pin is cheap (models already resident) but the loop also re-loads anything that was
+    evicted (e.g. another job grabbed VRAM), so it self-heals.
+
+Fail-open [pattern:fail-open]: an unreachable / erroring Ollama NEVER raises. One-shot
+prints a degraded note and exits 0; the loop logs the degraded tick and keeps going.
+
+Injectable [pattern:injectable]: `post_fn(url, json, timeout) -> obj-with-.json()/.raise_for_status()`
+defaults to None -> lazily resolved to `requests.post` at call time, so importing this
+module never hard-requires `requests` and tests stub the HTTP layer with NO live Ollama.
+
+Grounding is SILENT on: exact keep_alive TTL policy and re-pin interval — chosen here as
+keep_alive=-1 (indefinite) and a 240s default loop interval; both are configurable.
+Grounding is SILENT on a torch/nvidia-smi call being desired for GPU state, so GPU state is
+best-effort: Ollama /api/ps (authoritative for what Ollama holds) plus an optional
+nvidia-smi probe that is itself fail-open.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import Callable, Optional
+
+# Same base-URL convention as embed_ops.py / llm_local.py.
+_OLLAMA = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_URL") or ""
+
+# The two hot models to keep resident. [gen] qwen2.5:3b, [retrieval] nomic-embed-text.
+_GEN_MODEL = os.environ.get("WARM_GEN_MODEL", "qwen2.5:3b")
+_EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+
+# Generous timeout: a cold load is ~70s [substrate]; 120s covers cold-load + tiny gen.
+_TIMEOUT = float(os.environ.get("OLLAMA_WARM_TIMEOUT", "120"))
+
+# keep_alive: -1 = never unload. Configurable via env; accepts "-1", "30m", "2h", etc.
+_KEEP_ALIVE = os.environ.get("WARM_KEEP_ALIVE", "-1")
+
+# Default re-pin cadence for --loop (grounding silent; 240s is a light keeper).
+_DEFAULT_INTERVAL = float(os.environ.get("WARM_INTERVAL", "240"))
+
+
+def _resolve_post(post_fn: Optional[Callable]) -> Optional[Callable]:
+    """Lazily resolve the HTTP poster. Returns None if requests is unavailable
+    (fail-open: caller treats None as 'Ollama unreachable')."""
+    if post_fn is not None:
+        return post_fn
+    try:
+        import requests
+        return requests.post
+    except Exception:
+        return None
+
+
+def _coerce_keep_alive(value):
+    """keep_alive of "-1" should go to Ollama as the int -1 (indefinite). Duration
+    strings like "30m" pass through untouched."""
+    if value in ("-1", -1):
+        return -1
+    return value
+
+
+def pin_model(model: str, kind: str, keep_alive=_KEEP_ALIVE,
+              post_fn: Optional[Callable] = None) -> dict:
+    """Force one model resident via a minimal request with keep_alive set.
+
+    kind: "gen" -> /api/generate (empty-ish prompt, num_predict=0 so it only loads);
+          "embed" -> /api/embed (one tiny input).
+    Returns {model, kind, ok, keep_alive, error?}. Fail-open: never raises.
+    """
+    result = {"model": model, "kind": kind, "ok": False,
+              "keep_alive": _coerce_keep_alive(keep_alive)}
+    if not _OLLAMA:
+        result["error"] = "no OLLAMA_BASE_URL/OLLAMA_URL configured"
+        return result
+    post = _resolve_post(post_fn)
+    if post is None:
+        result["error"] = "requests unavailable"
+        return result
+
+    ka = _coerce_keep_alive(keep_alive)
+    if kind == "embed":
+        url = f"{_OLLAMA}/api/embed"
+        body = {"model": model, "input": "warm", "keep_alive": ka}
+    else:
+        url = f"{_OLLAMA}/api/generate"
+        # num_predict=0 -> load the model but emit no tokens; cheapest possible pin.
+        body = {"model": model, "prompt": "warm", "stream": False,
+                "keep_alive": ka, "options": {"num_predict": 0}}
+    try:
+        r = post(url, json=body, timeout=_TIMEOUT)
+        r.raise_for_status()
+        r.json()  # ensure a well-formed body; value itself is unused for a pin
+        result["ok"] = True
+    except Exception as e:  # fail-open [pattern:fail-open]
+        result["error"] = f"{type(e).__name__}: {e}"
+    return result
+
+
+def ollama_ps(post_fn: Optional[Callable] = None) -> dict:
+    """Query /api/ps for what Ollama currently holds resident. Fail-open.
+
+    Returns {ok, models:[{name, size_vram?, expires_at?}], error?}.
+    """
+    out = {"ok": False, "models": []}
+    if not _OLLAMA:
+        out["error"] = "no OLLAMA_BASE_URL/OLLAMA_URL configured"
+        return out
+    post = _resolve_post(post_fn)
+    if post is None:
+        out["error"] = "requests unavailable"
+        return out
+    # /api/ps is a GET in Ollama; we go through the injected poster for stub-ability and
+    # fall back to requests.get only for the real (non-stubbed) path.
+    try:
+        try:
+            import requests
+            r = requests.get(f"{_OLLAMA}/api/ps", timeout=min(_TIMEOUT, 15))
+        except Exception:
+            # If the real requests import fails but a stub poster was injected, use it.
+            r = post(f"{_OLLAMA}/api/ps", json=None, timeout=min(_TIMEOUT, 15))
+        r.raise_for_status()
+        data = r.json() or {}
+        models = []
+        for m in data.get("models", []) or []:
+            models.append({
+                "name": m.get("name") or m.get("model"),
+                "size_vram": m.get("size_vram"),
+                "expires_at": m.get("expires_at"),
+            })
+        out["ok"] = True
+        out["models"] = models
+    except Exception as e:
+        out["error"] = f"{type(e).__name__}: {e}"
+    return out
+
+
+def gpu_state() -> dict:
+    """Best-effort GPU state via nvidia-smi. Fail-open: returns {available:False} if
+    nvidia-smi is missing or errors. Grounding is silent on wanting a torch probe here,
+    so we keep this dependency-free and optional."""
+    out = {"available": False, "gpus": []}
+    exe = shutil.which("nvidia-smi")
+    if not exe:
+        out["note"] = "nvidia-smi not found"
+        return out
+    try:
+        q = ("--query-gpu=index,name,memory.used,memory.total,utilization.gpu"
+             " --format=csv,noheader,nounits")
+        p = subprocess.run([exe] + q.split(), capture_output=True, text=True, timeout=10)
+        if p.returncode != 0:
+            out["note"] = "nvidia-smi returned non-zero"
+            return out
+        for line in p.stdout.strip().splitlines():
+            parts = [x.strip() for x in line.split(",")]
+            if len(parts) >= 5:
+                out["gpus"].append({
+                    "index": parts[0], "name": parts[1],
+                    "mem_used_mib": parts[2], "mem_total_mib": parts[3],
+                    "util_pct": parts[4],
+                })
+        out["available"] = bool(out["gpus"])
+    except Exception as e:
+        out["note"] = f"{type(e).__name__}: {e}"
+    return out
+
+
+def warm_once(keep_alive=_KEEP_ALIVE, post_fn: Optional[Callable] = None,
+              include_gpu: bool = True) -> dict:
+    """Pin both hot models once and gather residency + GPU state.
+
+    Returns a well-formed report dict. degraded=True if either pin failed or Ollama is
+    unreachable. NEVER raises [pattern:fail-open].
+    """
+    pins = [
+        pin_model(_GEN_MODEL, "gen", keep_alive=keep_alive, post_fn=post_fn),
+        pin_model(_EMBED_MODEL, "embed", keep_alive=keep_alive, post_fn=post_fn),
+    ]
+    ps = ollama_ps(post_fn=post_fn)
+    degraded = (not all(p["ok"] for p in pins)) or (not ps["ok"])
+    report = {
+        "ts": time.time(),
+        "ollama": _OLLAMA or None,
+        "pins": pins,
+        "ps": ps,
+        "degraded": degraded,
+    }
+    if include_gpu:
+        report["gpu"] = gpu_state()
+    return report
+
+
+def _print_report(report: dict) -> None:
+    """Human-readable one-shot / per-tick summary to stdout."""
+    if report.get("degraded"):
+        bad = [f'{p["kind"]}:{p["model"]} ({p.get("error", "?")})'
+               for p in report["pins"] if not p["ok"]]
+        if not report["ps"]["ok"]:
+            bad.append(f'ps ({report["ps"].get("error", "?")})')
+        print(f"[gpu_warm] DEGRADED — Ollama at {report['ollama'] or '<unset>'} "
+              f"unreachable or partial: {'; '.join(bad) or 'see report'}")
+    else:
+        pinned = ", ".join(f'{p["model"]} (keep_alive={p["keep_alive"]})'
+                           for p in report["pins"])
+        print(f"[gpu_warm] pinned: {pinned}")
+    resident = report["ps"].get("models") or []
+    if resident:
+        print("[gpu_warm] /api/ps resident: " +
+              ", ".join(f'{m["name"]}' + (f' [{m["size_vram"]}B vram]'
+                        if m.get("size_vram") else "") for m in resident))
+    elif report["ps"]["ok"]:
+        print("[gpu_warm] /api/ps resident: (none)")
+    gpu = report.get("gpu") or {}
+    if gpu.get("available"):
+        for g in gpu["gpus"]:
+            print(f"[gpu_warm] GPU{g['index']} {g['name']}: "
+                  f"{g['mem_used_mib']}/{g['mem_total_mib']} MiB, util {g['util_pct']}%")
+    elif gpu.get("note"):
+        print(f"[gpu_warm] GPU state: {gpu['note']}")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Keep hot Ollama models warm on GPU.")
+    ap.add_argument("--loop", action="store_true",
+                    help="re-pin forever (lightweight keeper) instead of one-shot")
+    ap.add_argument("--interval", type=float, default=_DEFAULT_INTERVAL,
+                    help=f"seconds between re-pins in --loop mode (default {_DEFAULT_INTERVAL})")
+    ap.add_argument("--keep-alive", default=_KEEP_ALIVE,
+                    help='keep_alive TTL sent to Ollama: "-1" (indefinite) or "30m","2h"')
+    ap.add_argument("--json", action="store_true", help="emit the raw report as JSON")
+    ap.add_argument("--no-gpu", action="store_true", help="skip the nvidia-smi probe")
+    args = ap.parse_args(argv)
+
+    def _tick():
+        report = warm_once(keep_alive=args.keep_alive, include_gpu=not args.no_gpu)
+        if args.json:
+            print(json.dumps(report))
+        else:
+            _print_report(report)
+        return report
+
+    if not args.loop:
+        _tick()
+        return 0  # always exit 0 — fail-open [pattern:fail-open]
+
+    print(f"[gpu_warm] keeper up: re-pinning every {args.interval:.0f}s "
+          f"(keep_alive={args.keep_alive}). Ctrl-C to stop.")
+    try:
+        while True:
+            _tick()
+            time.sleep(max(1.0, args.interval))
+    except KeyboardInterrupt:
+        print("[gpu_warm] keeper stopped.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reembed_daemon.md
+++ b/scripts/reembed_daemon.md
@@ -1,0 +1,77 @@
+# reembed_daemon — GPU batch re-embed / index refresh (SAFE, dry-run default)
+
+Incremental, idempotent batch job that (re)embeds Qdrant point vectors on the local GPU
+via the Ollama nomic path. Use it after an embed model/version change, or to backfill
+points that are missing a vector.
+
+## Safety model (read first)
+
+- **Default is DRY-RUN.** Without `--apply` the job only *scans* and reports how many
+  points *would* be re-embedded. It writes nothing and does not even call the GPU.
+- **`--apply` is the only mutating path.** There is no destructive default.
+- **Fail-open, per batch.** An embed or upsert error (or a Qdrant hiccup) is logged and
+  the run continues; it never raises. A total scan failure returns `degraded:true` and
+  exit code 1 without having written anything.
+
+## What counts as "stale" (incremental targeting)
+
+A point is targeted only if:
+- it has **no vector** (missing / backfill), OR
+- its payload `embed_model` differs from the current target, OR
+- its payload `embed_version` differs from the current target.
+
+On re-embed we stamp `embed_model` + `embed_version` into the payload, so a second run
+targets nothing — **safe to re-run**.
+
+## Usage
+
+```bash
+# 1) dry-run: how many points WOULD be re-embedded? (writes nothing)
+python3 scripts/reembed_daemon.py --collection hermes_memory
+
+# 2) apply: actually re-embed the stale/missing points
+python3 scripts/reembed_daemon.py --collection hermes_memory --apply
+
+# named-vector collection, custom batch, new version marker
+python3 scripts/reembed_daemon.py --collection agent_core_chunks \
+    --vector-name dense --batch-size 128 --embed-version 2 --apply
+```
+
+Always run the dry-run first, eyeball `targeted`, then re-run with `--apply`.
+
+## Config (env)
+
+| var | purpose | default |
+|-----|---------|---------|
+| `QDRANT_URL` | Qdrant endpoint (separate k3s host, CPU) | — (required) |
+| `QDRANT_API_KEY` | Qdrant key; falls back to `~/.claude/settings.json` `mcpServers.hermes_memory.env` | "" |
+| `OLLAMA_BASE_URL` / `OLLAMA_URL` | Ollama for the warm-GPU nomic embed path | — |
+| `EMBED_MODEL` | current embed model tag | `nomic-embed-text` |
+| `EMBED_VERSION` | current embed version marker | `1` |
+
+The embed step reuses `mcp/embed_ops.py::embed_texts` (768-dim nomic, warm on GPU). The
+GPU work here is **embedding, not generation**.
+
+## Report fields
+
+`scanned`, `missing_vector`, `stale_meta`, `targeted` (what dry-run counts), `reembedded`
+(what apply actually wrote), `embed_batches` / `upserted_batches`, `errors[]`, `degraded`.
+
+## Flags
+
+`--collection` (required) · `--apply` · `--batch-size` (default 64) ·
+`--page-limit` (default 256) · `--embed-model` · `--embed-version` · `--vector-name`.
+
+## Notes / caveats
+
+- Source text is read from the first present payload field of:
+  `document, text, content, summary, title`. A targeted point with no text in payload is
+  skipped and noted in `errors` (nothing to embed).
+- `qdrant_client` and `embed_fn` are **injectable** (both default `None` → lazy-resolve
+  from env), so `import reembed_daemon` hard-requires nothing and tests stub both.
+- **Grounding gap:** the exact payload key names (`embed_model`, `embed_version`) and the
+  document text field are conventions chosen here, not verified against the live
+  hermes_memory / agent_core_chunks schema. Confirm the real payload keys before
+  `--apply` on production data, and override `--vector-name` if those collections use
+  named vectors. Central integration wires this into the server later.
+```

--- a/scripts/reembed_daemon.py
+++ b/scripts/reembed_daemon.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""reembed_daemon.py — SAFE, incremental GPU batch re-embed / index refresh for Qdrant.
+
+Re-embeds (or backfills) the dense vectors of Qdrant points on the local GPU via the
+Ollama nomic embedding path, for model/version changes or for points that are simply
+missing a vector. This is the batch counterpart to the online embed tier.
+
+Substrate this is built against (session grounding — verify against live code):
+  - [retrieval] Qdrant is a SEPARATE k3s host (CPU, no GPU); collections include
+    hermes_memory + agent_core_chunks (~1.84M points). It stores the vectors; we only
+    read/rewrite them. QDRANT_URL / QDRANT_API_KEY come from env (same convention as
+    scripts/qdrant_payload_indexes.py and scripts/mnemosyne_qdrant_sync.py).
+  - [gen]/[rerank note] The GPU work here is EMBEDDING, not generation. Embeddings come
+    from Ollama nomic-embed-text (768-dim), warm on GPU (OLLAMA_BASE_URL). We reuse the
+    exact embed path from mcp/embed_ops.py (embed_texts) as the default embed_fn.
+  - [pattern:fail-open] Every batch fails open: an embed or upsert error is logged and we
+    CONTINUE to the next batch; we never raise out of the run. Mirrors embed_ops/llm_local.
+  - [pattern:injectable] qdrant_client and embed_fn are injected (default None -> lazy
+    resolve from env), so importing this module hard-requires nothing and tests stub both.
+
+SAFETY (critical):
+  - DEFAULT IS DRY-RUN. Without --apply we SCAN the collection, decide which points are
+    stale/missing, and REPORT the count — writing NOTHING and not even calling the GPU.
+  - --apply is the only way to mutate. There is no destructive default anywhere.
+
+Incremental / idempotent:
+  - A point is targeted only if it is MISSING a vector, or its payload embed_model /
+    embed_version differs from the current target. Freshly re-embedded points get those
+    payload fields stamped, so a second run targets nothing. Safe to re-run.
+
+Usage:
+    # dry-run: report how many points WOULD be re-embedded, write nothing
+    python3 scripts/reembed_daemon.py --collection hermes_memory
+    # actually re-embed the stale/missing points
+    python3 scripts/reembed_daemon.py --collection hermes_memory --apply
+
+Env:
+    QDRANT_URL, QDRANT_API_KEY   — Qdrant endpoint (key falls back to ~/.claude settings)
+    OLLAMA_BASE_URL / OLLAMA_URL — Ollama for the nomic embed path (via embed_ops)
+    EMBED_MODEL                  — current embed model tag (default nomic-embed-text)
+    EMBED_VERSION                — current embed version marker (default "1")
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any, Callable, Optional
+
+# Current embedding target — a point whose payload disagrees with EITHER of these
+# (or has no vector at all) is considered stale and gets re-embedded.
+_EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+_EMBED_VERSION = os.environ.get("EMBED_VERSION", "1")
+
+# Payload keys we stamp on re-embed and compare against for staleness.
+_MODEL_KEY = "embed_model"
+_VERSION_KEY = "embed_version"
+
+# Candidate payload fields to pull the source text from, in priority order.
+_TEXT_KEYS = ("document", "text", "content", "summary", "title")
+
+
+# ── injectable resolvers (lazy; importing this module requires nothing) ──────────
+
+def _resolve_qdrant():
+    """Build a QdrantClient from env. Only called when no client was injected."""
+    from qdrant_client import QdrantClient  # lazy: not needed for import or tests
+    url = os.environ.get("QDRANT_URL")
+    key = os.environ.get("QDRANT_API_KEY", "")
+    if not key:
+        try:
+            import json
+            home = os.path.expanduser("~")
+            cfg = json.load(open(os.path.join(home, ".claude", "settings.json")))
+            key = cfg["mcpServers"]["hermes_memory"]["env"]["QDRANT_API_KEY"]
+        except Exception:
+            key = ""
+    if not url:
+        raise RuntimeError("QDRANT_URL is not set")
+    return QdrantClient(url=url, api_key=key or None)
+
+
+def _resolve_embed_fn() -> Callable[[list[str]], list[list[float]]]:
+    """Default embed function — the warm-GPU nomic path from mcp/embed_ops.py [gen]."""
+    # Add mcp/ to the path so we reuse the exact online embed implementation.
+    here = os.path.dirname(os.path.abspath(__file__))
+    mcp_dir = os.path.join(os.path.dirname(here), "mcp")
+    if mcp_dir not in sys.path:
+        sys.path.insert(0, mcp_dir)
+    import embed_ops  # noqa: E402
+    return embed_ops.embed_texts
+
+
+# ── small structure helpers (points may be objects or plain dicts) ──────────────
+
+def _attr(point: Any, name: str, default=None):
+    if isinstance(point, dict):
+        return point.get(name, default)
+    return getattr(point, name, default)
+
+
+def _point_text(payload: Optional[dict], text_keys) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    for k in text_keys:
+        v = payload.get(k)
+        if v:
+            return v if isinstance(v, str) else str(v)
+    return ""
+
+
+def _has_vector(point: Any, vector_name: Optional[str]) -> bool:
+    vec = _attr(point, "vector")
+    if vector_name:
+        return isinstance(vec, dict) and bool(vec.get(vector_name))
+    if isinstance(vec, dict):
+        # a named-vector point where we didn't ask for a specific name
+        return any(bool(v) for v in vec.values())
+    return bool(vec)
+
+
+def _is_stale(point: Any, vector_name: Optional[str],
+              embed_model: str, embed_version: str) -> bool:
+    """A point is stale if it has no vector, or its stamped model/version differs."""
+    if not _has_vector(point, vector_name):
+        return True
+    payload = _attr(point, "payload") or {}
+    if not isinstance(payload, dict):
+        return True
+    if payload.get(_MODEL_KEY) != embed_model:
+        return True
+    if payload.get(_VERSION_KEY) != embed_version:
+        return True
+    return False
+
+
+def _chunks(seq: list, size: int):
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+def _make_point(pid, vector, payload: dict, vector_name: Optional[str]):
+    """Build an upsert point. Prefer qdrant's PointStruct; fall back to a dict."""
+    vec_payload = {vector_name: vector} if vector_name else vector
+    try:
+        from qdrant_client.models import PointStruct  # lazy
+        return PointStruct(id=pid, vector=vec_payload, payload=payload)
+    except Exception:
+        return {"id": pid, "vector": vec_payload, "payload": payload}
+
+
+# ── core ────────────────────────────────────────────────────────────────────────
+
+def reembed(collection: str,
+            *,
+            qdrant_client=None,
+            embed_fn: Optional[Callable[[list[str]], list[list[float]]]] = None,
+            apply: bool = False,
+            batch_size: int = 64,
+            page_limit: int = 256,
+            embed_model: str = _EMBED_MODEL,
+            embed_version: str = _EMBED_VERSION,
+            vector_name: Optional[str] = None,
+            text_keys=_TEXT_KEYS,
+            logger: Optional[Callable[[str], None]] = None) -> dict:
+    """Scan `collection` and (only with apply=True) re-embed stale/missing points.
+
+    Injected deps (both default None -> lazily resolved from env [pattern:injectable]):
+      qdrant_client : object with .scroll(...) -> (points, next_offset) and .upsert(...).
+      embed_fn      : list[str] -> list[list[float]] (fail-open: [] on failure).
+
+    Returns a report dict (never raises [pattern:fail-open]):
+      {applied, dry_run, collection, scanned, missing_vector, stale_meta, targeted,
+       reembedded, upserted_batches, embed_batches, errors:[...], degraded}
+    `reembedded` is what was actually written (0 on dry-run). On dry-run, `targeted` is
+    the count that WOULD be re-embedded and nothing (not even the GPU) is touched.
+    """
+    log = logger or (lambda m: print(m, file=sys.stderr))
+    report = {
+        "applied": bool(apply),
+        "dry_run": not apply,
+        "collection": collection,
+        "scanned": 0,
+        "missing_vector": 0,
+        "stale_meta": 0,
+        "targeted": 0,        # points that qualify for re-embed (dry-run stops here)
+        "reembedded": 0,      # points actually re-embedded + upserted (apply only)
+        "embed_batches": 0,
+        "upserted_batches": 0,
+        "errors": [],
+        "degraded": False,
+        "embed_model": embed_model,
+        "embed_version": embed_version,
+    }
+
+    # Resolve injected deps lazily. Failure to resolve = fail-open degraded report.
+    try:
+        client = qdrant_client if qdrant_client is not None else _resolve_qdrant()
+    except Exception as e:
+        report["degraded"] = True
+        report["errors"].append(f"qdrant-resolve: {e}")
+        log(f"[reembed] cannot resolve qdrant client, aborting: {e}")
+        return report
+    ef = embed_fn if embed_fn is not None else None  # resolve only if we actually embed
+
+    # A buffer of (point_id, text, base_payload) awaiting a flush at batch_size.
+    pending: list[tuple] = []
+
+    def _flush(batch: list[tuple]) -> None:
+        """Embed + upsert one batch. Fail-open: log and return on any error."""
+        if not batch:
+            return
+        nonlocal ef
+        report["embed_batches"] += 1
+        texts = [t for (_pid, t, _pl) in batch]
+        try:
+            if ef is None:
+                ef = embed_fn if embed_fn is not None else _resolve_embed_fn()
+            vecs = ef(texts)
+        except Exception as e:
+            report["errors"].append(f"embed: {e}")
+            log(f"[reembed] embed error on batch of {len(batch)}, skipping: {e}")
+            return
+        if not vecs or len(vecs) != len(batch):
+            report["errors"].append(
+                f"embed-count: got {len(vecs) if vecs else 0} for {len(batch)}")
+            log(f"[reembed] embed returned {len(vecs) if vecs else 0} vectors for "
+                f"{len(batch)} texts, skipping batch (fail-open)")
+            return
+        points = []
+        for (pid, _t, base_payload), vec in zip(batch, vecs):
+            payload = dict(base_payload or {})
+            payload[_MODEL_KEY] = embed_model
+            payload[_VERSION_KEY] = embed_version
+            points.append(_make_point(pid, vec, payload, vector_name))
+        try:
+            client.upsert(collection_name=collection, points=points)
+        except Exception as e:
+            report["errors"].append(f"upsert: {e}")
+            log(f"[reembed] upsert error on batch of {len(points)}, skipping: {e}")
+            return
+        report["upserted_batches"] += 1
+        report["reembedded"] += len(points)
+
+    # ── scroll the whole collection, paging ───────────────────────────────────
+    offset = None
+    while True:
+        try:
+            points, offset = client.scroll(
+                collection_name=collection,
+                limit=page_limit,
+                offset=offset,
+                with_payload=True,
+                with_vectors=True,
+            )
+        except Exception as e:
+            report["degraded"] = True
+            report["errors"].append(f"scroll: {e}")
+            log(f"[reembed] scroll error, stopping scan (fail-open): {e}")
+            break
+
+        for point in (points or []):
+            report["scanned"] += 1
+            missing = not _has_vector(point, vector_name)
+            stale = _is_stale(point, vector_name, embed_model, embed_version)
+            if missing:
+                report["missing_vector"] += 1
+            elif stale:
+                report["stale_meta"] += 1
+            if not stale:
+                continue
+            report["targeted"] += 1
+            if not apply:
+                continue  # DRY-RUN: count only, never buffer/embed/write
+            payload = _attr(point, "payload") or {}
+            text = _point_text(payload, text_keys)
+            if not text:
+                # nothing to embed for this point; note and skip (fail-open)
+                report["errors"].append(f"no-text: {_attr(point, 'id')}")
+                continue
+            pending.append((_attr(point, "id"), text, payload))
+            if len(pending) >= batch_size:
+                _flush(pending)
+                pending = []
+
+        if not offset or not points:
+            break
+
+    if apply and pending:
+        _flush(pending)
+        pending = []
+
+    verb = "would re-embed" if not apply else "re-embedded"
+    log(f"[reembed] {collection}: scanned={report['scanned']} "
+        f"missing={report['missing_vector']} stale_meta={report['stale_meta']} "
+        f"targeted={report['targeted']} {verb}={report['reembedded'] if apply else report['targeted']} "
+        f"errors={len(report['errors'])} dry_run={report['dry_run']}")
+    return report
+
+
+def _parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--collection", required=True, help="Qdrant collection to scan")
+    p.add_argument("--apply", action="store_true",
+                   help="MUTATE: actually re-embed + upsert (default is dry-run)")
+    p.add_argument("--batch-size", type=int, default=64,
+                   help="embed/upsert batch size (default 64, GPU-efficient)")
+    p.add_argument("--page-limit", type=int, default=256,
+                   help="scroll page size (default 256)")
+    p.add_argument("--embed-model", default=_EMBED_MODEL)
+    p.add_argument("--embed-version", default=_EMBED_VERSION)
+    p.add_argument("--vector-name", default=None,
+                   help="named vector to target (default: unnamed/default vector)")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if not args.apply:
+        print("[reembed] DRY-RUN (default): scanning only, nothing will be written. "
+              "Pass --apply to mutate.", file=sys.stderr)
+    report = reembed(
+        args.collection,
+        apply=args.apply,
+        batch_size=args.batch_size,
+        page_limit=args.page_limit,
+        embed_model=args.embed_model,
+        embed_version=args.embed_version,
+        vector_name=args.vector_name,
+    )
+    import json
+    print(json.dumps(report, indent=2, default=str))
+    # Non-zero exit only on a hard degrade (couldn't scan at all), never on skipped batches.
+    return 1 if report.get("degraded") else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vllm_serve.md
+++ b/scripts/vllm_serve.md
@@ -1,0 +1,124 @@
+# Deploying vLLM on oxalis's RTX 2080 Ti — batched OpenAI-compatible generation
+
+This is the concrete deploy plan for the primary path of `mcp/batched_gen.py`. It stands up a
+vLLM OpenAI-compatible server on oxalis's **second** GPU so high-concurrency workflow fan-out
+gets true continuous batching instead of Ollama's serialized one-request-at-a-time behavior.
+
+> Status: **plan, not yet executed.** `batched_gen.generate_batch` degrades to the sequential
+> Ollama tier (`mcp/llm_local.generate`) until `VLLM_BASE_URL` points at a running server.
+
+## Why a 2nd server at all
+
+Grounding recap:
+- `[hardware]` oxalis has two GPUs: the **RTX 4070 Ti** (torch `cuda:0` inside `mcp/.venv`) and a
+  **RTX 2080 Ti, 11 GB** on the Windows/Ollama side (`OLLAMA_BASE_URL=http://100.73.200.19:11434`).
+- `[rerank]` the 4070 Ti is already committed to the CrossEncoder reranker in `server.py`.
+- `[gen]` the current local-generation tier is Ollama `qwen2.5:3b`, pinned warm via `keep_alive`.
+
+Ollama serves requests essentially serially. When a workflow fans out N planning/research
+agents (or runs a per-item map/gate over dozens of short prompts), that serialization is the
+bottleneck. vLLM's **continuous batching** interleaves many in-flight sequences on one GPU, so
+throughput scales with concurrency instead of collapsing to it.
+
+Putting vLLM on the **2080 Ti** keeps it off the 4070 Ti reranker and off Ollama's queue —
+the two generation tiers run on different GPUs and don't contend.
+
+## Pick a model that fits 11 GB
+
+The 2080 Ti has 11 GB and no bf16 tensor cores, so **use fp16** and a small instruct model.
+`Qwen2.5-3B-Instruct` is the natural match — same family as the Ollama `qwen2.5:3b` tier, so the
+fallback path stays behaviorally consistent. In fp16, 3B weights are ~6 GB, leaving room for the
+KV cache. If VRAM is tight, `--max-model-len` (below) is the main knob; a 1.5B model is the
+smaller fallback.
+
+## Docker command (recommended)
+
+Run on the host that owns the 2080 Ti. If that GPU is index `1` on the Windows/WSL box, pin it
+explicitly so vLLM never grabs the 4070 Ti.
+
+```bash
+docker run --rm --name vllm-qwen \
+  --gpus '"device=1"' \                       # pin the 2080 Ti; verify index with nvidia-smi
+  -p 8000:8000 \
+  -e HF_TOKEN="$HF_TOKEN" \                    # only if the model repo requires auth
+  -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
+  vllm/vllm-openai:latest \
+  --model Qwen/Qwen2.5-3B-Instruct \
+  --served-model-name Qwen2.5-3B-Instruct \   # this is the `model` field clients send
+  --dtype float16 \                           # 2080 Ti has no bf16; force fp16
+  --gpu-memory-utilization 0.90 \             # fraction of the 11 GB vLLM may claim
+  --max-model-len 8192 \                      # cap context to bound KV-cache VRAM
+  --port 8000
+```
+
+Notes:
+- `--gpu-memory-utilization 0.90` tells vLLM to pre-reserve ~90% of the 11 GB for weights +
+  KV cache. Lower it (e.g. `0.85`) if anything else shares the card; raise cautiously.
+- `--served-model-name Qwen2.5-3B-Instruct` MUST match what clients put in the request `model`
+  field. `batched_gen` defaults to exactly this string (`VLLM_MODEL`, default
+  `"Qwen2.5-3B-Instruct"`), so leaving both at the default "just works".
+- `--max-model-len` bounds the KV cache; if vLLM logs "No available memory for the cache",
+  lower it or lower `--gpu-memory-utilization`.
+
+### TGI alternative
+
+`batched_gen` posts OpenAI-style `/v1/completions`, which HuggingFace **TGI** also serves
+(`ghcr.io/huggingface/text-generation-inference`, message/completions routes). vLLM is the
+default here because its OpenAI surface and continuous batching are the closest fit; TGI is a
+drop-in if preferred. Either way, point `VLLM_BASE_URL` at its base (no `/v1` suffix).
+
+## Wire it up
+
+`batched_gen` treats `VLLM_BASE_URL` as the sole on/off switch: **unset → Ollama fallback; set →
+try batched first, fall back on failure.** Set the base URL (host + port, no `/v1`):
+
+```bash
+# Same box as the MCP server:
+export VLLM_BASE_URL="http://localhost:8000"
+
+# Reaching the Windows/WSL GPU host over tailscale (mirrors OLLAMA_BASE_URL's host):
+export VLLM_BASE_URL="http://100.73.200.19:8000"
+
+# Optional overrides (defaults shown):
+export VLLM_MODEL="Qwen2.5-3B-Instruct"   # must equal --served-model-name
+export VLLM_TIMEOUT="120"                 # seconds
+```
+
+`batched_gen` appends `/v1/completions` itself — pass only the base.
+
+## Smoke test (no client code)
+
+```bash
+curl -s "$VLLM_BASE_URL/v1/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen2.5-3B-Instruct","prompt":"ping","max_tokens":8}' | jq .
+```
+
+A JSON body with `choices[0].text` means the primary path is live and
+`generate_batch` will stop falling back to Ollama.
+
+## When vLLM beats Ollama (and when it doesn't)
+
+**Use vLLM (batched path) when:**
+- A workflow fans out **many concurrent short generations** — per-agent prompts, map/gate/
+  classify over a list, N-way planning. Continuous batching is the whole point; this is the
+  win the module exists for.
+- You want stable throughput under bursty concurrency instead of a serialized Ollama queue.
+
+**Stick with Ollama (fallback) when:**
+- **Low concurrency / single prompts** — one-off `llm_local.generate` calls. Ollama's warm
+  `keep_alive` model has no batching overhead and no second server to babysit.
+- The 2080 Ti is busy or the model won't fit — the fallback keeps generation working.
+- You need a model already pulled in Ollama and don't want to manage a HF download.
+
+Because the fallback is automatic and fail-open (`[pattern:fail-open]`), you can deploy vLLM for
+the throughput win and lose nothing if it's down: `generate_batch` silently reverts to the
+sequential Ollama tier, one prompt at a time.
+
+## Open items grounding is silent on
+- Exact GPU **device index** of the 2080 Ti on the WSL/Windows host — verify with `nvidia-smi`
+  before pinning `--gpus`.
+- Whether the 2080 Ti is reachable to the vLLM container under WSL2 GPU passthrough, or whether
+  vLLM must run on the Windows side and be exposed over the tailscale IP.
+- Real measured tokens/s and max concurrency on this specific card — benchmark before relying on
+  it for latency-sensitive paths.


### PR DESCRIPTION
Integrates the four parallel-built GPU pieces and reconciles their design with the DAMA ant-trainer's philosophy — **one physical box, one policy**.

## Retrieval
- **`reranker.py`** — pluggable cross-encoder via `RERANK_MODEL`. `server.py._get_cross_encoder` now **delegates** to it: default `ms-marco-MiniLM-L-6-v2` = unchanged behavior; **`BAAI/bge-reranker-v2-m3` opt-in**. Removed the now-dead `_cross_encoder` globals. Flipping to bge is a retrieval-quality change **gated behind a shadow-eval/A-B**, mirroring DAMA's shadow-eval + canary discipline.

## Generation
- **`batched_gen.py`** — fixed the defect the adversarial verifier caught: the primary path issued per-prompt requests in a **blocking loop**, so vLLM continuous batching (the whole point) never engaged. Now dispatches **concurrently via a thread pool** (order-preserving, per-prompt isolation). Ollama fallback unchanged. MCP tool `generate_batch`.

## Placement — the "combine philosophy" ask
- **`gpu_placement.md`** reconciled with `dama-gotchi/training/GPU_PACKING_POLICY.md`: the **2080 Ti is the ant-trainer's GPU**, so a batched-gen server there is an *opportunistic tenant that yields to training*, not a persistent squatter (corrects the earlier draft, which would have collided with every training burst). Added a **combined-philosophy** section: telemetry-driven packing, gated rollout, fail-open/warm — the same discipline the training pipeline uses.

## Ops tools
- `reembed_daemon.py` (safe **dry-run default**) + `gpu_warm.py` (keep-alive pinning) land standalone.

## Tests
reranker (9), batched_gen (11), reembed_daemon (8), gpu_warm — all stubbed. **Full suite: 357 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45