### PR TITLE
feat(verify): pull real code + surface reasoning in verify_finding

### DIFF
--- a/mcp/tests/test_verify.py
+++ b/mcp/tests/test_verify.py
@@ -258,6 +258,25 @@ def test_reasoning_falls_back_to_raw_text_when_absent():
     assert '"verdict": "confirmed"' in r["reasoning"]
 
 
+def test_degraded_coerces_nonstring_text_to_string():
+    # A not-ok result whose "text" is None must not leak None into reasoning:
+    # _degraded is the single normalization point and keeps the all-strings return shape.
+    def _not_ok_none_text(prompt, *, fmt=None, max_tokens=256):
+        return {"ok": False, "text": None}
+
+    r = V.verify_finding("some claim", gen_fn=_not_ok_none_text)
+    assert r["verdict"] == "uncertain"
+    assert r["degraded"] is True
+    assert isinstance(r["reasoning"], str) and r["reasoning"] == ""
+    assert isinstance(r["refutation"], str)
+
+
+def test_degraded_direct_nonstring_args_coerced():
+    d = V._degraded(refutation=None, reasoning=123)
+    assert d["refutation"] == "" and d["reasoning"] == "123"
+    assert isinstance(d["refutation"], str) and isinstance(d["reasoning"], str)
+
+
 def test_claim_only_still_works_without_refs():
     # No code_refs, no file:line anywhere -> reader must never be consulted; behavior unchanged.
     def _reader(path):
@@ -299,6 +318,19 @@ def test_default_reader_size_cap(monkeypatch):
     monkeypatch.setattr(V, "_MAX_FILE_BYTES", 16)
     text = V._lazy_read_file("mcp/verify.py")
     assert 0 < len(text) <= 16
+
+
+def test_default_reader_size_cap_is_byte_accurate(monkeypatch, tmp_path):
+    # The cap is BYTES, not characters: a multibyte file must not read past the byte cap.
+    # Under the old text-mode f.read(n) this capped characters and could return more bytes.
+    p = tmp_path / "multibyte.txt"
+    p.write_text("é" * 100, encoding="utf-8")  # each 'é' is 2 UTF-8 bytes
+    monkeypatch.setattr(V, "_MAX_FILE_BYTES", 10)
+    monkeypatch.setattr(V, "_safe_resolve", lambda path: str(p))
+    text = V._lazy_read_file("multibyte.txt")
+    # Never decode more than the byte cap allowed (10 bytes -> at most 5 'é' chars).
+    assert len(text.encode("utf-8")) <= 10
+    assert 0 < len(text) <= 5
 
 
 def test_absolute_code_ref_reads_nothing_end_to_end():

--- a/mcp/tests/test_verify.py
+++ b/mcp/tests/test_verify.py
@@ -207,6 +207,44 @@ def test_unreadable_ref_fails_open_and_still_verifies():
     assert r["verdict"] == "confirmed"
 
 
+def _capture_fetch(refs, reader):
+    """Exercise _fetch_code directly (bypasses ref-parsing) so we can assert the block."""
+    return V._fetch_code(refs, reader)
+
+
+def test_zero_line_ref_normalizes_to_line_one():
+    # A ref like file.py:0 must not yield an empty block; it clamps to line 1 and the
+    # header reflects the ACTUAL displayed line, not the raw 0.
+    def _reader(path):
+        return "alpha\nbeta\ngamma\n"
+
+    block = _capture_fetch([("m.py", 0, 0)], _reader)
+    assert block, "0-line ref should still emit a non-empty block"
+    assert "--- m.py:1 ---" in block          # header from actual span, not ':0'
+    assert "1: alpha" in block
+    assert ":0" not in block                   # raw 0 never surfaces
+
+
+def test_truncated_ref_header_reflects_displayed_span():
+    # An oversized end (past EOF and past _MAX_LINES_PER_REF) must show the real s..e span
+    # in the header, not the requested 1-999.
+    body = "".join(f"line{i}\n" for i in range(1, 201))   # 200 lines
+    block = _capture_fetch([("big.py", 1, 999)], lambda p: body)
+    cap = V._MAX_LINES_PER_REF
+    assert f"--- big.py:1-{cap} ---" in block            # clamped to the cap, not 1-999
+    assert "1-999" not in block
+    # Exactly _MAX_LINES_PER_REF numbered lines are present.
+    assert f"{cap}: line{cap}" in block
+    assert f"{cap + 1}: line{cap + 1}" not in block
+
+
+def test_ref_clamped_to_eof_header_reflects_last_line():
+    # end past EOF (but within the line cap) clamps the header to the last real line.
+    block = _capture_fetch([("m.py", 2, 50)], lambda p: "a\nb\nc\n")   # only 3 lines
+    assert "--- m.py:2-3 ---" in block
+    assert "3: c" in block
+
+
 def test_reasoning_field_is_surfaced():
     r = V.verify_finding("f() returns 1", gen_fn=_ok(_CONFIRMED_REASONING))
     assert r["verdict"] == "confirmed"

