### PR TITLE
feat(graph): replace/prune option for clean code-graph re-ingest

### DIFF
--- a/mcp/graph/kuzu_store.py
+++ b/mcp/graph/kuzu_store.py
@@ -698,6 +698,57 @@ class KuzuStore:
             logger.debug("ingest_code failed: %s", exc)
             return counts
 
+    def delete_code_under(self, path_prefix: str) -> dict:
+        """Delete code-graph nodes under ``path_prefix`` so a re-ingest is clean.
+
+        Removes ``CodeFile`` + ``CodeSymbol`` nodes whose path/file is the prefix
+        itself or lies strictly beneath it, plus their attached edges
+        (DEFINES/CALLS/IMPORTS and any inbound REFERENCES) via ``DETACH DELETE``.
+        Finding / Entity / Investigation nodes are never deleted — only a
+        REFERENCES edge pointing INTO a removed CodeSymbol goes away with it.
+
+        Powers ``code_graph_ingest(replace=True)`` for a moved/updated checkout.
+        Guards against an empty or root-only prefix so a stray call cannot wipe
+        the whole code graph. Fail-open: returns zero counts on any error.
+
+        Returns ``{"files_deleted": int, "symbols_deleted": int}``.
+        """
+        out = {"files_deleted": 0, "symbols_deleted": 0}
+        if not self.ok:
+            return out
+        prefix = (path_prefix or "").strip()
+        # Over-broad guard: empty, or a path made only of separators ("/", "//").
+        if not prefix or not prefix.strip("/"):
+            logger.warning("delete_code_under refused over-broad prefix: %r", path_prefix)
+            return out
+        # Match the prefix exactly (single-file ingest) AND everything strictly
+        # beneath it, but never a sibling that merely shares the string prefix
+        # ("/a/b" must not match "/a/bc").
+        sub = prefix.rstrip("/") + "/"
+        try:
+            srows = self._rows(
+                "MATCH (s:CodeSymbol) WHERE s.file = $p OR s.file STARTS WITH $sub "
+                "RETURN count(s)", {"p": prefix, "sub": sub},
+            )
+            frows = self._rows(
+                "MATCH (c:CodeFile) WHERE c.path = $p OR c.path STARTS WITH $sub "
+                "RETURN count(c)", {"p": prefix, "sub": sub},
+            )
+            self._exec(
+                "MATCH (s:CodeSymbol) WHERE s.file = $p OR s.file STARTS WITH $sub "
+                "DETACH DELETE s", {"p": prefix, "sub": sub},
+            )
+            self._exec(
+                "MATCH (c:CodeFile) WHERE c.path = $p OR c.path STARTS WITH $sub "
+                "DETACH DELETE c", {"p": prefix, "sub": sub},
+            )
+            out["symbols_deleted"] = int(srows[0][0]) if srows else 0
+            out["files_deleted"] = int(frows[0][0]) if frows else 0
+            return out
+        except Exception as exc:
+            logger.debug("delete_code_under failed: %s", exc)
+            return out
+
     def _resolve_symbol(self, ref: str) -> Optional[str]:
         """Resolve a CALLS dst to a CodeSymbol id: try id, then by name (best-effort)."""
         try:

--- a/mcp/graph_tools.py
+++ b/mcp/graph_tools.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("loci-mcp")
 _get_kuzu = None  # injected by register()
 
 
-def code_graph_ingest(path: str, max_files: Optional[int] = None) -> str:
+def code_graph_ingest(path: str, max_files: Optional[int] = None, replace: bool = False) -> str:
     """
     Parse a source file or directory with tree-sitter and ingest its symbol graph
     into the Kuzu code graph (CodeFile / CodeSymbol nodes; DEFINES / CALLS / IMPORTS
@@ -24,12 +24,21 @@ def code_graph_ingest(path: str, max_files: Optional[int] = None) -> str:
     parse but currently yield file-level nodes only). Binary/oversized files and
     common vendor dirs (.git, node_modules, .venv, build, dist, target) are skipped.
 
+    Ingest is additive (MERGE) by default. When ``replace=True`` the existing
+    CodeFile/CodeSymbol nodes under this ``path`` (and their DEFINES/CALLS/IMPORTS
+    edges + inbound REFERENCES) are deleted BEFORE parsing, so re-ingesting a
+    moved or updated checkout stays idempotent and drops stale-path nodes. Only
+    code nodes are pruned — Findings / Investigations / Entities are untouched.
+
     Args:
         path: A source file or a directory root to walk.
         max_files: Optional cap on files parsed (directory mode).
+        replace: If True, prune existing code nodes under ``path`` before ingest
+            (idempotent re-ingest). Default False preserves additive behaviour.
 
     Returns:
-        JSON with per-run counts {files, symbols, defines, calls, imports} or an error.
+        JSON with per-run counts {files, symbols, defines, calls, imports} (and a
+        ``pruned`` block when ``replace`` is set) or an error.
     """
     ks = _get_kuzu()
     if not ks:
