### PR TITLE
deps: pin mcp[cli] below 2.0 to restore CI

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "Loci — persistent memory and knowledge MCP server for AI agent meshes"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp[cli]>=1.2.0",
+    "mcp[cli]>=1.2.0,<2",
     "python-dotenv>=1.0.0",
     "qdrant-client>=1.17.0,<1.19.0",
     "fastembed>=0.7.0",

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.2.0
+mcp[cli]>=1.2.0,<2
 python-dotenv>=1.0.0
 qdrant-client>=1.17.0,<1.19.0
 fastembed>=0.7.0


### PR DESCRIPTION
Fixes the red CI on `main`.

## Cause

`mcp[cli]` was constrained as an open `>=1.2.0`. mcp 2.0 dropped `mcp.server.fastmcp` — `FastMCP` is now `MCPServer` under `mcp.server.mcpserver` — so the first fresh dependency resolve after 2.0 shipped pulled it in and `server.py:64` died at import:

```
server.py:64: from mcp.server.fastmcp import FastMCP
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

That takes out **MCP server tests** and **MCP tool integration tests** with 7 collection errors, before a single test runs. `main` went red on `2b963f6` for exactly this — not for anything in that diff. The previous green run on `c97818b` (Jul 27) predates the 2.0 release.

## Change

Pin `<2` in both declaration sites — `mcp/requirements.txt:1` and `mcp/pyproject.toml:11`. These are the only two; `loci_mcp.egg-info/requires.txt` is generated.

## Verification

Clean venv rebuilt from scratch against the new constraint:

- resolves `mcp 1.29.0` (with `ladybug 0.19.1`)
- `pytest tests/` → **467 passed, 0 skipped**
- ruff gate (`E9,F401,F811,F821,F841`) → `All checks passed!`

## Not in scope

Migrating to the 2.0 API is separate work: 60 `@mcp.tool()` registrations plus the `@mcp.resource()` templates. Pinning first keeps that a deliberate change rather than one forced by a transitive resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_