### PR TITLE
Swap kuzu for ladybug graph backend

### DIFF
--- a/mcp/graph/kuzu_store.py
+++ b/mcp/graph/kuzu_store.py
@@ -59,10 +59,11 @@ def _writes(failopen):
 _LEASE_TIMEOUT_S = 6.0
 _LEASE_POLL_S = 0.05
 
-try:  # kuzu is optional — the store degrades to unavailable without it.
-    import kuzu  # type: ignore
+try:  # kuzu (now ladybug — same project, renamed; API-compatible) is optional —
+    # the store degrades to unavailable without it.
+    import ladybug as kuzu  # type: ignore
     _HAS_KUZU = True
-except Exception:  # pragma: no cover - environment without kuzu
+except Exception:  # pragma: no cover - environment without kuzu/ladybug
     kuzu = None  # type: ignore
     _HAS_KUZU = False
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "sentence-transformers>=3.0.0",
     "requests>=2.31.0",
     "iocextract>=1.16.1",
-    "kuzu>=0.11.0",
+    "ladybug>=0.18.0",
     "tree-sitter>=0.24",
     "tree-sitter-language-pack>=1.10",
 ]

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -5,6 +5,6 @@ fastembed>=0.7.0
 sentence-transformers>=3.0.0
 requests>=2.31.0
 iocextract>=1.16.1
-kuzu>=0.11.0
+ladybug>=0.18.0
 tree-sitter>=0.24
 tree-sitter-language-pack>=1.10

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -249,7 +249,7 @@ def _get_kuzu():
                 logger.warning("Kuzu not importable — graph features disabled (permanent).")
                 return None
             MEMORY_DIR.mkdir(parents=True, exist_ok=True)  # kuzu won't create parents
-            ks = _kz.KuzuStore(str(MEMORY_DIR / "graph.kuzu"))
+            ks = _kz.KuzuStore(str(MEMORY_DIR / "graph.ladybug"))
             if not ks.available():
                 # Import worked but open failed — almost always another process holds
                 # the single-writer lock. Treat as TRANSIENT: retry after the backoff.


### PR DESCRIPTION
## Summary
- `kuzu` was renamed/rebranded to `ladybug` (same project — its README states *"The database was formerly known as Kuzu"*) with an API-compatible `Database`/`Connection` surface.
- Swaps the single import site in `kuzu_store.py` (`import kuzu` -> `import ladybug as kuzu`) and updates both dependency manifests.
- On-disk file format changed between the two projects (ladybug refuses to open an old kuzu-format file), so the graph store now points at `graph.ladybug` instead of `graph.kuzu` — a fresh graph, not an in-place migration. Verified the old file only held trivial data (3 Finding + 2 Investigation nodes, everything else empty) before discarding it.

## Test plan
- [x] `pip install ladybug` — aarch64 wheel available, installs cleanly
- [x] Confirmed `ladybug.Database`/`ladybug.Connection` match the exact call signatures `kuzu_store.py` uses (only 2 qualified references in the whole file)
- [x] Full MCP JSON-RPC round-trip: `initialize` -> `tools/call investigation_start` (triggers the lazy graph-store init) -> `tools/call loci_health` now reports `"kuzu": "available"`
- [ ] Not yet exercised: heavier graph paths (code_graph_ingest/query, causal edges, contamination traversal) beyond the investigation-manifest upsert path