--- a/mcp/tests/test_verify.py
+++ b/mcp/tests/test_verify.py
@@ -230,6 +230,92 @@ def test_claim_only_still_works_without_refs():
     assert r["confidence"] == 0.9
 
 
+# --- SECURITY: file refs from free-form text must not read arbitrary files ---
+
+def test_parse_refs_drops_absolute_and_traversal_paths():
+    # Absolute paths and '..' traversal parsed from free-form text must never become refs.
+    refs = V._parse_refs("see /etc/passwd:1 and ../../secret.txt:2 but src/ok.py:3 is fine")
+    paths = [p for (p, _s, _e) in refs]
+    assert "/etc/passwd" not in paths
+    assert not any(".." in p.split("/") for p in paths)
+    assert "src/ok.py" in paths        # the legitimate repo-relative ref survives
+
+
+def test_default_reader_rejects_absolute_path():
+    # The default FS reader must refuse to read an absolute path (local file disclosure).
+    assert V._lazy_read_file("/etc/passwd") == ""
+
+
+def test_default_reader_rejects_traversal():
+    assert V._lazy_read_file("../../../../../../etc/passwd") == ""
+
+
+def test_default_reader_reads_repo_relative_file():
+    # A legitimate repo-relative path resolves under the repo root and reads.
+    text = V._lazy_read_file("mcp/verify.py")
+    assert "_safe_resolve" in text
+
+
+def test_default_reader_size_cap(monkeypatch):
+    # An oversized read is capped, not slurped whole.
+    monkeypatch.setattr(V, "_MAX_FILE_BYTES", 16)
+    text = V._lazy_read_file("mcp/verify.py")
+    assert 0 < len(text) <= 16
+
+
+def test_absolute_code_ref_reads_nothing_end_to_end():
+    # Passing an absolute path via code_refs with the default reader leaks no file content.
+    fetched = {}
+
+    def _gen(prompt, *, fmt=None, max_tokens=256):
+        fetched["prompt"] = prompt
+        return {"text": _CONFIRMED, "ok": True}
+
+    r = V.verify_finding("claim", code_refs=["/etc/passwd:1-3"], gen_fn=_gen)
+    assert r["verdict"] == "confirmed"          # still verifies (fail-open)
+    assert "root:" not in fetched["prompt"]     # no /etc/passwd content in the prompt
+    assert "(none)" in fetched["prompt"]        # code block was empty
+
+
+# --- code_refs coercion: accept list or single string, ignore other types ---
+
+def test_code_refs_single_string_is_accepted():
+    # A bare string (not a list) must be treated as one ref, not split into characters.
+    captured = {}
+
+    def _reader(path):
+        captured["path"] = path
+        return "def f():\n    x = 1\n    return x\n"
+
+    def _gen(prompt, *, fmt=None, max_tokens=256):
+        captured["prompt"] = prompt
+        return {"text": _CONFIRMED, "ok": True}
+
+    r = V.verify_finding("f() returns 1", code_refs="mymod.py:2-3",
+                         gen_fn=_gen, reader=_reader)
+    assert r["verdict"] == "confirmed"
+    assert captured["path"] == "mymod.py"       # whole path, not a single char
+    assert "x = 1" in captured["prompt"]
+
+
+def test_code_refs_nonlist_type_is_ignored_and_autodetect_survives():
+    # A junk type (e.g. int) must be ignored without raising, and auto-detection from the
+    # context must still work (the broad try must not be killed by list(code_refs)).
+    def _reader(path):
+        return "alpha\nbeta\ngamma\n"
+
+    captured = {}
+
+    def _gen(prompt, *, fmt=None, max_tokens=256):
+        captured["prompt"] = prompt
+        return {"text": _REFUTED, "ok": True}
+
+    r = V.verify_finding("second line is beta", context="see src/data.py:2",
+                         code_refs=123, gen_fn=_gen, reader=_reader)
+    assert r["verdict"] == "refuted"
+    assert "beta" in captured["prompt"]         # auto-detected ref still fetched
+
+
 def test_default_gen_fn_is_lazy_and_fails_open(monkeypatch):
     # With no llm_local importable, the lazy default must fail-open, not raise.
     import builtins

