### PR TITLE
feat(investigation_list): paginate + summary mode to avoid token overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Docker and systemd deployment.
 | `investigation_entity_lookup` | Look up an entity by name across stored findings |
 | `investigation_related_cases` | Find related prior investigations |
 | `investigation_finding_provenance` | Trace source provenance for a finding |
-| `investigation_list` | List all investigations |
+| `investigation_list` | List investigations, most-recent first. Paginated (`limit=30`, `offset=0`) and compact by default (`summary=True`); pass `summary=False` for full records and `limit=0` for all. Response includes `total`/`limit`/`offset`. |
 | `audit_log` | Append to the audit trail |
 | `memory_self_check` | Cross-check stored memories for consistency |
 | `code_memory_correlate` | Correlate a code change with stored memory context |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Docker and systemd deployment.
 | `investigation_entity_lookup` | Look up an entity by name across stored findings |
 | `investigation_related_cases` | Find related prior investigations |
 | `investigation_finding_provenance` | Trace source provenance for a finding |
-| `investigation_list` | List investigations, most-recent first. Paginated (`limit=30`, `offset=0`) and compact by default (`summary=True`); pass `summary=False` for full records and `limit=0` for all. Response includes `total`/`limit`/`offset`. |
+| `investigation_list` | List investigations, most-recent first. Paginated (`limit=30`, `offset=0`) and compact by default (`summary=True`); pass `summary=False` for full records and `limit=0` (or any value `<=0`) for all — note `offset` still applies in no-limit mode, returning all *remaining* records starting at `offset`. Response includes `total`/`limit`/`offset`. |
 | `audit_log` | Append to the audit trail |
 | `memory_self_check` | Cross-check stored memories for consistency |
 | `code_memory_correlate` | Correlate a code change with stored memory context |

--- a/docs/memory-and-code-review-tools.md
+++ b/docs/memory-and-code-review-tools.md
@@ -215,7 +215,7 @@ $HERMES_MEMORY_DIR/
 | `investigation_store(investigation_id, finding_type, text, source, confidence?, tags?, derived_from?)` | Record a finding. Writes to JSONL + Mnemosyne + Qdrant. `derived_from` links lineage for retraction cleanup. |
 | `investigation_note(investigation_id, field, value)` | Update manifest fields: `context`, `hypothesis`, `next_step`, `open_question_add/remove`, `checked_source`, `closed_summary`. |
 | `investigation_reflect(investigation_id)` | Synthesize current state — finding breakdown, open questions, gaps, key entities, advisory self-check. |
-| `investigation_list()` | List all investigations with status and finding counts, most-recently-updated first. |
+| `investigation_list(limit?, offset?, summary?)` | List investigations with status and finding counts, most-recently-updated first. Bounded by default to avoid token overflow: returns `limit` (default 30) compact records (`summary=True`) starting at `offset` (default 0). Pass `summary=False` for full records (created_at, open_questions_count, hypothesis, visibility, tier_counts); `limit=0`/negative for all remaining. Response wraps results with `total`/`limit`/`offset`. |
 
 #### Investigation Search and Evidence
 
@@ -1009,7 +1009,7 @@ mismatch. Either set `EMBED_DIM=384` when using fastembed, or restore Ollama.
 | `investigation_entity_lookup` | Find every finding mentioning a specific IP, email, hostname, hash, or CVE. O(1) via Qdrant payload indexes. |
 | `investigation_related_cases` | Find prior investigations that dealt with the same entities. Call before opening a new investigation. |
 | `investigation_finding_provenance` | Trace a finding back through `derived_from` links to root observed evidence. |
-| `investigation_list` | List all investigations with status and finding counts, most-recently-updated first. |
+| `investigation_list` | List investigations with status and finding counts, most-recently-updated first. Paginated + compact by default (`limit=30`, `offset=0`, `summary=True`) to stay under the tool-result token cap. `summary=False` returns full records; `limit=0`/negative returns all remaining. Result is `{investigations, total, limit, offset}`. |
 | `audit_log` | Record a tool call and full output to global daily JSONL, investigation JSONL, Mnemosyne, and Qdrant. |
 | `memory_self_check` | Advisory provenance and contradiction checks over stored findings. Surfaces hallucination candidates. Never auto-retracts. |
 | `memory_retract` | Soft-tombstone a hallucinated finding and its contaminated lineage. `dry_run=True` (default) previews without changing anything. |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,7 +88,7 @@ Add to `~/.claude/settings.json` under `mcpServers`:
 - `investigation_load(investigation_id, last_n_findings?, include_retracted?)` — load manifest + recent findings
 - `investigation_note(investigation_id, field, value)` — update hypothesis/next_step/open_questions/checked_source
 - `investigation_reflect(investigation_id)` — synthesize current investigation state
