### PR TITLE
bridge: stop the context bridge from feeding itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install pytest pytest-timeout
+          # a2a_context_bridge sys.exit()s at import without aiohttp, which aborts
+          # collection for the whole directory rather than failing one test.
+          pip install aiohttp
 
       - name: Run tests
         run: pytest tests/ -v --tb=short --timeout=30

--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -307,7 +307,9 @@ AGENT_CARD = {
             'description': (
                 'Store a memory locally AND push it to all peer A2A endpoints (PEER_A2A_URLS). '
                 'Used by the context bridge cron to propagate discoveries across the mesh. '
-                'Input: {content: str, source?: str, importance?: float=0.5, bank?: str}'
+                'Set store_local=false when relaying something this node already holds. '
+                'Input: {content: str, source?: str, importance?: float=0.5, bank?: str, '
+                'store_local?: bool=true}'
             )
         },
         {
@@ -984,13 +986,21 @@ async def skill_context_broadcast(task: dict) -> dict:
     if not content:
         return {'error': 'content is required'}
 
-    # 1. Store locally first
-    local_result = await skill_memory_remember({
-        'input': {'content': content, 'source': source,
-                  'importance': importance, 'bank': bank},
-        'sender': sender
-    })
-    stored_locally = 'error' not in local_result
+    # 1. Store locally first — unless the caller is relaying something it already holds.
+    # The context bridge reads this node's own database and pushes through this skill, so
+    # storing would insert a fresh copy of a memory that is already here, with a new id and
+    # a new created_at. That copy then looks "new" to the next bridge run and gets relayed
+    # again: unbounded local growth with no peer involved.
+    store_local = bool(inp.get('store_local', True))
+    if store_local:
+        local_result = await skill_memory_remember({
+            'input': {'content': content, 'source': source,
+                      'importance': importance, 'bank': bank},
+            'sender': sender
+        })
+        stored_locally = 'error' not in local_result
+    else:
+        stored_locally = False
 
     # 2. Fan-out to peers
     peer_urls_raw = os.environ.get('PEER_A2A_URLS', '')

--- a/a2a_server/tests/test_context_broadcast_store_local.py
+++ b/a2a_server/tests/test_context_broadcast_store_local.py
@@ -1,0 +1,79 @@
+"""context_broadcast's store_local flag.
+
+The context bridge relays memories by POSTing them to its OWN server's context_broadcast.
+That skill stored before fanning out, so a relayed memory was re-inserted into the database
+it had just been read from - new id, new created_at - which made the copy look "new" to the
+next bridge run and got it relayed again. Unbounded local growth, no peer required.
+
+store_local=false lets a caller relay something the node already holds.
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import unittest
+from unittest import mock
+
+os.environ.setdefault("HERMES_A2A_TOKEN", "test-token-abc123")
+os.environ.setdefault("HERMES_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_storelocal_impl", _server_path)
+a2a = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a)
+
+
+def run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def call(**inp):
+    """Invoke context_broadcast with no peers configured, capturing local stores."""
+    calls = []
+
+    async def fake_remember(task):
+        calls.append(task)
+        return {"id": "stored-id", "status": "stored"}
+
+    with mock.patch.dict(os.environ, {"PEER_A2A_URLS": ""}, clear=False), \
+         mock.patch.object(a2a, "skill_memory_remember", fake_remember):
+        out = run(a2a.skill_context_broadcast({"input": inp, "sender": "test"}))
+    return out, calls
+
+
+class TestStoreLocal(unittest.TestCase):
+    def test_defaults_to_storing(self):
+        out, calls = call(content="hello")
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(out["stored_locally"])
+
+    def test_explicit_true_stores(self):
+        _, calls = call(content="hello", store_local=True)
+        self.assertEqual(len(calls), 1)
+
+    def test_false_does_not_store(self):
+        out, calls = call(content="hello", store_local=False)
+        self.assertEqual(calls, [])
+        self.assertFalse(out["stored_locally"])
+
+    def test_false_still_attempts_the_fan_out(self):
+        # Suppressing the local write must not suppress the actual point of the skill.
+        out, _ = call(content="hello", store_local=False)
+        self.assertIn("broadcast", out)
+
+    def test_empty_content_still_rejected(self):
+        out, calls = call(content="   ", store_local=False)
+        self.assertIn("error", out)
+        self.assertEqual(calls, [])
+
+    def test_source_and_importance_reach_the_local_store(self):
+        _, calls = call(content="hello", source="bridge:loci", importance=0.9)
+        self.assertEqual(calls[0]["input"]["source"], "bridge:loci")
+        self.assertEqual(calls[0]["input"]["importance"], 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/a2a_context_bridge.py
+++ b/scripts/a2a_context_bridge.py
@@ -85,39 +85,77 @@ def _save_state(state: dict):
 
 
 # ── Mnemosyne query ───────────────────────────────────────────────────────────────
+# Sources that must never be re-bridged. Anything already in flight through the mesh will
+# come back with one of these stamps, and re-sending it is what turns two nodes into an
+# infinite loop. `bridge:` is what THIS script stamps on what it sends (see
+# _broadcast_memory), `broadcast:` is what a peer's context_broadcast stamps on what it
+# receives, and `context_broadcast` marks a memory the local server has already fanned out
+# to every peer itself.
+ECHO_SOURCE_PREFIXES = [
+    p.strip() for p in os.environ.get(
+        "BRIDGE_EXCLUDE_SOURCES", "bridge:,broadcast:,context_broadcast"
+    ).split(",") if p.strip()
+]
+
+
 def _fetch_recent_memories(since: str, min_importance: float, max_items: int) -> list[dict]:
     """
-    Fetch working_memory rows newer than `since` (ISO timestamp) with importance >= min_importance.
-    Falls back to memories table if working_memory doesn't exist.
+    Fetch memories newer than `since` (ISO timestamp) with importance >= min_importance,
+    excluding anything that arrived through the mesh (see ECHO_SOURCE_PREFIXES).
+
+    Reads BOTH tiers. This used to read working_memory and fall back to `memories` only on
+    OperationalError -- i.e. only if the table did not exist. working_memory does exist, and
+    it is the small staging tier (2 rows on hugbot5000-jetson against 139 in `memories`), so
+    the fallback was unreachable and the real corpus was never bridged at all.
+
+    created_at is normalised before comparison. Mnemosyne writes mostly ISO-with-T but not
+    exclusively (138 T-separated vs 1 space-separated on that same host), and a raw string
+    compare puts every space-separated row below every T-separated one, because ' ' (0x20)
+    sorts under 'T' (0x54). Those rows would be silently skipped forever once `since` is a
+    T-format timestamp.
     """
     if not os.path.exists(MNEMOSYNE_DB):
         log.warning("Mnemosyne DB not found: %s", MNEMOSYNE_DB)
         return []
 
+    echo_clause = ""
+    params_tail: list = []
+    if ECHO_SOURCE_PREFIXES:
+        echo_clause = " AND source IS NOT NULL AND " + " AND ".join(
+            ["source NOT LIKE ?"] * len(ECHO_SOURCE_PREFIXES)
+        )
+        # An exact name like context_broadcast needs no wildcard; a prefix like bridge: does.
+        params_tail = [p + "%" if p.endswith(":") else p for p in ECHO_SOURCE_PREFIXES]
+
     conn = sqlite3.connect(MNEMOSYNE_DB, timeout=10)
     conn.row_factory = sqlite3.Row
-    rows = []
+    out: list[dict] = []
+    seen: set = set()
+    since_norm = (since or "").replace(" ", "T")
     try:
-        # Try working_memory first (primary store)
-        try:
-            rows = conn.execute(
-                "SELECT id, content, importance, created_at, source FROM working_memory "
-                "WHERE created_at > ? AND importance >= ? "
-                "ORDER BY created_at DESC LIMIT ?",
-                (since, min_importance, max_items)
-            ).fetchall()
-        except sqlite3.OperationalError:
-            # Fallback to memories table
-            rows = conn.execute(
-                "SELECT id, content, importance, created_at, source FROM memories "
-                "WHERE created_at > ? AND importance >= ? "
-                "ORDER BY created_at DESC LIMIT ?",
-                (since, min_importance, max_items)
-            ).fetchall()
+        for table in ("memories", "working_memory"):
+            try:
+                rows = conn.execute(
+                    f"SELECT id, content, importance, created_at, source FROM {table} "
+                    "WHERE REPLACE(created_at, ' ', 'T') > ? AND importance >= ?"
+                    + echo_clause +
+                    " ORDER BY created_at DESC LIMIT ?",
+                    (since_norm, min_importance, *params_tail, max_items)
+                ).fetchall()
+            except sqlite3.OperationalError as e:
+                log.debug("skipping %s: %s", table, e)
+                continue
+            for r in rows:
+                d = dict(r)
+                if d["id"] in seen:
+                    continue
+                seen.add(d["id"])
+                out.append(d)
     finally:
         conn.close()
 
-    return [dict(r) for r in rows]
+    out.sort(key=lambda m: (m.get("created_at") or "").replace(" ", "T"), reverse=True)
+    return out[:max_items]
 
 
 # ── A2A call ──────────────────────────────────────────────────────────────────────
@@ -134,9 +172,19 @@ async def _broadcast_memory(session: aiohttp.ClientSession, mem: dict, dry_run: 
             "message":  mem["content"],
             "input": {
                 "content":    mem["content"],
-                "source":     mem.get("source") or "bridge",
+                # Stamp what WE send so both ends can recognise it as mesh traffic and refuse
+                # to bridge it onward. Passing the original source through (the old behaviour)
+                # meant a bridged memory arrived at the peer looking locally-authored, so the
+                # peer's own filter could not identify it and bridged it straight back.
+                "source":     f"bridge:{AGENT_ID}",
                 "importance": float(mem.get("importance") or 0.5),
                 "bank":       "default",
+                # We are relaying through our OWN server, and context_broadcast stores before
+                # it fans out. Without this the bridge re-inserts a fresh copy of each memory
+                # into the database it just read from -- with a new id and a new created_at,
+                # so the copy is "new" next run and gets bridged again. That is unbounded
+                # growth on a SINGLE node, no peer required.
+                "store_local": False,
             },
             "sender": AGENT_ID,
         },

--- a/scripts/tests/test_context_bridge_echo.py
+++ b/scripts/tests/test_context_bridge_echo.py
@@ -1,0 +1,168 @@
+"""Tests for the context bridge's echo suppression and source selection.
+
+The bridge relays memories to mesh peers. Three separate defects made scheduling it unsafe:
+
+1. It read `working_memory` and only fell back to `memories` on OperationalError - i.e. only
+   if the table were missing. It exists, and it is the small staging tier, so the real corpus
+   was never bridged.
+2. Nothing excluded memories that had themselves arrived through the mesh, and the push
+   passed the ORIGINAL source through, so a relayed memory reached the peer looking
+   locally-authored and was relayed straight back.
+3. created_at was compared as a raw string, so space-separated timestamps sort below every
+   T-separated one and get skipped forever.
+
+These pin all three. They matter more than most tests here: the failure mode is unbounded
+growth on both nodes, not a wrong answer.
+"""
+
+import importlib.util
+import os
+import pathlib
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("HERMES_ENV_FILE", "/nonexistent-env-file-for-tests")
+os.environ.setdefault("LOCI_A2A_TOKEN", "t")
+os.environ.setdefault("HERMES_A2A_TOKEN", "t")
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "bridge_impl", _SCRIPTS / "a2a_context_bridge.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bridge = _load()
+
+SCHEMA = ("CREATE TABLE {t} (id TEXT, content TEXT, importance REAL, "
+          "created_at TEXT, source TEXT)")
+
+
+class _DB:
+    def __init__(self, memories=(), working=()):
+        fd, self.path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        con = sqlite3.connect(self.path)
+        for t in ("memories", "working_memory"):
+            con.execute(SCHEMA.format(t=t))
+        for t, rows in (("memories", memories), ("working_memory", working)):
+            con.executemany(f"INSERT INTO {t} VALUES (?,?,?,?,?)", rows)
+        con.commit()
+        con.close()
+
+
+def row(i, created="2026-07-27T12:00:00", imp=0.9, source="local-work"):
+    return (i, f"content {i}", imp, created, source)
+
+
+class TestEchoSuppression(unittest.TestCase):
+    def _fetch(self, memories, since="2026-07-01T00:00:00"):
+        db = _DB(memories=memories)
+        self.addCleanup(os.unlink, db.path)
+        with mock.patch.object(bridge, "MNEMOSYNE_DB", db.path):
+            return bridge._fetch_recent_memories(since, 0.5, 20)
+
+    def test_locally_authored_memory_is_bridged(self):
+        got = self._fetch([row("a")])
+        self.assertEqual([m["id"] for m in got], ["a"])
+
+    def test_peer_broadcast_is_not_re_bridged(self):
+        got = self._fetch([row("a"), row("echo", source="broadcast:oxalis-mrpink")])
+        self.assertEqual([m["id"] for m in got], ["a"])
+
+    def test_our_own_bridge_output_is_not_re_bridged(self):
+        got = self._fetch([row("a"), row("mine", source="bridge:loci")])
+        self.assertEqual([m["id"] for m in got], ["a"])
+
+    def test_context_broadcast_already_fanned_out_is_not_re_bridged(self):
+        got = self._fetch([row("a"), row("cb", source="context_broadcast")])
+        self.assertEqual([m["id"] for m in got], ["a"])
+
+    def test_null_source_is_not_bridged(self):
+        # A null source cannot be shown to be locally authored; excluding it is the safe
+        # direction, since the cost of a false exclude is one un-propagated memory and the
+        # cost of a false include is a loop.
+        got = self._fetch([row("a"), row("nul", source=None)])
+        self.assertEqual([m["id"] for m in got], ["a"])
+
+    def test_all_echo_rows_yields_nothing(self):
+        got = self._fetch([row("x", source="broadcast:p"), row("y", source="bridge:q")])
+        self.assertEqual(got, [])
+
+
+class TestSourceTables(unittest.TestCase):
+    def _fetch(self, memories, working, since="2026-07-01T00:00:00"):
+        db = _DB(memories=memories, working=working)
+        self.addCleanup(os.unlink, db.path)
+        with mock.patch.object(bridge, "MNEMOSYNE_DB", db.path):
+            return bridge._fetch_recent_memories(since, 0.5, 20)
+
+    def test_reads_the_memories_table_even_when_working_memory_exists(self):
+        # The regression: working_memory exists, so the old fallback never fired.
+        got = self._fetch([row("real")], [row("staged")])
+        self.assertIn("real", [m["id"] for m in got])
+
+    def test_reads_both_tiers(self):
+        got = self._fetch([row("real")], [row("staged")])
+        self.assertEqual({m["id"] for m in got}, {"real", "staged"})
+
+    def test_id_in_both_tiers_is_not_duplicated(self):
+        got = self._fetch([row("dup")], [row("dup")])
+        self.assertEqual(len(got), 1)
+
+
+class TestTimestampNormalisation(unittest.TestCase):
+    def _fetch(self, memories, since):
+        db = _DB(memories=memories)
+        self.addCleanup(os.unlink, db.path)
+        with mock.patch.object(bridge, "MNEMOSYNE_DB", db.path):
+            return bridge._fetch_recent_memories(since, 0.5, 20)
+
+    def test_space_separated_row_is_not_lost(self):
+        # ' ' (0x20) sorts below 'T' (0x54), so a raw string compare drops this row.
+        got = self._fetch([row("space", created="2026-07-27 12:00:00")],
+                          since="2026-07-26T00:00:00")
+        self.assertEqual([m["id"] for m in got], ["space"])
+
+    def test_space_separated_since_still_filters(self):
+        got = self._fetch([row("old", created="2026-07-25T00:00:00")],
+                          since="2026-07-26 00:00:00")
+        self.assertEqual(got, [])
+
+    def test_older_rows_are_still_excluded(self):
+        got = self._fetch([row("old", created="2026-07-01T00:00:00"),
+                           row("new", created="2026-07-27T00:00:00")],
+                          since="2026-07-26T00:00:00")
+        self.assertEqual([m["id"] for m in got], ["new"])
+
+
+class TestImportanceAndLimit(unittest.TestCase):
+    def _fetch(self, memories, min_imp=0.5, max_items=20):
+        db = _DB(memories=memories)
+        self.addCleanup(os.unlink, db.path)
+        with mock.patch.object(bridge, "MNEMOSYNE_DB", db.path):
+            return bridge._fetch_recent_memories("2026-07-01T00:00:00", min_imp, max_items)
+
+    def test_below_threshold_is_excluded(self):
+        got = self._fetch([row("lo", imp=0.2), row("hi", imp=0.9)])
+        self.assertEqual([m["id"] for m in got], ["hi"])
+
+    def test_max_items_is_honoured_across_both_tiers(self):
+        got = self._fetch([row(f"m{i}", created=f"2026-07-27T12:00:{i:02d}")
+                           for i in range(10)], max_items=3)
+        self.assertEqual(len(got), 3)
+
+    def test_newest_first(self):
+        got = self._fetch([row("old", created="2026-07-27T10:00:00"),
+                           row("new", created="2026-07-27T18:00:00")])
+        self.assertEqual([m["id"] for m in got], ["new", "old"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found while wiring the context bridge up on the `hugbot5000-jetson` / `oxalis-mrpink` mesh. Three defects, and together they made scheduling this script **unsafe**, not merely useless. Numbers below are from that host.

## 1. It never bridged the corpus

`_fetch_recent_memories` read `working_memory` and fell back to `memories` only on `OperationalError` — i.e. only if the table did not exist. It does exist. It is the small staging tier: **2 rows against 139** in `memories`. The fallback was unreachable and the real corpus was invisible. Now reads both tiers, deduping by id.

## 2. It fed itself

The push goes to this node's **own** server via `context_broadcast`, which stores before it fans out. So every relayed memory was re-inserted into the database it had just been read from — fresh id, fresh `created_at` — which made the copy *"new"* to the next run, and it got relayed again.

That is unbounded growth on a **single node, with no peer involved**: roughly `BRIDGE_MAX_ITEMS` rows per tick, forever. `context_broadcast` now accepts `store_local`, and the bridge passes `false`.

## 3. It could not recognise its own traffic

The push passed the **original** source through, so a relayed memory arrived at the peer looking locally-authored. The peer had no way to tell it came from the mesh, and would relay it straight back — two nodes, one loop. A `NOT LIKE 'broadcast:%'` filter alone would not have caught this, because the relayed row never carried that stamp.

The bridge now stamps what it sends as `bridge:<agent_id>`, and the fetch excludes `bridge:`, `broadcast:` and `context_broadcast` (configurable via `BRIDGE_EXCLUDE_SOURCES`). That host already holds **7 rows sourced `broadcast:oxalis-mrpink`** — the fuel was in place, only the scheduling was missing.

## Also: timestamp normalisation

`created_at` was compared as a raw string. Mnemosyne writes mostly ISO-with-T but not exclusively — **138 T-separated against 1 space-separated** on that host — and `' '` (0x20) sorts below `'T'` (0x54), so space-separated rows fall under every T-separated one and are skipped forever once `since` is a T-format timestamp.

Null sources are excluded as well. A null cannot be shown to be locally authored, and the asymmetry is stark: a false exclude costs one un-propagated memory, a false include costs a loop.

## Tests

33 new: 21 on the bridge (echo suppression per source type, both tiers, dedup, timestamp normalisation, importance, limit) and 6 on `store_local`, plus argument plumbing.

```
99 passed across a2a_server/tests and scripts/tests
```

## Not scheduled

Deliberately still unscheduled. That is a separate step, one node first, watched for a cycle before the second joins.