### PR TITLE
Close the quality loop: flip bge reranker + wire query_expand (judge-eval evidence)

### DIFF
--- a/.claude/workflows/judge-eval.js
+++ b/.claude/workflows/judge-eval.js
@@ -1,0 +1,34 @@
+export const meta = {
+  name: 'judge-eval',
+  description: 'Judge-based relevance grading — one strict agent per query grades its candidate pool',
+  whenToUse: 'Step 2 of the judge-based A/B retrieval eval. args = {file, query_ids, show}. Each agent reads its own query+pool from disk (no huge inline payload) and returns relevant ids -> {grades: {query_id: [relevant_ids]}}.',
+  phases: [{ title: 'Judge', detail: 'one relevance-judge agent per query, in parallel' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const FILE = A.file || ''
+const SHOW = A.show || ''
+const IDS = Array.isArray(A.query_ids) ? A.query_ids : []
+if (!FILE || !SHOW || !IDS.length) { log('need file + show + query_ids'); return { grades: {} } }
+
+phase('Judge')
+const results = await parallel(IDS.map((qid) => () =>
+  agent(
+    'You are a STRICT retrieval-relevance judge. First load your query and its candidate documents by running:\n'
+    + '  python3 ' + SHOW + ' ' + FILE + ' ' + qid + '\n'
+    + 'It prints QUERY then each candidate as [id] followed by its text. Decide which documents are '
+    + 'genuinely RELEVANT to the query — ones the person issuing this query would actually want. Judge '
+    + 'topical/semantic relevance, NOT mere keyword overlap; be strict; exclude a near-verbatim restatement '
+    + 'of the query itself if present. Return ONLY the relevant document ids.',
+    { label: 'judge:' + String(qid).slice(0, 8), phase: 'Judge', effort: 'low',
+      schema: { type: 'object', required: ['relevant'],
+        properties: { relevant: { type: 'array', items: { type: 'string' } } } } })
+    .then((r) => ({ id: qid, relevant: (r && Array.isArray(r.relevant)) ? r.relevant : [] }))
+    .catch(() => ({ id: qid, relevant: [] })),
+))
+
+const grades = {}
+let total = 0
+for (const r of results.filter(Boolean)) { grades[r.id] = r.relevant; total += r.relevant.length }
+log('judged ' + Object.keys(grades).length + ' queries, ' + total + ' relevant marks')
+return { grades }

--- a/mcp/backends.py
+++ b/mcp/backends.py
@@ -108,8 +108,11 @@ def vllm_model() -> str:
 
 
 def rerank_model() -> str:
+    # Default flipped MiniLM -> bge on judge-eval evidence (+14% nDCG@10, no regression;
+    # see scripts/judge_eval.py). bge is heavier (~600MB, slower/query); constrained hosts
+    # pin the lighter model back via RERANK_MODEL / [rerank].model in the gitignored config.
     return os.environ.get("RERANK_MODEL") or _cfg(
-        "rerank", "model", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+        "rerank", "model", "BAAI/bge-reranker-v2-m3")
 
 
 def qdrant() -> tuple[str, str]:

--- a/mcp/reranker.py
+++ b/mcp/reranker.py
@@ -5,11 +5,12 @@ This factors the cross-encoder reranking that currently lives inline in server.p
 importable primitive. server.py should delegate to `rerank()` here instead of
 carrying its own CrossEncoder singleton.
 
-Two backends, chosen by env RERANK_MODEL:
-  - 'cross-encoder/ms-marco-MiniLM-L-6-v2'  (DEFAULT — reproduces current server.py
-    behavior exactly [rerank]: the 22M-param ms-marco MiniLM cross-encoder.)
-  - 'BAAI/bge-reranker-v2-m3'               (opt-in — a stronger reranker that lifts
-    retrieval precision [rerank]; heavier, multilingual.)
+Two backends, chosen by env RERANK_MODEL (default resolved via backends.rerank_model()):
+  - 'BAAI/bge-reranker-v2-m3'               (DEFAULT — a stronger reranker that lifts
+    retrieval precision [rerank]; heavier (~600MB), multilingual. Flipped in on
+    judge-eval evidence: +14% nDCG@10, no regression. See scripts/judge_eval.py.)
+  - 'cross-encoder/ms-marco-MiniLM-L-6-v2'  (opt-in — the lighter 22M-param ms-marco
+    MiniLM cross-encoder; pin it back on constrained hosts via RERANK_MODEL.)
 Any other value is passed through verbatim to CrossEncoder, so operators can point at
 an arbitrary sentence-transformers cross-encoder without a code change.
 
@@ -49,8 +50,9 @@ from typing import Callable, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
-# Default backend reproduces current server.py behavior [rerank].
-_DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+# Ultimate fallback if `backends` can't be imported. Flipped to bge on judge-eval
+# evidence (+14% nDCG@10); pin MiniLM back via RERANK_MODEL on constrained hosts.
+_DEFAULT_MODEL = "BAAI/bge-reranker-v2-m3"
 
 # Module-global model cache, mirroring server.py's `_cross_encoder` singleton [rerank]:
 #   None  -> not yet attempted (lazy)

--- a/mcp/retrieval_eval.py
+++ b/mcp/retrieval_eval.py
@@ -110,6 +110,37 @@ def evaluate(query_set: Sequence[dict],
     }
 
 
+def score_configs(rankings_by_config: dict, relevant: set, k: int) -> dict:
+    """Per-query: score each config's ranking against a JUDGE-supplied relevant set — the
+    real-relevance path that replaces the same-investigation proxy. rankings_by_config maps a
+    config name to its ranked [doc_id, ...]. Returns {config -> {recall, mrr, ndcg}} (raw)."""
+    out = {}
+    for cfg, ranked in (rankings_by_config or {}).items():
+        rel = set(relevant or ())
+        out[cfg] = {"recall": recall_at_k(ranked, rel, k), "mrr": mrr(ranked, rel),
+                    "ndcg": ndcg_at_k(ranked, rel, k)}
+    return out
+
+
+def aggregate(per_query_scores: list, k: int) -> dict:
+    """Mean each config's metrics across queries. Input is the list of score_configs() dicts.
+    Returns {config -> {recall@k, mrr, ndcg@k, n, k}} — the shape compare() consumes. Queries
+    with an empty judge-relevant set contribute 0s (a config can't recall what has no relevant)."""
+    agg, counts = {}, {}
+    for pq in per_query_scores or ():
+        for cfg, m in (pq or {}).items():
+            a = agg.setdefault(cfg, {"recall": 0.0, "mrr": 0.0, "ndcg": 0.0})
+            for kk in ("recall", "mrr", "ndcg"):
+                a[kk] += m.get(kk, 0.0)
+            counts[cfg] = counts.get(cfg, 0) + 1
+    out = {}
+    for cfg, a in agg.items():
+        n = counts[cfg] or 1
+        out[cfg] = {f"recall@{k}": round(a["recall"] / n, 4), "mrr": round(a["mrr"] / n, 4),
+                    f"ndcg@{k}": round(a["ndcg"] / n, 4), "n": counts[cfg], "k": k}
+    return out
+
+
 def compare(baseline_name: str, baseline: dict, candidate_name: str, candidate: dict,
             primary: str = "ndcg", min_rel_gain: float = 0.02) -> dict:
     """Compare two eval results and recommend whether to flip to the candidate.

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -7078,6 +7078,7 @@ def rag_context_search(
     budget_chars: int = 6000,
     exclude_types: Optional[list] = None,
     decay: bool = True,
+    expand_query: Optional[bool] = None,
 ) -> str:
     """
     Hybrid RAG search over Qdrant corpus. Returns prompt-ready context with cited sources.
@@ -7097,6 +7098,11 @@ def rag_context_search(
         decay: If True (default), apply Ebbinghaus exponential time-decay rescoring to
                findings from the main investigation collection before ranking.
                Set False to disable decay and use raw similarity scores.
+        expand_query: Fan retrieval out over LLM-generated query paraphrases + keywords
+               (query_expand) before the cross-encoder re-pass, lifting recall. None
+               (default) reads env LOCI_RAG_EXPAND (default ON); True/False force it.
+               Fail-open: if the local generator is unavailable, falls back to the bare
+               query with no error. Gated on judge-eval evidence: +4% nDCG@10, no regression.
 
     Returns:
         JSON with {query, context, sources, total_chars, truncated, result_count, mode,
@@ -7124,6 +7130,33 @@ def rag_context_search(
 
     all_results: list[dict] = []
     errors: list[str] = []
+    expansion_info: Optional[dict] = None
+
+    # Optional query expansion: fan retrieval out over LLM paraphrases + keywords for recall.
+    # Gate: expand_query arg wins; else env LOCI_RAG_EXPAND (default ON). Fail-open — if the
+    # generator is down, `expand` returns just the original query, so retrieval is unaffected.
+    _do_expand = expand_query
+    if _do_expand is None:
+        _do_expand = os.environ.get("LOCI_RAG_EXPAND", "1").strip().lower() not in ("0", "false", "no", "off", "")
+    search_queries = [query]
+    if _do_expand:
+        try:
+            import query_expand as _qe
+            _exp = _qe.expand(query, n_queries=3, n_keywords=6)
+            # `queries` already leads with the original; append keywords as one extra recall probe.
+            _sq = list(_exp.get("queries") or [query])
+            _kw = _exp.get("keywords") or []
+            if _kw:
+                _sq.append(" ".join(_kw))
+            # De-dup search strings, preserving order (original stays first).
+            _seen_q: set = set()
+            search_queries = [q for q in _sq if q and not (q in _seen_q or _seen_q.add(q))] or [query]
+            expansion_info = {"enabled": True, "degraded": bool(_exp.get("degraded")),
+                              "n_queries": len(search_queries), "keywords": _kw}
+        except Exception as _exp_exc:
+            logger.debug("rag_context_search: query expansion failed (fail-open): %s", _exp_exc)
+            search_queries = [query]
+            expansion_info = {"enabled": True, "degraded": True, "error": str(_exp_exc)}
 
     # Build the GPS-exclusion filter for agent_core_chunks (only).
     _agent_filter = None
@@ -7131,14 +7164,25 @@ def rag_context_search(
         from qdrant_client.models import Filter, FieldCondition, MatchAny
         _agent_filter = Filter(must_not=[FieldCondition(key="type", match=MatchAny(any=exclude_types))])
 
+    # Retrieve per (collection x expanded query), unioning hits deduped by (origin, id) keeping
+    # the best bi-encoder score. The cross-encoder re-pass below re-ranks against the ORIGINAL
+    # query, so expansion only widens the candidate pool (recall) without diluting precision.
+    _best: dict = {}
     for col in _collections:
-        try:
-            qf = _agent_filter if col == "agent_core_chunks" else None
-            hits = _qdrant_search_collection(query, collection_name=col, limit=limit, query_filter=qf)
-            all_results.extend(hits)
-        except Exception as exc:
-            errors.append(f"{col}: {exc}")
-            logger.warning("rag_context_search: collection %s failed: %s", col, exc)
+        qf = _agent_filter if col == "agent_core_chunks" else None
+        for _sq in search_queries:
+            try:
+                hits = _qdrant_search_collection(_sq, collection_name=col, limit=limit, query_filter=qf)
+            except Exception as exc:
+                errors.append(f"{col}: {exc}")
+                logger.warning("rag_context_search: collection %s failed: %s", col, exc)
+                continue
+            for h in hits:
+                key = (h.get("origin"), h.get("id"))
+                prev = _best.get(key)
+                if prev is None or float(h.get("score") or 0.0) > float(prev.get("score") or 0.0):
+                    _best[key] = h
+    all_results.extend(_best.values())
 
     # Apply Ebbinghaus exponential time-decay rescoring to findings from the main
     # investigation collection only (agent_core_chunks is static knowledge, not time-sensitive).
@@ -7211,6 +7255,8 @@ def rag_context_search(
     ctx["mode"] = "rag_hybrid"
     ctx["collections_searched"] = _collections
     ctx["qdrant_available"] = True
+    if expansion_info is not None:
+        ctx["query_expansion"] = expansion_info
     if errors:
         ctx["collection_errors"] = errors
     return json.dumps(ctx, indent=2)

--- a/mcp/tests/test_reranker.py
+++ b/mcp/tests/test_reranker.py
@@ -76,8 +76,14 @@ def test_empty_docs():
     assert R.rerank("q", []) == []
 
 
-def test_model_id_reads_env(monkeypatch):
+def test_model_id_reads_env(monkeypatch, tmp_path):
+    # Isolate from any real gitignored ~/.loci/backends.toml so we test the CODE default.
     monkeypatch.delenv("RERANK_MODEL", raising=False)
-    assert R._model_id() == "cross-encoder/ms-marco-MiniLM-L-6-v2"
-    monkeypatch.setenv("RERANK_MODEL", "BAAI/bge-reranker-v2-m3")
+    monkeypatch.setenv("LOCI_CONFIG", str(tmp_path / "no-such.toml"))
+    import backends as B
+    B._reset_cache()
+    # Default flipped to bge on judge-eval evidence (+14% nDCG@10).
     assert R._model_id() == "BAAI/bge-reranker-v2-m3"
+    monkeypatch.setenv("RERANK_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+    assert R._model_id() == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    B._reset_cache()

--- a/mcp/tests/test_retrieval_eval.py
+++ b/mcp/tests/test_retrieval_eval.py
@@ -62,6 +62,24 @@ def test_evaluate_fail_open_skips_bad_query():
     assert r["n"] == 1 and r["skipped"] == 1              # one scored, one skipped, no raise
 
 
+def test_score_configs_and_aggregate():
+    # two queries, judge-relevant sets; two configs with different rankings.
+    q1 = RE.score_configs({"a": ["x", "y", "z"], "b": ["z", "y", "x"]}, {"x"}, k=3)
+    assert q1["a"]["mrr"] == 1.0 and q1["b"]["mrr"] == 1 / 3     # 'a' ranks the relevant doc first
+    q2 = RE.score_configs({"a": ["p", "q"], "b": ["q", "p"]}, {"q"}, k=3)
+    agg = RE.aggregate([q1, q2], k=3)
+    assert agg["a"]["n"] == 2 and agg["b"]["n"] == 2
+    assert agg["a"]["mrr"] > agg["b"]["mrr"]                     # 'a' wins on average
+    # aggregate output feeds compare() unchanged
+    out = RE.compare("a", agg["a"], "b", agg["b"])
+    assert out["recommend_flip"] is False                        # b does not beat a
+
+
+def test_score_configs_empty_relevant():
+    s = RE.score_configs({"a": ["x", "y"]}, set(), k=3)
+    assert s["a"] == {"recall": 0.0, "mrr": 0.0, "ndcg": 0.0}    # nothing relevant -> all 0
+
+
 def test_compare_recommends_flip_only_on_clear_win():
     base = {"recall@10": 0.50, "mrr": 0.40, "ndcg@10": 0.45}
     better = {"recall@10": 0.55, "mrr": 0.44, "ndcg@10": 0.52}   # +15% ndcg, no regression

--- a/scripts/judge_eval.py
+++ b/scripts/judge_eval.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Judge-based A/B retrieval eval — Claude as the relevance oracle on real queries.
+
+Replaces shadow_eval's weak same-investigation proxy with real relevance judged by Claude, so
+a reranker/query_expand flip is earned on actual relevance. Three steps:
+
+  1. prep : sample queries, retrieve + rank with each config, emit the per-query pools to judge
+       scripts/judge_eval.py --prep --out judge_prep.json [--queries 40 --pool 24 --k 10 --rerankers a,b --query-expand]
+  2. judge: a workflow fans out one judge agent per query -> {query_id: [relevant_doc_ids]}
+       (see .claude/workflows/judge-eval.js; run it on judge_prep.json -> judge_grades.json)
+  3. score: real recall@k / MRR / nDCG@k per config vs the judge grades + the flip gate
+       scripts/judge_eval.py --score judge_prep.json judge_grades.json
+
+Reuses shadow_eval's live retrieval/rerank helpers. Env: OLLAMA_BASE_URL/EMBED_MODEL/QDRANT_*.
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def _prep(args) -> int:
+    import retrieval_eval as RE
+    import shadow_eval as SE
+    corpus = SE._load_corpus(args.scan)
+    if not corpus:
+        print("no corpus (qdrant unavailable?)", file=sys.stderr)
+        return 1
+    by_id = {c["id"]: c for c in corpus}
+    # Query set: sample corpus items whose text is a real, non-trivial query.
+    qs = [c for c in corpus if len(c.get("text", "")) > 40][: args.queries]
+    retrieve = SE._make_retrieve(args.pool)
+    models = [m.strip() for m in args.rerankers.split(",") if m.strip()]
+    exp_retrieve = SE._expand_retrieve(retrieve, args.pool) if args.query_expand else None
+
+    # 1. Retrieve the candidate pools per query FIRST (no rerank model -> no cache thrash).
+    base_pool, exp_pool = {}, {}
+    for c in qs:
+        try:
+            base_pool[c["id"]] = retrieve(c["text"], c["id"])
+            if exp_retrieve is not None:
+                exp_pool[c["id"]] = exp_retrieve(c["text"], c["id"])
+        except Exception as exc:
+            print(f"skip retrieve {c['id']}: {exc}", file=sys.stderr)
+
+    # 2. Rank CONFIG-MAJOR: load each reranker ONCE, rank every query's pool with it. Avoids
+    # reloading the 600MB bge model per query (the thrash bug that made this hang).
+    rankings: dict = {c["id"]: {} for c in qs if c["id"] in base_pool}
+    for m in models:
+        rr = SE._make_rerank(m)
+        for c in qs:
+            if c["id"] not in base_pool:
+                continue
+            ranked = rr(c["text"], base_pool[c["id"]])
+            rankings[c["id"]][f"rerank:{m}"] = [r["id"] for r in ranked][: args.k]
+    if exp_retrieve is not None:
+        rr = SE._make_rerank(models[0])
+        for c in qs:
+            if c["id"] not in exp_pool:
+                continue
+            ranked = rr(c["text"], exp_pool[c["id"]])
+            rankings[c["id"]]["query_expand+" + models[0]] = [r["id"] for r in ranked][: args.k]
+
+    # 3. Assemble each query's union pool (docs any config ranked in top-k) for the judge.
+    out_queries = []
+    for c in qs:
+        rk = rankings.get(c["id"])
+        if not rk:
+            continue
+        pool_ids: set = set()
+        for ids in rk.values():
+            pool_ids.update(ids)
+        pool = [{"id": pid, "text": str(by_id.get(pid, {}).get("text", ""))[:500]}
+                for pid in pool_ids if pid in by_id]
+        out_queries.append({"id": c["id"], "query": c["text"][:800], "pool": pool, "rankings": rk})
+
+    report = {"k": args.k, "baseline": f"rerank:{models[0]}", "queries": out_queries}
+    with open(args.out, "w") as f:
+        json.dump(report, f)
+    print(f"prepped {len(out_queries)} queries, {sum(len(x['pool']) for x in out_queries)} pool docs "
+          f"-> {args.out}", file=sys.stderr)
+    return 0
+
+
+def _score(prep_path: str, grades_path: str) -> int:
+    import retrieval_eval as RE
+    prep = json.load(open(prep_path))
+    grades = json.load(open(grades_path))  # {query_id: [relevant_doc_ids]}
+    k = prep["k"]
+    baseline = prep["baseline"]
+    per_query = []
+    graded = 0
+    for q in prep["queries"]:
+        rel = grades.get(q["id"])
+        if rel is None:
+            continue
+        graded += 1
+        per_query.append(RE.score_configs(q["rankings"], set(rel), k))
+    configs = RE.aggregate(per_query, k)
+    comparisons = []
+    for cfg, metrics in configs.items():
+        if cfg == baseline:
+            continue
+        comparisons.append(RE.compare(baseline, configs[baseline], cfg, metrics))
+    report = {"graded_queries": graded, "baseline": baseline, "configs": configs,
+              "comparisons": comparisons}
+    print(json.dumps(report, indent=2))
+    for c in comparisons:
+        print(f"[gate] {c['candidate']} vs {c['baseline']}: flip={c['recommend_flip']} — {c['reason']}",
+              file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prep", action="store_true")
+    ap.add_argument("--score", nargs=2, metavar=("PREP_JSON", "GRADES_JSON"))
+    ap.add_argument("--out", default="judge_prep.json")
+    ap.add_argument("--queries", type=int, default=40)
+    ap.add_argument("--pool", type=int, default=24)
+    ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--scan", type=int, default=4000)
+    ap.add_argument("--rerankers", default="cross-encoder/ms-marco-MiniLM-L-6-v2,BAAI/bge-reranker-v2-m3")
+    ap.add_argument("--query-expand", action="store_true")
+    args = ap.parse_args()
+    if args.score:
+        return _score(args.score[0], args.score[1])
+    if args.prep:
+        return _prep(args)
+    ap.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/judge_eval.py
+++ b/scripts/judge_eval.py
@@ -23,7 +23,6 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 
 def _prep(args) -> int:
-    import retrieval_eval as RE
     import shadow_eval as SE
     corpus = SE._load_corpus(args.scan)
     if not corpus:

--- a/scripts/judge_show.py
+++ b/scripts/judge_show.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Print one query + its candidate pool from a judge_eval --prep file, for a judge agent.
+Usage: judge_show.py <prep_or_input.json> <query_id>"""
+import json
+import sys
+
+d = json.load(open(sys.argv[1]))
+q = next((x for x in d["queries"] if x["id"] == sys.argv[2]), None)
+if not q:
+    print("query not found", file=sys.stderr)
+    raise SystemExit(1)
+print("QUERY:\n" + q["query"])
+print("\nCANDIDATE DOCUMENTS (id then text):")
+for p in q.get("pool", []):
+    print(f"\n[{p['id']}]\n{p['text']}")


### PR DESCRIPTION
## What

Ships both gated retrieval upgrades **ON**, each justified by a real-relevance A/B eval (Claude-as-relevance-oracle over 23 judged queries, 99 relevance marks) that replaces the weak same-investigation proxy the shadow-eval was stuck on.

Baseline = MiniLM reranker, no expansion:

| candidate | recall@10 | MRR | nDCG@10 | gate |
|---|---|---|---|---|
| **bge-reranker-v2-m3** | 0.844 (+7%) | 0.760 (+15%) | **0.753 (+14%)** | flip ✅ |
| **query_expand** | 0.827 (+5%) | 0.682 (+3%) | **0.687 (+4%)** | flip ✅ |

Both clear `compare()` — primary metric (nDCG) up ≥ 2% relative, no regression on the others.

> The same-investigation proxy (shadow-eval) penalized bge's semantic strength and reported a regression; grading on *actual* relevance flipped that to a +14% win. This is why the judge harness exists.

## Changes

**bge flip** — default resolved via `backends.rerank_model()` → bge, `reranker._DEFAULT_MODEL` fallback flipped to match. bge is heavier (~600MB, slower/query); constrained hosts pin MiniLM back via `RERANK_MODEL` or `[rerank].model` in the gitignored config. Nothing hardcoded.

**query_expand wiring** — `rag_context_search` fans retrieval out over LLM paraphrases + keywords, unioning hits deduped by `(origin, id)` keeping best score. The cross-encoder re-pass still ranks against the **original** query, so expansion only widens recall without diluting precision. Gated by `expand_query` arg → env `LOCI_RAG_EXPAND` (default ON). **Fail-open**: if the local generator is down, `expand()` returns the bare query and retrieval is unaffected. Verified live (6 → 13 candidates, `mode=rag_hybrid`).

**Judge-eval harness** (produced the evidence, reusable):
- `retrieval_eval.score_configs/aggregate` — real-relevance scoring vs a judge-supplied relevant set; output shape `compare()` consumes unchanged.
- `scripts/judge_eval.py` — `--prep` (config-major ranking, loads each reranker once) + `--score` (metrics + gate).
- `scripts/judge_show.py` + `.claude/workflows/judge-eval.js` — one strict relevance-judge agent per query, each reads its own pool from disk (no huge inline payload).

## Test

`373 passed` (full mcp suite). Live smoke of the wired `rag_context_search` against Qdrant confirmed expansion + dedup + rerank end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45