### PR TITLE
graph: read ladybug's upper-cased internal keys, and un-skip the graph tests

### DIFF
--- a/mcp/graph/queries.py
+++ b/mcp/graph/queries.py
@@ -91,6 +91,16 @@ def _internal_id(id_dict: Any) -> Optional[tuple]:
     return None
 
 
+def _meta(node: dict, name: str) -> Any:
+    """Read an internal key off a returned node/rel dict.
+
+    ladybug returns these upper-cased (``_ID``/``_LABEL``/``_SRC``/``_DST``);
+    kuzu used lower-case. Accept either so the reader survives the rename.
+    """
+    up = f"_{name.upper()}"
+    return node[up] if up in node else node.get(f"_{name.lower()}")
+
+
 def _rel_pattern(rels: Any) -> str:
     """Build the type filter for a var-length pattern: ``""`` or ``":A|B"``.
 
@@ -169,7 +179,7 @@ def subgraph(
         for node in [anchor_node, *path_nodes]:
             if not isinstance(node, dict):
                 continue
-            nid = _internal_id(node.get("_id"))
+            nid = _internal_id(_meta(node, "id"))
             if nid is None or nid in seen:
                 continue
             seen.add(nid)
@@ -180,7 +190,7 @@ def subgraph(
     id_to_key: dict = {}
     nodes_out: list = []
     for nid, node in kept:
-        label = node.get("_label")
+        label = _meta(node, "label")
         key = node.get(_PK.get(label, ""))
         id_to_key[nid] = key
         nodes_out.append({"label": label, "key": key, "props": _props(node)})
@@ -192,11 +202,11 @@ def subgraph(
         for rel in (row[2] or []):
             if not isinstance(rel, dict):
                 continue
-            src = _internal_id(rel.get("_src"))
-            dst = _internal_id(rel.get("_dst"))
+            src = _internal_id(_meta(rel, "src"))
+            dst = _internal_id(_meta(rel, "dst"))
             if src not in kept_ids or dst not in kept_ids:
                 continue
-            rel_label = rel.get("_label")
+            rel_label = _meta(rel, "label")
             sig = (src, dst, rel_label)
             if sig in edge_seen:
                 continue

--- a/mcp/tests/test_kuzu_lease.py
+++ b/mcp/tests/test_kuzu_lease.py
@@ -15,7 +15,7 @@ import threading
 
 import pytest
 
-kuzu = pytest.importorskip("kuzu")
+pytest.importorskip("ladybug")
 
 from graph import kuzu_store as kz
 from graph.kuzu_store import KuzuStore

--- a/mcp/tests/test_kuzu_store.py
+++ b/mcp/tests/test_kuzu_store.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-kuzu = pytest.importorskip("kuzu")
+pytest.importorskip("ladybug")
 
 from graph.kuzu_store import KuzuStore
 from memcheck.checks.contagion import find_contamination

--- a/mcp/tests/test_linker.py
+++ b/mcp/tests/test_linker.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-kuzu = pytest.importorskip("kuzu")
+pytest.importorskip("ladybug")
 
 from graph.kuzu_store import KuzuStore
 from graph.linker import (

--- a/mcp/tests/test_queries.py
+++ b/mcp/tests/test_queries.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-kuzu = pytest.importorskip("kuzu")
+pytest.importorskip("ladybug")
 
 from graph.kuzu_store import KuzuStore
 from graph import queries as Q


### PR DESCRIPTION
The kuzu -> ladybug rename left two artifacts behind.

kuzu_store.py already imports `ladybug as kuzu`, but the four graph test
modules still gated on `pytest.importorskip("kuzu")`. Since kuzu is no
longer a declared dependency (and is unmaintained), that gate skipped all
39 of them on every run, CI included, and reported green. Gate on ladybug
instead — the module the code actually imports.

That un-skip surfaced a real bug. ladybug returns a node/rel's internal
keys upper-cased (_ID/_LABEL/_SRC/_DST) where kuzu lower-cased them, but
queries.py still read node.get("_id") & co. All five reads resolved to
None, so subgraph()'s `if nid is None: continue` dropped every node and
the function fail-opened to {"nodes": [], "edges": []} for every input --
silently, since fail-open swallows it. subgraph() is the primitive the
other query builders compose from, so every graph-walking MCP tool has
been returning empty neighbourhoods against ladybug.

Route the five reads through a _meta() helper that accepts either case,
so the reader survives the rename in both directions. _props() was
already safe -- it filters on the "_" prefix rather than exact names.

mcp/tests: 467 passed, 0 skipped (was 427 passed, 4 skipped).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa