### PR TITLE
a2a: rerank rag_search results with a cross-encoder

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -45,6 +45,14 @@ Optional / tunable:
                             Default: '' (TOTP disabled)
   HERMES_AGENT_ID           Agent identity tag written into memory metadata.
                             Default: 'hermes-agent'
+  RERANK_HTTP_URL           llama.cpp `llama-server --rerank --pooling rank` endpoint,
+                            e.g. http://127.0.0.1:8082/rerank. When set, rag_search
+                            reorders its merged cross-collection hits with a
+                            cross-encoder instead of trusting raw cosine scores that
+                            are not comparable across collections. Adds no torch
+                            dependency here. Unset = cosine order (previous behaviour).
+                            Fails open on any error.
+  RERANK_TIMEOUT_S          Rerank request timeout. Default: 10
 
 Qdrant (shared with session_end_sync.py + state_db_qdrant_sync.py):
 
@@ -289,6 +297,7 @@ AGENT_CARD = {
                 'Fan-out semantic search across Qdrant collections without requiring '
                 'direct Qdrant credentials. Core: hermes_memory, hermes_sessions, mnemosyne. '
                 'Additional collections: set EXTRA_RAG_COLLECTIONS env var (comma-separated). '
+                'Cross-encoder reranking when RERANK_HTTP_URL is set (fails open to cosine order). '
                 'Input: {query: str, top_k?: int=5, collections?: [str]}'
             )
         },
@@ -744,6 +753,70 @@ async def skill_memory_sleep(task: dict) -> dict:
 
 
 # ── skill: rag_search ────────────────────────────────────────────────────────────
