### PR TITLE
feat(lifecycle): finding resolution status + exclusion-aware grounding

### DIFF
--- a/mcp/grounding.py
+++ b/mcp/grounding.py
@@ -38,6 +38,10 @@ def _default_memory_dir() -> str:
 
 _MEMORY_DIR_DEFAULT = _default_memory_dir()
 
+# Finding resolution states that count as "handled" — the exclusion lane surfaces these
+# as a "do NOT re-report" block so re-audits skip already-fixed/accepted items.
+_RESOLVED_STATES = frozenset({"fixed", "intentional", "wontfix"})
+
 # Sources/types whose text is a raw conversation dump — never inject these.
 _DUMP_MARKERS = ("pre_compress", "session_end", "session_dump", "conversation", "transcript", "turn")
 _ROLE_RE = re.compile(r'\b(user|assistant|system)\b\s*[:"]', re.IGNORECASE)
@@ -203,6 +207,39 @@ def ground(task: dict, opts: Optional[dict] = None) -> dict:
                         add(f"case:{cid}:finding", str(f.get("text", "")), 0.08)
         except Exception:
             continue
+
+    # 2. Exclusion lane: findings already resolved (fixed/intentional/wontfix) for the
+    # grounded cases -> a compact "do NOT re-report" block so a re-audit auto-skips items
+    # already handled (the manual known-state step, automated). Budget-bounded, noise-
+    # filtered, fail-open: a missing/empty resolution set simply omits the block. Uses a
+    # separate load (large last_n) so the case lane above stays byte-for-byte unchanged.
+    resolved_known: list[str] = []
+    _seen_known: set = set()
+    for cid in (task.get("caseIds") or [])[:3]:
+        if not S:
+            break
+        try:
+            data = _jload(S.investigation_load(cid, last_n_findings=200))
+            if not isinstance(data, dict) or data.get("error"):
+                continue
+            for f in (data.get("recent_findings") or []):
+                if not isinstance(f, dict):
+                    continue
+                res = str(f.get("resolution", "open") or "open").lower()
+                if res not in _RESOLVED_STATES:
+                    continue
+                txt = str(f.get("text", "")).strip()
+                if not txt:
+                    continue
+                h = re.sub(r"\s+", " ", txt.lower())[:120]
+                if h in _seen_known:
+                    continue
+                _seen_known.add(h)
+                resolved_known.append(f"[{res}] {txt[:180]}")
+        except Exception:
+            continue
+    if resolved_known:
+        add("known — do NOT re-report", " • ".join(resolved_known[:12]), 0.15)
 
     # 3. Exact entities -> entity_lookup (O(1), no embedding). Fail-open per entity.
     for ent in (task.get("entities") or [])[:5]:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -185,6 +185,12 @@ REFLECTION_SIGNATURE_MAP_LIMIT = 500
 # Defined once here to avoid the same dict appearing inline in multiple functions.
 _CONFIDENCE_RANK: dict[str, int] = {"low": 0, "medium": 1, "high": 2}
 
+# Finding lifecycle/resolution states. "open" is the default and the implied value for
+# any finding record stored before this field existed (absent -> "open"). The three
+# resolved states are what exclusion-aware grounding treats as "handled — do not re-report".
+_RESOLUTION_STATES: frozenset = frozenset({"open", "fixed", "intentional", "wontfix", "superseded"})
+_RESOLVED_STATES: frozenset = frozenset({"fixed", "intentional", "wontfix"})
+
 # ---------------------------------------------------------------------------
 # Optional Qdrant + fastembed
 # ---------------------------------------------------------------------------
@@ -2725,6 +2731,11 @@ def investigation_load(
         ]
 
     recent = findings[-last_n_findings:]
