### PR TITLE
feat(a2a): /bootstrap endpoint — pre-shared-key session tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ like a set of notes.
 ![Loci architecture](docs/img/loci-overview.svg)
 
 Loci runs as an MCP server alongside Claude Code. When Claude needs to remember or recall
-something, it calls one of Loci's 25 tools — the same way it calls any other tool. Your
+something, it calls one of Loci's 24 tools — the same way it calls any other tool. Your
 data stays on your own infrastructure: Qdrant and Ollama run locally or on your own server.
 
 > **New to terms like "vector search", "RAG", or "MCP"?**
@@ -227,7 +227,7 @@ HERMES_MCP_TRANSPORT=sse HERMES_MCP_HOST=0.0.0.0 HERMES_MCP_PORT=8000 \
 
 ```
 loci/
-├── mcp/                   MCP server — 25 tools: investigation memory, RAG, claim validation
+├── mcp/                   MCP server — 24 tools: investigation memory, RAG, claim validation
 │   ├── server.py          FastMCP server entry point
 │   ├── memcheck/          Standalone claim-validation + code-hallucination module
 │   ├── pyproject.toml     Package definition (pip install -e .)

--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -30,6 +30,12 @@ Required:
                             Generate: python3 -c "import secrets;print(secrets.token_hex(32))"
 
 Optional / tunable:
+  HERMES_A2A_BOOTSTRAP_KEY  Pre-shared key for POST /bootstrap. Callers
+                            present this to receive a 24h session token
+                            usable as a bearer without TOTP. Eliminates
+                            the need to distribute HERMES_A2A_TOKEN+TOTP
+                            to every new session. If unset, /bootstrap 501s.
+                            Generate: python3 -c "import secrets;print(secrets.token_hex(24))"
   HERMES_A2A_HOST           Bind address.  Default: 0.0.0.0
   HERMES_A2A_PORT           Bind port.     Default: 8201
   HERMES_A2A_URL            Public base URL injected into the agent card.
@@ -94,6 +100,7 @@ ENDPOINTS
   GET  /.well-known/agent.json      Agent card (RFC-002) — no auth required
   GET  /.well-known/agent-card.json Agent card alias — no auth
   GET  /health                       Liveness + config check — no auth required
+  POST /bootstrap                    Exchange bootstrap key → 24h session token — no auth
   POST /a2a                          JSON-RPC 2.0 dispatch — Bearer required
   GET  /a2a/tasks/{task_id}          Task status — Bearer required
 
@@ -156,7 +163,7 @@ JSON-RPC CALL SHAPE
   }
 """
 
-import os, sys, asyncio, uuid, json, sqlite3, logging, datetime, hmac, time, collections
+import os, sys, asyncio, uuid, json, sqlite3, logging, datetime, hmac, time, collections, secrets
 from typing import Optional, Any
 
 # ── load .env before anything else ─────────────────────────────────────────────
@@ -187,7 +194,8 @@ if not A2A_TOKEN:
     print('ERROR: HERMES_A2A_TOKEN is not set. Generate one with: '
           'python3 -c "import secrets;print(secrets.token_hex(32))"', flush=True)
     sys.exit(1)
-TOTP_SEED = os.environ.get('HERMES_A2A_TOTP_SEED', '')
+TOTP_SEED      = os.environ.get('HERMES_A2A_TOTP_SEED', '')
+BOOTSTRAP_KEY  = os.environ.get('HERMES_A2A_BOOTSTRAP_KEY', '')
 AGENT_ID  = os.environ.get('HERMES_AGENT_ID', 'hermes-agent')
 AGENT_URL = os.environ.get('HERMES_A2A_URL', 'http://127.0.0.1:8201')
 
@@ -358,14 +366,24 @@ def _store_task(task_id: str, task: dict) -> None:
         del _tasks[oldest]
     _tasks[task_id] = task
 
+# session tokens issued by /bootstrap — token → expiry (UTC)
+_session_tokens: dict[str, datetime.datetime] = {}
+
 # ── FastAPI app + auth ──────────────────────────────────────────────────────────
 app = FastAPI(title=f'{_LOG_AGENT_ID} A2A', version='0.1.0')
 _bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def _verify_bearer(creds: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme)):
-    if not creds or not hmac.compare_digest(creds.credentials, A2A_TOKEN):
-        raise HTTPException(status_code=401, detail='Unauthorized — invalid or missing bearer token')
+    if not creds:
+        raise HTTPException(status_code=401, detail='Unauthorized — missing bearer token')
+    tok = creds.credentials
+    if hmac.compare_digest(tok, A2A_TOKEN):
+        return
+    exp = _session_tokens.get(tok)
+    if exp and exp > datetime.datetime.now(datetime.timezone.utc):
+        return
+    raise HTTPException(status_code=401, detail='Unauthorized — invalid or expired token')
 
 
 # TOTP rate limiter: max 5 attempts per 60 seconds per client IP
@@ -1254,6 +1272,41 @@ async def health():
         'qdrant_configured': bool(QDRANT_URL),
         'ollama_configured': bool(OLLAMA_BASE),
         'totp_enabled': bool(TOTP_SEED),
+        'bootstrap_configured': bool(BOOTSTRAP_KEY),
+        'active_sessions': len(_session_tokens),
+    })
+
+
+@app.post('/bootstrap')
+async def bootstrap(request: Request):
+    """Exchange a bootstrap key for a 24h session token (no TOTP required on session token)."""
+    if not BOOTSTRAP_KEY:
+        raise HTTPException(status_code=501, detail='Bootstrap not configured — set HERMES_A2A_BOOTSTRAP_KEY')
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail='Invalid JSON')
+    presented = body.get('bootstrap_key', '')
+    if not secrets.compare_digest(presented, BOOTSTRAP_KEY):
+        raise HTTPException(status_code=401, detail='Invalid bootstrap key')
+
+    ttl_hours = min(int(body.get('ttl_hours', 24)), 168)  # cap at 7 days
+    now = datetime.datetime.now(datetime.timezone.utc)
+    expires_at = now + datetime.timedelta(hours=ttl_hours)
+    session_token = secrets.token_hex(32)
+    _session_tokens[session_token] = expires_at
+
+    # Prune expired sessions
+    expired = [t for t, exp in list(_session_tokens.items()) if exp <= now]
+    for t in expired:
+        _session_tokens.pop(t, None)
+
+    agent_id = body.get('agent_id', 'unknown')
+    log.info(f'Bootstrap: issued session token for agent_id={agent_id} ttl={ttl_hours}h expires={expires_at.isoformat()}')
+    return JSONResponse({
+        'session_token': session_token,
+        'expires_at': expires_at.isoformat(),
+        'totp_required': False,
     })
 
 
@@ -1344,6 +1397,7 @@ def main() -> None:
     log.info(f'Qdrant:        {QDRANT_URL}')
     log.info(f'Ollama embed:  {OLLAMA_BASE}  model={EMBED_MODEL}')
     log.info(f'TOTP:          {"enabled" if TOTP_SEED else "disabled (set HERMES_A2A_TOTP_SEED to enable)"}')
+    log.info(f'Bootstrap:     {"enabled (POST /bootstrap)" if BOOTSTRAP_KEY else "disabled (set HERMES_A2A_BOOTSTRAP_KEY to enable)"}')
     log.info(f'Skills:        {", ".join(_SKILL_MAP.keys())}')
     uvicorn.run(app, host=A2A_HOST, port=A2A_PORT, log_level='info', timeout_graceful_shutdown=5)
 

--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -374,14 +374,19 @@ app = FastAPI(title=f'{_LOG_AGENT_ID} A2A', version='0.1.0')
 _bearer_scheme = HTTPBearer(auto_error=False)
 
 
+def _is_live_session_token(tok: str) -> bool:
+    """True if tok is a /bootstrap-issued session token that has not expired."""
+    exp = _session_tokens.get(tok)
+    return bool(exp and exp > datetime.datetime.now(datetime.timezone.utc))
+
+
 def _verify_bearer(creds: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme)):
     if not creds:
         raise HTTPException(status_code=401, detail='Unauthorized — missing bearer token')
     tok = creds.credentials
     if hmac.compare_digest(tok, A2A_TOKEN):
         return
-    exp = _session_tokens.get(tok)
-    if exp and exp > datetime.datetime.now(datetime.timezone.utc):
+    if _is_live_session_token(tok):
         return
     raise HTTPException(status_code=401, detail='Unauthorized — invalid or expired token')
 
@@ -392,7 +397,16 @@ _TOTP_MAX_ATTEMPTS = 5
 _totp_attempts: dict = collections.defaultdict(list)
 
 
-def _verify_totp(request: Request, x_totp: Optional[str] = Header(default=None)):
+def _verify_totp(request: Request,
+                 x_totp: Optional[str] = Header(default=None),
+                 creds: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme)):
+    # A /bootstrap session token already proves possession of the pre-shared
+    # bootstrap key and carries its own expiry, so it stands alone as a bearer —
+    # that is the entire point of issuing one. Without this, enabling TOTP makes
+    # session tokens useless (they'd still need X-TOTP) and /bootstrap's
+    # 'totp_required': False response would be a lie.
+    if creds and _is_live_session_token(creds.credentials):
+        return
     if TOTP_SEED:
         if x_totp is None:
             raise HTTPException(status_code=401, detail='X-TOTP header required (TOTP is enabled)')

--- a/a2a_server/tests/test_bootstrap.py
+++ b/a2a_server/tests/test_bootstrap.py
@@ -1,0 +1,150 @@
+"""Tests for POST /bootstrap and the session tokens it issues.
+
+The point of a session token is that it authenticates on its own — a caller
+that presented the pre-shared bootstrap key should not also need the TOTP
+seed. These tests run with TOTP ENABLED, because that is the only
+configuration in which the feature does anything.
+"""
+
+import datetime
+import importlib.util
+import os
+import pathlib
+import unittest
+
+import pyotp
+
+TOTP_SEED = pyotp.random_base32()
+
+os.environ["HERMES_ENV_FILE"] = "/nonexistent-env-file-for-tests"
+os.environ["HERMES_A2A_TOKEN"] = "test-token-abc123"
+os.environ["HERMES_A2A_TOTP_SEED"] = TOTP_SEED
+os.environ["HERMES_A2A_BOOTSTRAP_KEY"] = "test-bootstrap-key"
+os.environ.setdefault("HERMES_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_bootstrap_impl", _server_path)
+a2a_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a_server)
+
+# server.py latches TOTP_SEED / BOOTSTRAP_KEY into module globals at import, so
+# drop them from the shared environment now. Otherwise the next test module to
+# load its own copy of server.py in the same pytest session inherits TOTP and
+# every one of its unauthenticated-by-design requests starts 401ing.
+os.environ.pop("HERMES_A2A_TOTP_SEED", None)
+os.environ.pop("HERMES_A2A_BOOTSTRAP_KEY", None)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+client = TestClient(a2a_server.app, raise_server_exceptions=False)
+
+RPC = {
+    "jsonrpc": "2.0",
+    "id": "t",
+    "method": "tasks/send",
+    "params": {"skill_id": "memory_stats", "message": "", "input": {}, "sender": "test"},
+}
+
+
+def _bootstrap(key="test-bootstrap-key", **extra):
+    return client.post("/bootstrap", json={"bootstrap_key": key, **extra})
+
+
+class TestBootstrapIssuance(unittest.TestCase):
+    def test_correct_key_issues_token(self):
+        r = _bootstrap()
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json()["session_token"])
+
+    def test_wrong_key_401s(self):
+        self.assertEqual(_bootstrap(key="nope").status_code, 401)
+
+    def test_missing_key_401s(self):
+        self.assertEqual(client.post("/bootstrap", json={}).status_code, 401)
+
+    def test_invalid_json_400s(self):
+        r = client.post(
+            "/bootstrap", content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_ttl_capped_at_7_days(self):
+        exp = datetime.datetime.fromisoformat(_bootstrap(ttl_hours=9999).json()["expires_at"])
+        ahead = exp - datetime.datetime.now(datetime.timezone.utc)
+        self.assertLessEqual(ahead, datetime.timedelta(hours=168))
+
+    def test_response_advertises_no_totp_required(self):
+        self.assertFalse(_bootstrap().json()["totp_required"])
+
+
+class TestSessionTokenAuth(unittest.TestCase):
+    """TOTP is enabled in this module, so these assert the actual feature."""
+
+    def test_session_token_works_without_totp(self):
+        tok = _bootstrap().json()["session_token"]
+        r = client.post(
+            "/a2a", json=RPC,
+            headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json"},
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_primary_token_still_requires_totp(self):
+        r = client.post(
+            "/a2a", json=RPC,
+            headers={"Authorization": "Bearer test-token-abc123"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_primary_token_with_valid_totp_works(self):
+        r = client.post(
+            "/a2a", json=RPC,
+            headers={
+                "Authorization": "Bearer test-token-abc123",
+                "X-TOTP": pyotp.TOTP(TOTP_SEED).now(),
+            },
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_unknown_bearer_401s(self):
+        r = client.post("/a2a", json=RPC, headers={"Authorization": "Bearer bogus"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_expired_session_token_401s(self):
+        tok = _bootstrap(ttl_hours=0).json()["session_token"]
+        r = client.post("/a2a", json=RPC, headers={"Authorization": f"Bearer {tok}"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_expired_session_token_does_not_bypass_totp(self):
+        # An expired token must not sneak past the TOTP gate either.
+        tok = _bootstrap(ttl_hours=0).json()["session_token"]
+        a2a_server._session_tokens[tok] = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        )
+        r = client.post("/a2a", json=RPC, headers={"Authorization": f"Bearer {tok}"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_session_token_works_on_tasks_get_route(self):
+        tok = _bootstrap().json()["session_token"]
+        r = client.get(
+            "/a2a/tasks/00000000-0000-0000-0000-000000000000",
+            headers={"Authorization": f"Bearer {tok}"},
+        )
+        # 404 (unknown task) proves auth passed; 401 would mean it did not.
+        self.assertEqual(r.status_code, 404)
+
+
+class TestHealthReporting(unittest.TestCase):
+    def test_health_reports_bootstrap_configured(self):
+        self.assertTrue(client.get("/health").json()["bootstrap_configured"])
+
+    def test_health_counts_active_sessions(self):
+        before = client.get("/health").json()["active_sessions"]
+        _bootstrap()
+        self.assertGreater(client.get("/health").json()["active_sessions"], before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
       - path: .env
         required: false
     environment:
-      LOCI_A2A_TOKEN: ${LOCI_A2A_TOKEN:?LOCI_A2A_TOKEN is required}
-      LOCI_A2A_URL: ${LOCI_A2A_URL:-http://localhost:8201}
+      HERMES_A2A_TOKEN: ${HERMES_A2A_TOKEN:?HERMES_A2A_TOKEN is required}
+      HERMES_A2A_URL: ${HERMES_A2A_URL:-http://localhost:8201}
       HERMES_AGENT_ID: ${HERMES_AGENT_ID:-loci}
       QDRANT_URL: ${QDRANT_URL:-http://localhost:6333}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}


### PR DESCRIPTION
## Summary
- Adds `POST /bootstrap`: agents exchange `HERMES_A2A_BOOTSTRAP_KEY` for a 24h (configurable, max 7d) session token usable as a standard bearer — no TOTP required on the session token
- `_verify_bearer` extended to accept valid session tokens alongside the primary `HERMES_A2A_TOKEN`
- `hmac.compare_digest` used throughout for constant-time comparison
- Health endpoint exposes `bootstrap_configured` and `active_sessions` fields
- Endpoint 501s when `HERMES_A2A_BOOTSTRAP_KEY` is unset (opt-in only)

## Motivation
New sessions currently need both `HERMES_A2A_TOKEN` + TOTP to authenticate. Bootstrap lets operators distribute a shorter-lived credential to agents without handing out the primary long-lived token.

## Follow-up fix in this PR

The endpoint as first written did not deliver the feature. `_verify_bearer` accepted session tokens, but `_verify_totp` is a *separate* FastAPI dependency that only inspected `TOTP_SEED` and the `X-TOTP` header — it never learned the bearer was a session token. So with TOTP enabled (the only configuration where a session token buys you anything) a freshly issued token still got:

```
401 {"detail":"X-TOTP header required (TOTP is enabled)"}
```

which also made the `'totp_required': False` in the `/bootstrap` response untrue. `_verify_totp` now short-circuits for a live session token; expired tokens fall through to the normal TOTP gate instead of bypassing it.

## Test plan — executed

`a2a_server/tests/test_bootstrap.py`, 15 cases, all running with **TOTP enabled**:

- [x] correct key -> `session_token`; wrong key -> 401; missing key -> 401; malformed JSON -> 400
- [x] `ttl_hours: 9999` clamped to the 7-day cap
- [x] response advertises `totp_required: false`
- [x] session token as plain bearer on `POST /a2a` **without** `X-TOTP` -> 200
- [x] session token on `GET /a2a/tasks/{id}` -> 404 not 401 (proves auth passed)
- [x] primary token without `X-TOTP` -> still 401; with valid `X-TOTP` -> 200
- [x] unknown bearer -> 401; expired session token -> 401; expired token cannot bypass the TOTP gate
- [x] `/health` reports `bootstrap_configured` and a rising `active_sessions`

Two of these fail against the previous revision of this branch. Full suite: `50 passed` in `a2a_server/tests/`.

