### PR TITLE
fix(test): allow kuzu 'contended' in the health state assertion

### DIFF
--- a/mcp/tests/test_health_warm.py
+++ b/mcp/tests/test_health_warm.py
@@ -29,7 +29,9 @@ def test_loci_health_returns_expected_keys():
     # Subset (not ==) so additive fields don't break this contract.
     assert _EXPECTED_KEYS <= set(out.keys())
     # kuzu is one of the documented states
-    assert out["kuzu"] in ("available", "unavailable", "latched", "backoff")
+    assert out["kuzu"] in (
+        "available", "contended", "unavailable", "latched", "backoff"
+    )
     # booleans for reachability, strings for model names / version
     for k in ("ollama_reachable", "vllm_reachable", "qdrant_reachable", "warm"):
         assert isinstance(out[k], bool)


### PR DESCRIPTION
`test_health_warm.py::test_loci_health_returns_expected_keys` asserts:

```python
assert out["kuzu"] in ("available", "unavailable", "latched", "backoff")
```

but #136 added a fifth state, `contended` (store is up, another process holds Kuzu's single-writer lock). Both `loci_health()` and its own docstring document all five:

```
mcp/server.py:7757:   kuzu: 'available' | 'contended' | 'unavailable' | 'latched' | 'backoff'
```

Only the test's whitelist was missed, so the assertion trips whenever a second Loci instance holds the lock as CI runs:

```
AssertionError: assert 'contended' in ('available', 'unavailable', 'latched', 'backoff')
1 failed, 466 passed
```

This is red on `main` right now and is the sole failing check on #137, #138 and #139 — none of which touch this code. Merging this unblocks all three.