@@ -50,8 +59,13 @@ def code_graph_ingest(path: str, max_files: Optional[int] = None) -> str:
             parsed = [parse_source(str(p), src, lang)]
         else:
             parsed = parse_path(str(p), max_files=max_files)
+        # Prune stale/duplicate code nodes under this path so re-ingest is clean.
+        pruned = ks.delete_code_under(str(p)) if replace else None
         counts = ks.ingest_code(parsed)
-        return json.dumps({"path": str(p), "parsed_files": len(parsed), "ingested": counts}, indent=2)
+        out = {"path": str(p), "parsed_files": len(parsed), "ingested": counts}
+        if pruned is not None:
+            out["pruned"] = pruned
+        return json.dumps(out, indent=2)
     except Exception as exc:
         logger.debug("code_graph_ingest failed: %r", exc)
         return json.dumps({"error": f"code_graph_ingest failed: {exc!r}"})

--- a/mcp/tests/test_kuzu_store.py
+++ b/mcp/tests/test_kuzu_store.py
@@ -398,6 +398,100 @@ def test_code_query_write_guard(tmp_path):
             store.code_query(bad)
 
 
+def _sym(sid, name, file, line=1, lang="python"):
+    return {"id": sid, "name": name, "kind": "function",
+            "line": line, "lang": lang, "file": file}
+
+
+def test_delete_code_under_scopes_to_prefix(tmp_path):
+    """delete_code_under removes only code nodes under the prefix, leaving
+    sibling code AND non-code (Finding/Entity/Investigation) nodes intact."""
+    store = KuzuStore(str(tmp_path / "deldb"))
+    assert store.available()
+
+    store.ingest_code([
+        {"file": "/repo/a/x.py", "lang": "python",
+         "symbols": [_sym("/repo/a/x.py::f", "f", "/repo/a/x.py")],
+         "edges": [], "imports": []},
+        # Sibling that merely shares the "/repo/a" string prefix — must survive.
+        {"file": "/repo/ab/y.py", "lang": "python",
+         "symbols": [_sym("/repo/ab/y.py::g", "g", "/repo/ab/y.py")],
+         "edges": [], "imports": []},
+    ])
+    # A finding referencing the to-be-deleted symbol; the finding must survive.
+    store.upsert_finding({"id": "F1", "text": "about f", "investigation": "invZ"})
+    store.link_references("F1", ["/repo/a/x.py::f"])
+
+    res = store.delete_code_under("/repo/a")
+    assert res["symbols_deleted"] == 1
+    assert res["files_deleted"] == 1
+
+    # Deleted symbol/file gone; sibling under /repo/ab untouched.
+    assert store.code_query("MATCH (s:CodeSymbol {id:'/repo/a/x.py::f'}) RETURN s.id") == []
+    assert store.code_query("MATCH (c:CodeFile {path:'/repo/a/x.py'}) RETURN c.path") == []
+    assert ["/repo/ab/y.py::g"] in store.code_query("MATCH (s:CodeSymbol) RETURN s.id")
+    assert ["/repo/ab/y.py"] in store.code_query("MATCH (c:CodeFile) RETURN c.path")
+
+    # Non-code nodes survive (only the REFERENCES edge into the dead symbol went away).
+    assert store.code_query("MATCH (f:Finding {id:'F1'}) RETURN f.id") == [["F1"]]
+    assert store.code_query("MATCH (i:Investigation {id:'invZ'}) RETURN i.id") == [["invZ"]]
+
+
+def test_delete_code_under_rejects_overbroad_prefix(tmp_path):
+    """Empty / whitespace / root-only prefixes are refused (no deletion)."""
+    store = KuzuStore(str(tmp_path / "guardpref"))
+    assert store.available()
+    store.ingest_code([
+        {"file": "/repo/x.py", "lang": "python",
+         "symbols": [_sym("/repo/x.py::f", "f", "/repo/x.py")],
+         "edges": [], "imports": []},
+    ])
+    for bad in ("", "   ", "/", "//"):
+        res = store.delete_code_under(bad)
+        assert res == {"files_deleted": 0, "symbols_deleted": 0}
+    # The code node is still there — nothing was wiped.
+    assert ["/repo/x.py::f"] in store.code_query("MATCH (s:CodeSymbol) RETURN s.id")
+
+
+def test_reingest_replace_is_idempotent(tmp_path):
+    """code_graph_ingest(replace=True) re-ingesting the same tree does not double
+    node counts, and a file removed between runs has its symbols pruned."""
+    import graph_tools
+
+    store = KuzuStore(str(tmp_path / "reingestdb"))
+    assert store.available()
+    _orig = graph_tools._get_kuzu
+    graph_tools._get_kuzu = lambda: store
+
+    src = tmp_path / "src"
+    (src / "pkg").mkdir(parents=True)
+    keep = src / "pkg" / "keep.py"
+    drop = src / "pkg" / "drop.py"
+    keep.write_text("def kept():\n    return 1\n")
+    drop.write_text("def dropped():\n    return 2\n")
+
+    try:
+        graph_tools.code_graph_ingest(str(src))
+        files_1 = store.code_query("MATCH (c:CodeFile) RETURN count(c)")[0][0]
+        syms_1 = store.code_query("MATCH (s:CodeSymbol) RETURN count(s)")[0][0]
+        assert files_1 >= 2 and syms_1 >= 2
+
+        # Remove one file, then re-ingest with replace=True.
+        drop.unlink()
+        graph_tools.code_graph_ingest(str(src), replace=True)
+
+        files_2 = store.code_query("MATCH (c:CodeFile) RETURN count(c)")[0][0]
+        syms_2 = store.code_query("MATCH (s:CodeSymbol) RETURN count(s)")[0][0]
+    finally:
+        graph_tools._get_kuzu = _orig
+    # Counts did not double (idempotent) and the removed file's symbol is gone.
+    assert files_2 <= files_1
+    assert syms_2 < syms_1
+    assert store.callers_of("dropped") == []  # nothing references it; symbol pruned
+    assert store.code_query("MATCH (s:CodeSymbol {name:'dropped'}) RETURN s.id") == []
+    assert ["kept"] in store.code_query("MATCH (s:CodeSymbol) RETURN s.name")
+
+
 def test_fail_open_on_bad_query(tmp_path):
     store = KuzuStore(str(tmp_path / "faildb"))
     assert store.available()


