### PR TITLE
sync: create the Qdrant collections, and read the tier that actually holds the corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,30 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v --tb=short --timeout=30
 
+  test-scripts:
+    name: Sync script tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: scripts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest pytest-timeout
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short --timeout=30
+
   lint:
     name: Lint (ruff)
     runs-on: ubuntu-latest

--- a/scripts/mnemosyne_qdrant_sync.py
+++ b/scripts/mnemosyne_qdrant_sync.py
@@ -85,6 +85,70 @@ def embed_and_get_vector(chunks):
 def stable_num_id(s: str) -> int:
     return int(hashlib.sha256(s.encode()).hexdigest()[:15], 16)
 
+def ensure_collection(name=None, dim=None):
+    """Create the collection if it does not exist.
+
+    Nothing in this repo ever created one -- every sync path only upserts points, and
+    a2a_server's _qdrant_search swallows a 404 and returns [], so a missing collection
+    surfaces as "0 results" rather than an error. That is how `mnemosyne` and
+    `hermes_sessions` sat absent on a host while every consumer reported success.
+
+    Schema matches what the consumers require: a NAMED "dense" vector, Cosine.
+    """
+    name = name or COLLECTION
+    dim  = int(dim or os.environ.get("MNEMOSYNE_EMBEDDING_DIM", 768))
+    # curl() swallows every exception and returns {} -- the same fail-quiet habit that let this
+    # bug hide -- so probe by response shape rather than by catching HTTPError, which never
+    # reaches us. A present collection answers {"result": {...}, "status": "ok"}.
+    if curl("GET", f"{QDRANT}/collections/{name}").get("result"):
+        return False
+    curl("PUT", f"{QDRANT}/collections/{name}",
+         {"vectors": {"dense": {"size": dim, "distance": "Cosine"}}})
+    # Re-read: PUT on an existing collection conflicts and curl() would hide that too, so
+    # confirm the collection is actually there before the caller starts upserting into it.
+    if not curl("GET", f"{QDRANT}/collections/{name}").get("result"):
+        print(f"[mnemosyne->qdrant] WARNING: {name} still missing after create attempt",
+              file=sys.stderr)
+        return False
+    print(f"[mnemosyne->qdrant] created missing collection {name} (dense {dim}d Cosine)")
+    return True
+
+def load_memories(conn, tables=(("memories", "memory"), ("working_memory", "working"))):
+    """Read every memory tier out of the Mnemosyne DB, newest tier precedence first.
+
+    `conn` must have row_factory = sqlite3.Row.
+
+    This used to be an inline SELECT against working_memory alone -- the short-lived staging
+    tier. On a real node that is a couple of rows while the corpus sits in `memories` (137 vs 2
+    on hugbot5000-jetson), so the sync ran clean, printed a success line, and left the semantic
+    index essentially empty.
+
+    Rows with empty content are dropped (nothing to embed). An id present in more than one tier
+    keeps its FIRST occurrence, so the durable `memories` copy wins over a staging duplicate.
+    A missing table is skipped rather than fatal -- schemas differ across hosts.
+    """
+    out, seen = [], set()
+    for table, tier in tables:
+        try:
+            rows = conn.execute(
+                f"SELECT id, content, source, importance, session_id, created_at FROM {table} "
+                "WHERE content IS NOT NULL AND TRIM(content) != '' ORDER BY created_at ASC"
+            ).fetchall()
+        except sqlite3.OperationalError as e:
+            print(f"[mnemosyne->qdrant] skipping {table}: {e}")
+            continue
+        kept = 0
+        for r in rows:
+            d = dict(r)
+            if d["id"] in seen:
+                continue
+            seen.add(d["id"])
+            d["tier"] = tier
+            out.append(d)
+            kept += 1
+        print(f"[mnemosyne->qdrant]   {table}: {len(rows)} rows, {kept} new")
+    return out
+
 def get_synced_ids():
     """Return set of memory_ids already in the mnemosyne Qdrant collection.
     Uses paginated scroll to handle collections with >10000 points."""
@@ -106,20 +170,21 @@ def get_synced_ids():
     return synced
 
 def main():
+    ensure_collection()
+
     conn = sqlite3.connect(MNEMOSYNE_DB)
     conn.row_factory = sqlite3.Row