+    # Surface the lifecycle/resolution state; findings stored before this field
+    # existed read as "open" (additive, backwards-compatible).
+    for _f in recent:
+        if isinstance(_f, dict) and not _f.get("resolution"):
+            _f["resolution"] = "open"
 
     return json.dumps({
         "manifest": manifest,
@@ -3032,6 +3043,7 @@ def investigation_store(
     valid_until: Optional[str] = None,
     authored_by: Optional[str] = None,
     tier: str = "warm",
+    resolution: str = "open",
 ) -> str:
     """
     Record a finding in the investigation.
@@ -3076,6 +3088,15 @@ def investigation_store(
               hot  — indexed in Qdrant AND summarized in manifest notes (instantly in-context).
               warm — indexed in Qdrant only (default, searchable).
               cold — stored in JSONL only, NOT indexed in Qdrant (archived).
+        resolution: Lifecycle state of the finding. One of:
+              open (default) — active/unresolved; the normal state for a new finding.
+              fixed          — the issue has been addressed/remediated.
+              intentional    — reviewed and deemed acceptable/by-design.
+              wontfix        — acknowledged but will not be actioned.
+              superseded     — replaced by a newer finding.
+              The three resolved states (fixed/intentional/wontfix) let
+              exclusion-aware grounding auto-skip handled items on re-audit.
+              Findings stored before this field existed read as "open".
 
     Returns:
         JSON: {"stored": true, "finding_id": "<uuid>", "type": "<finding_type>",
@@ -3096,6 +3117,9 @@ def investigation_store(
         return json.dumps({"error": "confidence must be one of: high, medium, low"})
     if tier not in {"hot", "warm", "cold"}:
         return json.dumps({"error": "tier must be one of: hot, warm, cold"})
+    resolution = str(resolution or "open").lower()
+    if resolution not in _RESOLUTION_STATES:
+        return json.dumps({"error": "resolution must be one of: open, fixed, intentional, wontfix, superseded"})
 
     # Resolve numeric_confidence: caller-supplied (clamped) or derived from string confidence.
     _confidence_to_numeric = {"high": 0.9, "medium": 0.6, "low": 0.3}
@@ -3126,6 +3150,7 @@ def investigation_store(
         "valid_until": valid_until,
         "authored_by": authored_by or "",
         "tier": tier,
+        "resolution": resolution,
     }
     derived = _normalize_derived_from(derived_from)
     if derived:
@@ -4138,6 +4163,7 @@ def investigation_search(
     limit: int = 10,
     include_retracted: bool = False,
     min_confidence: str = "low",
+    resolution: Optional[str] = None,
 ) -> str:
     """
     Search findings by similarity.
@@ -4154,10 +4180,23 @@ def investigation_search(
         investigation_id: Limit to one investigation, or omit to search all.
         limit: Maximum results to return (default 10).
         include_retracted: Include soft-retracted findings (default False).
+        resolution: Optional lifecycle filter. When set to one of
+                    open/fixed/intentional/wontfix/superseded, only findings in that
+                    resolution state are returned. Omit (default) to return all.
+                    Each result row surfaces its ``resolution`` (absent -> "open").
 
     Returns:
         JSON list of matching findings with investigation context.
     """
+    # Normalise resolution filter (fail-open: an unknown value disables the filter).
+    resolution = str(resolution).lower() if resolution else None
+    if resolution is not None and resolution not in _RESOLUTION_STATES:
+        logger.warning(
+            "investigation_search: unknown resolution %r — ignoring filter; valid "
+            "values: %s", resolution, ", ".join(sorted(_RESOLUTION_STATES))
+        )
+        resolution = None
+
     # Normalise confidence floor so callers passing "High" or "MEDIUM" are not
     # silently ignored by the lowercase dict lookup downstream.
     min_confidence = str(min_confidence or "low").lower()
@@ -4274,6 +4313,36 @@ def investigation_search(
             if _CONFIDENCE_RANK.get(str(r.get("confidence", "low")).lower(), 0) >= floor
         ]
 
+    # Surface each row's resolution and optionally filter by it. Rows sourced from
+    # mnemosyne carry no resolution, so we build an authoritative finding_id ->
+    # resolution map from JSONL — scoped to only the investigations that actually
+    # produced rows, so cost is bounded regardless of how many investigations exist.
+    # Absent record -> "open". Fail-open (a failed map build just falls back to the
+    # per-row payload value, defaulting to "open").
+    _resolution_map: dict[str, str] = {}
+    try:
+        _invs_in_results = {str(r.get("investigation_id", "")) for r in deduped}
+        _invs_in_results.discard("")
+        for _inv in _invs_in_results:
+            for _f in _read_jsonl(MEMORY_DIR / _inv / "findings.jsonl"):
+                _fid = str(_f.get("id", ""))
+                if _fid:
+                    _resolution_map[_fid] = str(_f.get("resolution") or "open").lower()
+    except Exception as exc:  # fail-open — never block search on the map build
+        logger.debug("resolution map build failed, using per-row values: %r", exc)
+        _resolution_map = {}
+
+    def _row_resolution(row: dict) -> str:
+        fid = str(row.get("finding_id") or row.get("id") or "")
+        if fid and fid in _resolution_map:
+            return _resolution_map[fid]
+        return str(row.get("resolution") or "open").lower()
+
+    for r in deduped:
+        r["resolution"] = _row_resolution(r)
+    if resolution is not None:
+        deduped = [r for r in deduped if r.get("resolution") == resolution]
+
     if not deduped:
         qdrant_avail = bool(os.environ.get("QDRANT_URL", ""))
         # Only use rag_required mode when Qdrant itself is unavailable.
@@ -4307,6 +4376,7 @@ def investigation_search(
         "results": deduped[: max(1, min(limit, 200))],
         "excluded_retracted": _excluded_retracted["n"],
         "include_retracted": include_retracted,
+        "resolution_filter": resolution,
         "mnemo_status": {
             "enabled": mnemo_enabled,
             "bank": _mnemo_bank() if mnemo_enabled else None,

--- a/mcp/tests/test_grounding.py
+++ b/mcp/tests/test_grounding.py
@@ -101,6 +101,51 @@ def test_ground_fail_open_no_server(monkeypatch):
     assert isinstance(r["sources"], list)
 
 
+def test_ground_emits_exclusion_block_for_resolved_findings(monkeypatch):
+    # Findings marked fixed/intentional/wontfix on a grounded case must surface as a
+    # compact "do NOT re-report" block so re-audits auto-exclude handled items.
+    import types
+    fake = types.ModuleType("server")
+    fake.investigation_load = lambda cid, **k: {
+        "manifest": {"hypothesis": "h", "next_step": "n"},
+        "recent_findings": [
+            {"text": "null-deref in parse()", "resolution": "fixed"},
+            {"text": "wide CORS is by design", "resolution": "intentional"},
+            {"text": "still an open bug in retry loop", "resolution": "open"},
+            {"text": "legacy flag, leave it", "resolution": "wontfix"},
+        ],
+    }
+    monkeypatch.setitem(sys.modules, "server", fake)
+    r = G.ground({"title": "re-audit", "caseIds": ["c1"]},
+                 {"budgetChars": 4000, "memoryDir": "/nonexistent"})
+    assert "known — do NOT re-report" in r["block"]
+    # Isolate the exclusion-block line and assert it lists the resolved findings only.
+    known_line = next(ln for ln in r["block"].splitlines() if "known — do NOT re-report" in ln)
+    assert "null-deref in parse()" in known_line
+    assert "wide CORS is by design" in known_line
+    assert "legacy flag, leave it" in known_line
+    # An open finding must NOT be excluded (it stays re-reportable).
+    assert "still an open bug" not in known_line
+
+
+def test_ground_omits_exclusion_block_when_nothing_resolved(monkeypatch):
+    # No resolved findings (all open / absent field) -> the block is omitted entirely.
+    import types
+    fake = types.ModuleType("server")
+    fake.investigation_load = lambda cid, **k: {
+        "manifest": {"hypothesis": "h"},
+        "recent_findings": [
+            {"text": "an open finding"},                       # no resolution -> open
+            {"text": "another active item", "resolution": "open"},
+        ],
+    }
+    monkeypatch.setitem(sys.modules, "server", fake)
+    r = G.ground({"title": "re-audit", "caseIds": ["c1"]},
+                 {"budgetChars": 4000, "memoryDir": "/nonexistent"})
+    assert "known — do NOT re-report" not in r["block"]
+    assert set(r) == {"block", "sources", "chars", "degraded"}
+
+
 def test_ground_budget_respected(tmp_path, monkeypatch):
     (tmp_path / "MEMORY.md").write_text(
         "- [a](a.md) — dispatch referenced flag dead-code registry rules detection\n")

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -2163,5 +2163,127 @@ class TestWiringObligationTracker(unittest.TestCase):
         self.assertIn("error", result)
 
 
+class TestFindingResolution(unittest.TestCase):
+    """resolution lifecycle field: store persists it, load surfaces it (absent -> open),
+    and investigation_search can optionally filter by it."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = server.MEMORY_DIR
+        server.MEMORY_DIR = Path(self._tmp.name)
+
+    def tearDown(self):
+        server.MEMORY_DIR = self._orig
+        self._tmp.cleanup()
+
+    def test_store_persists_resolution(self):
+        inv_id = _new_id("res-store")
+        server.investigation_start(investigation_id=inv_id, title="Resolution store test")
+        stored = _json(server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="Null-deref in parse() was patched.",
+            source="test",
+            resolution="fixed",
+        ))
+        self.assertTrue(stored.get("stored"))
+        # Persisted in the JSONL
+        findings = server._read_jsonl(server.MEMORY_DIR / inv_id / "findings.jsonl")
+        self.assertEqual(findings[0].get("resolution"), "fixed")
+
+    def test_store_rejects_bad_resolution(self):
+        inv_id = _new_id("res-bad")
+        server.investigation_start(investigation_id=inv_id, title="Bad resolution test")
+        result = _json(server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="x",
+            source="test",
+            resolution="banana",
+        ))
+        self.assertIn("error", result)
+
+    def test_store_defaults_resolution_open(self):
+        inv_id = _new_id("res-default")
+        server.investigation_start(investigation_id=inv_id, title="Default resolution test")
+        server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="observed",
+            text="A normal finding with no resolution given.",
+            source="test",
+        )
+        findings = server._read_jsonl(server.MEMORY_DIR / inv_id / "findings.jsonl")
+        self.assertEqual(findings[0].get("resolution"), "open")
+
+    def test_load_surfaces_resolution_and_legacy_reads_open(self):
+        inv_id = _new_id("res-load")
+        server.investigation_start(investigation_id=inv_id, title="Load resolution test")
+        server.investigation_store(
+            investigation_id=inv_id, finding_type="observed",
+            text="Fixed thing.", source="test", resolution="fixed",
+        )
+        # Simulate a legacy record with NO resolution field by appending raw JSONL.
+        legacy = {
+            "id": "legacy-1", "investigation_id": inv_id, "record_type": "observed",
+            "type": "observed", "text": "Legacy finding without resolution.",
+            "source": "test", "confidence": "medium", "tags": [],
+        }
+        server._append_jsonl(server.MEMORY_DIR / inv_id / "findings.jsonl", legacy)
+
+        loaded = _json(server.investigation_load(investigation_id=inv_id))
+        by_text = {f["text"]: f for f in loaded["recent_findings"]}
+        self.assertEqual(by_text["Fixed thing."]["resolution"], "fixed")
+        # A record stored before the field existed must read as "open".
+        self.assertEqual(by_text["Legacy finding without resolution."]["resolution"], "open")
+
+    def test_search_filters_by_resolution(self):
+        inv_id = _new_id("res-search")
+        server.investigation_start(investigation_id=inv_id, title="Search resolution test")
+        open_stored = _json(server.investigation_store(
+            investigation_id=inv_id, finding_type="observed",
+            text="Open bug in the retry loop.", source="test", resolution="open",
+        ))
+        fixed_stored = _json(server.investigation_store(
+            investigation_id=inv_id, finding_type="observed",
+            text="Fixed the CORS misconfig.", source="test", resolution="fixed",
+        ))
+
+        # This test env has no Qdrant/mnemosyne backend, so drive the recall lane with a
+        # synthetic stub that returns rows referencing the two real findings. The
+        # resolution surfacing/filter reads the authoritative state from JSONL.
+        rows = [
+            {"investigation_id": inv_id, "finding_id": open_stored["finding_id"],
+             "record_type": "observed", "source": "test", "text": "Open bug in the retry loop.",
+             "score": 0.9},
+            {"investigation_id": inv_id, "finding_id": fixed_stored["finding_id"],
+             "record_type": "observed", "source": "test", "text": "Fixed the CORS misconfig.",
+             "score": 0.8},
+        ]
+        orig_recall = server._mnemo_recall
+        server._mnemo_recall = lambda *a, **k: [dict(r) for r in rows]
+        try:
+            # Default (no filter): both returned, each with resolution surfaced.
+            res_all = _json(server.investigation_search("bug", investigation_id=inv_id))
+            res_by_text = {r["text"]: r for r in res_all["results"]}
+            self.assertEqual(res_by_text["Open bug in the retry loop."]["resolution"], "open")
+            self.assertEqual(res_by_text["Fixed the CORS misconfig."]["resolution"], "fixed")
+
+            # Filter open -> only the open finding.
+            res_open = _json(server.investigation_search(
+                "bug", investigation_id=inv_id, resolution="open"))
+            texts_open = [r["text"] for r in res_open["results"]]
+            self.assertIn("Open bug in the retry loop.", texts_open)
+            self.assertNotIn("Fixed the CORS misconfig.", texts_open)
+
+            # Filter fixed -> only the fixed finding.
+            res_fixed = _json(server.investigation_search(
+                "bug", investigation_id=inv_id, resolution="fixed"))
+            texts_fixed = [r["text"] for r in res_fixed["results"]]
+            self.assertIn("Fixed the CORS misconfig.", texts_fixed)
+            self.assertNotIn("Open bug in the retry loop.", texts_fixed)
+        finally:
+            server._mnemo_recall = orig_recall
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds an optional, backward-compatible **finding resolution lifecycle** field and makes grounding **auto-exclude already-handled items** on re-audit (automating the manual known-state step).