-- `investigation_list(limit?, offset?, summary?)` — list sessions, most-recent first; paginated (`limit=30`, `offset=0`) and compact (`summary=True`) by default. Pass `summary=False` for full records, `limit=0` for all. Returns `{investigations, total, limit, offset}`
+- `investigation_list(limit?, offset?, summary?)` — list sessions, most-recent first; paginated (`limit=30`, `offset=0`) and compact (`summary=True`) by default. Pass `summary=False` for full records, `limit=0` (or any value `<=0`) for all — `offset` is still honored in no-limit mode, so it returns all *remaining* records starting at `offset`. Returns `{investigations, total, limit, offset}`
 
 **Finding storage:**
 - `investigation_store(investigation_id, finding_type, text, source, confidence?, tags?, derived_from?)` — store a finding

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,7 +88,7 @@ Add to `~/.claude/settings.json` under `mcpServers`:
 - `investigation_load(investigation_id, last_n_findings?, include_retracted?)` — load manifest + recent findings
 - `investigation_note(investigation_id, field, value)` — update hypothesis/next_step/open_questions/checked_source
 - `investigation_reflect(investigation_id)` — synthesize current investigation state
-- `investigation_list()` — list all sessions
+- `investigation_list(limit?, offset?, summary?)` — list sessions, most-recent first; paginated (`limit=30`, `offset=0`) and compact (`summary=True`) by default. Pass `summary=False` for full records, `limit=0` for all. Returns `{investigations, total, limit, offset}`
 
 **Finding storage:**
 - `investigation_store(investigation_id, finding_type, text, source, confidence?, tags?, derived_from?)` — store a finding

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5090,14 +5090,35 @@ def investigation_list(
 
     Args:
         limit: Max investigations to return (default 30). Use 0 or a negative
-            value for no limit (return all).
+            value for no limit (return all remaining). Note: offset is still
+            honored when limit<=0, so this returns everything *starting at*
+            offset, not the entire list.
         offset: Number of investigations to skip from the front (default 0).
+            Always applied, including when limit<=0.
         summary: If True (default), return only compact fields; if False,
             return the full record including tier counts.
 
     Returns:
         JSON: {"investigations": [...], "total": N, "limit": ..., "offset": ...}
     """
+    # Coerce limit/offset once up front, BEFORE any early return, so both the
+    # empty-MEMORY_DIR path and the normal path echo normalized ints. String
+    # JSON tool args must not leak through inconsistently (early return echoing
+    # raw strings while the non-empty path echoes coerced ints).
+    try:
+        offset = max(0, int(offset))
+    except (TypeError, ValueError):
+        offset = 0
+    # A string limit (e.g. via JSON tool args) would otherwise raise TypeError
+    # in the `limit <= 0` comparison and `offset + limit` slice below,
+    # contradicting the documented "limit<=0 returns everything" behavior.
+    # None stays None (explicit no-limit); garbage falls back to the default.
+    if limit is not None:
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 30
+
     if not MEMORY_DIR.exists():
         return json.dumps({"investigations": [], "total": 0, "limit": limit, "offset": offset})
 
@@ -5115,20 +5136,6 @@ def investigation_list(
 
     total = len(entries)
 
-    try:
-        offset = max(0, int(offset))
-    except (TypeError, ValueError):
-        offset = 0
-    # Coerce limit the same way offset is coerced: a string limit (e.g. via
-    # JSON tool args) would otherwise raise TypeError in the `limit <= 0`
-    # comparison and `offset + limit` slice below, contradicting the
-    # documented "limit<=0 returns everything" behavior. None stays None
-    # (explicit no-limit); garbage falls back to the documented default.
-    if limit is not None:
-        try:
-            limit = int(limit)
-        except (TypeError, ValueError):
-            limit = 30
     if limit is None or limit <= 0:
         page = entries[offset:]
     else:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5112,8 +5112,12 @@ def investigation_list(
     # A string limit (e.g. via JSON tool args) would otherwise raise TypeError
     # in the `limit <= 0` comparison and `offset + limit` slice below,
     # contradicting the documented "limit<=0 returns everything" behavior.
-    # None stays None (explicit no-limit); garbage falls back to the default.
-    if limit is not None:
+    # Normalize None to 0 so it collapses into the documented limit<=0 no-limit
+    # case; the echoed `limit` is then always an int, matching the signature
+    # (limit: int) and docstring. Garbage falls back to the default.
+    if limit is None:
+        limit = 0
+    else:
         try:
             limit = int(limit)
         except (TypeError, ValueError):
@@ -5136,14 +5140,13 @@ def investigation_list(
 
     total = len(entries)
 
-    if limit is None or limit <= 0:
+    if limit <= 0:
         page = entries[offset:]
     else:
         page = entries[offset:offset + limit]
 
     investigations = []
     for d, manifest in page:
-        acl = manifest.get("acl") or []
         record = {
             "id": manifest["id"],
             "title": manifest["title"],
@@ -5164,6 +5167,9 @@ def investigation_list(
                         tier_counts["warm"] += 1  # default for legacy findings
             except Exception:
                 pass  # fail-open
+            # acl is only needed to derive visibility, which is a full-mode-only
+            # field — skip the lookup entirely on the default summary path.
+            acl = manifest.get("acl") or []
             record.update({
                 "created_at": manifest["created_at"],
                 "open_questions_count": len(manifest["open_questions"]),

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5072,25 +5072,70 @@ def investigation_evidence_precheck(
 # ---- Tool: investigation_list ----
 
 @mcp.tool()
-def investigation_list() -> str:
+def investigation_list(
+    limit: int = 30,
+    offset: int = 0,
+    summary: bool = True,
+) -> str:
     """
-    List all investigations with status and finding counts, most recently
+    List investigations with status and finding counts, most recently
     updated first.
 
+    Bounded by default to avoid overflowing the tool-result token cap: only
+    `limit` investigations are returned starting at `offset`, and `summary`
+    mode returns a compact record per investigation (id, title, status,
+    finding_counts, updated_at). Set summary=False for the full record
+    (created_at, open_questions_count, hypothesis, visibility, tier_counts)
+    and/or raise limit to page through or fetch everything.
+
+    Args:
+        limit: Max investigations to return (default 30). Use 0 or a negative
+            value for no limit (return all).
+        offset: Number of investigations to skip from the front (default 0).
+        summary: If True (default), return only compact fields; if False,
+            return the full record including tier counts.
+
     Returns:
-        JSON list of investigation summaries.
+        JSON: {"investigations": [...], "total": N, "limit": ..., "offset": ...}
     """
     if not MEMORY_DIR.exists():
-        return json.dumps({"investigations": []})
+        return json.dumps({"investigations": [], "total": 0, "limit": limit, "offset": offset})
 
-    investigations = []
+    # Collect valid investigation dirs (most-recently-updated first) before
+    # doing any per-record work, so pagination is over investigations — not
+    # over stray files/dirs — and the expensive findings scan only runs for
+    # the page actually returned.
+    entries = []
     for d in sorted(MEMORY_DIR.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
         if not d.is_dir():
             continue
         manifest = _load_manifest(d.name)
         if manifest:
-            acl = manifest.get("acl") or []
-            # Scan findings.jsonl to build tier counts
+            entries.append((d, manifest))
+
+    total = len(entries)
+
+    try:
+        offset = max(0, int(offset))
+    except (TypeError, ValueError):
+        offset = 0
+    if limit is None or limit <= 0:
+        page = entries[offset:]
+    else:
+        page = entries[offset:offset + limit]
+
+    investigations = []
+    for d, manifest in page:
+        acl = manifest.get("acl") or []
+        record = {
+            "id": manifest["id"],
+            "title": manifest["title"],
+            "status": manifest["status"],
+            "updated_at": manifest["updated_at"],
+            "finding_counts": manifest["finding_counts"],
+        }
+        if not summary:
+            # Scan findings.jsonl to build tier counts (only in full mode)
             tier_counts = {"hot": 0, "warm": 0, "cold": 0}
             try:
                 findings_path = d / "findings.jsonl"
@@ -5102,20 +5147,21 @@ def investigation_list() -> str:
                         tier_counts["warm"] += 1  # default for legacy findings
             except Exception:
                 pass  # fail-open
-            investigations.append({
-                "id": manifest["id"],
-                "title": manifest["title"],
-                "status": manifest["status"],
+            record.update({
                 "created_at": manifest["created_at"],
-                "updated_at": manifest["updated_at"],
-                "finding_counts": manifest["finding_counts"],
                 "open_questions_count": len(manifest["open_questions"]),
                 "hypothesis": manifest["hypothesis"],
                 "visibility": "shared" if acl else "private",
                 "tier_counts": tier_counts,
             })
+        investigations.append(record)
 
-    return json.dumps({"investigations": investigations}, indent=2)
+    return json.dumps({
+        "investigations": investigations,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }, indent=2)
 
 
 # ---- Tool: investigation_share ----

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5123,6 +5123,15 @@ def investigation_list(
         except (TypeError, ValueError):
             limit = 30
 
+    # Coerce summary like limit/offset: a stringly-typed client (JSON tool args)
+    # passing summary='false' would otherwise be truthy and wrongly select
+    # summary-mode instead of full records. Map common string falsey forms to
+    # False; everything else (including real bools) goes through bool().
+    if isinstance(summary, str):
+        summary = summary.strip().lower() not in ("false", "0", "no", "")
+    else:
+        summary = bool(summary)
+
     if not MEMORY_DIR.exists():
         return json.dumps({"investigations": [], "total": 0, "limit": limit, "offset": offset})
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5127,7 +5127,14 @@ def investigation_list(
     # passing summary='false' would otherwise be truthy and wrongly select
     # summary-mode instead of full records. Map common string falsey forms to
     # False; everything else (including real bools) goes through bool().
-    if isinstance(summary, str):
+    #
+    # None (JSON null) must PRESERVE the documented default (summary=True):
+    # bool(None) is False, which would force FULL-mode records and reintroduce
+    # the large-output/token-overflow this pagination path exists to prevent.
+    # Only string/real-bool values may select full mode.
+    if summary is None:
+        summary = True
+    elif isinstance(summary, str):
         summary = summary.strip().lower() not in ("false", "0", "no", "")
     else:
         summary = bool(summary)

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5119,6 +5119,16 @@ def investigation_list(
         offset = max(0, int(offset))
     except (TypeError, ValueError):
         offset = 0
+    # Coerce limit the same way offset is coerced: a string limit (e.g. via
+    # JSON tool args) would otherwise raise TypeError in the `limit <= 0`
+    # comparison and `offset + limit` slice below, contradicting the
+    # documented "limit<=0 returns everything" behavior. None stays None
+    # (explicit no-limit); garbage falls back to the documented default.
+    if limit is not None:
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 30
     if limit is None or limit <= 0:
         page = entries[offset:]
     else:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5132,10 +5132,17 @@ def investigation_list(
     # bool(None) is False, which would force FULL-mode records and reintroduce
     # the large-output/token-overflow this pagination path exists to prevent.
     # Only string/real-bool values may select full mode.
+    #
+    # An empty / whitespace-only string is treated as UNSET (not falsey): a
+    # client accidentally passing summary='' is far more likely to have meant
+    # "leave the default" than "give me full/overflow-prone output", so it must
+    # also preserve summary=True. Only the explicit tokens 'false'/'0'/'no'
+    # select full mode. (Empty string is simply absent from the falsey tuple,
+    # so `not in` yields True for it.)
     if summary is None:
         summary = True
     elif isinstance(summary, str):
-        summary = summary.strip().lower() not in ("false", "0", "no", "")
+        summary = summary.strip().lower() not in ("false", "0", "no")
     else:
         summary = bool(summary)
 

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -189,6 +189,34 @@ class TestInvestigationLifecycle(unittest.TestCase):
         self.assertEqual(second["total"], 5)
         self.assertEqual([i["id"] for i in second["investigations"]], ids[2:4])
 
+    def test_investigation_list_nonpositive_limit_returns_everything(self):
+        """Documented contract: limit<=0 (and a string form of it) returns all.
+
+        Also guards the coercion: a string limit must not raise TypeError in
+        the `limit <= 0` / `offset + limit` paths — it is coerced like offset.
+        """
+        ids = [_new_id("nolimit") for _ in range(5)]
+        for inv_id in ids:
+            server.investigation_start(investigation_id=inv_id, title=f"NoLimit {inv_id}")
+        self._set_updated_order(ids)
+
+        # limit=0 -> everything
+        zero = _json(server.investigation_list(limit=0))
+        self.assertEqual(zero["total"], 5)
+        self.assertEqual([i["id"] for i in zero["investigations"]], ids)
+
+        # negative limit -> everything
+        neg = _json(server.investigation_list(limit=-1))
+        self.assertEqual([i["id"] for i in neg["investigations"]], ids)
+
+        # string "0" must coerce, not raise, and behave like 0 (everything)
+        str_zero = _json(server.investigation_list(limit="0"))
+        self.assertEqual([i["id"] for i in str_zero["investigations"]], ids)
+
+        # string positive limit must coerce and paginate, not raise
+        str_two = _json(server.investigation_list(limit="2", offset=0))
+        self.assertEqual([i["id"] for i in str_two["investigations"]], ids[:2])
+
     def test_investigation_list_summary_omits_verbose_fields(self):
         inv_id = _new_id("summary")
         server.investigation_start(investigation_id=inv_id, title="Summary test")

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -288,6 +288,28 @@ class TestInvestigationLifecycle(unittest.TestCase):
                     "open_questions_count"):
             self.assertNotIn(key, rec)
 
+    def test_investigation_list_summary_empty_string_preserves_default(self):
+        """summary='' (empty / whitespace-only string) must preserve the default.
+
+        An empty string for an optional arg is far more likely UNSET than an
+        intentional falsey value; treating it as falsey would force FULL-mode
+        records and reintroduce the token-overflow this path prevents. So ''
+        (and whitespace-only) must behave like the default summary=True —
+        compact records — while only 'false'/'0'/'no' select full mode.
+        """
+        inv_id = _new_id("summary-empty-str")
+        server.investigation_start(investigation_id=inv_id, title="Summary empty string test")
+        for empty in ("", "   "):
+            result = _json(server.investigation_list(summary=empty))
+            rec = next(i for i in result["investigations"] if i["id"] == inv_id)
+            # Compact fields present.
+            for key in ("id", "title", "status", "finding_counts", "updated_at"):
+                self.assertIn(key, rec)
+            # Verbose full-mode fields MUST be absent ('' preserved summary mode).
+            for key in ("hypothesis", "tier_counts", "created_at", "visibility",
+                        "open_questions_count"):
+                self.assertNotIn(key, rec)
+
     def test_investigation_list_empty(self):
         result = _json(server.investigation_list())
         self.assertEqual(result["investigations"], [])

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -245,6 +245,29 @@ class TestInvestigationLifecycle(unittest.TestCase):
                     "open_questions_count"):
             self.assertIn(key, rec)
 
+    def test_investigation_list_summary_false_string_returns_full(self):
+        """String summary='false' must coerce to full mode, not summary mode.
+
+        Mirrors the limit/offset string-coercion guards: a stringly-typed
+        client (JSON tool args) passing the truthy string 'false' must not be
+        treated as truthy True and wrongly select the compact summary record.
+        """
+        inv_id = _new_id("summary-false-str")
+        server.investigation_start(investigation_id=inv_id, title="Summary false string test")
+        result = _json(server.investigation_list(summary="false"))
+        rec = next(i for i in result["investigations"] if i["id"] == inv_id)
+        # Full-mode fields must be present (summary='false' == full records).
+        for key in ("hypothesis", "tier_counts", "created_at", "visibility",
+                    "open_questions_count"):
+            self.assertIn(key, rec)
+
+        # The truthy string 'true' still selects summary mode.
+        summ = _json(server.investigation_list(summary="true"))
+        rec2 = next(i for i in summ["investigations"] if i["id"] == inv_id)
+        for key in ("hypothesis", "tier_counts", "created_at", "visibility",
+                    "open_questions_count"):
+            self.assertNotIn(key, rec2)
+
     def test_investigation_list_empty(self):
         result = _json(server.investigation_list())
         self.assertEqual(result["investigations"], [])

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -217,6 +217,14 @@ class TestInvestigationLifecycle(unittest.TestCase):
         str_two = _json(server.investigation_list(limit="2", offset=0))
         self.assertEqual([i["id"] for i in str_two["investigations"]], ids[:2])
 
+        # limit=None (explicit no-limit) must normalize to the limit<=0 case:
+        # returns everything AND echoes an int, matching the `limit: int`
+        # signature/docstring — never a null in the response.
+        none_limit = _json(server.investigation_list(limit=None))
+        self.assertEqual([i["id"] for i in none_limit["investigations"]], ids)
+        self.assertIsInstance(none_limit["limit"], int)
+        self.assertEqual(none_limit["limit"], 0)
+
     def test_investigation_list_summary_omits_verbose_fields(self):
         inv_id = _new_id("summary")
         server.investigation_start(investigation_id=inv_id, title="Summary test")

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -268,6 +268,26 @@ class TestInvestigationLifecycle(unittest.TestCase):
                     "open_questions_count"):
             self.assertNotIn(key, rec2)
 
+    def test_investigation_list_summary_none_preserves_default(self):
+        """summary=None (JSON null) must preserve the default (summary mode).
+
+        bool(None) is False, which would force FULL-mode records and reintroduce
+        the large-output/token-overflow this pagination path exists to prevent.
+        Since summary defaults to True, an explicit null must behave like the
+        default — compact records with the verbose fields absent — not full mode.
+        """
+        inv_id = _new_id("summary-none")
+        server.investigation_start(investigation_id=inv_id, title="Summary none test")
+        result = _json(server.investigation_list(summary=None))
+        rec = next(i for i in result["investigations"] if i["id"] == inv_id)
+        # Compact fields present.
+        for key in ("id", "title", "status", "finding_counts", "updated_at"):
+            self.assertIn(key, rec)
+        # Verbose full-mode fields MUST be absent (None preserved summary mode).
+        for key in ("hypothesis", "tier_counts", "created_at", "visibility",
+                    "open_questions_count"):
+            self.assertNotIn(key, rec)
+
     def test_investigation_list_empty(self):
         result = _json(server.investigation_list())
         self.assertEqual(result["investigations"], [])

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -14,6 +14,7 @@ Run: pytest mcp/tests/test_mcp_integration.py -v
 """
 
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -160,6 +161,58 @@ class TestInvestigationLifecycle(unittest.TestCase):
         ids = [i.get("id") for i in result["investigations"]]
         self.assertIn(inv_a, ids)
         self.assertIn(inv_b, ids)
+
+    def _set_updated_order(self, inv_ids):
+        """Force directory mtimes so inv_ids[0] is the most-recently updated.
+
+        The list is sorted by directory st_mtime; creating investigations in
+        fast succession can tie, so pin distinct mtimes for deterministic order.
+        """
+        base = 1_000_000
+        for i, inv_id in enumerate(inv_ids):
+            d = server.MEMORY_DIR / inv_id
+            ts = base + (len(inv_ids) - i) * 10  # earlier in list => newer
+            os.utime(d, (ts, ts))
+
+    def test_investigation_list_respects_limit_and_offset(self):
+        ids = [_new_id("page") for _ in range(5)]
+        for inv_id in ids:
+            server.investigation_start(investigation_id=inv_id, title=f"Page {inv_id}")
+        # ids[0] newest ... ids[4] oldest
+        self._set_updated_order(ids)
+
+        first = _json(server.investigation_list(limit=2, offset=0))
+        self.assertEqual(first["total"], 5)
+        self.assertEqual([i["id"] for i in first["investigations"]], ids[:2])
+
+        second = _json(server.investigation_list(limit=2, offset=2))
+        self.assertEqual(second["total"], 5)
+        self.assertEqual([i["id"] for i in second["investigations"]], ids[2:4])
+
+    def test_investigation_list_summary_omits_verbose_fields(self):
+        inv_id = _new_id("summary")
+        server.investigation_start(investigation_id=inv_id, title="Summary test")
+        result = _json(server.investigation_list(summary=True))
+        rec = next(i for i in result["investigations"] if i["id"] == inv_id)
+        for key in ("id", "title", "status", "finding_counts", "updated_at"):
+            self.assertIn(key, rec)
+        for key in ("hypothesis", "tier_counts", "created_at", "visibility",
+                    "open_questions_count"):
+            self.assertNotIn(key, rec)
+
+    def test_investigation_list_full_includes_verbose_fields(self):
+        inv_id = _new_id("full")
+        server.investigation_start(investigation_id=inv_id, title="Full test")
+        result = _json(server.investigation_list(summary=False))
+        rec = next(i for i in result["investigations"] if i["id"] == inv_id)
+        for key in ("hypothesis", "tier_counts", "created_at", "visibility",
+                    "open_questions_count"):
+            self.assertIn(key, rec)
+
+    def test_investigation_list_empty(self):
+        result = _json(server.investigation_list())
+        self.assertEqual(result["investigations"], [])
+        self.assertEqual(result["total"], 0)
 
     def test_store_roundtrip_finding_id_in_load(self):
         inv_id = _new_id("roundtrip")
@@ -891,7 +944,7 @@ class TestInvestigationACL(unittest.TestCase):
         server.investigation_start(investigation_id=inv_shared, title="Shared investigation")
         server.investigation_share(investigation_id=inv_shared, agent_ids=["agent-a"])
 
-        result = _json(server.investigation_list())
+        result = _json(server.investigation_list(summary=False))
         by_id = {i["id"]: i for i in result["investigations"]}
         self.assertIn("visibility", by_id[inv_private])
         self.assertEqual(by_id[inv_private]["visibility"], "private")
@@ -1497,7 +1550,7 @@ class TestMemoryTiers(unittest.TestCase):
             source="test",
             tier="cold",
         )