-    rows = conn.execute(
-        "SELECT id, content, source, importance, session_id, created_at FROM working_memory ORDER BY created_at ASC"
-    ).fetchall()
-    memories = [dict(r) for r in rows]
+    memories = load_memories(conn)
     conn.close()
     print(f"[mnemosyne->qdrant] Found {len(memories)} memories")
 
     # Check what's already in mnemosyne collection (paginated)
     existing_ids = get_synced_ids()
-    print(f"[mnemosyne->qdrant] {len(existing_ids)} already synced, {len(memories) - len(existing_ids)} to add")
-
     to_sync = [m for m in memories if m["id"] not in existing_ids]
+    # Count the actual delta, not len(memories) - len(existing_ids): existing_ids is every
+    # point in the collection, so that subtraction goes negative once the index outgrows
+    # whatever this run happens to read.
+    print(f"[mnemosyne->qdrant] {len(existing_ids)} already synced, {len(to_sync)} to add")
     if not to_sync:
         print("[mnemosyne->qdrant] All up to date.")
         return

--- a/scripts/state_db_qdrant_sync.py
+++ b/scripts/state_db_qdrant_sync.py
@@ -46,6 +46,28 @@ def curl_json(method, url, data=None, key=""):
     except json.JSONDecodeError:
         return {"_raw": r.stdout[:200]}
 
+def ensure_collection(key, name=None, dim=None):
+    """Create the collection if it does not exist.
+
+    Same gap as mnemosyne_qdrant_sync: this script only ever upserts points, and
+    a2a_server's _qdrant_search turns a 404 into [], so a `hermes_sessions` collection that
+    was never created reads as "session_search found nothing" on every call.
+
+    curl_json returns {} rather than raising, so probe by response shape.
+    """
+    name = name or COLLECTION
+    dim  = int(dim or os.environ.get("MNEMOSYNE_EMBEDDING_DIM", 768))
+    if curl_json("GET", f"{QDRANT}/collections/{name}", key=key).get("result"):
+        return False
+    curl_json("PUT", f"{QDRANT}/collections/{name}",
+              {"vectors": {"dense": {"size": dim, "distance": "Cosine"}}}, key=key)
+    if not curl_json("GET", f"{QDRANT}/collections/{name}", key=key).get("result"):
+        print(f"[state_db->qdrant] WARNING: {name} still missing after create attempt",
+              file=sys.stderr)
+        return False
+    print(f"[state_db->qdrant] created missing collection {name} (dense {dim}d Cosine)")
+    return True
+
 def stable_id(s: str) -> int:
     return int(hashlib.sha256(s.encode()).hexdigest()[:15], 16)
 
@@ -180,6 +202,8 @@ def main():
     if not key:
         print("ERROR: could not retrieve Qdrant API key", file=sys.stderr)
         sys.exit(1)
+
+    ensure_collection(key)
 
     conn = sqlite3.connect(STATE_DB)
     conn.row_factory = sqlite3.Row

