### PR TITLE
chore(a2a): drop dead MRPINK_A2A_* env from the Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ mcp/loci_mcp.egg-info/
 # Loci machine-specific backend config (keep out of the public repo)
 backends.toml
 .loci/
+
+# A2A deploy env (holds PEER_A2A_TOKENS_JSON / PEER_A2A_TOTP_SEEDS_JSON)
+.a2a-deploy.env
+.a2a-deploy.env.bak-*

--- a/a2a_server/Dockerfile
+++ b/a2a_server/Dockerfile
@@ -12,16 +12,13 @@ RUN pip install --no-cache-dir \
 
 COPY server.py client.py ./
 
-# MRPINK_A2A_TOKEN is required — server exits at startup if unset.
+# HERMES_A2A_TOKEN is required — server exits at startup if unset.
 # Provide it via .env file or environment injection.
 # Generate: python3 -c "import secrets;print(secrets.token_hex(32))"
 
 # Mnemosyne SQLite path — mount a volume here for persistence across restarts
 ENV MNEMOSYNE_DATA_DIR=/data/mnemosyne
 # A2A identity
-ENV MRPINK_A2A_HOST=0.0.0.0
-ENV MRPINK_A2A_PORT=8201
-ENV MRPINK_A2A_URL=http://localhost:8201
 ENV HERMES_AGENT_ID=mrpink
 # External services
 ENV QDRANT_URL=http://localhost:6333


### PR DESCRIPTION
The image bakes `ENV MRPINK_A2A_HOST/PORT/URL`, left over from when this server ran under the mrpink profile. Nothing reads them: `server.py` only ever looks at `HERMES_A2A_HOST` / `HERMES_A2A_PORT` / `HERMES_A2A_URL` / `HERMES_AGENT_ID`, and there are zero `MRPINK` hits in the running image's `/app/server.py`.

They are not harmless clutter — `MRPINK_A2A_URL=http://localhost:8201` reads as if the node points at mrpink when it is really naming itself, which is actively misleading when debugging the peer mesh. (The real mrpink answers on `100.115.69.88:8200`, not `:8201`.)

Deleted rather than renamed to `HERMES_*`: renaming would make them live-read and change the env-file-less default agent-card URL from server.py's `127.0.0.1` to `localhost`. Deleting is a true no-op.

Also fixes a stale comment naming `MRPINK_A2A_TOKEN` as required when the code requires `HERMES_A2A_TOKEN`, and gitignores `.a2a-deploy.env` — the bare `.env` pattern did not match it, and that file holds `PEER_A2A_TOKENS_JSON` / `PEER_A2A_TOTP_SEEDS_JSON`.

Verified a fresh container off the current image still inherits all three vars, so this is only closed at the next rebuild.