### PR TITLE
feat(verify): add verify_finding adversarial-verification primitive

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6959,6 +6959,22 @@ def query_expand(query: str, n_queries: int = 3, n_keywords: int = 6) -> str:
 
 
 @mcp.tool()
+def verify_finding(claim: str, context: str = "", investigation_id: Optional[str] = None) -> str:
+    """
+    Adversarially VERIFY a claim/finding using the LOCAL model — a skeptic actively tries to
+    REFUTE it (candidate->skeptic->keep-if-survives), the same discipline workflows run per
+    finding. Pass optional `context` (code snippet / file refs / evidence); if omitted and an
+    `investigation_id` is given, best-effort RAG grounding is pulled (fail-open). Skeptical by
+    default: only 'confirmed' when the skeptic cannot refute it, else 'refuted'/'uncertain'.
+    Fail-open: if the local model is down or output is unparseable, returns verdict='uncertain'
+    with degraded=True. Returns JSON {verdict, refutation, confidence, degraded}.
+    """
+    import verify as _v
+    return json.dumps(_v.verify_finding(claim, context=context,
+                                        investigation_id=investigation_id), indent=2)
+
+
+@mcp.tool()
 def classify_text(text: str, labels: list) -> str:
     """
     Pick the single best label from `labels` for `text` using the LOCAL model — a cheap

--- a/mcp/tests/test_verify.py
+++ b/mcp/tests/test_verify.py
@@ -1,0 +1,168 @@
+"""Tests for verify — adversarial finding verification. Generation is stubbed; no live Ollama."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import verify as V  # noqa: E402
+
+
+# --- stub gen_fn factories: match the shared contract gen_fn(prompt, *, fmt, max_tokens) ---
+
+def _ok(text):
+    def _fn(prompt, *, fmt=None, max_tokens=256):
+        assert fmt == "json"                # verify_finding must request JSON format
+        assert isinstance(prompt, str) and "CLAIM:" in prompt
+        return {"text": text, "ok": True}
+    return _fn
+
+
+def _not_ok(prompt, *, fmt=None, max_tokens=256):
+    return {"text": "irrelevant", "ok": False}   # caller should fall back
+
+
+def _raises(prompt, *, fmt=None, max_tokens=256):
+    raise RuntimeError("boom")
+
+
+_REFUTED = ('{"verdict": "refuted", "refutation": "The base already sends 1005 at 0.1Hz, '
+            'so the claim is false.", "confidence": 0.9}')
+
+_CONFIRMED = ('{"verdict": "confirmed", "refutation": "Tried to break it; the log lines '
+              'directly support the claim.", "confidence": 0.8}')
+
+_CONFIRMED_PROSE = (
+    "Sure, here's my analysis:\n"
+    "```json\n"
+    '{"verdict": "confirmed", "refutation": "cannot refute", "confidence": 0.7}\n'
+    "```\n"
+    "Hope that helps."
+)
+
+
+def test_refutation_yields_refuted():
+    r = V.verify_finding("The base omits RTCM 1005", gen_fn=_ok(_REFUTED))
+    assert r["verdict"] == "refuted"
+    assert r["degraded"] is False
+    assert "1005" in r["refutation"]
+    assert r["confidence"] == 0.9
+
+
+def test_confirmation_yields_confirmed():
+    r = V.verify_finding("The log shows a decode", context="AcGg rx_ok=3", gen_fn=_ok(_CONFIRMED))
+    assert r["verdict"] == "confirmed"
+    assert r["degraded"] is False
+    assert 0.0 <= r["confidence"] <= 1.0
+
+
+def test_confirmed_embedded_in_prose_with_fences():
+    r = V.verify_finding("claim", gen_fn=_ok(_CONFIRMED_PROSE))
+    assert r["verdict"] == "confirmed"
+    assert r["degraded"] is False
+
+
+def test_gen_not_ok_fails_open_to_uncertain():
+    r = V.verify_finding("some claim", gen_fn=_not_ok)
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True
+    assert r["confidence"] == 0.0
+
+
+def test_gen_error_fails_open_to_uncertain():
+    r = V.verify_finding("some claim", gen_fn=_raises)
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True
+
+
+def test_malformed_json_fails_open_to_uncertain():
+    r = V.verify_finding("some claim", gen_fn=_ok('{"verdict": "refuted", oops'))
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True
+
+
+def test_garbage_no_braces_fails_open():
+    r = V.verify_finding("some claim", gen_fn=_ok("no json here at all"))
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True
+
+
+def test_unknown_verdict_coerced_to_uncertain():
+    # Model returns valid JSON but an out-of-set verdict -> skeptical default.
+    r = V.verify_finding("c", gen_fn=_ok('{"verdict": "maybe", "confidence": 0.5}'))
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is False        # parsed fine; just not a keep-worthy verdict
+
+
+def test_missing_refutation_and_confidence_are_coerced():
+    r = V.verify_finding("c", gen_fn=_ok('{"verdict": "confirmed"}'))
+    assert r["verdict"] == "confirmed"
+    assert r["refutation"] == ""         # missing -> empty string, not a crash
+    assert r["confidence"] == 0.0        # missing -> cautious 0.0
+
+
+def test_out_of_range_confidence_clamped():
+    r = V.verify_finding("c", gen_fn=_ok('{"verdict": "refuted", "confidence": 5}'))
+    assert r["confidence"] == 1.0        # clamped into [0,1]
+
+
+def test_nonstring_confidence_defaults_to_zero():
+    r = V.verify_finding("c", gen_fn=_ok('{"verdict": "confirmed", "confidence": "high"}'))
+    assert r["confidence"] == 0.0
+
+
+def test_empty_claim_short_circuits():
+    r = V.verify_finding("   ", gen_fn=_ok(_CONFIRMED))
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True
+
+
+def test_investigation_id_pulls_rag_context_fail_open():
+    # rag_fn is injectable; a returned context should be woven into the prompt.
+    captured = {}
+
+    def _rag(query, *, limit=5):
+        return {"context": "GROUNDING: the base emits 1005 every 10s"}
+
+    def _gen(prompt, *, fmt=None, max_tokens=256):
+        captured["prompt"] = prompt
+        return {"text": _REFUTED, "ok": True}
+
+    r = V.verify_finding("claim without context", investigation_id="inv-1",
+                         gen_fn=_gen, rag_fn=_rag)
+    assert r["verdict"] == "refuted"
+    assert "GROUNDING: the base emits 1005" in captured["prompt"]
+
+
+def test_rag_error_does_not_break_verification():
+    def _rag(query, *, limit=5):
+        raise RuntimeError("qdrant down")
+
+    r = V.verify_finding("claim", investigation_id="inv-2",
+                         gen_fn=_ok(_CONFIRMED), rag_fn=_rag)
+    # RAG blew up but verification still proceeds ungrounded.
+    assert r["verdict"] == "confirmed"
+
+
+def test_explicit_context_skips_rag():
+    def _rag(query, *, limit=5):
+        raise AssertionError("rag_fn must not be called when context is provided")
+
+    r = V.verify_finding("claim", context="explicit evidence here",
+                         investigation_id="inv-3", gen_fn=_ok(_REFUTED), rag_fn=_rag)
+    assert r["verdict"] == "refuted"
+
+
+def test_default_gen_fn_is_lazy_and_fails_open(monkeypatch):
+    # With no llm_local importable, the lazy default must fail-open, not raise.
+    import builtins
+    real_import = builtins.__import__
+
+    def _blocked(name, *a, **k):
+        if name == "llm_local":
+            raise ImportError("llm_local not importable")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    r = V.verify_finding("some claim")   # no gen_fn -> lazy import path
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True

--- a/mcp/verify.py
+++ b/mcp/verify.py
@@ -1,0 +1,210 @@
+"""Adversarial finding-verification — the candidate->skeptic->keep-if-survives loop as a tool.
+
+Workflows run a per-finding "try to refute this" pass before keeping a claim: a skeptic
+reads the claim (plus any grounding context) and actively tries to break it. If it survives
+the attack, we keep it (confirmed); if the attack lands, we drop it (refuted); if the skeptic
+can't tell, we stay cautious (uncertain). This module makes that loop a reusable Loci
+primitive so any caller gets the same discipline without re-implementing the prompt.
+
+Design mirrors mcp/query_expand.py:
+
+- Reasoning runs on the *generation* tier (Ollama qwen2.5:3b), injectable so a warm client
+  can be reused and tests can stub it. `gen_fn` defaults to None; when None we LAZILY import
+  ``llm_local.generate`` at call time, so importing this module never hard-requires llm_local.
+
+  gen_fn contract (shared): gen_fn(prompt, *, fmt=None, max_tokens=256) -> {"text": str,
+  "ok": bool}. ok=False signals the caller should fall back — we treat it as degraded.
+
+- Grounding is optional. When an investigation_id is given and no explicit context is passed,
+  we LAZILY + fail-open pull a little RAG context (rag_context_search) to help the skeptic.
+  This is injectable via `rag_fn` for tests; a dead/absent RAG lane just means no extra context.
+
+- Fail-open + skeptical default: on not-ok / timeout / parse failure / any error we return a
+  well-formed {"verdict": "uncertain"} result rather than raising. We also default to the
+  cautious verdict when the model is unsure — a claim is only 'confirmed' when the skeptic
+  explicitly fails to refute it. Never raises.
+
+Grounding: [pattern:injectable] lazy llm_local import + injectable gen_fn; [interface] the
+gen_fn contract above; [pattern:fail-open] degraded 'uncertain' fallback. The skeptic prompt
+copy and the JSON schema {verdict,refutation,confidence} are this task's design.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Callable, Optional
+
+# Injectable function types: match the shared [interface] contracts.
+GenFn = Callable[..., dict]
+RagFn = Callable[..., dict]
+
+_VALID_VERDICTS = ("confirmed", "refuted", "uncertain")
+
+_PROMPT_TMPL = (
+    "You are a rigorous SKEPTIC performing adversarial verification of a claim.\n"
+    "Your job is to TRY TO REFUTE the claim — actively look for a counterexample, a logical\n"
+    "flaw, a missing precondition, or evidence in the context that contradicts it.\n"
+    "Do NOT try to confirm it; assume it is wrong until it survives your attack.\n\n"
+    "Decide a verdict:\n"
+    "  - \"refuted\": you found a concrete reason the claim is false or unsupported.\n"
+    "  - \"confirmed\": you genuinely tried and CANNOT refute it; the claim holds.\n"
+    "  - \"uncertain\": you cannot tell from the claim and context (default when unsure).\n"
+    "Prefer \"refuted\" or \"uncertain\" over \"confirmed\" when in doubt.\n\n"
+    "Respond with ONLY a JSON object of this exact shape, no prose:\n"
+    '{{"verdict": "confirmed|refuted|uncertain", "refutation": "your strongest attack or '
+    'why it survives", "confidence": 0.0}}\n\n'
+    "CLAIM:\n{claim}\n\n"
+    "CONTEXT (may be empty — do not assume it is complete):\n{context}\n"
+)
+
+
+def _lazy_generate(prompt: str, *, fmt: Optional[str] = None, max_tokens: int = 256) -> dict:
+    """Default gen_fn: import llm_local.generate only when actually called (fail-open)."""
+    try:
+        from llm_local import generate  # imported lazily so module import never needs it
+        return generate(prompt, fmt=fmt, max_tokens=max_tokens)
+    except Exception:
+        return {"text": "", "ok": False}
+
+
+def _lazy_rag(query: str, *, limit: int = 5) -> dict:
+    """Default rag_fn: best-effort grounding via rag_context_search. Fail-open to {}.
+
+    server.rag_context_search returns a JSON string; we parse it defensively. Any failure
+    (Qdrant down, tool absent, bad JSON) yields {} so verification proceeds ungrounded.
+    """
+    try:
+        import server
+        raw = server.rag_context_search(query, limit=limit)
+        obj = json.loads(raw) if isinstance(raw, str) else raw
+        return obj if isinstance(obj, dict) else {}
+    except Exception:
+        return {}
+
+
+def _extract_json_object(text: str) -> Optional[dict]:
+    """Defensively pull a JSON object out of possibly-noisy model text.
+
+    Handles: clean JSON, JSON wrapped in ```json fences, and JSON embedded in stray prose.
+    Returns the parsed dict, or None if nothing parseable is found.
+    """
+    if not text or not isinstance(text, str):
+        return None
+    # 1) straight parse
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, dict):
+            return obj
+    except Exception:
+        pass
+    # 2) strip code fences and retry
+    fenced = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL | re.IGNORECASE)
+    if fenced:
+        try:
+            obj = json.loads(fenced.group(1))
+            if isinstance(obj, dict):
+                return obj
+        except Exception:
+            pass
+    # 3) brace-match scan: first '{' whose balanced span parses as an object
+    depth = 0
+    start = -1
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start >= 0:
+                    try:
+                        obj = json.loads(text[start:i + 1])
+                        if isinstance(obj, dict):
+                            return obj
+                    except Exception:
+                        start = -1  # keep scanning for a later valid object
+    return None
+
+
+def _coerce_verdict(raw) -> str:
+    """Map model output to one of _VALID_VERDICTS, skeptically. Unknown -> 'uncertain'."""
+    if not isinstance(raw, str):
+        return "uncertain"
+    v = raw.strip().lower()
+    return v if v in _VALID_VERDICTS else "uncertain"
+
+
+def _coerce_confidence(raw) -> float:
+    """Coerce confidence to a float in [0,1]; unparseable -> 0.0 (cautious)."""
+    try:
+        c = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    if c != c:  # NaN
+        return 0.0
+    return max(0.0, min(1.0, c))
+
+
+def _degraded(refutation: str = "") -> dict:
+    """Well-formed skeptical fallback: uncertain, low confidence, degraded=True."""
+    return {"verdict": "uncertain", "refutation": refutation, "confidence": 0.0,
+            "degraded": True}
+
+
+def verify_finding(claim: str,
+                   context: str = "",
+                   investigation_id: Optional[str] = None,
+                   gen_fn: Optional[GenFn] = None,
+                   rag_fn: Optional[RagFn] = None) -> dict:
+    """Adversarially verify a `claim`: run a skeptic that tries to refute it.
+
+    Args:
+        claim: the finding/claim to stress-test.
+        context: optional grounding (code snippet, file refs, prior evidence).
+        investigation_id: if given and `context` is empty, best-effort pull RAG grounding
+            (fail-open) to give the skeptic something to attack with.
+        gen_fn: injectable generation fn (shared contract). None -> lazy llm_local.generate.
+        rag_fn: injectable grounding fn. None -> lazy rag_context_search.
+
+    Returns:
+        {"verdict": "confirmed"|"refuted"|"uncertain", "refutation": str,
+         "confidence": float, "degraded": bool}. Fail-open: on any failure returns a
+        skeptical uncertain result. Never raises.
+    """
+    c = (claim or "").strip()
+    if not c:
+        return _degraded()
+
+    ctx = (context or "").strip()
+    # Optional, fail-open grounding: only when we have an investigation and no explicit context.
+    if not ctx and investigation_id:
+        rag = rag_fn or _lazy_rag
+        try:
+            res = rag(c)
+            if isinstance(res, dict):
+                ctx = str(res.get("context") or "").strip()
+        except Exception:
+            ctx = ""
+
+    prompt = _PROMPT_TMPL.format(claim=c, context=ctx or "(none)")
+    fn = gen_fn or _lazy_generate
+    try:
+        res = fn(prompt, fmt="json", max_tokens=384)
+    except Exception:
+        return _degraded()
+
+    if not isinstance(res, dict) or not res.get("ok"):
+        return _degraded()
+
+    obj = _extract_json_object(res.get("text", ""))
+    if obj is None:
+        return _degraded()
+
+    verdict = _coerce_verdict(obj.get("verdict"))
+    refutation = obj.get("refutation")
+    if not isinstance(refutation, str):
+        refutation = "" if refutation is None else str(refutation)
+    confidence = _coerce_confidence(obj.get("confidence"))
+    return {"verdict": verdict, "refutation": refutation.strip(),
+            "confidence": confidence, "degraded": False}


### PR DESCRIPTION
## What

Adds a reusable `verify_finding` MCP tool that runs the candidate->skeptic->keep-if-survives loop we previously ran per-finding inside workflows.

New thin, self-contained module `mcp/verify.py`:
- Runs an ADVERSARIAL "try to refute this" pass on the local generation tier (Ollama qwen2.5:3b).
- Returns `{verdict: confirmed|refuted|uncertain, refutation, confidence, degraded}`.
- **Skeptical by default**: only `confirmed` when the skeptic genuinely cannot refute the claim; anything unsure or unparseable degrades to `uncertain`.
- **Injectable** `gen_fn` (like embed_ops/reranker), lazily defaulting to `llm_local.generate` — so tests pass a stub, no real model runs.
- Optional, **fail-open** RAG grounding via an injectable `rag_fn` (lazy `rag_context_search`): when an `investigation_id` is given and no explicit context is passed, it best-effort pulls grounding context for the skeptic to attack with. A dead/absent RAG lane just means ungrounded verification.
- **Fail-open**: on any error/timeout/bad output it returns `{verdict:'uncertain', degraded:True}` rather than raising. Never raises.

Registered as the `verify_finding` MCP tool in `server.py`, mirroring the `query_expand` registration.

## Scope / safety

Purely additive and backward-compatible: one new module, one new tool registration, one new test file. No existing code refactored. Defaults preserve current server behavior.

## Tests

`mcp/tests/test_verify.py` (16 tests, all stubbed — no live Ollama): refutation -> `refuted`; confirmation -> `confirmed`; gen not-ok / gen error / malformed JSON / garbage -> `uncertain` (fail-open); prose-wrapped JSON parsed; unknown verdict coerced to `uncertain`; missing/out-of-range/non-string confidence coerced; empty claim short-circuits; investigation_id pulls RAG context into the prompt; RAG error does not break verification; explicit context skips RAG; lazy default gen_fn fails open when `llm_local` is unimportable.

## Validation

- Full mcp suite green: `391 passed, 4 subtests passed`.
- `ruff check verify.py tests/test_verify.py server.py --select E9,F401,F811,F821,F841 --ignore E402` -> All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45