### PR DESCRIPTION
## Problem

`code_graph_ingest` is additive (MERGE, no prune). Re-ingesting a **moved or updated checkout** duplicates `CodeFile`/`CodeSymbol` nodes and leaves stale-path nodes behind — we hit this when the audit checkout moved.

## Change

- Add `replace: bool = False` to `code_graph_ingest`. When `True`, existing code nodes under the ingest path prefix are deleted **before** parsing, so re-ingest is idempotent and current. Output gains a `pruned` block.
- Add `KuzuStore.delete_code_under(path_prefix)`: parameterized-Cypher `DETACH DELETE` of `CodeFile` + `CodeSymbol` nodes at/under the prefix (and their `DEFINES`/`CALLS`/`IMPORTS` + inbound `REFERENCES` edges). Matches the prefix exactly or strictly beneath it (no `/a/b` → `/a/bc` sibling over-match). Refuses an empty/root-only (`''`/`/`) prefix. Fail-open, never raises.
- **Only code nodes are pruned** — `Finding` / `Investigation` / `Entity` nodes are never deleted.

## Backward compatibility

Default `replace=False` preserves the current additive behaviour exactly. Additive, fail-open.

## Tests

`mcp/tests/test_kuzu_store.py`:
- `replace=True` re-ingest does not double `CodeFile`/`CodeSymbol` counts and prunes a removed file's symbols.
- `delete_code_under` scopes to the prefix — leaves sibling code + non-code (Finding/Investigation) nodes intact.
- Empty / whitespace / root-only prefixes are rejected (no deletion).

Full `mcp` suite green (378 passed).

## Note

Ruff flags one **pre-existing** `F401` (`typing.Any` unused in `graph/kuzu_store.py:27`, identical on `origin/main`, unchanged by this diff — `Any` appears only in comments). Left untouched to avoid unrelated scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45