+async def _rerank(query: str, hits: list) -> bool:
+    """
+    Reorder `hits` IN PLACE with a cross-encoder, if RERANK_HTTP_URL is configured.
+
+    rag_search fans out across collections and then merges on raw cosine score. Those
+    scores are not comparable across collections -- different content types, different
+    chunk sizes, different embedding neighbourhoods -- so the merge is the weakest link
+    in the whole path, and it is exactly what a cross-encoder is good at.
+
+    Points at a llama.cpp `llama-server --rerank --pooling rank` endpoint (the same one
+    mcp/reranker.py's RERANK_HTTP_URL uses), so a host already serving a reranker needs
+    no second model and this process gains no torch dependency.
+
+    FAILS OPEN. Unset URL, unreachable server, malformed response, or a short/oversized
+    result list all leave the cosine ordering untouched and return False. Search
+    degrading to "slightly worse ordering" is correct; degrading to an error is not.
+
+    Returns True only if the order was actually replaced.
+    """
+    url = os.environ.get('RERANK_HTTP_URL', '').strip()
+    if not url or len(hits) < 2:
+        return False
+
+    docs = [(h.get('content') or '') for h in hits]
+    if not any(d.strip() for d in docs):
+        return False
+
+    try:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=float(os.environ.get('RERANK_TIMEOUT_S', 10)))
+        ) as sess, sess.post(url, json={'query': query, 'documents': docs}) as r:
+            if r.status != 200:
+                log.warning(f'rerank: HTTP {r.status} — keeping cosine order')
+                return False
+            data = await r.json()
+    except Exception as e:
+        log.warning(f'rerank: {e!r} — keeping cosine order')
+        return False
+
+    scored = []
+    for item in (data.get('results') or []):
+        try:
+            idx = int(item['index'])
+            if 0 <= idx < len(hits):
+                scored.append((idx, float(item['relevance_score'])))
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    # Partial coverage would silently drop hits, so only accept a complete permutation.
+    if len(scored) != len(hits) or len({i for i, _ in scored}) != len(hits):
+        log.warning(f'rerank: got {len(scored)} scores for {len(hits)} hits — keeping cosine order')
+        return False
+
+    scored.sort(key=lambda t: t[1], reverse=True)
+    reordered = []
+    for idx, score in scored:
+        h = hits[idx]
+        h['cosine_score'] = h.get('score')      # keep the original so callers can compare
+        h['rerank_score'] = round(score, 4)
+        reordered.append(h)
+    hits[:] = reordered
+    return True
+
+
 async def skill_rag_search(task: dict) -> dict:
     """
     Fan-out semantic search across ALL 768-dim Qdrant collections.
@@ -810,10 +883,13 @@ async def skill_rag_search(task: dict) -> dict:
             seen.add(key)
             deduped.append(h)
 
+    reranked = await _rerank(query, deduped)
+
     return {
         'results':              deduped[:top_k * 2],   # return more than top_k since multi-collection
         'query':                query,
         'collections_searched': collections,
+        'reranked':             reranked,
         'total_hits':           len(deduped),
     }
 

--- a/a2a_server/tests/test_rag_rerank.py
+++ b/a2a_server/tests/test_rag_rerank.py
@@ -1,0 +1,180 @@
+"""Tests for rag_search's cross-encoder rerank hook.
+
+rag_search fans out across collections and merges on raw cosine score, which is not
+comparable across collections. _rerank() replaces that ordering when RERANK_HTTP_URL is
+set. It must FAIL OPEN in every degraded case -- search returning slightly worse ordering
+is acceptable, search erroring is not -- so most of these assert the fallback.
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import unittest
+from unittest import mock
+
+os.environ.setdefault("HERMES_A2A_TOKEN", "test-token-abc123")
+os.environ.setdefault("HERMES_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_rerank_impl", _server_path)
+a2a = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a)
+
+URL = "http://127.0.0.1:8082/rerank"
+
+
+def hits(n=3):
+    return [
+        {"collection": "c", "id": str(i), "score": 0.9 - i * 0.1, "content": f"doc {i}"}
+        for i in range(n)
+    ]
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None, boom=False):
+        self.status = status
+        self._payload = payload or {}
+        self._boom = boom
+
+    async def json(self):
+        if self._boom:
+            raise ValueError("not json")
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Session:
+    def __init__(self, resp=None, raise_on_post=None):
+        self._resp = resp
+        self._raise = raise_on_post
+
+    def post(self, *a, **kw):
+        if self._raise:
+            raise self._raise
+        return self._resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def with_session(sess):
+    return mock.patch.object(a2a.aiohttp, "ClientSession", lambda *a, **kw: sess)
+
+
+class TestRerankDisabled(unittest.TestCase):
+    def test_no_url_leaves_order_untouched(self):
+        h = hits()
+        before = [x["id"] for x in h]
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(run(a2a._rerank("q", h)))
+        self.assertEqual([x["id"] for x in h], before)
+
+    def test_blank_url_is_treated_as_unset(self):
+        with mock.patch.dict(os.environ, {"RERANK_HTTP_URL": "   "}):
+            self.assertFalse(run(a2a._rerank("q", hits())))
+
+    def test_single_hit_is_not_sent(self):
+        with mock.patch.dict(os.environ, {"RERANK_HTTP_URL": URL}):
+            self.assertFalse(run(a2a._rerank("q", hits(1))))
+
+    def test_all_empty_content_is_not_sent(self):
+        h = [{"collection": "c", "id": "0", "score": 0.5, "content": "  "},
+             {"collection": "c", "id": "1", "score": 0.4, "content": ""}]
+        with mock.patch.dict(os.environ, {"RERANK_HTTP_URL": URL}):
+            self.assertFalse(run(a2a._rerank("q", h)))
+
+
+class TestRerankApplies(unittest.TestCase):
+    def _reranked(self, scores):
+        payload = {"results": [{"index": i, "relevance_score": s} for i, s in scores]}
+        h = hits(3)
+        with mock.patch.dict(os.environ, {"RERANK_HTTP_URL": URL}), \
+             with_session(_Session(_Resp(200, payload))):
+            ok = run(a2a._rerank("q", h))
+        return ok, h
+
+    def test_reorders_by_relevance(self):
+        # cosine order is 0,1,2; the cross-encoder prefers the reverse.
+        ok, h = self._reranked([(0, -9.0), (1, -3.0), (2, -1.0)])
+        self.assertTrue(ok)
+        self.assertEqual([x["id"] for x in h], ["2", "1", "0"])
+
+    def test_preserves_original_cosine_score(self):
+        _, h = self._reranked([(0, -9.0), (1, -3.0), (2, -1.0)])
+        top = h[0]
+        self.assertEqual(top["cosine_score"], 0.7)     # hit id=2 started at 0.9-0.2
+        self.assertEqual(top["rerank_score"], -1.0)
+
+    def test_no_hits_are_lost(self):
+        _, h = self._reranked([(0, -9.0), (1, -3.0), (2, -1.0)])
+        self.assertEqual(sorted(x["id"] for x in h), ["0", "1", "2"])
+
+    def test_already_correct_order_is_stable(self):
+        ok, h = self._reranked([(0, -1.0), (1, -3.0), (2, -9.0)])
+        self.assertTrue(ok)
+        self.assertEqual([x["id"] for x in h], ["0", "1", "2"])
+
+
+class TestRerankFailsOpen(unittest.TestCase):
+    def _fails_open(self, session):
+        h = hits(3)
+        before = [x["id"] for x in h]
+        with mock.patch.dict(os.environ, {"RERANK_HTTP_URL": URL}), with_session(session):
+            ok = run(a2a._rerank("q", h))
+        self.assertFalse(ok)
+        self.assertEqual([x["id"] for x in h], before)
+
+    def test_non_200_keeps_cosine_order(self):
+        self._fails_open(_Session(_Resp(503, {})))
+
+    def test_connection_error_keeps_cosine_order(self):
+        self._fails_open(_Session(raise_on_post=OSError("connection refused")))
+
+    def test_unparseable_body_keeps_cosine_order(self):
+        self._fails_open(_Session(_Resp(200, boom=True)))
+
+    def test_missing_results_key_keeps_cosine_order(self):
+        self._fails_open(_Session(_Resp(200, {"nope": []})))
+
+    def test_partial_coverage_is_rejected_rather_than_dropping_hits(self):
+        # 2 scores for 3 hits: accepting this would silently lose a result.
+        payload = {"results": [{"index": 0, "relevance_score": -1.0},
+                               {"index": 1, "relevance_score": -2.0}]}
+        self._fails_open(_Session(_Resp(200, payload)))
+
+    def test_duplicate_indices_are_rejected(self):
+        payload = {"results": [{"index": 0, "relevance_score": -1.0},
+                               {"index": 0, "relevance_score": -2.0},
+                               {"index": 1, "relevance_score": -3.0}]}
+        self._fails_open(_Session(_Resp(200, payload)))
+
+    def test_out_of_range_index_is_rejected(self):
+        payload = {"results": [{"index": 0, "relevance_score": -1.0},
+                               {"index": 1, "relevance_score": -2.0},
+                               {"index": 99, "relevance_score": -3.0}]}
+        self._fails_open(_Session(_Resp(200, payload)))
+
+    def test_malformed_entries_are_rejected(self):
+        payload = {"results": [{"index": 0, "relevance_score": "high"},
+                               {"index": 1},
+                               {"relevance_score": -3.0}]}
+        self._fails_open(_Session(_Resp(200, payload)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`rag_search` fans out across every configured Qdrant collection and merges the hits with:

```python
all_hits.sort(key=lambda x: x['score'], reverse=True)
```

Raw cosine scores are **not comparable across collections** — different content types, chunk sizes, and embedding neighbourhoods — so this merge was the weakest step in the retrieval path. Cross-collection ordering is exactly the job a cross-encoder does well.

The A2A server had **no reranking of any kind**; it existed only on the MCP path (`mcp/reranker.py`, #138). On `hugbot5000-jetson` that meant a GPU reranker running on `:8082`, actively used by Claude Code, and never once seen by the A2A server on the same box — `grep -c RERANK /app/server.py` → `0`.

## Changes

`RERANK_HTTP_URL` points at a llama.cpp `llama-server --rerank --pooling rank` endpoint — the same env var and endpoint shape `mcp/reranker.py` already uses, so a host already serving a reranker needs no second model. The call is `aiohttp` against HTTP, so this process gains **no torch dependency**.

- Unset → previous cosine behaviour, unchanged.
- `cosine_score` is preserved alongside `rerank_score`, and the response carries `reranked: bool`, so a caller can tell which ordering it got rather than guessing.

## Fails open, everywhere

Search degrading to a slightly worse ordering is acceptable. Search erroring because a ranking nicety is down is not. So unset URL, unreachable server, non-200, unparseable body, missing `results` key, and malformed entries all keep the cosine order and return `False`.

Partial coverage is **rejected rather than applied** — accepting scores for only some hits would silently drop the rest from the result set, which is a correctness bug wearing a performance improvement's clothes.

## Tests

`a2a_server/tests/test_rag_rerank.py` — 16 cases, most on the fail-open paths (non-200, connection error, unparseable body, partial coverage, duplicate indices, out-of-range index, malformed entries), plus reorder / stability / no-hits-lost / score-preservation.

```
66 passed in a2a_server/tests/
```