-        result = _json(server.investigation_list())
+        result = _json(server.investigation_list(summary=False))
         inv_summary = next((i for i in result["investigations"] if i["id"] == inv_id), None)
         self.assertIsNotNone(inv_summary, "Investigation not found in list")
         self.assertIn("tier_counts", inv_summary)

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -242,6 +242,28 @@ class TestInvestigationLifecycle(unittest.TestCase):
         self.assertEqual(result["investigations"], [])
         self.assertEqual(result["total"], 0)
 
+    def test_investigation_list_missing_dir_echoes_coerced_ints(self):
+        """MEMORY_DIR-does-not-exist early return must echo normalized ints.
+
+        Regression guard: string JSON tool args (limit="2", offset="1") must
+        be coerced up front so the empty-dir early return echoes the same
+        int types as the non-empty path — not the raw strings.
+        """
+        missing = Path(self._tmp.name) / "does_not_exist"
+        self.assertFalse(missing.exists())
+        orig = server.MEMORY_DIR
+        server.MEMORY_DIR = missing
+        try:
+            result = _json(server.investigation_list(limit="2", offset="1"))
+        finally:
+            server.MEMORY_DIR = orig
+        self.assertEqual(result["investigations"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["limit"], 2)
+        self.assertEqual(result["offset"], 1)
+        self.assertIsInstance(result["limit"], int)
+        self.assertIsInstance(result["offset"], int)
+
     def test_store_roundtrip_finding_id_in_load(self):
         inv_id = _new_id("roundtrip")
         server.investigation_start(investigation_id=inv_id, title="Roundtrip test")


### PR DESCRIPTION
## Problem

`investigation_list` returned **every** investigation with all verbose fields. On live servers this overflowed the tool-result token cap (a 58KB result spilled to a file).

## Fix

Bounded, backward-compatible defaults:

- `limit` (default **30**) + `offset` for pagination. `limit<=0` returns everything.
- `summary` mode (default **True**) returns a compact record per investigation: `{id, title, status, finding_counts, updated_at}`.
- Full detail (`created_at`, `open_questions_count`, `hypothesis`, `visibility`, `tier_counts`) remains available via `summary=False`.
- Most-recently-updated-first ordering preserved.
- The expensive `findings.jsonl` tier scan now runs only for the returned page, and only in full mode.
- Response also carries `total` / `limit` / `offset` so callers can page.

The smaller, paginated default result **is** the fix.

## Tests

Added focused tests (limit+offset most-recent-first, summary omits verbose fields, full includes them, empty case). Two existing tests that asserted the pre-change default now pass `summary=False`. Full mcp suite green (412 passed) + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45