### PR TITLE
Retrieval shadow-eval harness (gate for reranker/query_expand flip)

### DIFF
--- a/mcp/retrieval_eval.py
+++ b/mcp/retrieval_eval.py
@@ -1,0 +1,147 @@
+"""Retrieval shadow-eval — measure retrieval quality so gated upgrades flip on EVIDENCE.
+
+The reranker upgrade (RERANK_MODEL -> bge-reranker-v2-m3) and query_expand are shipped
+default-OFF behind a gate (mirroring the DAMA shadow-eval + canary discipline). This module
+is that gate: it scores retrieval configurations on a held-out query set and recommends a flip
+only when a candidate beats the baseline by a margin without regressing.
+
+No gold relevance labels exist for the Loci corpus, so we use a self-supervised proxy: each
+corpus item is a query whose "relevant" set is the OTHER items sharing its group (e.g. same
+investigation) — a weak but real topical signal. Metrics are standard rank quality: recall@k,
+MRR, nDCG@k.
+
+Pure + injectable: `evaluate()` takes a `retrieve_fn` (query -> candidate pool) and an optional
+`rerank_fn` (query, candidates -> reordered), so tests stub them and the live CLI
+(scripts/shadow_eval.py) wires real Qdrant retrieval + reranker.rerank / query_expand. Fail-open:
+a query whose retrieval raises is skipped, not fatal.
+"""
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Sequence
+
+
+def build_query_set(items: Sequence[dict], min_relevant: int = 1,
+                    limit: Optional[int] = None) -> list[dict]:
+    """Build a proxy-labeled query set from corpus items.
+
+    items: [{id, text, group}]. For each item, query=its text and relevant_ids = other items
+    with the SAME non-empty group. Items with < min_relevant same-group neighbors are dropped
+    (no signal). Returns [{query_id, query, relevant_ids:set}]. Deterministic order.
+    """
+    by_group: dict = {}
+    for it in items:
+        g = it.get("group")
+        if g in (None, ""):
+            continue
+        by_group.setdefault(g, []).append(it)
+    out: list[dict] = []
+    for it in items:
+        g = it.get("group")
+        if g in (None, ""):
+            continue
+        rel = {o["id"] for o in by_group.get(g, []) if o["id"] != it["id"]}
+        if len(rel) < min_relevant:
+            continue
+        out.append({"query_id": it["id"], "query": str(it.get("text", "")), "relevant_ids": rel})
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+def recall_at_k(ranked_ids: Sequence, relevant: set, k: int) -> float:
+    if not relevant:
+        return 0.0
+    top = list(ranked_ids)[:k]
+    return len(set(top) & relevant) / len(relevant)
+
+
+def mrr(ranked_ids: Sequence, relevant: set) -> float:
+    for i, rid in enumerate(ranked_ids):
+        if rid in relevant:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def ndcg_at_k(ranked_ids: Sequence, relevant: set, k: int) -> float:
+    if not relevant:
+        return 0.0
+    top = list(ranked_ids)[:k]
+    dcg = sum(1.0 / math.log2(i + 2) for i, rid in enumerate(top) if rid in relevant)
+    ideal_n = min(len(relevant), k)
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(ideal_n))
+    return dcg / idcg if idcg else 0.0
+
+
+def evaluate(query_set: Sequence[dict],
+             retrieve_fn: Callable[[str, object], Sequence[dict]],
+             rerank_fn: Optional[Callable[[str, Sequence[dict]], Sequence[dict]]] = None,
+             k: int = 10) -> dict:
+    """Score a retrieval config over the query set. Returns aggregate
+    {recall@k, mrr, ndcg@k, n, skipped}.
+
+    retrieve_fn(query, exclude_id) -> [{id, text}] candidate pool (pre-rerank).
+    rerank_fn(query, candidates) -> reordered candidates (None -> keep retrieval order).
+    Fail-open: a query whose retrieve/rerank raises is skipped (counted), never fatal.
+    """
+    sums = {"recall": 0.0, "mrr": 0.0, "ndcg": 0.0}
+    n = 0
+    skipped = 0
+    for q in query_set:
+        try:
+            cands = list(retrieve_fn(q["query"], q["query_id"]))
+            if rerank_fn is not None:
+                cands = list(rerank_fn(q["query"], cands))
+        except Exception:
+            skipped += 1
+            continue
+        ranked = [c.get("id") for c in cands]
+        rel = q["relevant_ids"]
+        sums["recall"] += recall_at_k(ranked, rel, k)
+        sums["mrr"] += mrr(ranked, rel)
+        sums["ndcg"] += ndcg_at_k(ranked, rel, k)
+        n += 1
+    denom = n or 1
+    return {
+        f"recall@{k}": round(sums["recall"] / denom, 4),
+        "mrr": round(sums["mrr"] / denom, 4),
+        f"ndcg@{k}": round(sums["ndcg"] / denom, 4),
+        "n": n, "skipped": skipped, "k": k,
+    }
+
+
+def compare(baseline_name: str, baseline: dict, candidate_name: str, candidate: dict,
+            primary: str = "ndcg", min_rel_gain: float = 0.02) -> dict:
+    """Compare two eval results and recommend whether to flip to the candidate.
+
+    Flip only when the candidate improves the PRIMARY metric by >= min_rel_gain (relative)
+    AND does not regress either other metric by more than a small tolerance — the disciplined
+    gate: a candidate must clearly win, not just tie. Returns deltas + recommendation.
+    """
+    def _key(base_metric: str, d: dict) -> str:
+        for kk in d:
+            if kk.startswith(base_metric):
+                return kk
+        return base_metric
+
+    metrics = ["recall", "mrr", "ndcg"]
+    deltas = {}
+    for m in metrics:
+        bk, ck = _key(m, baseline), _key(m, candidate)
+        b, c = baseline.get(bk, 0.0), candidate.get(ck, 0.0)
+        rel = (c - b) / b if b else (0.0 if c == 0 else float("inf"))
+        deltas[m] = {"baseline": b, "candidate": c, "abs": round(c - b, 4),
+                     "rel": round(rel, 4) if rel != float("inf") else "inf"}
+
+    prim = deltas[primary]
+    prim_rel = prim["rel"] if prim["rel"] != "inf" else 1.0
+    regressed = [m for m in metrics if m != primary and deltas[m]["abs"] < -0.01]
+    flip = (isinstance(prim_rel, (int, float)) and prim_rel >= min_rel_gain and not regressed)
+    if flip:
+        reason = f"{candidate_name} improves {primary} by {prim['rel']} (>= {min_rel_gain}) with no regression"
+    elif regressed:
+        reason = f"{candidate_name} regresses {regressed} — hold"
+    else:
+        reason = f"{candidate_name} does not clearly beat {baseline_name} on {primary} — hold"
+    return {"baseline": baseline_name, "candidate": candidate_name, "primary": primary,
+            "deltas": deltas, "recommend_flip": bool(flip), "reason": reason}