--- a/mcp/tests/test_verify.py
+++ b/mcp/tests/test_verify.py
@@ -39,6 +39,11 @@ _CONFIRMED_PROSE = (
     "Hope that helps."
 )
 
+_CONFIRMED_REASONING = (
+    '{"verdict": "confirmed", "reasoning": "Line 2 assigns x=1 and returns it, so the claim '
+    'that it returns 1 holds.", "refutation": "cannot refute", "confidence": 0.8}'
+)
+
 
 def test_refutation_yields_refuted():
     r = V.verify_finding("The base omits RTCM 1005", gen_fn=_ok(_REFUTED))
@@ -150,6 +155,79 @@ def test_explicit_context_skips_rag():
     r = V.verify_finding("claim", context="explicit evidence here",
                          investigation_id="inv-3", gen_fn=_ok(_REFUTED), rag_fn=_rag)
     assert r["verdict"] == "refuted"
+
+
+def test_code_ref_fetches_source_into_prompt():
+    # A stubbed reader returns file text; the cited lines must land in the skeptic's prompt.
+    captured = {}
+    file_text = "def f():\n    x = 1\n    return x\n"
+
+    def _reader(path):
+        captured["path"] = path
+        return file_text
+
+    def _gen(prompt, *, fmt=None, max_tokens=256):
+        captured["prompt"] = prompt
+        return {"text": _CONFIRMED, "ok": True}
+
+    r = V.verify_finding("f() returns 1", code_refs=["mymod.py:2-3"],
+                         gen_fn=_gen, reader=_reader)
+    assert r["verdict"] == "confirmed"
+    assert captured["path"] == "mymod.py"
+    # The fetched, line-numbered source is present (not just the prose claim).
+    assert "2: " in captured["prompt"] and "x = 1" in captured["prompt"]
+    assert "return x" in captured["prompt"]
+    assert "mymod.py:2-3" in captured["prompt"]
+
+
+def test_file_ref_in_context_is_auto_fetched():
+    # A ref embedded in the context string is picked up without an explicit code_refs arg.
+    captured = {}
+
+    def _reader(path):
+        return "alpha\nbeta\ngamma\n"
+
+    def _gen(prompt, *, fmt=None, max_tokens=256):
+        captured["prompt"] = prompt
+        return {"text": _REFUTED, "ok": True}
+
+    r = V.verify_finding("the second line is beta", context="see src/data.py:2",
+                         gen_fn=_gen, reader=_reader)
+    assert r["verdict"] == "refuted"
+    assert "beta" in captured["prompt"]
+
+
+def test_unreadable_ref_fails_open_and_still_verifies():
+    def _reader(path):
+        raise FileNotFoundError(path)
+
+    r = V.verify_finding("claim", code_refs=["nope.py:1-3"],
+                         gen_fn=_ok(_CONFIRMED), reader=_reader)
+    # Reader blew up but verification proceeds ungrounded.
+    assert r["verdict"] == "confirmed"
+
+
+def test_reasoning_field_is_surfaced():
+    r = V.verify_finding("f() returns 1", gen_fn=_ok(_CONFIRMED_REASONING))
+    assert r["verdict"] == "confirmed"
+    assert "Line 2 assigns x=1" in r["reasoning"]
+
+
+def test_reasoning_falls_back_to_raw_text_when_absent():
+    # No explicit reasoning field -> caller still gets the model's raw output to judge.
+    r = V.verify_finding("c", gen_fn=_ok('{"verdict": "confirmed", "confidence": 0.6}'))
+    assert r["verdict"] == "confirmed"
+    assert '"verdict": "confirmed"' in r["reasoning"]
+
+
+def test_claim_only_still_works_without_refs():
+    # No code_refs, no file:line anywhere -> reader must never be consulted; behavior unchanged.
+    def _reader(path):
+        raise AssertionError("reader must not be called when there are no refs")
+
+    r = V.verify_finding("The base omits RTCM 1005", gen_fn=_ok(_REFUTED), reader=_reader)
+    assert r["verdict"] == "refuted"
+    assert r["confidence"] == 0.9
 
 
 def test_default_gen_fn_is_lazy_and_fails_open(monkeypatch):

--- a/mcp/verify.py
+++ b/mcp/verify.py
@@ -19,6 +19,14 @@ Design mirrors mcp/query_expand.py:
   we LAZILY + fail-open pull a little RAG context (rag_context_search) to help the skeptic.
   This is injectable via `rag_fn` for tests; a dead/absent RAG lane just means no extra context.
 
+- Code grounding is optional. For CODE claims a prose summary is a poor thing to reason over
+  (the live smoke saw a clearly-true code claim come back 'uncertain'), so when the claim /
+  context / an explicit `code_refs` arg carry ``file:line`` (or ``file:start-end``) references
+  we FETCH the actual source lines and put them in the prompt so the skeptic reasons over real
+  code. The file reader is injectable via `reader` for tests; it is fail-open (an unreadable
+  path just contributes no code). We also surface the model's RAW `reasoning` alongside the
+  verdict so a caller can still judge when the verdict is the cautious 'uncertain'.
+
 - Fail-open + skeptical default: on not-ok / timeout / parse failure / any error we return a
   well-formed {"verdict": "uncertain"} result rather than raising. We also default to the
   cautious verdict when the model is unsure — a claim is only 'confirmed' when the skeptic
@@ -37,8 +45,19 @@ from typing import Callable, Optional
 # Injectable function types: match the shared [interface] contracts.
 GenFn = Callable[..., dict]
 RagFn = Callable[..., dict]
+# reader(path) -> full file text; fail-open to "" on any error.
+ReaderFn = Callable[..., str]
 
 _VALID_VERDICTS = ("confirmed", "refuted", "uncertain")
