### PR TITLE
feat(lifecycle): in-place finding_resolve + code-ref staleness + verify-all (#1,#3,#5)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1837,6 +1837,132 @@ def _rewrite_jsonl_set_field(path: Path, target_ids: set, field: str, value) -> 
 
 
 # ---------------------------------------------------------------------------
+# Finding lifecycle: append-only updates log + staleness (code-ref hashing).
+#
+# findings.jsonl stays pure (only real finding records) so every existing reader
+# is untouched. In-place resolution and verify-all verdicts are recorded as
+# APPEND-ONLY update records in a sibling ``finding_updates.jsonl`` and folded in
+# last-write-wins by the read path. Both features are additive + fail-open.
+# ---------------------------------------------------------------------------
+
+# Injectable generation fn for investigation_verify_all — None means "use the
+# shipped verify.py default" (lazy llm_local). Tests set this to a stub.
+_verify_gen_fn = None
+
+# Update-record types recorded in finding_updates.jsonl.
+_LIFECYCLE_UPDATE_TYPES: frozenset = frozenset({"resolution", "verification"})
+
+# A file-path-with-optional-line reference in finding text, e.g. "mcp/server.py:3204"
+# or "verify.py". Requires an extension so ordinary prose ("e.g.") doesn't match.
+_FILE_REF_RE = re.compile(r"\b((?:[\w.\-]+/)*[\w.\-]+\.[A-Za-z][\w]*)(?::(\d+))?\b")
+
+
+def _finding_updates_path(investigation_id: str) -> Path:
+    return _inv_dir(investigation_id) / "finding_updates.jsonl"
+
+
+def _load_resolution_overrides(investigation_id: str) -> dict[str, str]:
+    """Return {finding_id: resolution} from finding_updates.jsonl, last-write-wins.
+
+    Only 'resolution' update records with a valid state participate. Fail-open: any
+    read/parse error yields {} so the read path falls back to stored/default values.
+    """
+    overrides: dict[str, str] = {}
+    try:
+        for rec in _read_jsonl(_finding_updates_path(investigation_id)):
+            if not isinstance(rec, dict) or rec.get("record_type") != "resolution":
+                continue
+            fid = str(rec.get("finding_id") or "")
+            res = str(rec.get("resolution") or "").lower()
+            if fid and res in _RESOLUTION_STATES:
+                overrides[fid] = res  # later line wins
+    except Exception as exc:  # noqa: BLE001 — never block a read on the overrides log
+        logger.debug("resolution overrides load failed (fail-open): %r", exc)
+    return overrides
+
+
+def _hash_file_bytes(path_str: str) -> Optional[str]:
+    """sha256 of a referenced file's current bytes, or None if unreadable (fail-open)."""
+    try:
+        p = Path(path_str)
+        if not p.is_file():
+            return None
+        return hashlib.sha256(p.read_bytes()).hexdigest()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _compute_code_refs(text: str, explicit=None) -> list[dict]:
+    """Best-effort: extract file paths from ``text`` (and optional ``explicit`` refs),
+    hash each file that currently exists, and return [{"path": .., "hash": ..}].
+
+    Fully optional + fail-open: unreadable/nonexistent paths are simply omitted, and
+    any error returns []. Line suffixes ("file.py:12") are stripped for hashing.
+    """
+    candidates: list[str] = []
+    try:
+        if explicit:
+            items = explicit if isinstance(explicit, list) else str(explicit).split(",")
+            candidates.extend(str(i) for i in items)
+        for m in _FILE_REF_RE.finditer(text or ""):
+            candidates.append(m.group(1))
+    except Exception:  # noqa: BLE001
+        return []
+    out: list[dict] = []
+    seen: set[str] = set()
+    for c in candidates:
+        path = (c or "").strip().split(":")[0].strip()
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        h = _hash_file_bytes(path)
+        if h is not None:
+            out.append({"path": path, "hash": h})
+    return out
+
+
+def _finding_is_stale(finding: dict) -> Optional[bool]:
+    """Re-hash a finding's stamped code_refs. Returns True if any referenced file's
+    content changed, False if refs exist and none changed, None if the finding has
+    no usable refs (caller omits the ``stale`` key in that case). Fail-open."""
+    refs = finding.get("code_refs") if isinstance(finding, dict) else None
+    if not isinstance(refs, list) or not refs:
+        return None
+    checked = False
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        path = ref.get("path")
+        old = ref.get("hash")
+        if not path or not old:
+            continue
+        cur = _hash_file_bytes(str(path))
+        if cur is None:
+            continue  # unreadable now -> don't flag (fail-open)
+        checked = True
+        if cur != old:
+            return True
+    return False if checked else None
+
+
+def _apply_lifecycle(findings: list[dict], investigation_id: str) -> None:
+    """In-place: stamp effective ``resolution`` (append-log override else stored/'open')
+    and ``stale`` (only when the finding carries usable code_refs). Fail-open."""
+    overrides = _load_resolution_overrides(investigation_id)
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        fid = str(f.get("id", ""))
+        if fid and fid in overrides:
+            f["resolution"] = overrides[fid]
+        elif not f.get("resolution"):
+            f["resolution"] = "open"
+        stale = _finding_is_stale(f)
+        if stale is not None:
+            f["stale"] = stale
+
+
+# ---------------------------------------------------------------------------
 # Session hints — module-level ring buffer updated by investigation_store so
 # that memory_hints (and the MCP resource) can surface "what changed recently"
 # without re-scanning JSONL.  Each key is an investigation_id; the value is a
@@ -2758,11 +2884,10 @@ def investigation_load(
         ]
 
     recent = findings[-last_n_findings:]
-    # Surface the lifecycle/resolution state; findings stored before this field
-    # existed read as "open" (additive, backwards-compatible).
-    for _f in recent:
-        if isinstance(_f, dict) and not _f.get("resolution"):
-            _f["resolution"] = "open"
+    # Surface the lifecycle/resolution state (append-log overrides win, else stored/
+    # default "open") and staleness for findings that carry code_refs. Additive +
+    # backwards-compatible: findings without these fields read as "open"/not-stale.
+    _apply_lifecycle(recent, investigation_id)
 
     return json.dumps({
         "manifest": manifest,
@@ -3071,6 +3196,7 @@ def investigation_store(
     authored_by: Optional[str] = None,
     tier: str = "warm",
     resolution: str = "open",
+    code_refs: Optional[str] = None,
 ) -> str:
     """
     Record a finding in the investigation.
@@ -3124,6 +3250,12 @@ def investigation_store(
               The three resolved states (fixed/intentional/wontfix) let
               exclusion-aware grounding auto-skip handled items on re-audit.
               Findings stored before this field existed read as "open".
+        code_refs: Optional comma-separated (or list of) file paths this finding
+                   refers to, e.g. "mcp/server.py,mcp/verify.py". When omitted, refs
+                   are best-effort parsed from ``text`` (tokens like "path/file.py:12").
+                   Each readable file's current sha256 is stamped so investigation_load
+                   / investigation_search can flag the finding ``stale`` once that file
+                   changes. Fully optional + fail-open: unreadable paths are skipped.
 
     Returns:
         JSON: {"stored": true, "finding_id": "<uuid>", "type": "<finding_type>",
@@ -3187,6 +3319,16 @@ def investigation_store(
             return json.dumps({"error": f"derived_from contains unknown parent id(s): {unknown}. Verify the parent findings exist before linking."})
         finding["derived_from"] = derived
     finding["entities"] = _extract_entities(text)
+
+    # Staleness: stamp sha256 of any referenced code file so a later re-hash can flag
+    # the finding stale once that file changes. Best-effort + fail-open (no refs / an
+    # unreadable file -> omit; never error).
+    try:
+        _refs = _compute_code_refs(text, code_refs)
+        if _refs:
+            finding["code_refs"] = _refs
+    except Exception as _cr_exc:  # noqa: BLE001
+        logger.debug("investigation_store: code-ref hashing failed (fail-open): %r", _cr_exc)
 
     if finding_type == "procedure":
         finding["procedure_meta"] = {
@@ -3282,6 +3424,67 @@ def investigation_store(
         result["conflict_id"] = conflict_id
 
     return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def finding_resolve(
+    investigation_id: str,
+    finding_id: str,
+    resolution: str,
+    note: Optional[str] = None,
+) -> str:
+    """
+    Mark a finding's lifecycle state in place (open -> fixed / intentional / wontfix /
+    superseded, or back to open). Completes the lifecycle gap: findings could only get
+    a resolution at store time, never afterwards.
+
+    findings.jsonl is append-only, so this records an append-only update record in a
+    sibling ``finding_updates.jsonl``; investigation_load / investigation_search fold it
+    in last-write-wins. The original finding is never rewritten and no data is lost.
+
+    Args:
+        investigation_id: Investigation that owns the finding.
+        finding_id: ID of the finding to resolve.
+        resolution: One of open, fixed, intentional, wontfix, superseded.
+        note: Optional free-text note explaining the resolution.
+
+    Returns:
+        JSON: {"resolved": true, "finding_id": ..., "resolution": ...}
+        On error: {"error": "<message>"}
+    """
+    manifest = _load_manifest(investigation_id)
+    if not manifest:
+        return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
+
+    res = str(resolution or "").lower()
+    if res not in _RESOLUTION_STATES:
+        return json.dumps({"error": "resolution must be one of: open, fixed, intentional, wontfix, superseded"})
+
+    # Confirm the finding exists so we don't record an orphan resolution.
+    findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
+    if not any(str(f.get("id", "")) == str(finding_id) for f in findings):
+        return json.dumps({"error": f"Finding '{finding_id}' not found in investigation '{investigation_id}'."})
+
+    record = {
+        "record_type": "resolution",
+        "investigation_id": investigation_id,
+        "finding_id": str(finding_id),
+        "resolution": res,
+        "note": note or "",
+        "ts": _now(),
+    }
+    _append_jsonl(_finding_updates_path(investigation_id), record)
+    _event_log_append({
+        "op": "finding_resolve",
+        "investigation_id": investigation_id,
+        "finding_id": str(finding_id),
+        "resolution": res,
+    })
+    return json.dumps({
+        "resolved": True,
+        "finding_id": str(finding_id),
+        "resolution": res,
+    }, indent=2)
 
 
 # ---- Tool: procedure_attempt ----
@@ -4347,6 +4550,7 @@ def investigation_search(
     # Absent record -> "open". Fail-open (a failed map build just falls back to the
     # per-row payload value, defaulting to "open").
     _resolution_map: dict[str, str] = {}
+    _coderefs_map: dict[str, list] = {}
     try:
         _invs_in_results = {str(r.get("investigation_id", "")) for r in deduped}
         _invs_in_results.discard("")
@@ -4355,9 +4559,16 @@ def investigation_search(
                 _fid = str(_f.get("id", ""))
                 if _fid:
                     _resolution_map[_fid] = str(_f.get("resolution") or "open").lower()
+                    _crefs = _f.get("code_refs")
+                    if isinstance(_crefs, list) and _crefs:
+                        _coderefs_map[_fid] = _crefs
+            # Fold in append-only resolution overrides (finding_resolve) last-write-wins.
+            for _ofid, _ores in _load_resolution_overrides(_inv).items():
+                _resolution_map[_ofid] = _ores
     except Exception as exc:  # fail-open — never block search on the map build
         logger.debug("resolution map build failed, using per-row values: %r", exc)
         _resolution_map = {}
+        _coderefs_map = {}
 
     def _row_resolution(row: dict) -> str:
         fid = str(row.get("finding_id") or row.get("id") or "")
@@ -4367,6 +4578,14 @@ def investigation_search(
 
     for r in deduped:
         r["resolution"] = _row_resolution(r)
+        # Staleness: rows from mnemo/qdrant don't carry code_refs, so consult the
+        # JSONL-derived map. Only set ``stale`` when the finding has usable refs.
+        _rfid = str(r.get("finding_id") or r.get("id") or "")
+        _refs = _coderefs_map.get(_rfid)
+        if _refs:
+            _st = _finding_is_stale({"code_refs": _refs})
+            if _st is not None:
+                r["stale"] = _st
     if resolution is not None:
         deduped = [r for r in deduped if r.get("resolution") == resolution]
 
@@ -7069,6 +7288,88 @@ def verify_finding(claim: str, context: str = "", investigation_id: Optional[str
     import verify as _v
     return json.dumps(_v.verify_finding(claim, context=context,
                                         investigation_id=investigation_id), indent=2)
+
+
+@mcp.tool()
+def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
+    """
+    Batch adversarial-verify the OPEN findings of an investigation — run the skeptic
+    (verify.verify_finding) over each and return per-finding {finding_id, verdict,
+    confidence}. A triage aid, NOT a lifecycle change: the verdict is recorded as an
+    append-only verification note and does NOT overwrite the finding's resolution
+    (a verdict != a lifecycle state). Use finding_resolve to actually resolve.
+
+    Skips resolved (fixed/intentional/wontfix/superseded) and soft-retracted findings.
+    Fail-open: an unavailable local model yields verdict='uncertain' per finding.
+
+    Args:
+        investigation_id: Investigation whose open findings to verify.
+        limit: Max number of open findings to verify (default 20).
+
+    Returns:
+        JSON: {"investigation_id": ..., "verified": N,
+               "results": [{"finding_id", "verdict", "confidence"}, ...]}
+        On error: {"error": "<message>"}
+    """
+    manifest = _load_manifest(investigation_id)
+    if not manifest:
+        return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
+
+    import verify as _v
+
+    findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
+    overrides = _load_resolution_overrides(investigation_id)
+    retracted = _load_retracted_ids(investigation_id)
+
+    def _effective_res(f: dict) -> str:
+        fid = str(f.get("id", ""))
+        if fid in overrides:
+            return overrides[fid]
+        return str(f.get("resolution") or "open").lower()
+
+    open_findings = [
+        f for f in findings
+        if isinstance(f, dict)
+        and _effective_res(f) == "open"
+        and str(f.get("id", "")) not in retracted
+        and str(f.get("text") or "").strip()
+    ]
+    try:
+        _limit = max(0, int(limit))
+    except (TypeError, ValueError):
+        _limit = 20
+    open_findings = open_findings[:_limit]
+
+    results = []
+    for f in open_findings:
+        fid = str(f.get("id", ""))
+        res = _v.verify_finding(
+            str(f.get("text") or ""),
+            investigation_id=investigation_id,
+            gen_fn=_verify_gen_fn,
+        )
+        verdict = res.get("verdict", "uncertain")
+        confidence = res.get("confidence", 0.0)
+        # Record as an append-only verification note — does NOT touch resolution.
+        _append_jsonl(_finding_updates_path(investigation_id), {
+            "record_type": "verification",
+            "investigation_id": investigation_id,
+            "finding_id": fid,
+            "verdict": verdict,
+            "confidence": confidence,
+            "ts": _now(),
+        })
+        results.append({
+            "finding_id": fid,
+            "verdict": verdict,
+            "confidence": confidence,
+        })
+
+    return json.dumps({
+        "investigation_id": investigation_id,
+        "verified": len(results),
+        "results": results,
+    }, indent=2)
 
 
 @mcp.tool()

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1881,11 +1881,56 @@ def _load_resolution_overrides(investigation_id: str) -> dict[str, str]:
     return overrides
 
 
-def _hash_file_bytes(path_str: str) -> Optional[str]:
-    """sha256 of a referenced file's current bytes, or None if unreadable (fail-open)."""
+# Files larger than this are never hashed — a code ref points at source, not
+# blobs, and this caps how much a rogue ref can make the server read. Overridable.
+_HASH_FILE_MAX_BYTES = int(os.environ.get("LOCI_HASH_FILE_MAX_BYTES", str(8 * 1024 * 1024)))
+
+
+def _code_root() -> Path:
+    """Root that user-supplied code refs must stay under. Defaults to the process
+    working directory (the repo being investigated); overridable via LOCI_CODE_ROOT.
+    Re-read each call so tests / re-rooted runs are honored."""
+    root = os.environ.get("LOCI_CODE_ROOT") or os.getcwd()
+    return Path(root).resolve()
+
+
+def _safe_repo_path(path_str: str) -> Optional[Path]:
+    """Resolve a user-controlled ref to a real path UNDER the code root, else None.
+
+    Security boundary for _hash_file_bytes: file refs come from finding text /
+    caller-supplied code_refs, so an absolute path or ``..`` traversal could probe
+    any readable file on the host. This rejects absolute paths and any ``..``
+    component, resolves relative to the code root, and requires the resolved path
+    (symlinks included) to remain inside that root. Fail-open — returns None on
+    anything rejected or unresolvable so the caller simply skips the ref."""
     try:
-        p = Path(path_str)
-        if not p.is_file():
+        raw = (path_str or "").strip()
+        if not raw:
+            return None
+        p = Path(raw)
+        if p.is_absolute() or any(part == ".." for part in p.parts):
+            return None
+        root = _code_root()
+        resolved = (root / p).resolve()
+        if not resolved.is_relative_to(root):
+            return None
+        return resolved
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _hash_file_bytes(path_str: str) -> Optional[str]:
+    """sha256 of a referenced file's current bytes, or None if unreadable (fail-open).
+
+    The path is scoped to the code root via _safe_repo_path (absolute paths, ``..``
+    traversal, and anything escaping the root are rejected) and files larger than
+    _HASH_FILE_MAX_BYTES are skipped — so this only ever hashes in-repo source,
+    never arbitrary or oversized files on the host."""
+    try:
+        p = _safe_repo_path(path_str)
+        if p is None or not p.is_file():
+            return None
+        if p.stat().st_size > _HASH_FILE_MAX_BYTES:
             return None
         return hashlib.sha256(p.read_bytes()).hexdigest()
     except Exception:  # noqa: BLE001
@@ -3196,7 +3241,7 @@ def investigation_store(
     authored_by: Optional[str] = None,
     tier: str = "warm",
     resolution: str = "open",
-    code_refs: Optional[str] = None,
+    code_refs: str | list[str] | None = None,
 ) -> str:
     """
     Record a finding in the investigation.
@@ -3462,7 +3507,7 @@ def finding_resolve(
 
     # Confirm the finding exists so we don't record an orphan resolution.
     findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
-    if not any(str(f.get("id", "")) == str(finding_id) for f in findings):
+    if not any(isinstance(f, dict) and str(f.get("id", "")) == str(finding_id) for f in findings):
         return json.dumps({"error": f"Finding '{finding_id}' not found in investigation '{investigation_id}'."})
 
     record = {

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1840,17 +1840,21 @@ def _rewrite_jsonl_set_field(path: Path, target_ids: set, field: str, value) -> 
 # Finding lifecycle: append-only updates log + staleness (code-ref hashing).
 #
 # findings.jsonl stays pure (only real finding records) so every existing reader
-# is untouched. In-place resolution and verify-all verdicts are recorded as
-# APPEND-ONLY update records in a sibling ``finding_updates.jsonl`` and folded in
-# last-write-wins by the read path. Both features are additive + fail-open.
+# is untouched. In-place resolutions are recorded as APPEND-ONLY update records in
+# a sibling ``finding_updates.jsonl`` and folded in last-write-wins by the read
+# path. verify-all verdicts are written to a SEPARATE ``finding_verifications.jsonl``
+# (round-3 scaling fix) so the resolution read path never scans the high-churn
+# verification log. Both features are additive + fail-open.
 # ---------------------------------------------------------------------------
 
 # Injectable generation fn for investigation_verify_all — None means "use the
 # shipped verify.py default" (lazy llm_local). Tests set this to a stub.
 _verify_gen_fn = None
 
-# Update-record types recorded in finding_updates.jsonl.
-_LIFECYCLE_UPDATE_TYPES: frozenset = frozenset({"resolution", "verification"})
+# Update-record types recorded in finding_updates.jsonl. Only 'resolution' records
+# land here; verify-all verdicts are written to the separate finding_verifications.jsonl
+# (see _finding_verifications_path) and are NOT part of this constant.
+_LIFECYCLE_UPDATE_TYPES: frozenset = frozenset({"resolution"})
 
 # Known source/config/doc file extensions a code ref may end in. Requiring the
 # extension to be from THIS set (not merely "some letters after a dot") is what

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1984,17 +1984,22 @@ def _compute_code_refs(text: str, explicit=None) -> list[dict]:
     """Best-effort: resolve file paths to [{"path": .., "hash": ..}] by hashing each
     file that currently exists.
 
-    ``explicit`` refs are AUTHORITATIVE when provided: the caller named exactly the
-    files this finding refers to, so text-parsing is skipped entirely. Only when no
-    explicit refs are given are paths best-effort parsed from ``text`` (tokens like
-    "path/file.py:12").
+    ``explicit`` refs are AUTHORITATIVE whenever they are *provided* — including when
+    provided but empty. The distinction is NOT-PROVIDED vs PROVIDED:
+      * ``explicit is None``       -> not provided: paths are best-effort parsed from
+                                      ``text`` (tokens like "path/file.py:12").
+      * ``explicit`` == '' or []   -> provided but empty: authoritative "no refs", so
+                                      text-parsing is skipped and [] is returned.
+      * ``explicit`` non-empty     -> the caller named exactly the files this finding
+                                      refers to; text-parsing is skipped entirely.
 
     Fully optional + fail-open: unreadable/nonexistent paths are simply omitted, and
     any error returns []. Line suffixes ("file.py:12") are stripped for hashing.
     """
     candidates: list[str] = []
     try:
-        if explicit:
+        if explicit is not None:
+            # Provided (possibly empty) -> authoritative, never fall back to text.
             items = explicit if isinstance(explicit, list) else str(explicit).split(",")
             candidates.extend(str(i) for i in items)
         else:
@@ -3345,8 +3350,10 @@ def investigation_store(
               exclusion-aware grounding auto-skip handled items on re-audit.
               Findings stored before this field existed read as "open".
         code_refs: Optional comma-separated (or list of) file paths this finding
-                   refers to, e.g. "mcp/server.py,mcp/verify.py". When omitted, refs
-                   are best-effort parsed from ``text`` (tokens like "path/file.py:12").
+                   refers to, e.g. "mcp/server.py,mcp/verify.py". Authoritative when
+                   provided: pass ``[]`` / ``""`` to assert "no refs" (text is NOT
+                   parsed). Only when omitted entirely (None) are refs best-effort
+                   parsed from ``text`` (tokens like "path/file.py:12").
                    Each readable file's current sha256 is stamped so investigation_load
                    / investigation_search can flag the finding ``stale`` once that file
                    changes. Fully optional + fail-open: unreadable paths are skipped.

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1883,7 +1883,39 @@ def _load_resolution_overrides(investigation_id: str) -> dict[str, str]:
 
 # Files larger than this are never hashed — a code ref points at source, not
 # blobs, and this caps how much a rogue ref can make the server read. Overridable.
-_HASH_FILE_MAX_BYTES = int(os.environ.get("LOCI_HASH_FILE_MAX_BYTES", str(8 * 1024 * 1024)))
+_HASH_FILE_MAX_BYTES_DEFAULT = 8 * 1024 * 1024
+
+
+def _parse_hash_file_max_bytes() -> int:
+    """Parse the file-hash size cap from the environment, fail-open to the default.
+
+    A non-integer (or non-positive) LOCI_HASH_FILE_MAX_BYTES must never crash
+    server startup — the whole code-ref hashing path is best-effort, so a bad
+    override falls back to the default cap rather than raising at import time.
+    """
+    raw = os.environ.get("LOCI_HASH_FILE_MAX_BYTES")
+    if raw is None:
+        return _HASH_FILE_MAX_BYTES_DEFAULT
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "invalid LOCI_HASH_FILE_MAX_BYTES=%r; falling back to default %d",
+            raw,
+            _HASH_FILE_MAX_BYTES_DEFAULT,
+        )
+        return _HASH_FILE_MAX_BYTES_DEFAULT
+    if val <= 0:
+        logger.warning(
+            "non-positive LOCI_HASH_FILE_MAX_BYTES=%r; falling back to default %d",
+            raw,
+            _HASH_FILE_MAX_BYTES_DEFAULT,
+        )
+        return _HASH_FILE_MAX_BYTES_DEFAULT
+    return val
+
+
+_HASH_FILE_MAX_BYTES = _parse_hash_file_max_bytes()
 
 
 def _code_root() -> Path:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1858,13 +1858,24 @@ _FILE_REF_RE = re.compile(r"\b((?:[\w.\-]+/)*[\w.\-]+\.[A-Za-z][\w]*)(?::(\d+))?
 
 
 def _finding_updates_path(investigation_id: str) -> Path:
+    """Resolution overrides log — scanned by every read path (load/search), so it
+    stays SMALL: only finding_resolve appends here (last-write-wins resolutions)."""
     return _inv_dir(investigation_id) / "finding_updates.jsonl"
+
+
+def _finding_verifications_path(investigation_id: str) -> Path:
+    """Verify-all verdict notes — kept in a SEPARATE, high-churn log so the
+    resolution read path (_load_resolution_overrides) never has to scan the
+    accumulating per-finding verification records. Write-only for now."""
+    return _inv_dir(investigation_id) / "finding_verifications.jsonl"
 
 
 def _load_resolution_overrides(investigation_id: str) -> dict[str, str]:
     """Return {finding_id: resolution} from finding_updates.jsonl, last-write-wins.
 
-    Only 'resolution' update records with a valid state participate. Fail-open: any
+    Only 'resolution' update records with a valid state participate; any other
+    record type is skipped cheaply. Verification verdicts live in a separate log
+    (finding_verifications.jsonl) so they never bloat this scan. Fail-open: any
     read/parse error yields {} so the read path falls back to stored/default values.
     """
     overrides: dict[str, str] = {}
@@ -1970,8 +1981,13 @@ def _hash_file_bytes(path_str: str) -> Optional[str]:
 
 
 def _compute_code_refs(text: str, explicit=None) -> list[dict]:
-    """Best-effort: extract file paths from ``text`` (and optional ``explicit`` refs),
-    hash each file that currently exists, and return [{"path": .., "hash": ..}].
+    """Best-effort: resolve file paths to [{"path": .., "hash": ..}] by hashing each
+    file that currently exists.
+
+    ``explicit`` refs are AUTHORITATIVE when provided: the caller named exactly the
+    files this finding refers to, so text-parsing is skipped entirely. Only when no
+    explicit refs are given are paths best-effort parsed from ``text`` (tokens like
+    "path/file.py:12").
 
     Fully optional + fail-open: unreadable/nonexistent paths are simply omitted, and
     any error returns []. Line suffixes ("file.py:12") are stripped for hashing.
@@ -1981,8 +1997,9 @@ def _compute_code_refs(text: str, explicit=None) -> list[dict]:
         if explicit:
             items = explicit if isinstance(explicit, list) else str(explicit).split(",")
             candidates.extend(str(i) for i in items)
-        for m in _FILE_REF_RE.finditer(text or ""):
-            candidates.append(m.group(1))
+        else:
+            for m in _FILE_REF_RE.finditer(text or ""):
+                candidates.append(m.group(1))
     except Exception:  # noqa: BLE001
         return []
     out: list[dict] = []
@@ -7427,8 +7444,10 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
         )
         verdict = res.get("verdict", "uncertain")
         confidence = res.get("confidence", 0.0)
-        # Record as an append-only verification note — does NOT touch resolution.
-        _append_jsonl(_finding_updates_path(investigation_id), {
+        # Record as an append-only verification note in a SEPARATE log so these
+        # accumulating records never slow the resolution read path — does NOT
+        # touch resolution.
+        _append_jsonl(_finding_verifications_path(investigation_id), {
             "record_type": "verification",
             "investigation_id": investigation_id,
             "finding_id": fid,

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1852,9 +1852,31 @@ _verify_gen_fn = None
 # Update-record types recorded in finding_updates.jsonl.
 _LIFECYCLE_UPDATE_TYPES: frozenset = frozenset({"resolution", "verification"})
 
+# Known source/config/doc file extensions a code ref may end in. Requiring the
+# extension to be from THIS set (not merely "some letters after a dot") is what
+# keeps ordinary prose out: "e.g." would otherwise parse as file "e" ext "g".
+_CODE_REF_EXTS = (
+    "pyi|pyx|py|ipynb|"
+    "tsx|ts|jsx|js|mjs|cjs|vue|svelte|"
+    "kts|kt|java|scala|sc|groovy|gradle|"
+    "cpp|cxx|cc|hpp|hxx|hh|c|h|"
+    "rs|go|rb|php|swift|mm|m|cs|dart|lua|"
+    "sh|bash|zsh|fish|ps1|"
+    "sql|proto|graphql|"
+    "html|htm|css|scss|sass|less|"
+    "json|jsonl|yaml|yml|toml|ini|cfg|conf|xml|"
+    "md|rst|txt|"
+    "tf|hcl|dockerfile|mk|cmake|bzl"
+)
 # A file-path-with-optional-line reference in finding text, e.g. "mcp/server.py:3204"
-# or "verify.py". Requires an extension so ordinary prose ("e.g.") doesn't match.
-_FILE_REF_RE = re.compile(r"\b((?:[\w.\-]+/)*[\w.\-]+\.[A-Za-z][\w]*)(?::(\d+))?\b")
+# or "verify.py". The path segment ends in a KNOWN code/config/doc extension (see
+# _CODE_REF_EXTS, case-insensitive), so ordinary prose such as "e.g." — which would
+# parse as file "e" with extension "g" — does not match. A trailing lookahead keeps
+# "file.pyc"-style longer suffixes from matching only the "py" prefix.
+_FILE_REF_RE = re.compile(
+    r"\b((?:[\w.\-]+/)*[\w.\-]+\.(?:" + _CODE_REF_EXTS + r"))(?![\w.\-])(?::(\d+))?",
+    re.IGNORECASE,
+)
 
 
 def _finding_updates_path(investigation_id: str) -> Path:
@@ -3574,7 +3596,11 @@ def finding_resolve(
         "note": note or "",
         "ts": _now(),
     }
-    _append_jsonl(_finding_updates_path(investigation_id), record)
+    try:
+        _append_jsonl(_finding_updates_path(investigation_id), record)
+    except Exception as exc:  # noqa: BLE001 — fail-open: never raise out of a tool
+        logger.warning("finding_resolve append failed (fail-open): %r", exc)
+        return json.dumps({"error": f"Could not record resolution: {exc}"})
     _event_log_append({
         "op": "finding_resolve",
         "investigation_id": investigation_id,
@@ -7453,15 +7479,21 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
         confidence = res.get("confidence", 0.0)
         # Record as an append-only verification note in a SEPARATE log so these
         # accumulating records never slow the resolution read path — does NOT
-        # touch resolution.
-        _append_jsonl(_finding_verifications_path(investigation_id), {
-            "record_type": "verification",
-            "investigation_id": investigation_id,
-            "finding_id": fid,
-            "verdict": verdict,
-            "confidence": confidence,
-            "ts": _now(),
-        })
+        # touch resolution. Guarded per-finding: a single write failure (disk
+        # full, permission) is logged and skipped so the rest of the run
+        # continues rather than aborting the whole verification batch.
+        try:
+            _append_jsonl(_finding_verifications_path(investigation_id), {
+                "record_type": "verification",
+                "investigation_id": investigation_id,
+                "finding_id": fid,
+                "verdict": verdict,
+                "confidence": confidence,
+                "ts": _now(),
+            })
+        except Exception as exc:  # noqa: BLE001 — never abort the batch on one write
+            logger.warning("verification note append failed for %s (fail-open, skipped): %r",
+                           fid, exc)
         results.append({
             "finding_id": fid,
             "verdict": verdict,

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -3588,6 +3588,8 @@ def finding_resolve(
         return json.dumps({"error": "resolution must be one of: open, fixed, intentional, wontfix, superseded"})
 
     # Confirm the finding exists so we don't record an orphan resolution.
+    # Uses the codebase-wide _read_jsonl (whole-file read, tolerant of a
+    # partial last line) — same semantics as every other findings.jsonl reader.
     findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
     if not any(isinstance(f, dict) and str(f.get("id", "")) == str(finding_id) for f in findings):
         return json.dumps({"error": f"Finding '{finding_id}' not found in investigation '{investigation_id}'."})
@@ -7458,18 +7460,25 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
             return overrides[fid]
         return str(f.get("resolution") or "open").lower()
 
-    open_findings = [
-        f for f in findings
-        if isinstance(f, dict)
-        and _effective_res(f) == "open"
-        and str(f.get("id", "")) not in retracted
-        and str(f.get("text") or "").strip()
-    ]
     try:
         _limit = max(0, int(limit))
     except (TypeError, ValueError):
         _limit = 20
-    open_findings = open_findings[:_limit]
+
+    # Apply the limit WHILE iterating so we stop after collecting `_limit` open
+    # findings instead of materializing every open finding and then slicing
+    # (Copilot round 7): cheaper on large findings sets.
+    open_findings = []
+    for f in findings:
+        if len(open_findings) >= _limit:
+            break
+        if (
+            isinstance(f, dict)
+            and _effective_res(f) == "open"
+            and str(f.get("id", "")) not in retracted
+            and str(f.get("text") or "").strip()
+        ):
+            open_findings.append(f)
 
     results = []
     for f in open_findings:

--- a/mcp/tests/test_finding_lifecycle.py
+++ b/mcp/tests/test_finding_lifecycle.py
@@ -179,6 +179,27 @@ class FindingLifecycleTest(unittest.TestCase):
         finally:
             server._HASH_FILE_MAX_BYTES = orig
 
+    def test_hash_file_max_bytes_env_parse_fails_open(self):
+        # A bad LOCI_HASH_FILE_MAX_BYTES must fall back to the default cap and
+        # NEVER raise (an import-time ValueError would block server startup).
+        default = server._HASH_FILE_MAX_BYTES_DEFAULT
+        orig = os.environ.get("LOCI_HASH_FILE_MAX_BYTES")
+        try:
+            for bad in ("not-a-number", "", "8MB", "  ", "-1", "0"):
+                os.environ["LOCI_HASH_FILE_MAX_BYTES"] = bad
+                self.assertEqual(server._parse_hash_file_max_bytes(), default)
+            # A valid positive override is honored.
+            os.environ["LOCI_HASH_FILE_MAX_BYTES"] = "4096"
+            self.assertEqual(server._parse_hash_file_max_bytes(), 4096)
+            # Unset falls back to the default.
+            del os.environ["LOCI_HASH_FILE_MAX_BYTES"]
+            self.assertEqual(server._parse_hash_file_max_bytes(), default)
+        finally:
+            if orig is None:
+                os.environ.pop("LOCI_HASH_FILE_MAX_BYTES", None)
+            else:
+                os.environ["LOCI_HASH_FILE_MAX_BYTES"] = orig
+
     # -- #5 investigation_verify_all -----------------------------------------
 
     def test_verify_all_returns_per_finding_verdicts_with_stub(self):

--- a/mcp/tests/test_finding_lifecycle.py
+++ b/mcp/tests/test_finding_lifecycle.py
@@ -1,0 +1,185 @@
+"""Finding-lifecycle tests: in-place resolve (finding_resolve), code-ref staleness,
+and batch adversarial verify (investigation_verify_all).
+
+Runs fully in-process against a temp MEMORY_DIR, with no Qdrant/Ollama (all those
+paths are fail-open). gen is stubbed via server._verify_gen_fn.
+
+Run: pytest mcp/tests/test_finding_lifecycle.py -v
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_MCP_DIR = Path(__file__).resolve().parent.parent
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+import server  # noqa: E402
+
+
+def _json(result: str) -> dict:
+    try:
+        return json.loads(result)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"Tool returned non-JSON: {result!r}") from exc
+
+
+_counter = [0]
+
+
+def _new_id(prefix="lc"):
+    _counter[0] += 1
+    return f"{prefix}-{_counter[0]:04d}"
+
+
+class FindingLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = server.MEMORY_DIR
+        server.MEMORY_DIR = Path(self._tmp.name)
+        self._orig_gen = server._verify_gen_fn
+
+    def tearDown(self):
+        server.MEMORY_DIR = self._orig
+        server._verify_gen_fn = self._orig_gen
+        self._tmp.cleanup()
+
+    def _start(self, prefix="lc"):
+        inv_id = _new_id(prefix)
+        server.investigation_start(investigation_id=inv_id, title="lifecycle test")
+        return inv_id
+
+    def _store(self, inv_id, text="a finding", ftype="observed", **kw):
+        res = _json(server.investigation_store(inv_id, ftype, text, "unit-test", **kw))
+        self.assertTrue(res.get("stored"), res)
+        return res["finding_id"]
+
+    def _load_findings(self, inv_id):
+        loaded = _json(server.investigation_load(inv_id))
+        return {f["id"]: f for f in loaded["recent_findings"]}
+
+    # -- #1 finding_resolve --------------------------------------------------
+
+    def test_resolve_appends_and_load_reflects_last_write_wins(self):
+        inv_id = self._start()
+        fid = self._store(inv_id, "the bug is here")
+
+        # Default state is open.
+        self.assertEqual(self._load_findings(inv_id)[fid]["resolution"], "open")
+
+        r1 = _json(server.finding_resolve(inv_id, fid, "fixed", note="patched"))
+        self.assertTrue(r1["resolved"])
+        self.assertEqual(self._load_findings(inv_id)[fid]["resolution"], "fixed")
+
+        # Second resolve wins (last-write-wins over the append-only log).
+        _json(server.finding_resolve(inv_id, fid, "wontfix"))
+        self.assertEqual(self._load_findings(inv_id)[fid]["resolution"], "wontfix")
+
+        # findings.jsonl was NOT rewritten — the update lives in a sibling log.
+        raw = (server.MEMORY_DIR / inv_id / "findings.jsonl").read_text()
+        self.assertNotIn('"record_type": "resolution"', raw)
+        self.assertTrue((server.MEMORY_DIR / inv_id / "finding_updates.jsonl").exists())
+
+    def test_resolve_rejects_invalid_resolution(self):
+        inv_id = self._start()
+        fid = self._store(inv_id)
+        res = _json(server.finding_resolve(inv_id, fid, "bogus"))
+        self.assertIn("error", res)
+        # Unchanged: still open.
+        self.assertEqual(self._load_findings(inv_id)[fid]["resolution"], "open")
+
+    def test_resolve_unknown_finding_errors(self):
+        inv_id = self._start()
+        res = _json(server.finding_resolve(inv_id, "no-such-id", "fixed"))
+        self.assertIn("error", res)
+
+    # -- #3 staleness --------------------------------------------------------
+
+    def test_staleness_flags_changed_file_only(self):
+        inv_id = self._start()
+        # Two referenced files; only one will change.
+        f_change = Path(self._tmp.name) / "changing.py"
+        f_stable = Path(self._tmp.name) / "stable.py"
+        f_change.write_text("original = 1\n")
+        f_stable.write_text("constant = 1\n")
+
+        fid_change = self._store(inv_id, "bug in changing code", code_refs=str(f_change))
+        fid_stable = self._store(inv_id, "bug in stable code", code_refs=str(f_stable))
+
+        # Nothing changed yet -> both present-with-refs read as not stale.
+        loaded = self._load_findings(inv_id)
+        self.assertEqual(loaded[fid_change].get("stale"), False)
+        self.assertEqual(loaded[fid_stable].get("stale"), False)
+
+        # Mutate one referenced file.
+        f_change.write_text("original = 2  # edited\n")
+
+        loaded = self._load_findings(inv_id)
+        self.assertTrue(loaded[fid_change].get("stale"))
+        self.assertFalse(loaded[fid_stable].get("stale"))
+
+    def test_staleness_absent_when_no_refs(self):
+        inv_id = self._start()
+        fid = self._store(inv_id, "a plain finding with no file references")
+        # No usable code_refs -> the stale key is omitted entirely.
+        self.assertNotIn("stale", self._load_findings(inv_id)[fid])
+
+    # -- #5 investigation_verify_all -----------------------------------------
+
+    def test_verify_all_returns_per_finding_verdicts_with_stub(self):
+        inv_id = self._start()
+        fid1 = self._store(inv_id, "claim one")
+        fid2 = self._store(inv_id, "claim two")
+
+        calls = []
+
+        def _stub_gen(prompt, *, fmt=None, max_tokens=256):
+            calls.append(prompt)
+            return {"ok": True, "text": json.dumps(
+                {"verdict": "confirmed", "refutation": "", "confidence": 0.8})}
+
+        server._verify_gen_fn = _stub_gen
+
+        out = _json(server.investigation_verify_all(inv_id))
+        self.assertEqual(out["verified"], 2)
+        by_id = {r["finding_id"]: r for r in out["results"]}
+        self.assertEqual(by_id[fid1]["verdict"], "confirmed")
+        self.assertEqual(by_id[fid2]["verdict"], "confirmed")
+        self.assertEqual(by_id[fid1]["confidence"], 0.8)
+        self.assertEqual(len(calls), 2)
+
+        # A verification note is recorded but MUST NOT change the resolution.
+        self.assertEqual(self._load_findings(inv_id)[fid1]["resolution"], "open")
+
+    def test_verify_all_skips_resolved_findings(self):
+        inv_id = self._start()
+        fid_open = self._store(inv_id, "still open")
+        fid_done = self._store(inv_id, "already fixed")
+        _json(server.finding_resolve(inv_id, fid_done, "fixed"))
+
+        def _stub_gen(prompt, *, fmt=None, max_tokens=256):
+            return {"ok": True, "text": json.dumps(
+                {"verdict": "uncertain", "refutation": "", "confidence": 0.0})}
+
+        server._verify_gen_fn = _stub_gen
+        out = _json(server.investigation_verify_all(inv_id))
+        ids = {r["finding_id"] for r in out["results"]}
+        self.assertIn(fid_open, ids)
+        self.assertNotIn(fid_done, ids)
+
+    def test_verify_all_respects_limit(self):
+        inv_id = self._start()
+        for i in range(3):
+            self._store(inv_id, f"claim {i}")
+
+        server._verify_gen_fn = lambda *a, **k: {"ok": True, "text": json.dumps(
+            {"verdict": "uncertain", "refutation": "", "confidence": 0.0})}
+        out = _json(server.investigation_verify_all(inv_id, limit=2))
+        self.assertEqual(out["verified"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_finding_lifecycle.py
+++ b/mcp/tests/test_finding_lifecycle.py
@@ -12,6 +12,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 _MCP_DIR = Path(__file__).resolve().parent.parent
@@ -182,6 +183,26 @@ class FindingLifecycleTest(unittest.TestCase):
         fid = self._store(inv_id, "spans two files", code_refs=["a.py", "b.py"])
         # Both files present + unchanged -> not stale (proves both hashed).
         self.assertEqual(self._load_findings(inv_id)[fid].get("stale"), False)
+
+    def test_code_refs_empty_is_authoritative_no_refs(self):
+        # PROVIDED-BUT-EMPTY ('' or []) is authoritative "no refs": text-parsing
+        # must be SKIPPED even though the text contains a parseable ref token.
+        # Contrast: omitting code_refs entirely (None) falls back to text parsing.
+        (Path(self._code_root.name) / "parsed.py").write_text("q = 1\n")
+        text = "the bug lives in parsed.py:12"
+
+        # None (not provided) -> text-parsed ref is stamped.
+        self.assertEqual(server._compute_code_refs(text, None), [{"path": "parsed.py", "hash": mock.ANY}])
+        # [] (provided-but-empty) -> authoritative no refs.
+        self.assertEqual(server._compute_code_refs(text, []), [])
+        # '' (provided-but-empty) -> authoritative no refs.
+        self.assertEqual(server._compute_code_refs(text, ""), [])
+
+        # End-to-end through investigation_store: code_refs=[] leaves no code_refs
+        # on the stored finding despite the parseable token in the text.
+        inv_id = self._start()
+        fid = self._store(inv_id, text, code_refs=[])
+        self.assertNotIn("code_refs", self._load_findings(inv_id)[fid])
 
     def test_code_ref_path_scoping_rejects_escapes(self):
         # SECURITY: absolute paths and '..' traversal must be refused outright,

--- a/mcp/tests/test_finding_lifecycle.py
+++ b/mcp/tests/test_finding_lifecycle.py
@@ -8,6 +8,7 @@ Run: pytest mcp/tests/test_finding_lifecycle.py -v
 """
 
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -41,10 +42,20 @@ class FindingLifecycleTest(unittest.TestCase):
         self._orig = server.MEMORY_DIR
         server.MEMORY_DIR = Path(self._tmp.name)
         self._orig_gen = server._verify_gen_fn
+        # Code refs are scoped UNDER the code root; point it at a temp repo so
+        # relative refs resolve there (and absolute / traversal refs are rejected).
+        self._code_root = tempfile.TemporaryDirectory()
+        self._orig_code_root = os.environ.get("LOCI_CODE_ROOT")
+        os.environ["LOCI_CODE_ROOT"] = self._code_root.name
 
     def tearDown(self):
         server.MEMORY_DIR = self._orig
         server._verify_gen_fn = self._orig_gen
+        if self._orig_code_root is None:
+            os.environ.pop("LOCI_CODE_ROOT", None)
+        else:
+            os.environ["LOCI_CODE_ROOT"] = self._orig_code_root
+        self._code_root.cleanup()
         self._tmp.cleanup()
 
     def _start(self, prefix="lc"):
@@ -100,14 +111,16 @@ class FindingLifecycleTest(unittest.TestCase):
 
     def test_staleness_flags_changed_file_only(self):
         inv_id = self._start()
-        # Two referenced files; only one will change.
-        f_change = Path(self._tmp.name) / "changing.py"
-        f_stable = Path(self._tmp.name) / "stable.py"
+        # Two referenced files under the code root; only one will change.
+        root = Path(self._code_root.name)
+        f_change = root / "changing.py"
+        f_stable = root / "stable.py"
         f_change.write_text("original = 1\n")
         f_stable.write_text("constant = 1\n")
 
-        fid_change = self._store(inv_id, "bug in changing code", code_refs=str(f_change))
-        fid_stable = self._store(inv_id, "bug in stable code", code_refs=str(f_stable))
+        # Refs are relative to the code root (absolute refs are rejected by design).
+        fid_change = self._store(inv_id, "bug in changing code", code_refs="changing.py")
+        fid_stable = self._store(inv_id, "bug in stable code", code_refs="stable.py")
 
         # Nothing changed yet -> both present-with-refs read as not stale.
         loaded = self._load_findings(inv_id)
@@ -126,6 +139,45 @@ class FindingLifecycleTest(unittest.TestCase):
         fid = self._store(inv_id, "a plain finding with no file references")
         # No usable code_refs -> the stale key is omitted entirely.
         self.assertNotIn("stale", self._load_findings(inv_id)[fid])
+
+    def test_code_refs_accepts_list_form(self):
+        # The type hint widened to str | list — a list of refs must still resolve.
+        inv_id = self._start()
+        (Path(self._code_root.name) / "a.py").write_text("x = 1\n")
+        (Path(self._code_root.name) / "b.py").write_text("y = 1\n")
+        fid = self._store(inv_id, "spans two files", code_refs=["a.py", "b.py"])
+        # Both files present + unchanged -> not stale (proves both hashed).
+        self.assertEqual(self._load_findings(inv_id)[fid].get("stale"), False)
+
+    def test_code_ref_path_scoping_rejects_escapes(self):
+        # SECURITY: absolute paths and '..' traversal must be refused outright,
+        # and a rogue ref must never let the server hash a file outside the root.
+        outside = Path(self._tmp.name) / "secret.txt"  # under MEMORY_DIR, NOT code root
+        outside.write_text("top secret\n")
+
+        self.assertIsNone(server._safe_repo_path(str(outside)))         # absolute
+        self.assertIsNone(server._safe_repo_path("/etc/passwd"))        # absolute
+        self.assertIsNone(server._safe_repo_path("../secret.txt"))      # traversal
+        self.assertIsNone(server._safe_repo_path("a/../../secret.txt")) # nested traversal
+        self.assertIsNone(server._hash_file_bytes(str(outside)))        # not hashed
+
+        # A legitimate in-root ref still resolves + hashes.
+        (Path(self._code_root.name) / "ok.py").write_text("z = 1\n")
+        self.assertIsNotNone(server._safe_repo_path("ok.py"))
+        self.assertIsNotNone(server._hash_file_bytes("ok.py"))
+
+    def test_hash_file_size_cap_skips_oversized(self):
+        # SECURITY: files over the cap are skipped (returns None), never read whole.
+        big = Path(self._code_root.name) / "big.bin"
+        big.write_bytes(b"\0" * 64)
+        orig = server._HASH_FILE_MAX_BYTES
+        try:
+            server._HASH_FILE_MAX_BYTES = 16
+            self.assertIsNone(server._hash_file_bytes("big.bin"))
+            server._HASH_FILE_MAX_BYTES = 1024
+            self.assertIsNotNone(server._hash_file_bytes("big.bin"))
+        finally:
+            server._HASH_FILE_MAX_BYTES = orig
 
     # -- #5 investigation_verify_all -----------------------------------------
 

--- a/mcp/tests/test_finding_lifecycle.py
+++ b/mcp/tests/test_finding_lifecycle.py
@@ -308,6 +308,62 @@ class FindingLifecycleTest(unittest.TestCase):
         out = _json(server.investigation_verify_all(inv_id, limit=2))
         self.assertEqual(out["verified"], 2)
 
+    # -- fail-open write guards (Copilot round 5) ----------------------------
+
+    def test_resolve_append_failure_fails_open(self):
+        # An I/O error while recording the resolution must return a fail-open
+        # error result, NOT raise out of the tool.
+        inv_id = self._start()
+        fid = self._store(inv_id, "the bug is here")
+        with mock.patch.object(server, "_append_jsonl", side_effect=OSError("disk full")):
+            res = _json(server.finding_resolve(inv_id, fid, "fixed"))
+        self.assertIn("error", res)
+        self.assertNotIn("resolved", res)
+        # Nothing was recorded, so the finding is still open.
+        self.assertEqual(self._load_findings(inv_id)[fid]["resolution"], "open")
+
+    def test_verify_all_continues_when_a_note_write_fails(self):
+        # A single verification-note write failure must be skipped so the rest of
+        # the batch still runs (and every finding still gets a verdict result).
+        inv_id = self._start()
+        fids = [self._store(inv_id, f"claim {i}") for i in range(3)]
+
+        server._verify_gen_fn = lambda *a, **k: {"ok": True, "text": json.dumps(
+            {"verdict": "confirmed", "refutation": "", "confidence": 0.5})}
+
+        with mock.patch.object(server, "_append_jsonl", side_effect=OSError("disk full")):
+            out = _json(server.investigation_verify_all(inv_id))
+
+        # Every finding produced a verdict despite every note write failing.
+        self.assertEqual(out["verified"], 3)
+        self.assertEqual({r["finding_id"] for r in out["results"]}, set(fids))
+
+    # -- code-ref regex prose tightening (Copilot round 5) -------------------
+
+    def test_file_ref_re_ignores_prose_but_matches_code_refs(self):
+        # Prose tokens with a non-code trailing letter must NOT parse as refs.
+        for prose in ("e.g.", "i.e.", "et al.", "U.S.", "vs.", "a.m."):
+            self.assertEqual(
+                [m.group(1) for m in server._FILE_REF_RE.finditer(prose)],
+                [],
+                f"prose {prose!r} should not match as a code ref",
+            )
+        # Real code refs still match (bare, with dir, with line, case-insensitive).
+        cases = {
+            "see verify.py for details": "verify.py",
+            "in mcp/server.py:3204 the bug": "mcp/server.py",
+            "config lives in settings.yaml": "settings.yaml",
+            "the README.md file": "README.md",
+        }
+        for text, expected in cases.items():
+            matched = [m.group(1) for m in server._FILE_REF_RE.finditer(text)]
+            self.assertIn(expected, matched, f"{text!r} should match {expected!r}")
+        # A longer, non-code suffix ("file.pyc") must not match only the "py" prefix.
+        self.assertEqual(
+            [m.group(1) for m in server._FILE_REF_RE.finditer("compiled file.pyc here")],
+            [],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mcp/tests/test_finding_lifecycle.py
+++ b/mcp/tests/test_finding_lifecycle.py
@@ -134,6 +134,40 @@ class FindingLifecycleTest(unittest.TestCase):
         self.assertTrue(loaded[fid_change].get("stale"))
         self.assertFalse(loaded[fid_stable].get("stale"))
 
+    def test_search_surfaces_staleness_after_file_change(self):
+        # Staleness is surfaced on investigation_search() too (via the JSONL
+        # code_refs map), not just investigation_load(). Stub _mnemo_recall so the
+        # search returns our finding row without needing Mnemosyne/Qdrant.
+        inv_id = self._start()
+        root = Path(self._code_root.name)
+        (root / "searched.py").write_text("value = 1\n")
+        fid = self._store(inv_id, "bug in searched code", code_refs="searched.py")
+
+        orig_recall = server._mnemo_recall
+        try:
+            server._mnemo_recall = lambda *a, **k: [{
+                "investigation_id": inv_id,
+                "finding_id": fid,
+                "text": "bug in searched code",
+                "score": 1.0,
+            }]
+
+            def _search_row():
+                out = _json(server.investigation_search("bug", investigation_id=inv_id))
+                rows = out if isinstance(out, list) else out.get("results", out.get("findings", []))
+                match = [r for r in rows if str(r.get("finding_id") or r.get("id")) == fid]
+                self.assertTrue(match, f"finding row not in search results: {out}")
+                return match[0]
+
+            # Unchanged file -> not stale.
+            self.assertEqual(_search_row().get("stale"), False)
+
+            # Mutate the referenced file -> the same search row now reads stale.
+            (root / "searched.py").write_text("value = 2  # edited\n")
+            self.assertTrue(_search_row().get("stale"))
+        finally:
+            server._mnemo_recall = orig_recall
+
     def test_staleness_absent_when_no_refs(self):
         inv_id = self._start()
         fid = self._store(inv_id, "a plain finding with no file references")


### PR DESCRIPTION
Batch **[A-lifecycle]** — three related finding-lifecycle features. All additive, backward-compatible, and fail-open (this is a live-depended-on server). Closes lifecycle gaps noted in #130.

## #1 `finding_resolve(investigation_id, finding_id, resolution, note?)`
Mark a finding's lifecycle state **after** store time — previously a finding could only get a resolution at store time. `findings.jsonl` stays append-only: the update is an appended record in a sibling `finding_updates.jsonl`, folded in **last-write-wins** by `investigation_load` / `investigation_search`. Resolution validated against the existing `_RESOLUTION_STATES` set (`open|fixed|intentional|wontfix|superseded`); unknown findings and invalid states are rejected. The original finding record is never rewritten.

## #3 Staleness
`investigation_store` best-effort parses `file:line` refs from finding text (or accepts an explicit `code_refs` param) and stamps each readable file's current `sha256`. The read path re-hashes and sets `stale=true` for findings whose referenced file changed. Fully optional + fail-open: no refs / unreadable file just omits staleness, never errors.

## #5 `investigation_verify_all(investigation_id, limit?)`
Batch-runs the shipped `verify.verify_finding` skeptic over the **open** findings and returns per-finding `{finding_id, verdict, confidence}`, recording each verdict as an appended verification note. It is a **triage aid, not a lifecycle change** — the verdict never overwrites the finding's resolution. Skips resolved/retracted findings. `gen` is injectable via `server._verify_gen_fn` for tests.

## Compatibility
Findings stored before these fields existed read as `resolution="open"` and not-stale. No existing reader of `findings.jsonl` is affected (updates live in a separate append-only log).

## Validation
- Full `mcp` suite green: **416 passed**.
- New focused tests in `mcp/tests/test_finding_lifecycle.py` (8): resolve last-write-wins reflected by load, invalid-resolution rejection, staleness flags a changed file but not an unchanged one, verify-all per-finding verdicts via a stubbed gen_fn, resolved-skip, and limit.
- `ruff check` (E9,F401,F811,F821,F841) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45