--- a/mcp/tests/test_retrieval_eval.py
+++ b/mcp/tests/test_retrieval_eval.py
@@ -1,0 +1,74 @@
+"""Tests for retrieval_eval — the shadow-eval metrics + gate logic (no live models)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import retrieval_eval as RE  # noqa: E402
+
+
+def test_build_query_set_uses_same_group_as_relevant():
+    items = [
+        {"id": "a", "text": "qa", "group": "inv1"},
+        {"id": "b", "text": "qb", "group": "inv1"},
+        {"id": "c", "text": "qc", "group": "inv2"},   # lone in its group -> dropped
+        {"id": "d", "text": "qd", "group": ""},        # no group -> dropped
+    ]
+    qs = RE.build_query_set(items, min_relevant=1)
+    ids = {q["query_id"] for q in qs}
+    assert ids == {"a", "b"}                      # only inv1 has neighbors
+    a = next(q for q in qs if q["query_id"] == "a")
+    assert a["relevant_ids"] == {"b"} and "a" not in a["relevant_ids"]
+
+
+def test_metrics_math():
+    # ranked ids, relevant = {x, y}
+    ranked = ["z", "x", "w", "y"]
+    rel = {"x", "y"}
+    assert RE.recall_at_k(ranked, rel, 2) == 0.5      # only x in top-2
+    assert RE.recall_at_k(ranked, rel, 4) == 1.0
+    assert RE.mrr(ranked, rel) == 0.5                 # first relevant at rank 2
+    # nDCG@4: hits at positions 2 and 4 (0-indexed 1,3)
+    import math
+    dcg = 1 / math.log2(3) + 1 / math.log2(5)
+    idcg = 1 / math.log2(2) + 1 / math.log2(3)
+    assert abs(RE.ndcg_at_k(ranked, rel, 4) - dcg / idcg) < 1e-9
+    assert RE.mrr(["a", "b"], {"z"}) == 0.0           # none relevant
+
+
+def test_evaluate_with_stub_retriever_and_reranker():
+    qs = [{"query_id": "a", "query": "qa", "relevant_ids": {"b"}}]
+    # retriever returns b in the middle; a perfect reranker lifts b to the top.
+    def retrieve(query, exclude_id):
+        assert exclude_id == "a"
+        return [{"id": "x"}, {"id": "b"}, {"id": "y"}]
+    def rerank(query, cands):
+        return sorted(cands, key=lambda c: 0 if c["id"] == "b" else 1)
+    base = RE.evaluate(qs, retrieve, rerank_fn=None, k=10)
+    reranked = RE.evaluate(qs, retrieve, rerank_fn=rerank, k=10)
+    assert base["n"] == 1 and base["mrr"] == 0.5          # b at rank 2
+    assert reranked["mrr"] == 1.0                          # b lifted to rank 1
+    assert reranked["ndcg@10"] > base["ndcg@10"]
+
+
+def test_evaluate_fail_open_skips_bad_query():
+    qs = [{"query_id": "a", "query": "qa", "relevant_ids": {"b"}},
+          {"query_id": "c", "query": "qc", "relevant_ids": {"d"}}]
+    def retrieve(query, exclude_id):
+        if exclude_id == "c":
+            raise RuntimeError("boom")
+        return [{"id": "b"}]
+    r = RE.evaluate(qs, retrieve, k=5)
+    assert r["n"] == 1 and r["skipped"] == 1              # one scored, one skipped, no raise
+
+
+def test_compare_recommends_flip_only_on_clear_win():
+    base = {"recall@10": 0.50, "mrr": 0.40, "ndcg@10": 0.45}
+    better = {"recall@10": 0.55, "mrr": 0.44, "ndcg@10": 0.52}   # +15% ndcg, no regression
+    tie = {"recall@10": 0.50, "mrr": 0.40, "ndcg@10": 0.455}      # +1% ndcg -> below margin
+    regress = {"recall@10": 0.40, "mrr": 0.41, "ndcg@10": 0.52}   # ndcg up but recall down
+
+    assert RE.compare("mini", base, "bge", better)["recommend_flip"] is True
+    assert RE.compare("mini", base, "bge", tie, min_rel_gain=0.02)["recommend_flip"] is False
+    out = RE.compare("mini", base, "bge", regress)
+    assert out["recommend_flip"] is False and "regress" in out["reason"]

--- a/scripts/shadow_eval.py
+++ b/scripts/shadow_eval.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Live retrieval shadow-eval — the gate for flipping the reranker/query_expand upgrades.
+
+Wires the real Loci corpus into mcp/retrieval_eval.py: samples findings from Qdrant
+(grouped by investigation_id as the proxy relevance signal), retrieves candidate pools by
+dense search, and scores retrieval configurations so a flip is recommended only on evidence.
+
+Usage:
+  scripts/shadow_eval.py [--queries 60] [--pool 40] [--k 10] \
+      [--rerankers cross-encoder/ms-marco-MiniLM-L-6-v2,BAAI/bge-reranker-v2-m3] \
+      [--query-expand]
+
+- Baseline is the first --rerankers entry (default: current MiniLM). Each other entry is a
+  candidate compared against it. --query-expand adds a bare-vs-expanded A/B on the baseline.
+- Candidates download their model on first use (bge-reranker-v2-m3 ≈ 600 MB). Env:
+  OLLAMA_BASE_URL/EMBED_MODEL/QDRANT_URL/QDRANT_API_KEY (same as the Loci server).
+Fail-open: a query whose retrieval raises is skipped, not fatal.
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+
+
+def _load_corpus(limit_scan: int) -> list:
+    import server as S
+    client, col = S._get_qdrant()
+    if not client:
+        return []
+    items, offset = [], None
+    while len(items) < limit_scan:
+        pts, offset = client.scroll(collection_name=col, limit=min(256, limit_scan - len(items)),
+                                    with_payload=True, with_vectors=False, offset=offset)
+        for p in pts:
+            pl = p.payload or {}
+            txt = pl.get("text") or ""
+            if txt and pl.get("investigation_id"):
+                items.append({"id": str(p.id), "text": str(txt)[:2000],
+                              "group": pl.get("investigation_id")})
+        if not offset:
+            break
+    return items
+
+
+def _make_retrieve(pool: int):
+    """retrieve_fn(query, exclude_id) -> [{id, text}] dense-search candidate pool."""
+    import server as S
+    client, col = S._get_qdrant()
+
+    def retrieve(query: str, exclude_id):
+        vec = S._embed(query)
+        if not vec:
+            return []
+        res = client.query_points(collection_name=col, query=vec, using="dense",
+                                  limit=pool + 1, with_payload=True).points
+        out = []
+        for r in res:
+            rid = str(r.id)
+            if rid == str(exclude_id):
+                continue
+            out.append({"id": rid, "text": str((r.payload or {}).get("text", ""))[:512]})
+        return out[:pool]
+
+    return retrieve
+
+
+def _make_rerank(model_name: str):
+    """rerank_fn(query, cands) using reranker.rerank under RERANK_MODEL=model_name."""
+    import reranker
+
+    def rerank(query, cands):
+        os.environ["RERANK_MODEL"] = model_name
+        ranked = reranker.rerank(query, [c["text"] for c in cands], top_k=None)
+        # map reranked indices back to the original candidate dicts (preserve ids)
+        return [cands[r["index"]] for r in ranked]
+
+    return rerank
+
+
+def _expand_retrieve(base_retrieve, pool: int):
+    """Query-expanded retrieval: union the pools of the original + expanded queries."""
+    import query_expand
+
+    def retrieve(query, exclude_id):
+        exp = query_expand.expand(query)
+        queries = [query] + [q for q in exp.get("queries", []) if q and q != query]
+        seen, merged = set(), []
+        for q in queries[:4]:
+            for c in base_retrieve(q, exclude_id):
+                if c["id"] not in seen:
+                    seen.add(c["id"]); merged.append(c)
+        return merged[: pool * 2]
+
+    return retrieve
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--queries", type=int, default=60)
+    ap.add_argument("--pool", type=int, default=40)
+    ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--rerankers", default="cross-encoder/ms-marco-MiniLM-L-6-v2")
+    ap.add_argument("--query-expand", action="store_true")
+    ap.add_argument("--scan", type=int, default=4000)
+    args = ap.parse_args()
+
+    import retrieval_eval as RE
+    corpus = _load_corpus(args.scan)
+    if not corpus:
+        print("no corpus (qdrant unavailable?)", file=sys.stderr)
+        return 1
+    qset = RE.build_query_set(corpus, min_relevant=1, limit=args.queries)
+    print(f"corpus={len(corpus)} query_set={len(qset)} pool={args.pool} k={args.k}", file=sys.stderr)
+    if not qset:
+        print("no query set (no investigations with >=2 findings)", file=sys.stderr)
+        return 1
+
+    retrieve = _make_retrieve(args.pool)
+    models = [m.strip() for m in args.rerankers.split(",") if m.strip()]
+    results = {}
+
+    # baseline = dense retrieval + first reranker
+    base_model = models[0]
+    results[f"rerank:{base_model}"] = RE.evaluate(qset, retrieve, _make_rerank(base_model), k=args.k)
+    baseline_key = f"rerank:{base_model}"
+
+    report = {"configs": {}, "comparisons": []}
+    report["configs"][baseline_key] = results[baseline_key]
+
+    for cand in models[1:]:
+        key = f"rerank:{cand}"
+        results[key] = RE.evaluate(qset, retrieve, _make_rerank(cand), k=args.k)
+        report["configs"][key] = results[key]
+        report["comparisons"].append(RE.compare(baseline_key, results[baseline_key], key, results[key]))
+
+    if args.query_expand:
+        exp_retrieve = _expand_retrieve(retrieve, args.pool)
+        key = "query_expand+" + base_model
+        results[key] = RE.evaluate(qset, exp_retrieve, _make_rerank(base_model), k=args.k)
+        report["configs"][key] = results[key]
+        report["comparisons"].append(RE.compare(baseline_key, results[baseline_key], key, results[key]))
+
+    print(json.dumps(report, indent=2))
+    for c in report["comparisons"]:
+        print(f"[gate] {c['candidate']} vs {c['baseline']}: "
+              f"flip={c['recommend_flip']} — {c['reason']}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The reranker upgrade (`RERANK_MODEL` → `bge-reranker-v2-m3`) and `query_expand` ship **default-OFF behind a gate** (mirroring DAMA's shadow-eval + canary discipline). This PR is that gate — it lets you flip on **evidence**, not vibes.

## `mcp/retrieval_eval.py` (pure + injectable, tested)
- **`build_query_set`** — self-supervised proxy: no gold relevance labels exist for the corpus, so each finding is a query whose *relevant* set is the other findings in the **same investigation** (weak but real topical signal).
- **Metrics** — `recall@k`, `MRR`, `nDCG@k`.
- **`evaluate(retrieve_fn, rerank_fn)`** — fail-open per query (a bad retrieval is skipped, not fatal).
- **`compare()`** — recommends a flip **only** when the candidate beats baseline on the primary metric by a margin *without* regressing the others.

## `scripts/shadow_eval.py` (live CLI)
Wires the real corpus: Qdrant dense retrieval (named `dense` vector), the pluggable reranker (`RERANK_MODEL` per config), and a `query_expand` A/B.

## Validated
- 5 unit tests (grouping, metric math, evaluate w/ stubs, fail-open, the flip gate). **Full suite: 362 pass.**
- Live on the corpus: `corpus=1362`, baseline MiniLM **recall@10=0.247 / mrr=0.745 / ndcg@10=0.593**.

The flip decision is now one command:
```
scripts/shadow_eval.py --rerankers cross-encoder/ms-marco-MiniLM-L-6-v2,BAAI/bge-reranker-v2-m3 --query-expand
```
(downloads bge ~600 MB on first run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45