--- a/scripts/tests/test_qdrant_sync_collections.py
+++ b/scripts/tests/test_qdrant_sync_collections.py
@@ -1,0 +1,169 @@
+"""Tests for the collection-creation and source-table behaviour of the Qdrant sync scripts.
+
+Background: neither script ever created its collection, and a2a_server's _qdrant_search turns
+a 404 into [], so a missing collection reads as "0 results" at every call site rather than as
+an error. mnemosyne_qdrant_sync additionally read only `working_memory` -- the small staging
+tier -- so it reported success while leaving the semantic index effectively empty.
+
+These exercise the real functions with the network helper stubbed; no Qdrant required.
+"""
+
+import importlib.util
+import os
+import pathlib
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("HERMES_ENV_FILE", "/nonexistent-env-file-for-tests")
+os.environ.setdefault("QDRANT_URL", "http://qdrant.invalid:6333")
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load(modname, filename):
+    spec = importlib.util.spec_from_file_location(modname, _SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mq = _load("mnemosyne_sync_impl", "mnemosyne_qdrant_sync.py")
+sd = _load("state_db_sync_impl", "state_db_qdrant_sync.py")
+
+
+class _Recorder:
+    """Stands in for curl()/curl_json(); records calls and replays canned responses."""
+
+    def __init__(self, present_after_create=True, present_initially=False):
+        self.calls = []
+        self.present = present_initially
+        self.present_after_create = present_after_create
+
+    def __call__(self, method, url, data=None, *a, **kw):
+        self.calls.append((method, url, data))
+        if method == "GET":
+            return {"result": {"points_count": 0}, "status": "ok"} if self.present else {}
+        if method == "PUT" and "/points" not in url:
+            self.present = self.present_after_create
+            return {"result": True, "status": "ok"}
+        return {"result": {}, "status": "ok"}
+
+    def puts(self):
+        return [c for c in self.calls if c[0] == "PUT" and "/points" not in c[1]]
+
+
+class TestMnemosyneEnsureCollection(unittest.TestCase):
+    def test_creates_when_absent(self):
+        rec = _Recorder()
+        with mock.patch.object(mq, "curl", rec):
+            self.assertTrue(mq.ensure_collection("mnemosyne"))
+        self.assertEqual(len(rec.puts()), 1)
+
+    def test_schema_is_named_dense_cosine(self):
+        rec = _Recorder()
+        with mock.patch.object(mq, "curl", rec):
+            mq.ensure_collection("mnemosyne")
+        body = rec.puts()[0][2]
+        self.assertEqual(body["vectors"]["dense"]["distance"], "Cosine")
+        self.assertEqual(body["vectors"]["dense"]["size"], 768)
+
+    def test_noop_when_already_present(self):
+        rec = _Recorder(present_initially=True)
+        with mock.patch.object(mq, "curl", rec):
+            self.assertFalse(mq.ensure_collection("mnemosyne"))
+        self.assertEqual(rec.puts(), [])
+
+    def test_reports_failure_when_create_does_not_stick(self):
+        # curl() swallows errors and returns {}, so a failed create must be caught by re-reading.
+        rec = _Recorder(present_after_create=False)
+        with mock.patch.object(mq, "curl", rec):
+            self.assertFalse(mq.ensure_collection("mnemosyne"))
+
+    def test_dim_follows_embedding_env(self):
+        rec = _Recorder()
+        with mock.patch.dict(os.environ, {"MNEMOSYNE_EMBEDDING_DIM": "1024"}), \
+             mock.patch.object(mq, "curl", rec):
+            mq.ensure_collection("mnemosyne")
+        self.assertEqual(rec.puts()[0][2]["vectors"]["dense"]["size"], 1024)
+
+
+class TestStateDbEnsureCollection(unittest.TestCase):
+    def test_creates_when_absent(self):
+        rec = _Recorder()
+        with mock.patch.object(sd, "curl_json", rec):
+            self.assertTrue(sd.ensure_collection("k", "hermes_sessions"))
+        self.assertEqual(len(rec.puts()), 1)
+
+    def test_noop_when_already_present(self):
+        rec = _Recorder(present_initially=True)
+        with mock.patch.object(sd, "curl_json", rec):
+            self.assertFalse(sd.ensure_collection("k", "hermes_sessions"))
+        self.assertEqual(rec.puts(), [])
+
+
+class TestMemorySourceTables(unittest.TestCase):
+    """The regression that mattered: syncing only working_memory looked like success."""
+
+    def _db(self, memories, working):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        con = sqlite3.connect(path)
+        for t in ("memories", "working_memory"):
+            con.execute(
+                f"CREATE TABLE {t} (id TEXT, content TEXT, source TEXT, "
+                "importance REAL, session_id TEXT, created_at TEXT)"
+            )
+        for t, rows in (("memories", memories), ("working_memory", working)):
+            con.executemany(
+                f"INSERT INTO {t} VALUES (?,?,?,?,?,?)",
+                [(i, c, "s", 0.5, "", "2026-01-01") for i, c in rows],
+            )
+        con.commit()
+        con.close()
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def _load(self, memories, working):
+        con = sqlite3.connect(self._db(memories, working))
+        con.row_factory = sqlite3.Row
+        try:
+            return mq.load_memories(con)
+        finally:
+            con.close()
+
+    def test_includes_the_durable_memories_table(self):
+        # The regression: the old query read working_memory ONLY, so m1/m2 were never indexed.
+        got = self._load([("m1", "durable one"), ("m2", "durable two")], [("w1", "staged")])
+        self.assertEqual({m["id"] for m in got}, {"m1", "m2", "w1"})
+
+    def test_tier_is_recorded_per_row(self):
+        got = {m["id"]: m["tier"] for m in self._load([("m1", "a")], [("w1", "b")])}
+        self.assertEqual(got, {"m1": "memory", "w1": "working"})
+
+    def test_id_in_both_tiers_yields_one_row_preferring_durable(self):
+        got = self._load([("dup", "durable")], [("dup", "staged")])
+        self.assertEqual(len(got), 1)
+        self.assertEqual(got[0]["tier"], "memory")
+        self.assertEqual(got[0]["content"], "durable")
+
+    def test_empty_and_whitespace_content_is_dropped(self):
+        got = self._load([("m1", "real"), ("m2", ""), ("m3", "   ")], [])
+        self.assertEqual({m["id"] for m in got}, {"m1"})
+
+    def test_missing_table_is_skipped_not_fatal(self):
+        con = sqlite3.connect(self._db([("m1", "a")], []))
+        con.row_factory = sqlite3.Row
+        try:
+            got = mq.load_memories(
+                con, tables=(("memories", "memory"), ("no_such_table", "ghost")),
+            )
+        finally:
+            con.close()
+        self.assertEqual([m["id"] for m in got], ["m1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_qdrant_sync_collections.py
+++ b/scripts/tests/test_qdrant_sync_collections.py
@@ -12,7 +12,6 @@ import importlib.util
 import os
 import pathlib
 import sqlite3
-import sys
 import tempfile
 import unittest
 from unittest import mock


### PR DESCRIPTION
## Two bugs that combined into a silent no-op

**Nothing in this repo has ever created a Qdrant collection.** Both sync scripts only ever `PUT .../points`, and `a2a_server`'s `_qdrant_search` catches any non-200 and returns `[]`:

```python
if r.status == 200:
    return (await r.json()).get('result', [])
log.warning(f'qdrant search {collection}: HTTP {r.status}')
return []
```

So a collection that was never created surfaces as *"0 results"* at every call site rather than as an error. On `hugbot5000-jetson` both `mnemosyne` and `hermes_sessions` were simply absent:

- `memory_stats` → `{"mnemosyne": "HTTP 404", "hermes_sessions": "HTTP 404"}`
- `session_search` → `{"sessions": [], "total": 0}` with `status: completed`, on every query
- `memory_recall`'s semantic leg had nothing to search, so multi-word queries came back empty while single keywords still hit the SQLite `LIKE` leg

The only trace anywhere was a `log.warning` inside the container.

**And `mnemosyne_qdrant_sync` read `working_memory` alone** — the short-lived staging tier. On that host it holds 2 rows while the corpus sits in `memories` with 137. So even pointed at a collection that existed, it would have run clean, printed a success line, and indexed almost nothing.

## Changes

- Both scripts `ensure_collection()` up front, with the schema the consumers require: named `"dense"` vector, Cosine, dimension from `MNEMOSYNE_EMBEDDING_DIM` (default 768).
- The read is extracted into `load_memories()` — unions both tiers, drops empty content, and keeps the durable `memories` copy when an id appears in both.
- The `N to add` line counts the real delta. `len(memories) - len(existing_ids)` goes negative once the index outgrows whatever a given run reads.
- `ensure_collection` probes by **response shape** rather than catching `HTTPError`, because `curl()`/`curl_json()` swallow every exception and return `{}` — the same fail-quiet habit that hid this — and re-reads after the `PUT` so a failed create is reported rather than assumed.

## Tests

`scripts/` had no tests, and CI only collected `mcp/tests` and `a2a_server/tests` — so anything added here would never have run. This adds a **Sync script tests** job alongside the existing two, plus 12 cases covering create / no-op / failed-create / dimension, and the tier-union, dedup, empty-content and missing-table paths.

```
12 passed
```

## Verified on hardware

Backfilled `hugbot5000-jetson`: 137 memories embedded, both collections created.

| | before | after |
|---|---|---|
| `memory_recall("jetson orin hugbot5000 role")` | 0 results | 5 results, scored 0.62–0.71 |
| `memory_stats` qdrant | 2 × `HTTP 404` | `mnemosyne: 137, hermes_sessions: 0` |
| container log `HTTP 404` | steady stream | none |

`hermes_sessions` stays empty on that host — its source `~/.hermes/state.db` does not exist there. That is the correct outcome: an empty collection returns an honest zero-hit answer instead of a swallowed 404.