+
+# Caps so a stray/huge ref can't blow up the prompt. Fail-open, additive.
+_MAX_REFS = 8
+_MAX_LINES_PER_REF = 60
+
+# "file:line" or "file:start-end". Require the path to contain a '.' or '/' so bare
+# "10:30"-style tokens don't get mistaken for refs; anything that still slips through
+# just fails-open at read time (unreadable path -> no code).
+_REF_RE = re.compile(r"([\w./\-]*[./][\w./\-]*):(\d+)(?:-(\d+))?")
 
 _PROMPT_TMPL = (
     "You are a rigorous SKEPTIC performing adversarial verification of a claim.\n"
@@ -51,9 +70,11 @@ _PROMPT_TMPL = (
     "  - \"uncertain\": you cannot tell from the claim and context (default when unsure).\n"
     "Prefer \"refuted\" or \"uncertain\" over \"confirmed\" when in doubt.\n\n"
     "Respond with ONLY a JSON object of this exact shape, no prose:\n"
-    '{{"verdict": "confirmed|refuted|uncertain", "refutation": "your strongest attack or '
-    'why it survives", "confidence": 0.0}}\n\n'
+    '{{"verdict": "confirmed|refuted|uncertain", "reasoning": "your step-by-step skeptical '
+    'analysis", "refutation": "your strongest attack or why it survives", "confidence": 0.0}}\n\n'
     "CLAIM:\n{claim}\n\n"
+    "REFERENCED CODE (actual source at the cited locations — trust this over any summary):\n"
+    "{code}\n\n"
     "CONTEXT (may be empty — do not assume it is complete):\n{context}\n"
 )
 
@@ -80,6 +101,66 @@ def _lazy_rag(query: str, *, limit: int = 5) -> dict:
         return obj if isinstance(obj, dict) else {}
     except Exception:
         return {}
+
+
+def _lazy_read_file(path: str) -> str:
+    """Default reader: read a source file's full text. Fail-open to "" on any error."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:
+        return ""
+
+
+def _parse_refs(*texts: str):
+    """Pull unique (path, start, end) file:line refs out of the given strings, in order.
+
+    Deduplicated and capped at _MAX_REFS. Non-string inputs are ignored (fail-open).
+    """
+    refs = []
+    seen = set()
+    for t in texts:
+        if not isinstance(t, str):
+            continue
+        for m in _REF_RE.finditer(t):
+            path = m.group(1)
+            start = int(m.group(2))
+            end = int(m.group(3)) if m.group(3) else start
+            key = (path, start, end)
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append(key)
+            if len(refs) >= _MAX_REFS:
+                return refs
+    return refs
+
+
+def _fetch_code(refs, reader: ReaderFn) -> str:
+    """Read the cited line ranges via `reader` and format them (line-numbered) for the prompt.
+
+    Fail-open per ref: an unreadable/missing file or out-of-range span just contributes nothing.
+    """
+    blocks = []
+    for path, start, end in refs:
+        try:
+            text = reader(path)
+        except Exception:
+            text = ""
+        if not isinstance(text, str) or not text:
+            continue
+        lines = text.splitlines()
+        n = len(lines)
+        s = max(1, start)
+        if s > n:
+            continue
+        e = min(n, end if end >= start else start)
+        if e - s + 1 > _MAX_LINES_PER_REF:
+            e = s + _MAX_LINES_PER_REF - 1
+        numbered = "\n".join(f"{i}: {lines[i - 1]}" for i in range(s, e + 1))
+        header = f"--- {path}:{start}" + (f"-{end}" if end != start else "") + " ---"
+        blocks.append(header + "\n" + numbered)
+    return "\n\n".join(blocks)
 
 
 def _extract_json_object(text: str) -> Optional[dict]:
@@ -146,17 +227,22 @@ def _coerce_confidence(raw) -> float:
     return max(0.0, min(1.0, c))
 
 
-def _degraded(refutation: str = "") -> dict:
-    """Well-formed skeptical fallback: uncertain, low confidence, degraded=True."""
-    return {"verdict": "uncertain", "refutation": refutation, "confidence": 0.0,
-            "degraded": True}
+def _degraded(refutation: str = "", reasoning: str = "") -> dict:
+    """Well-formed skeptical fallback: uncertain, low confidence, degraded=True.
+
+    `reasoning` carries any raw model text we did manage to get, so a caller can still judge.
+    """
+    return {"verdict": "uncertain", "refutation": refutation, "reasoning": reasoning,
+            "confidence": 0.0, "degraded": True}
 
 
 def verify_finding(claim: str,
                    context: str = "",
                    investigation_id: Optional[str] = None,
                    gen_fn: Optional[GenFn] = None,
-                   rag_fn: Optional[RagFn] = None) -> dict:
+                   rag_fn: Optional[RagFn] = None,
+                   code_refs: Optional[list] = None,
+                   reader: Optional[ReaderFn] = None) -> dict:
     """Adversarially verify a `claim`: run a skeptic that tries to refute it.
 
     Args:
@@ -166,11 +252,16 @@ def verify_finding(claim: str,
             (fail-open) to give the skeptic something to attack with.
         gen_fn: injectable generation fn (shared contract). None -> lazy llm_local.generate.
         rag_fn: injectable grounding fn. None -> lazy rag_context_search.
+        code_refs: optional list of ``file:line`` / ``file:start-end`` strings whose source
+            should be fetched into the prompt. ``file:line`` refs found in the claim/context
+            are also picked up automatically. Fail-open: unreadable refs contribute nothing.
+        reader: injectable file reader ``reader(path) -> text``. None -> lazy FS read.
 
     Returns:
-        {"verdict": "confirmed"|"refuted"|"uncertain", "refutation": str,
-         "confidence": float, "degraded": bool}. Fail-open: on any failure returns a
-        skeptical uncertain result. Never raises.
+        {"verdict": "confirmed"|"refuted"|"uncertain", "refutation": str, "reasoning": str,
+         "confidence": float, "degraded": bool}. `reasoning` surfaces the model's raw analysis
+         so a caller can judge even on 'uncertain'. Fail-open: on any failure returns a
+         skeptical uncertain result. Never raises.
     """
     c = (claim or "").strip()
     if not c:
@@ -187,7 +278,17 @@ def verify_finding(claim: str,
         except Exception:
             ctx = ""
 
-    prompt = _PROMPT_TMPL.format(claim=c, context=ctx or "(none)")
+    # Optional, fail-open code grounding: fetch real source for any cited file:line refs so
+    # the skeptic reasons over code, not a prose summary. Explicit code_refs are authoritative.
+    code_block = ""
+    try:
+        refs = _parse_refs(*(list(code_refs) if code_refs else []), c, ctx)
+        if refs:
+            code_block = _fetch_code(refs, reader or _lazy_read_file)
+    except Exception:
+        code_block = ""
+
+    prompt = _PROMPT_TMPL.format(claim=c, code=code_block or "(none)", context=ctx or "(none)")
     fn = gen_fn or _lazy_generate
     try:
         res = fn(prompt, fmt="json", max_tokens=384)
@@ -195,16 +296,21 @@ def verify_finding(claim: str,
         return _degraded()
 
     if not isinstance(res, dict) or not res.get("ok"):
-        return _degraded()
+        return _degraded(reasoning=(res.get("text", "") if isinstance(res, dict) else ""))
 
-    obj = _extract_json_object(res.get("text", ""))
+    raw = res.get("text", "")
+    obj = _extract_json_object(raw)
     if obj is None:
-        return _degraded()
+        return _degraded(reasoning=raw if isinstance(raw, str) else "")
 
     verdict = _coerce_verdict(obj.get("verdict"))
     refutation = obj.get("refutation")
     if not isinstance(refutation, str):
         refutation = "" if refutation is None else str(refutation)
     confidence = _coerce_confidence(obj.get("confidence"))
+    # Surface raw reasoning: prefer the model's own field, fall back to its raw text.
+    reasoning = obj.get("reasoning")
+    if not isinstance(reasoning, str) or not reasoning.strip():
+        reasoning = raw if isinstance(raw, str) else ""
     return {"verdict": verdict, "refutation": refutation.strip(),
-            "confidence": confidence, "degraded": False}
+            "reasoning": reasoning.strip(), "confidence": confidence, "degraded": False}

--- a/mcp/verify.py
+++ b/mcp/verify.py
@@ -212,14 +212,22 @@ def _fetch_code(refs, reader: ReaderFn) -> str:
             continue
         lines = text.splitlines()
         n = len(lines)
+        if n == 0:
+            continue
+        # Clamp the START into the file (a ref like file.py:0 becomes line 1).
         s = max(1, start)
         if s > n:
             continue
-        e = min(n, end if end >= start else start)
+        # Clamp the END to the ACTUAL last displayable line: at least `s`, no past EOF,
+        # and no more than _MAX_LINES_PER_REF lines. The header is then formatted from the
+        # real s..e span so a 0/oversized/truncated ref never shows a misleading range or
+        # an empty block.
+        e = end if end >= start else start
+        e = min(n, max(s, e))
         if e - s + 1 > _MAX_LINES_PER_REF:
             e = s + _MAX_LINES_PER_REF - 1
         numbered = "\n".join(f"{i}: {lines[i - 1]}" for i in range(s, e + 1))
-        header = f"--- {path}:{start}" + (f"-{end}" if end != start else "") + " ---"
+        header = f"--- {path}:{s}" + (f"-{e}" if e != s else "") + " ---"
         blocks.append(header + "\n" + numbered)
     return "\n\n".join(blocks)
 

--- a/mcp/verify.py
+++ b/mcp/verify.py
@@ -39,20 +39,24 @@ copy and the JSON schema {verdict,refutation,confidence} are this task's design.
 from __future__ import annotations
 
 import json
+import os
 import re
+from functools import lru_cache
 from typing import Callable, Optional
 
 # Injectable function types: match the shared [interface] contracts.
 GenFn = Callable[..., dict]
 RagFn = Callable[..., dict]
 # reader(path) -> full file text; fail-open to "" on any error.
-ReaderFn = Callable[..., str]
+ReaderFn = Callable[[str], str]
 
 _VALID_VERDICTS = ("confirmed", "refuted", "uncertain")
 
 # Caps so a stray/huge ref can't blow up the prompt. Fail-open, additive.
 _MAX_REFS = 8
 _MAX_LINES_PER_REF = 60
+# Size cap on a single file read so an oversized/binary file can't blow up memory/prompt.
+_MAX_FILE_BYTES = 1_000_000
 
 # "file:line" or "file:start-end". Require the path to contain a '.' or '/' so bare
 # "10:30"-style tokens don't get mistaken for refs; anything that still slips through
@@ -103,11 +107,63 @@ def _lazy_rag(query: str, *, limit: int = 5) -> dict:
         return {}
 
 
-def _lazy_read_file(path: str) -> str:
-    """Default reader: read a source file's full text. Fail-open to "" on any error."""
+@lru_cache(maxsize=1)
+def _repo_root() -> str:
+    """Best-effort repo root used to sandbox file refs. Walk up from this module for a
+    ``.git`` marker; fall back to the package parent. Cached; never raises."""
     try:
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
-            return f.read()
+        here = os.path.dirname(os.path.abspath(__file__))
+        d = here
+        while True:
+            if os.path.exists(os.path.join(d, ".git")):
+                return os.path.realpath(d)
+            parent = os.path.dirname(d)
+            if parent == d:
+                break
+            d = parent
+        return os.path.realpath(os.path.dirname(here))  # mcp/ -> repo root
+    except Exception:
+        return os.path.realpath(os.getcwd())
+
+
+def _safe_resolve(path: str) -> Optional[str]:
+    """Resolve a repo-relative ref path to an absolute path UNDER the repo root.
+
+    SECURITY: file refs are parsed from free-form (attacker-influenceable) claim/context
+    text, so the default reader must never read arbitrary files. Rejects absolute paths and
+    any ``..`` traversal segment, resolves relative to the repo root, and returns None for
+    anything that still lands outside the root (e.g. via a symlink). Returns None on reject
+    (caller fails open by contributing no code). Never raises.
+    """
+    if not isinstance(path, str) or not path:
+        return None
+    if os.path.isabs(path):
+        return None
+    if ".." in path.replace("\\", "/").split("/"):
+        return None
+    try:
+        root = _repo_root()
+        full = os.path.realpath(os.path.join(root, path))
+        # realpath collapses symlinks/traversal; require the result to stay under the root.
+        if full == root or full.startswith(root + os.sep):
+            return full
+    except Exception:
+        return None
+    return None
+
+
+def _lazy_read_file(path: str) -> str:
+    """Default reader: read a repo-relative source file, SANDBOXED under the repo root.
+
+    Rejects absolute paths, ``..`` traversal, and anything resolving outside the repo, and
+    caps the read at ``_MAX_FILE_BYTES``. Fail-open to "" on any rejection or error.
+    """
+    try:
+        full = _safe_resolve(path)
+        if not full or not os.path.isfile(full):
+            return ""
+        with open(full, "r", encoding="utf-8", errors="replace") as f:
+            return f.read(_MAX_FILE_BYTES)
     except Exception:
         return ""
 
@@ -116,6 +172,9 @@ def _parse_refs(*texts: str):
     """Pull unique (path, start, end) file:line refs out of the given strings, in order.
 
     Deduplicated and capped at _MAX_REFS. Non-string inputs are ignored (fail-open).
+    SECURITY: absolute paths and ``..`` traversal are dropped here (defense-in-depth; the
+    default reader also sandboxes reads under the repo root) so a ref like ``/etc/passwd:1``
+    or ``../../secret.txt:1`` parsed from free-form text never becomes a fetched ref.
     """
     refs = []
     seen = set()
@@ -124,6 +183,8 @@ def _parse_refs(*texts: str):
             continue
         for m in _REF_RE.finditer(t):
             path = m.group(1)
+            if os.path.isabs(path) or ".." in path.replace("\\", "/").split("/"):
+                continue
             start = int(m.group(2))
             end = int(m.group(3)) if m.group(3) else start
             key = (path, start, end)
@@ -161,6 +222,22 @@ def _fetch_code(refs, reader: ReaderFn) -> str:
         header = f"--- {path}:{start}" + (f"-{end}" if end != start else "") + " ---"
         blocks.append(header + "\n" + numbered)
     return "\n\n".join(blocks)
+
+
+def _coerce_code_refs(code_refs) -> list:
+    """Normalize the ``code_refs`` arg to a list of ref strings; ignore other types.
+
+    Documented as a list, but a caller may pass a single ``file:line`` string; ``list(str)``
+    would split it into characters. Accept a list/tuple (keeping only its string items) or a
+    lone string; anything else yields []. Never raises.
+    """
+    if code_refs is None:
+        return []
+    if isinstance(code_refs, str):
+        return [code_refs]
+    if isinstance(code_refs, (list, tuple)):
+        return [x for x in code_refs if isinstance(x, str)]
+    return []
 
 
 def _extract_json_object(text: str) -> Optional[dict]:
@@ -282,7 +359,7 @@ def verify_finding(claim: str,
     # the skeptic reasons over code, not a prose summary. Explicit code_refs are authoritative.
     code_block = ""
     try:
-        refs = _parse_refs(*(list(code_refs) if code_refs else []), c, ctx)
+        refs = _parse_refs(*_coerce_code_refs(code_refs), c, ctx)
         if refs:
             code_block = _fetch_code(refs, reader or _lazy_read_file)
     except Exception:

--- a/mcp/verify.py
+++ b/mcp/verify.py
@@ -162,8 +162,11 @@ def _lazy_read_file(path: str) -> str:
         full = _safe_resolve(path)
         if not full or not os.path.isfile(full):
             return ""
-        with open(full, "r", encoding="utf-8", errors="replace") as f:
-            return f.read(_MAX_FILE_BYTES)
+        # Read raw BYTES so the cap is byte-accurate (text-mode f.read(n) caps CHARACTERS and
+        # can pull in more bytes for multibyte text). Read exactly the cap, then decode.
+        with open(full, "rb") as f:
+            raw = f.read(_MAX_FILE_BYTES)
+        return raw.decode("utf-8", errors="replace")
     except Exception:
         return ""
 
@@ -316,8 +319,13 @@ def _degraded(refutation: str = "", reasoning: str = "") -> dict:
     """Well-formed skeptical fallback: uncertain, low confidence, degraded=True.
 
     `reasoning` carries any raw model text we did manage to get, so a caller can still judge.
+    Callers may pass through non-string values (e.g. ``res.get('text')`` is None), so coerce
+    both text fields to a stripped str here — the single normalization point — to keep the
+    documented all-strings return shape.
     """
-    return {"verdict": "uncertain", "refutation": refutation, "reasoning": reasoning,
+    ref = refutation if isinstance(refutation, str) else ("" if refutation is None else str(refutation))
+    rea = reasoning if isinstance(reasoning, str) else ("" if reasoning is None else str(reasoning))
+    return {"verdict": "uncertain", "refutation": ref.strip(), "reasoning": rea.strip(),
             "confidence": 0.0, "degraded": True}
 
 


### PR DESCRIPTION
## Why
The live smoke showed `verify_finding` returning `verdict='uncertain'`, empty refutation, `confidence=0.0` on a **clearly-true code claim** — because the local 3B model reasoned over a **prose summary**, not the code.

## What
- **(a) Real code, not prose.** When the claim/context carry `file:line` / `file:start-end` refs (or a new optional `code_refs` param), fetch the actual referenced source lines into the skeptic prompt. File reader is injectable (`reader`) and fail-open — an unreadable/missing path just contributes nothing.
- **(b) Raw reasoning surfaced.** New `reasoning` field returns the model's own analysis (falling back to its raw text), so a caller can judge even when the verdict is the cautious `uncertain`. Degraded paths also carry any raw text they got.
- **(c) Backward-compatible.** Claim-only usage, `gen_fn`/`rag_fn` injection, the skeptical-by-default verdict and fail-open-to-`uncertain` behavior are all unchanged. New params (`code_refs`, `reader`) are appended so existing positional/keyword callers are unaffected.

## Tests
Added focused tests: code_ref fetched into the prompt (stubbed reader/gen), file:line ref auto-fetched from context, unreadable ref fails open and still verifies, `reasoning` surfaced + raw fallback, claim-only path never touches the reader. Full `mcp` suite green (**414 passed**); ruff clean.

## Note
Scope was `mcp/verify.py` (+ tests); `server.py`'s MCP tool signature is unchanged. The fix is still reachable through the existing tool because `file:line` refs in the already-passed `context` are auto-detected and the new `reasoning` field flows through `json.dumps`. Threading an explicit `code_refs` param through the MCP tool is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45