### PR TITLE
scripts: version the context-bridge systemd units

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -1,0 +1,56 @@
+# systemd units
+
+Templates. Copy to `/etc/systemd/system/`, adjust the marked block, then enable.
+
+## loci-context-bridge
+
+Runs `a2a_context_bridge.py` on a timer, pushing this node's locally-authored memories to
+its mesh peers.
+
+```bash
+sudo install -o root -g root -m 644 \
+    scripts/systemd/loci-context-bridge.service \
+    scripts/systemd/loci-context-bridge.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl start loci-context-bridge.service      # one run first, watch the journal
+sudo systemctl enable --now loci-context-bridge.timer
+```
+
+### Before enabling it on a second node
+
+The bridge relays through the local A2A server's `context_broadcast`. **That server must
+support `store_local`** (loci #144). Against an older server the flag is silently ignored,
+`context_broadcast` stores before it fans out, and every run re-inserts a copy of the memory
+it just read — with a fresh id and `created_at`, so the copy looks new next tick and is
+relayed again. Unbounded growth on a single node, no peer required.
+
+Check first:
+
+```bash
+curl -s localhost:8201/health >/dev/null && \
+  grep -c store_local /path/to/a2a_server/server.py   # must be > 0 on the RUNNING code
+```
+
+Echo suppression relies on `BRIDGE_EXCLUDE_SOURCES` (default `bridge:,broadcast:,context_broadcast`).
+Memories arriving from a peer are stamped `broadcast:<agent>` by the receiving server, and
+that is what stops them being relayed back. Bring both ends up on #144 or later before
+scheduling the bridge on more than one node, and watch a couple of cycles with row counts
+before and after.
+
+### Requirements
+
+- `aiohttp` — the script `sys.exit()`s at import without it, so a missing dependency looks
+  like a unit that fails instantly rather than one that quietly does nothing.
+- `HERMES_A2A_TOKEN` reachable via `EnvironmentFile`. The script's own loader checks
+  `~/.hermes/.env`, which does not exist on every host; where the A2A server runs as a
+  container the token usually lives in the checkout's `.env` instead.
+
+### Tuning
+
+| env | default | notes |
+| --- | --- | --- |
+| `BRIDGE_LOOKBACK_MIN` | 30 | only used on the first run; after that the state file drives the window |
+| `BRIDGE_MIN_IMP` | 0.5 | memories below this importance are not propagated |
+| `BRIDGE_MAX_ITEMS` | 20 | per run |
+| `BRIDGE_EXCLUDE_SOURCES` | `bridge:,broadcast:,context_broadcast` | echo suppression — do not narrow without reading #144 |
+| `BRIDGE_STATE_FILE` | `~/.hermes/bridge_state.json` | last successful run timestamp |

--- a/scripts/systemd/loci-context-bridge.service
+++ b/scripts/systemd/loci-context-bridge.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Loci A2A context bridge (push local memories to mesh peers)
+Documentation=https://github.com/rjmendez/loci
+# The bridge relays through THIS node's own A2A server, which may be a container or a
+# systemd unit depending on the host. No hard dependency either way: a run that cannot
+# reach it logs a failure and the next tick retries.
+After=network-online.target
+# Where the A2A server runs as a container, add docker.service here so a boot-time run does
+# not fire before it exists:
+#   After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# ── adjust these three for your host ────────────────────────────────────────────
+User=rjmendez
+Group=rjmendez
+WorkingDirectory=/home/rjmendez/loci
+
+# a2a_context_bridge.py looks for ~/.hermes/.env (or ~/.hermes/profiles/$HERMES_PROFILE/.env)
+# and loads it with os.environ.setdefault, so whatever systemd supplies here WINS. Point this
+# at wherever HERMES_A2A_TOKEN actually lives on this host — on a node where the A2A server
+# runs as a container that is usually the checkout's own .env, not ~/.hermes/.env.
+EnvironmentFile=/home/rjmendez/loci/.env
+
+ExecStart=/usr/bin/python3 /home/rjmendez/loci/scripts/a2a_context_bridge.py
+# ────────────────────────────────────────────────────────────────────────────────
+
+# Requires aiohttp: the script sys.exit()s at import without it, so a missing dependency
+# looks like a unit that fails instantly rather than one that does nothing.
+#   apt install python3-aiohttp   (or pip install aiohttp)
+
+# Nothing here is urgent, and mesh nodes are often memory-constrained.
+Nice=10
+MemoryMax=256M
+TimeoutStartSec=120
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=loci-bridge

--- a/scripts/systemd/loci-context-bridge.timer
+++ b/scripts/systemd/loci-context-bridge.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Run the Loci A2A context bridge periodically
+Documentation=https://github.com/rjmendez/loci
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+# Keep it off the same instant as other timers on the box.
+RandomizedDelaySec=60
+# Deliberately NOT Persistent. A missed window is not worth catching up, and a burst of
+# back-to-back runs after downtime is exactly the shape you do not want on a mesh path.
+# The script keeps its own state file, so a skipped tick loses nothing — the next run
+# picks up everything since the last successful one.
+Persistent=false
+Unit=loci-context-bridge.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The context bridge is now scheduled on `hugbot5000-jetson`, but the units existed only in that box's `/etc/systemd/system` — unversioned, and reproducible only from memory. That is the same fragility the mesh audit flagged for the A2A container, whose `docker run` is likewise hand-typed and referenced by nothing.

## What the README carries

Two things that are not obvious from the unit files and that would hurt on a second node:

- **The local A2A server must support `store_local` (#144).** Against an older server the flag is silently ignored, `context_broadcast` stores before it fans out, and every run re-inserts a copy of the memory it just read — with a fresh id and `created_at`, so the copy looks new next tick and is relayed again. Unbounded growth on one node, no peer required.
- **`aiohttp` is a hard requirement.** The script `sys.exit()`s at import without it, so a missing dependency presents as a unit that fails *instantly* rather than one that quietly does nothing. That is exactly how it read on the Jetson before installing it.

It also records what actually stops the loop, which is not what the code comment implies: the bridge stamps its sends `bridge:<agent_id>`, but the local server overwrites the source with `broadcast:<agent_id>` on the peer hop — so the load-bearing filter is `broadcast:`, and the `bridge:` stamp only matters on the local-store path. Verified on the wire: a bridged memory arrives at the peer as `broadcast:loci`.

## Timer shape

Deliberately **not** `Persistent`. A missed window is not worth catching up, and a burst of back-to-back runs after downtime is the wrong shape for a mesh path. The state file means a skipped tick loses nothing — the next run picks up everything since the last success.

`RandomizedDelaySec=60` keeps it off the same instant as the other timers on the box.

## Verified before scheduling

- echo filter against real data: 24 eligible → 20 sent, 4 excluded, and the 4 are exactly the `context_broadcast` and `broadcast:oxalis-mrpink` rows. Zero leaked.
- one controlled cycle: memory bridged, landed on the peer once, **no local duplicate** (`store_local=False` held), zero `bridge:*` rows written locally.
- idempotent: runs 2 and 3 find nothing, state advances.
- the token reaches the unit through `EnvironmentFile` — proven by a send that actually landed, not by the absence of an error.