### (C) Resolution field — additive, backward-compatible
- **`investigation_store`**: new `resolution` param — one of `open|fixed|intentional|wontfix|superseded`, default `open`. Validated and persisted on the finding record in `findings.jsonl`. Existing finding semantics unchanged.
- **`investigation_load`**: surfaces `resolution` on returned findings. Records stored before this field existed read as `open`.
- **`investigation_search`**: new optional `resolution` filter; each result row now surfaces its `resolution` (authoritative value read from JSONL, scoped to only the investigations that produced rows so cost stays bounded). Unknown filter values are ignored (fail-open). Adds `resolution_filter` to the response metadata.

### (D) Exclusion-aware grounding
- **`grounding.ground()`**: new lane collects `fixed`/`intentional`/`wontfix` findings for the grounded cases and emits a compact `[known — do NOT re-report]` block so re-audits auto-skip handled items. Budget-bounded, deduped/noise-filtered, fail-open; omitted entirely when nothing is resolved. Existing lanes and defaults are unchanged (the exclusion lane uses a separate load call so the case lane stays byte-for-byte identical).

## Compatibility / safety
- Purely additive; findings without `resolution` read as `open` everywhere.
- Fail-open throughout (bad values ignored, map-build failures fall back to per-row values, dead server lanes never abort `ground()`).

## Tests
- New store/load/search resolution tests (`test_mcp_integration.py`) + ground() exclusion-block emit/omit tests (`test_grounding.py`).
- Full mcp suite green: **382 passed**. `ruff check` (E9,F401,F811,F821,F841) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45