### PR TITLE
docs: correct factual drift against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ like a set of notes.
 ![Loci architecture](docs/img/loci-overview.svg)
 
 Loci runs as an MCP server alongside Claude Code. When Claude needs to remember or recall
-something, it calls one of Loci's 24 tools — the same way it calls any other tool. Your
+something, it calls one of Loci's 71 tools — the same way it calls any other tool. Your
 data stays on your own infrastructure: Qdrant and Ollama run locally or on your own server.
 
 > **New to terms like "vector search", "RAG", or "MCP"?**
@@ -80,36 +80,88 @@ See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Docker and systemd deployment.
 
 ---
 
-## MCP tools (24)
+## MCP tools (71)
 
 ![Tool groups](docs/img/loci-tools.svg)
+
+*This diagram groups an earlier 24-tool snapshot by purpose — the groupings still
+hold, but the surface has since grown to 71 tools: 60 defined in `mcp/server.py`
+plus 11 code-graph tools registered from `mcp/graph_tools.py` at import time. See
+the table below for the current inventory.*
 
 | Tool | Purpose |
 |---|---|
 | `investigation_start` | Open a new investigation session |
 | `investigation_load` | Load an existing investigation by ID |
+| `investigation_as_of` | Return findings as they were believed at a point in time |
 | `investigation_store` | Persist findings to the investigation |
-| `investigation_note` | Append a free-form note |
+| `finding_resolve` | Mark a finding's lifecycle state — fixed / intentional / wontfix / superseded, or back to open |
+| `procedure_attempt` | Record a pass/fail attempt against a procedure-type finding |
+| `procedure_search` | Search for procedure-type findings matching a query |
+| `investigation_note` | Update a manifest field — hypothesis, next step, context, open questions, checked sources, closing summary |
 | `investigation_reflect` | Run reflection over current findings |
+| `investigation_reason` | Reason over findings with grounded, multi-perspective analysis |
 | `investigation_search` | Search within an investigation |
 | `investigation_pre_answer_check` | Validate a claim against stored evidence before answering |
 | `investigation_evidence_precheck` | Pre-screen evidence before ingestion |
 | `investigation_entity_lookup` | Look up an entity by name across stored findings |
+| `entity_list` | List all named entities extracted from an investigation's findings |
+| `entity_timeline` | Chronological timeline of every finding mentioning an entity |
 | `investigation_related_cases` | Find related prior investigations |
 | `investigation_finding_provenance` | Trace source provenance for a finding |
+| `causal_edges_list` | List causal edges inferred for an investigation |
+| `conflict_list` | List detected conflicts for an investigation |
+| `conflict_resolve` | Resolve a detected conflict by recording a verdict |
 | `investigation_list` | List investigations, most-recent first. Paginated (`limit=30`, `offset=0`) and compact by default (`summary=True`); pass `summary=False` for full records and `limit=0` (or any value `<=0`) for all — note `offset` still applies in no-limit mode, returning all *remaining* records starting at `offset`. Response includes `total`/`limit`/`offset`. |
+| `investigation_share` | Grant read/write access to an investigation for one or more agents |
+| `investigation_unshare` | Revoke access to an investigation for one or more agents |
+| `investigation_export` | Export an investigation as a portable JSON bundle |
+| `investigation_import` | Import an investigation bundle produced by `investigation_export` |
 | `audit_log` | Append to the audit trail |
 | `memory_self_check` | Cross-check stored memories for consistency |
-| `code_memory_correlate` | Correlate a code change with stored memory context |
+| `code_memory_correlate` | Link a detected code hallucination to the memories it contaminated (advisory, read-only) |
 | `memory_health` | Report memory system health |
+| `loci_health` | Read-only self-diagnosis of the MCP server as a JSON snapshot |
 | `memory_retract` | Soft-retract an incorrect or stale memory |
 | `memory_restore` | Restore a previously retracted memory |
+| `memory_promote` | Promote a finding to a higher memory tier |
+| `memory_demote` | Demote a finding to a lower memory tier |
+| `memory_hints` | Return the most recent findings as lightweight hints |
+| `memory_surface` | Proactively surface prior findings relevant to the current working context |
+| `memory_route` | Mesh-aware search across all investigations — no `investigation_id` filter |
 | `reflection_loop_seed` | Seed the reflection loop with new material |
 | `reflection_loop_tick` | Advance the reflection loop one step |
 | `reflection_loop_status` | Report reflection loop queue status |
 | `rag_context_search` | Fan-out semantic search across all configured Qdrant collections |
+| `ground` | Assemble a provenance-tagged, character-budgeted grounding block for a task |
 | `memory_consolidate` | Trigger memory consolidation (dedup + merge) |
 | `memory_confidence` | Estimate confidence in a memory-derived claim before asserting it |
+| `contract_declare` | Store a cross-boundary contract declaration for an entity |
+| `contract_query` | Query stored contract declarations for an entity |
+| `contract_check` | Check whether a field name conflicts with stored contract declarations |
+| `wiring_obligation_declare` | Declare a wiring obligation — a method that should integrate but is unverified |
+| `wiring_obligation_list` | List wiring obligations for an investigation |
+| `wiring_obligation_resolve` | Resolve a wiring obligation with evidence of fulfilment |
+| `llm_local` | Generate with a local Ollama model — the generation tier of the offload path |
+| `generate_batch` | Generate for many prompts at once, for high-concurrency fan-out |
+| `query_expand` | Expand a search query (HyDE-lite) using the local model |
+| `verify_finding` | Adversarially verify a claim with the local model |
+| `investigation_verify_all` | Batch adversarial-verify an investigation's open findings |
+| `classify_text` | Pick the single best label for a text using the local model |
+| `compress_text` | Semantically condense text to a character budget using the local model |
+| `semantic_dedup` | Cluster near-duplicate items by embedding cosine similarity |
+| `semantic_relevance` | Score each text's cosine relevance to a topic on the local embedding path |
+| `code_graph_ingest` | Parse source with tree-sitter and ingest its symbol graph |
+| `code_graph_query` | Run a read-only Cypher query over the code + memory graph |
+| `code_memory_relink` | Rebuild every finding → code-symbol `REFERENCES` edge |
+| `code_memory_map` | Map the code/memory neighbourhood around an anchor node |
+| `symbol_impact` | Blast radius of a code symbol across code and memory |
+| `impact_report` | Change blast radius for a symbol or class, with the findings that reference it |
+| `finding_code_context` | The code a finding references, each symbol with its callers/callees |
+| `investigation_code_briefing` | The code story of an investigation in a single call |
+| `subsystem_report` | Full picture of a subsystem: code, call boundary, memory hotspots |
+| `related_investigations_via_code` | Other investigations that reference the same code symbols |
+| `dead_code_candidates` | Functions with no code caller and no finding reference |
 
 ---
 
@@ -227,7 +279,7 @@ HERMES_MCP_TRANSPORT=sse HERMES_MCP_HOST=0.0.0.0 HERMES_MCP_PORT=8000 \
 
 ```
 loci/
-├── mcp/                   MCP server — 24 tools: investigation memory, RAG, claim validation
+├── mcp/                   MCP server — 71 tools: investigation memory, RAG, claim validation, code graph
 │   ├── server.py          FastMCP server entry point
 │   ├── memcheck/          Standalone claim-validation + code-hallucination module
 │   ├── pyproject.toml     Package definition (pip install -e .)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,8 +30,10 @@ Primary structured store. Tables queried by this codebase:
 | `facts` | Structured fact store | Updated by fact-extraction pipeline |
 | `gists` | Compressed memory gists | Produced by consolidation |
 
-> Note: `graph_edges`, `conflicts`, and `annotations` may exist in the Mnemosyne
-> schema but are not directly queried by the scripts in this repository.
+> Note: `graph_edges` and `conflicts` *are* queried — written by
+> `scripts/amem_consolidation.py` and read/updated by `scripts/glymphatic_sweep.py`,
+> `scripts/spreading_activation.py`, and `scripts/mnem_fix.py`. `annotations` may
+> exist in the Mnemosyne schema but is not directly queried by this repository.
 
 ### Qdrant (configured via `QDRANT_URL`)
 
@@ -82,12 +84,13 @@ pre_llm_grounding.py (v3)
     ├── 6. Multi-signal ranking on four axes:
     │       relevance (cosine × importance) · recency (exponential decay)
     │       · trust (confidence tier) · record type (observed > inferred > assumed > gap)
-    │       Weights: RANKER_W_RELEVANCE, RANKER_W_RECENCY, RANKER_W_TRUST, RANKER_W_TYPE
+    │       Weights: HOOK_RANKER_W_RELEVANCE, HOOK_RANKER_W_RECENCY, HOOK_RANKER_W_TRUST,
+    │                HOOK_RANKER_W_TYPE
     ├── 7. Stigmergic pheromone deposit on retrieved hermes_memory points
-    │       (pheromone stored in Qdrant payload; decays by PHERO_HALFLIFE_H)
+    │       (pheromone stored in Qdrant payload; decays by HOOK_PHERO_HALFLIFE_H)
     ├── 8. MMR diversity selection with ε-exploration
-    │       (MMR_LAMBDA controls relevance-vs-diversity trade-off;
-    │        PHERO_EPSILON controls random exploration probability)
+    │       (HOOK_MMR_LAMBDA controls relevance-vs-diversity trade-off;
+    │        HOOK_PHERO_EPSILON controls random exploration probability)
     ├── 9. Optional spreading activation enrichment (SA-RAG, arxiv 2512.15922)
     │       Seeds from mnemosyne hits with mnemosyne_id payload;
     │       skipped if SA takes > HOOK_SA_TIMEOUT_MS or SA module is absent
@@ -115,9 +118,9 @@ grounding injection before tool calls.
 | `GROUNDING_EXTRA_COLLECTIONS` | `""` | Extra Qdrant collections for the grounding hook only |
 | `HOOK_SA_ENABLED` | `true` | Enable spreading activation enrichment |
 | `HOOK_SA_TIMEOUT_MS` | `25` | SA budget in ms; skipped if exceeded |
-| `MMR_LAMBDA` | `0.75` | MMR relevance weight (1.0 = pure relevance) |
-| `PHERO_BETA` | `0.08` | Pheromone score boost coefficient |
-| `PHERO_HALFLIFE_H` | `24` | Pheromone evaporation half-life (hours) |
+| `HOOK_MMR_LAMBDA` | `0.75` | MMR relevance weight (1.0 = pure relevance) |
+| `HOOK_PHERO_BETA` | `0.08` | Pheromone score boost coefficient |
+| `HOOK_PHERO_HALFLIFE_H` | `24` | Pheromone evaporation half-life (hours) |
 
 > `GROUNDING_EXTRA_COLLECTIONS` is read independently by the grounding hook.
 > `EXTRA_RAG_COLLECTIONS` is a separate variable read by `a2a_server/server.py`
@@ -176,8 +179,10 @@ all hooks.
 
 ## MCP server (loci-mcp)
 
-`mcp/server.py` is registered as `FastMCP('loci')` and exposes 18 tools under
-the `loci-mcp` server name. Key env vars:
+`mcp/server.py` is registered as `FastMCP('loci')` and exposes 71 tools under
+the `loci-mcp` server name — 60 declared with `@mcp.tool()` in `server.py` plus 11
+code-graph tools registered from `mcp/graph_tools.py` by
+`graph_tools.register(mcp, _get_kuzu)` at import time. Key env vars:
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -200,18 +205,16 @@ the `loci-mcp` server name. Key env vars:
 
 ## Consolidation and self-improvement pipeline
 
-Cron jobs (live in `~/.hermes/cron/jobs.json`):
+Cron jobs (defined in `cron/jobs.json`; deployed copy lives in `~/.hermes/cron/`):
 
 | Job | Script / Command | Interval | Purpose |
 |---|---|---|---|
 | mnemosyne-consolidation | `mnemosyne_activity_check.py` (agent decides whether to call `mnemosyne_sleep`) | 20m | Activity-gated Mnemosyne consolidation |
 | mnemosyne-session-summarizer | `mnemosyne_activity_check.py` (agent writes memories, triples, scratchpad) | 20m | Full session archival: memories, triples, scratchpad, sleep |
 | mnemosyne-sleep-cli | `mnemosyne_sleep_all.sh` | 30m | Prune expired working memory (no-agent mode) |
-| ebbinghaus-memory-decay | `ebbinghaus_consolidation.py` | 47m | Decay-triggered Qdrant refresh |
-| amem-consolidation | `amem_consolidation.py` | 61m | Cross-link graph + conflict detection |
-| skill-annotation-updater | `skill_annotation_updater.py` | 120m | SKILL.md learned constraints |
-| agentHER-relabeler | `agentHER_relabeler.py` | 720m | Failure → positive trace relabeling |
-| eval-harness-weekly | `eval/harness.py` | 10080m | Longitudinal grounding quality score |
+| deep-think-loci-harvest | `dtl_harvest.sh` | 7d | Rebuild dataset + retrain the bleed-detector (`enabled: false` — retrains a model from the corpus; enable deliberately) |
+| mnemosyne-qdrant-sync | `mnemosyne_qdrant_sync.py` | 30m | Sync Mnemosyne → mnemosyne Qdrant collection (no-agent mode) |
+| state-db-qdrant-sync | `state_db_qdrant_sync.py` | 5m | Sync Hermes state.db sessions → hermes_sessions Qdrant (no-agent mode) |
 
 > The `mnemosyne-consolidation` and `mnemosyne-session-summarizer` jobs both use
 > `mnemosyne_activity_check.py` as the script. The cron runner provides that
@@ -225,8 +228,11 @@ On-demand scripts (not croned):
 - `exif_skill_discovery.py` — EXIF skill gap analysis → candidate SKILL.md
 - `score_trace_collector.py` — build SCoRe fine-tuning dataset from logs
 - `skillops_maintenance.py` — skill shadow detection + last_validated update
-- `state_db_qdrant_sync.py` — sync Hermes state.db sessions → hermes_sessions Qdrant
-- `mnemosyne_qdrant_sync.py` — sync Mnemosyne → mnemosyne Qdrant collection
+- `ebbinghaus_consolidation.py` — decay-triggered Qdrant refresh
+- `amem_consolidation.py` — cross-link graph + conflict detection
+- `skill_annotation_updater.py` — SKILL.md learned constraints
+- `agentHER_relabeler.py` — failure → positive trace relabeling
+- `eval/harness.py` — longitudinal grounding quality score
 
 ---
 
@@ -259,16 +265,16 @@ post_tool_failure_reflection.sh
     │  - Mnemosyne (importance=7)
     │  - guard_tool_reflections.log (JSONL)
     │
-    ├──► ebbinghaus_consolidation.py (every 47m)
+    ├──► ebbinghaus_consolidation.py (on demand)
     │    Re-embeds decayed memories → Qdrant refresh
     │
-    ├──► amem_consolidation.py (every 61m)
+    ├──► amem_consolidation.py (on demand)
     │    Builds semantic cross-links, flags near-duplicate conflicts
     │
-    ├──► skill_annotation_updater.py (every 120m)
+    ├──► skill_annotation_updater.py (on demand)
     │    Reads guard_tool_reflections.log → updates SKILL.md "Learned constraints"
     │
-    ├──► agentHER_relabeler.py (every 720m)
+    ├──► agentHER_relabeler.py (on demand)
     │    Relabels failure memories as positive examples via Ollama
     │    Writes synthetic positives back to Mnemosyne + Qdrant
     │
@@ -302,6 +308,7 @@ credentials.
 | `memory_sleep` | Trigger Mnemosyne sleep consolidation via dashboard API |
 | `rag_search` | Fan-out semantic search across all configured Qdrant collections |
 | `context_broadcast` | Store locally and push to all peer A2A endpoints (PEER_A2A_URLS) |
+| `memory_prime` | SAR-style priming broadcast — decaying skepticism boost for a topic cluster, written to `~/.hermes/sar-priming.json` and optionally pushed to peers |
 | `mnemosyne_triple_add` | Store a knowledge triple in the SQLite `triples` table |
 | `mnemosyne_triple_query` | Query the knowledge graph by subject/predicate/object |
 | `gpu_inference` | Run a prompt through local Ollama |
@@ -320,7 +327,7 @@ credentials.
 | `HERMES_AGENT_ID` | `hermes-agent` | Agent identity tag |
 | `QDRANT_URL` | _(none)_ | Qdrant instance URL |
 | `QDRANT_API_KEY` | `""` | Qdrant API key |
-| `MNEMOSYNE_EMBEDDING_API_URL` | _(none)_ | Embedding base URL (with `/v1`) |
+| `MNEMOSYNE_EMBEDDING_API_URL` | `http://localhost:11434/v1` | Embedding base URL (with `/v1`) |
 | `MNEMOSYNE_EMBEDDING_MODEL` | `nomic-embed-text` | Embedding model |
 | `MNEMOSYNE_EMBEDDING_DIM` | `768` | Vector dimension |
 | `MNEMOSYNE_DATA_DIR` | `~/.hermes/mnemosyne/data` | Directory containing mnemosyne.db |

--- a/docs/COGNITIVE_FOUNDATIONS.md
+++ b/docs/COGNITIVE_FOUNDATIONS.md
@@ -46,7 +46,7 @@ cron intervals.
 |---|---|
 | `ebbinghaus_consolidation.py` triggers on R < 0.3 | Consolidate when 70%+ of memory trace has likely decayed |
 | Stability: FSRS DSR model — `S = (1 + recall_count)^(1/D) * (D/2)` initialized; success/failure FSRS update rules applied thereafter | Empirically outperforms SM-2 and linear approximations (open-spaced-repetition/FSRS); maps directly to the Difficulty/Stability/Retrievability DSR model |
-| Ebbinghaus cron at 47-minute intervals (prime) | Avoids resonance with other consolidation jobs; decay is checked per entry, not assumed |
+| Ebbinghaus consolidation is decay-triggered, not interval-triggered — no cron ships enabled; run on demand, or on a prime-numbered interval if you schedule it | Decay is checked per entry rather than assumed, so the cadence is a sampling rate, not the mechanism; a prime interval avoids resonance with the other consolidation jobs |
 | `working_memory.last_recalled` and `recall_count` drive Ebbinghaus stability updates | Recall history is load-bearing state — updated on every consolidation run |
 
 **FSRS parameters (all tunable via env vars):**
@@ -233,7 +233,7 @@ window allows memories to be updated with new context or corrected.
 | Design decision | Empirical basis |
 |---|---|
 | `agentHER_relabeler.py` — reads failure memories, runs Ollama relabeling, writes positive traces back | Computationally equivalent to reconsolidation: the memory is "recalled" (read), transformed (relabeled), and re-encoded (upserted) |
-| AgentHER runs nightly (720m cron), not in real time | Reconsolidation requires a consolidation window; nightly batch mirrors the offline consolidation that occurs during sleep in biological systems |
+| AgentHER runs as an offline batch (on demand; nightly is the intended cadence), not in real time | Reconsolidation requires a consolidation window; batch relabeling mirrors the offline consolidation that occurs during sleep in biological systems |
 
 **DB schema note:** `agentHER_relabeler.py` reads from the `working_memory` table directly.
 `exif_skill_discovery.py` reads from a `memories` table (with a `bank` column filter for

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -11,17 +11,21 @@ configured schedule and must be run on demand.
 ## Grounding pipeline
 
 ### `scripts/hooks/pre_llm_grounding.py`
-**Purpose:** Per-turn grounding. Embeds user message intent, fans out to 7 Qdrant
-collections in parallel, fuses scores, keyword-reranks, injects MEMORY MATCH context.
+**Purpose:** Per-turn grounding. Embeds user message intent, fans out to 3 base Qdrant
+collections (`mnemosyne`, `hermes_sessions`, `hermes_memory`) plus any named in
+`GROUNDING_EXTRA_COLLECTIONS`, in parallel; fuses scores, keyword-reranks, injects
+MEMORY MATCH context.
 
 **Invoked by:** `grounding_client.py` (via UDS or subprocess) on every UserPromptSubmit.
 
 **Key env vars:**
-- `QDRANT_URL` (default: `http://localhost:6333`)
-- `OLLAMA_BASE_URL` (default: `http://localhost:11434`)
+- `QDRANT_URL` (no default — Qdrant fan-out is skipped if unset)
+- `OLLAMA_BASE_URL` (no default — embedding falls back to BeamMemory FTS if unset)
 - `QDRANT_API_KEY`
 - `MNEMOSYNE_EMBEDDING_MODEL` (default: `nomic-embed-text`)
-- `HOOK_RECALL_TOP_K` (default: `5`)
+- `GROUNDING_EXTRA_COLLECTIONS` (default: empty) — comma-separated extra collections
+  to search alongside the 3 base ones
+- `HOOK_RECALL_TOP_K` (default: `3`; the shipped `.env.example` sets `5`)
 - `HOOK_RECALL_MIN_SCORE` (default: `0.55`)
 - `HOOK_QDRANT_WORKERS` (default: `8`)
 
@@ -119,12 +123,15 @@ a minimum accumulated signal count before the expensive embedding pass runs.
 
 ### `scripts/mnemosyne_qdrant_sync.py`
 **Purpose:** Syncs all Mnemosyne memories to the Qdrant `mnemosyne` collection.
-Uses embed-worker (`:30888`) and copies vectors from `agent_core_chunks` into `mnemosyne`.
-Runs incrementally to avoid re-uploading already-synced entries.
+Embeds via Ollama `/v1/embeddings` (`MNEMOSYNE_EMBEDDING_API_URL`) and upserts directly
+into the `mnemosyne` collection. Runs incrementally to avoid re-uploading already-synced
+entries.
 
 **Cron:** every 30m (`mnemosyne-qdrant-sync` in `cron/jobs.json`)
 
-**Key env vars:** `QDRANT_URL`, `EMBED_WORKER_URL` (default: `http://localhost:30888`)
+**Key env vars:** `QDRANT_URL`, `MNEMOSYNE_EMBEDDING_API_URL`, `MNEMOSYNE_EMBEDDING_MODEL`
+(default: `nomic-embed-text`), `MNEMOSYNE_DATA_DIR` (default: `~/.hermes/mnemosyne/data`),
+`EMBED_WORKER_URL` (no default; read but currently unused — this script embeds via Ollama only)
 
 ---
 
@@ -167,7 +174,7 @@ how to..."), stores synthetic positives back to both Mnemosyne SQLite and the Qd
 aggregates failures by tool_name, finds matching SKILL.md files, writes or updates
 "## Learned constraints" sections with top-3 failure patterns.
 
-**Cron:** every 120m
+**Cron:** No configured schedule — run on demand.
 
 **Key env vars:**
 - `STATE_DIR` (default: `~/.claude/hook-state`)
@@ -222,7 +229,7 @@ all SKILL.md frontmatter.
 **Run on demand** (or weekly; no cron currently)
 
 **Key env vars:**
-- `SKILL_SHADOW_THRESHOLD` (default: `0.92`)
+- `SHADOW_THRESHOLD` (default: `0.92`)
 - `OLLAMA_URL`, `EMBED_MODEL`
 
 **Research basis:** Skill Shadowing (arxiv 2605.24050, May 2026)
@@ -335,6 +342,7 @@ the workflow defaults to. Idempotent.
 | `state_db_qdrant_sync.py` | `state-db-qdrant-sync` | every 5m |
 
 Scripts not in this table (`ebbinghaus_consolidation.py`, `amem_consolidation.py`,
-`agentHER_relabeler.py`, `exif_skill_discovery.py`, `score_trace_collector.py`,
-`skillops_maintenance.py`, `memgas_hierarchy.py`) have no configured cron schedule
+`agentHER_relabeler.py`, `skill_annotation_updater.py`, `exif_skill_discovery.py`,
+`score_trace_collector.py`, `skillops_maintenance.py`, `memgas_hierarchy.py`)
+have no configured cron schedule
 and must be run on demand.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -77,7 +77,8 @@ are completely different.
 MCP stands for **Model Context Protocol** — a standard that lets AI tools like Claude Code
 call external functions. Think of it like browser extensions, but for AI agents.
 
-Loci ships 24 MCP tools that Claude can call. They fall into five groups:
+Loci ships 71 MCP tools that Claude can call. The map below groups the most commonly used
+ones into five families:
 
 ![Tool map](img/loci-tools.svg)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,7 +35,7 @@ The external services are swappable — see options below.
 | API | REST (HTTP) or gRPC |
 | Version | ≥ 1.7 (named-vector support required) |
 | Collection format | 768-dim Cosine, named vectors `{"dense": [...]}` |
-| Env var | `QDRANT_URL` (default: `http://localhost:6333`) |
+| Env var | `QDRANT_URL` (no code default — unset disables Qdrant; the Docker image sets `http://localhost:6333`) |
 | Auth | `QDRANT_API_KEY` (optional — leave blank if no auth) |
 
 **Options:**
@@ -43,7 +43,7 @@ The external services are swappable — see options below.
 - [Qdrant Cloud](https://cloud.qdrant.io/) — managed, free tier available
 - Any Qdrant-compatible endpoint
 
-Collections are created automatically on first run. If you change `QDRANT_COLLECTION_PREFIX`, new collections are created — existing data in the old names is unaffected.
+The findings collection is created automatically on first use. Despite the name, `QDRANT_COLLECTION_PREFIX` is the *whole* collection name, not a prefix — all findings live in one collection and `investigation_id` is a payload field. Changing it creates a new collection; data under the old name is untouched. **Caveat:** `memory_confidence` hardcodes `hermes_memory`, so it keeps reading the old collection after an override.
 
 ### Embedding API
 
@@ -183,9 +183,9 @@ Qdrant data persists in your external Qdrant instance and is not managed by thes
 
 ## First-run initialization
 
-On first startup the MCP server creates two Qdrant collections:
-- `hermes_memory` — investigation findings (30-day TTL sweep at startup)
-- `hermes_verdicts` — claim validation history
+The MCP server creates its Qdrant collections lazily, not at process start:
+- `hermes_memory` (or whatever `QDRANT_COLLECTION_PREFIX` is set to) — investigation findings; created on the first Qdrant-touching tool call, along with its payload indexes and a 30-day retention purge
+- `hermes_verdicts` — claim validation history; created on the first verdict write (`memory_self_check(record=True)` or `investigation_pre_answer_check`). Until then `memory_health` reports it as "not yet created", which is benign.
 
 The A2A server creates the Mnemosyne SQLite schema on first connect if the DB file does not exist.
 
@@ -216,9 +216,9 @@ Set `HERMES_A2A_TOKEN` in your `.env` file (or export it in the environment) reg
 
 | Variable | Default | Used by | Purpose |
 |---|---|---|---|
-| `QDRANT_URL` | `http://localhost:6333` | both | Qdrant REST endpoint |
+| `QDRANT_URL` | `http://localhost:6333` (Docker/compose only) | both | Qdrant REST endpoint; **no code default** — unset silently disables Qdrant and drops to keyword-only recall |
 | `QDRANT_API_KEY` | _(empty)_ | both | Qdrant auth key; omit for unauthenticated instances |
-| `OLLAMA_BASE_URL` | `http://localhost:11434` | hermes-mcp | Base URL of the embedding/LLM API |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` (Docker/compose only) | hermes-mcp | Base URL of the embedding/LLM API; **no code default** — unset forces the 384-dim fastembed fallback, which mismatches the 768-dim collection |
 | `MNEMOSYNE_EMBEDDING_API_URL` | `http://localhost:11434/v1` | hermes-a2a | OpenAI-compat embedding endpoint for Mnemosyne |
 | `EMBED_MODEL` | `nomic-embed-text` | both | Embedding model name |
 | `MNEMOSYNE_EMBEDDING_MODEL` | `nomic-embed-text` | hermes-a2a | Embedding model for Mnemosyne |
@@ -241,6 +241,6 @@ Set `HERMES_A2A_TOKEN` in your `.env` file (or export it in the environment) reg
 |---|---|---|
 | `LOCI_NAMESPACE` | _(empty)_ | Namespace tag stamped on all Qdrant writes; use to partition a shared instance |
 | `EXTRA_RAG_COLLECTIONS` | _(empty)_ | Comma-separated Qdrant collection names included in fan-out RAG search |
-| `GROUNDING_EXTRA_COLLECTIONS` | _(empty)_ | Same as above, scoped to the grounding hook only; defaults to `EXTRA_RAG_COLLECTIONS` |
+| `GROUNDING_EXTRA_COLLECTIONS` | _(empty)_ | Extra Qdrant collections for the grounding hook only; read independently of `EXTRA_RAG_COLLECTIONS` (different process) — set both if you want the same collections in both paths |
 | `CODE_CHUNKS_COLLECTION` | _(empty)_ | Collection of code-chunk embeddings for the `code_memory_correlate` tool |
-| `ROUTING_DECISIONS_COLLECTION` | _(empty)_ | Collection of routing/decision records for the routing query tool |
+| `ROUTING_DECISIONS_COLLECTION` | _(empty)_ | **Unused** — documented but read by no code; `memory_route` searches `QDRANT_COLLECTION_PREFIX` |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,7 +10,7 @@ Override any default by exporting the variable before running, or by editing
 
 | Variable | Default | Used by |
 |---|---|---|
-| `QDRANT_URL` | `http://localhost:6333` | all Qdrant-touching scripts |
+| `QDRANT_URL` | _(none — required; unset means Qdrant steps are skipped or the script errors out, never a localhost fallback)_ | all Qdrant-touching scripts |
 | `QDRANT_API_KEY` | _(none)_ | all Qdrant-touching scripts |
 | `OLLAMA_URL` | _(none, required)_ | most embedding + generation scripts (memgas_hierarchy.py, ebbinghaus_consolidation.py, amem_consolidation.py, agentHER_relabeler.py, skillops_maintenance.py, exif_skill_discovery.py, score_trace_collector.py, eval/harness.py) |
 | `OLLAMA_BASE_URL` | _(none)_ | hook scripts only: hooks/pre_llm_grounding.py, hooks/session_end_sync.py, swr_replay.py |
@@ -48,7 +48,7 @@ Hook scripts read `OLLAMA_BASE_URL` and append `/v1` internally.
 
 ## Cron jobs
 
-Live cron config: `cron/jobs.json` (in repo root; deployed path depends on your cron runner setup).
+Live cron config: `cron/jobs.json` (in repo root; deployed path depends on your cron runner setup). Six jobs are defined; the five enabled ones are below. `deep-think-loci-harvest` (`dtl_harvest.sh`, every 7d, `no_agent`) ships disabled and is omitted from the table.
 
 | ID | Name | Interval | Script |
 |---|---|---|---|

--- a/docs/memory-and-code-review-tools.md
+++ b/docs/memory-and-code-review-tools.md
@@ -39,7 +39,7 @@ Written from the actual running config and source code, not assumed behavior.
   User message ──────►  │  pre_llm_call hook                             │
                         │    └─ grounding_client.py → daemon socket      │
                         │    └─ embed message (nomic-embed-text, 768d)   │
-                        │    └─ parallel fan-out to 7 Qdrant collections │
+                        │    └─ parallel fan-out to 3 Qdrant collections │
                         │    └─ inject MEMORY MATCH block (~100ms)       │
                         │    └─ inject rules files (≤1200 chars)         │
                         │                                                 │
@@ -48,7 +48,7 @@ Written from the actual running config and source code, not assumed behavior.
                         │  pre_tool_call hook (every tool use)           │
                         │    └─ grounding enforcement (read before write) │
                         │    └─ dangerous command detection (log; BLOCK  │
-                        │       if BLOCK_MODE=1 in config)               │
+                        │       if HOOK_BLOCK_MODE=1 in config)          │
                         │    └─ audit log write                          │
                         │                                                 │
   Session ends ──────►  │  on_session_end hook                           │
@@ -67,7 +67,7 @@ Written from the actual running config and source code, not assumed behavior.
     hermes-grounding            — systemd --user — grounding daemon (UNIX socket)
 
   Interactive tools (in-session):
-    loci-mcp (hermes_memory)  — investigation/memory layer, 25 tools (see Section 2d)
+    loci-mcp (hermes_memory)  — investigation/memory/code-graph layer, 71 tools (see Section 2d)
     Mnemosyne MCP             — episodic facts, store/recall with semantic search
     Serena MCP                — LSP-powered code navigation (symbols, refs, diagnostics)
     CocoIndex MCP             — semantic code search (ccc) across indexed repos
@@ -198,13 +198,31 @@ $HERMES_MEMORY_DIR/
     YYYY-MM-DD.jsonl     — global cross-investigation audit log
 ```
 
-**finding_type enum:** `observed` | `inferred` | `assumed` | `gap`
+**finding_type enum:** `observed` | `inferred` | `assumed` | `gap` | `procedure`
 - `observed` — from a direct tool response; cite source and key values
 - `inferred` — reasoned from observations but not directly stated
 - `assumed` — working hypothesis with no current evidence
 - `gap` — something that should be checked but hasn't been
+- `procedure` — a reusable step-by-step runbook/playbook entry; takes
+  `procedure_preconditions`, `procedure_steps`, `procedure_postconditions`
 
-**25 MCP tools provided by loci-mcp:**
+**71 MCP tools provided by loci-mcp** — 60 decorated `@mcp.tool()` in `mcp/server.py`
+plus 11 registered from `mcp/graph_tools.py` via `graph_tools.register(mcp, _get_kuzu)`.
+The tables below cover the 24 most-used ones. The rest are:
+`investigation_as_of`, `investigation_share`, `investigation_unshare`,
+`investigation_verify_all`, `investigation_reason`, `investigation_export`,
+`investigation_import`, `finding_resolve`, `procedure_attempt`, `procedure_search`,
+`entity_list`, `entity_timeline`, `contract_declare`, `contract_query`,
+`contract_check`, `wiring_obligation_declare`, `wiring_obligation_list`,
+`wiring_obligation_resolve`, `llm_local`, `generate_batch`, `query_expand`,
+`verify_finding`, `classify_text`, `compress_text`, `semantic_dedup`,
+`semantic_relevance`, `loci_health`, `ground`, `memory_surface`, `memory_promote`,
+`memory_demote`, `memory_hints`, `memory_route`, `causal_edges_list`,
+`conflict_list`, `conflict_resolve`, and the 11 code-graph tools
+(`code_graph_ingest`, `code_graph_query`, `code_memory_relink`, `code_memory_map`,
+`symbol_impact`, `impact_report`, `finding_code_context`,
+`investigation_code_briefing`, `subsystem_report`,
+`related_investigations_via_code`, `dead_code_candidates`).
 
 #### Investigation CRUD
 
@@ -319,32 +337,44 @@ The daemon must be running for the fast path. See Section 4.
 ```
 1. Receive the user's message text
 2. Embed via nomic-embed-text on <your-host> Ollama → 768-dim vector
-3. Fan out to 7 Qdrant collections in parallel (ThreadPoolExecutor, 8 workers):
+3. Fan out to the 3 base Qdrant collections in parallel (ThreadPoolExecutor, 8 workers):
    - mnemosyne          — personal facts, preferences
    - hermes_sessions    — past conversation history
    - hermes_memory      — investigation notes, findings (written by loci-mcp)
-   - ecc_skills         — skill library
-   - agent_core_chunks  — knowledge base (infra, code, research)
-   - (any extra collections configured via GROUNDING_EXTRA_COLLECTIONS)
-4. Score fusion: Qdrant cosine_score × importance_weight (where available)
+   - plus any collections named in GROUNDING_EXTRA_COLLECTIONS (empty by default) — e.g.
+     ecc_skills (skill library), agent_core_chunks (infra/code/research KB)
+4. Rank: multi-signal score = 0.50 × relevance (Qdrant cosine × importance_weight)
+   + 0.20 × recency (7-day half-life) + 0.15 × source trust + 0.15 × record type,
+   plus a stigmergic pheromone boost on memories retrieved in earlier turns
+   (HOOK_RANKER_W_*, HOOK_RECENCY_HALFLIFE_DAYS, HOOK_PHERO_BETA)
 5. Filter: score ≥ 0.55, importance ≥ 0.2, deduplicate
-6. Take top 5 results, truncate each to 200 chars
+6. Take top HOOK_RECALL_TOP_K results (code default 3; `.env.example` ships 5),
+   truncate each to 200 chars
 7. Inject MEMORY MATCH block into the system prompt
 8. Inject rules files (≤1200 chars from ~/.hermes/rules/)
 ```
 
 **Guard conditions — hook skips if:**
-- Message is < 15 chars (too short to embed meaningfully)
-- Session is a subagent (avoid circular context injection)
+- Message is empty after stripping, or is a navigation-only slash command
+  (`/help`, `/clear`, `/compact`, `/cost`, `/status`, `/history`, `/ide`,
+  `/doctor`, `/login`, `/logout`) — code-affecting commands like `/fix`,
+  `/review` and `/remember` are still grounded, and there is no minimum
+  message length
 - Ollama is unreachable (falls back to BeamMemory FTS path — best-effort,
   requires mnemosyne library importable)
 
+**Subagent sessions are not skipped.** They take a lightweight path instead of the
+full fan-out: a single `hermes_memory` search capped at top 2, plus the rules
+summary. Skipping them (the pre-v4 behaviour) left workflow subagents ungrounded,
+which is where wrong import names and renamed fields crept in.
+
 **Output injected into context looks like:**
 ```
-[MEMORY MATCH — top 5 results across 7 collections]
-[mnemosyne 0.87] User prefers direct commands over explanations...
-[hermes_sessions 0.82] ...investigated proxy.ts dead middleware June 13...
-[agent_core_chunks 0.79] ...FedAvg implementation requires matching...
+MEMORY MATCH (3 results from 3 Qdrant collections) for "why is auth failing":
+[mnemosyne|0.87] User prefers direct commands over explanations...
+[hermes-sessions|0.82] ...investigated proxy.ts dead middleware June 13...
+[hermes-memory|0.79] ...auth guard short-circuits when the header is absent...
+Use mcp_mnemosyne_mnemosyne_recall for full content if relevant. Disclose recalled context to the user if it changes your answer.
 ```
 
 **Also reads:** `~/.hermes/.env` at startup for env overrides.
@@ -361,16 +391,23 @@ The hook's env vars are set both in config.yaml hooks stanza AND this .env file.
    first. Prevents "edit without reading" patterns.
 
 2. **Dangerous command detection** — scans terminal commands for:
-   `rm -rf`, `DROP TABLE`, `force-push`, `kubectl delete`, `chmod +x + execute`
-   Logs a warning to the audit log. Set `BLOCK_MODE=1` to also enforce blocking.
-   **Default is `BLOCK_MODE=0` — log only, no blocking.** This is an advisory
-   control in current config. Treat it as a record, not a guarantee.
+   `rm -rf`, `DROP TABLE/DATABASE/SCHEMA`, `git push --force` (without
+   `--force-with-lease`) and `git push -f`, `kubectl delete namespace`,
+   `docker system|volume|image prune`, `dd if=`, `mkfs`, `shred`, and raw device
+   writes (`> /dev/sdX`) — plus a separate Hades/Miasma supply-chain IOC pattern set.
+   Logs a warning to the audit log. Set `HOOK_BLOCK_MODE=1` to also enforce blocking.
+   **Default is `HOOK_BLOCK_MODE=0` — log only, no blocking of terminal commands.**
+   One narrow exception blocks even at the default: a write to an agent config file
+   (CLAUDE.md, AGENTS.md, `.cursorrules`, …) whose content matches a prompt-injection
+   pattern or whose target matches a supply-chain path IOC. Treat everything else as
+   a record, not a guarantee.
 
 3. **Audit log** — writes every tool call to a local audit log (capped at 5MB).
 
 **GROUNDING_TOOLS** (always allowed, no audit noise):
   All Mnemosyne MCP tools, Serena read tools, session_search, web_search,
-  web_extract, read_file, search_files, Open Design read tools.
+  web_extract, read_file, search_files, and the Claude Code read tools (Read,
+  ToolSearch, WebFetch, WebSearch). Open Design tools were removed 2026-06-13.
 
 ---
 
@@ -556,7 +593,8 @@ cd ~/open-design/deploy && docker compose up -d
 
 **Tools available:** `mcp_open_design_get_artifact`, `mcp_open_design_get_project`,
 `mcp_open_design_list_projects`, `mcp_open_design_search_files`, etc.
-These are GROUNDING_TOOLS — always allowed, no audit noise.
+These were removed from GROUNDING_TOOLS on 2026-06-13 — Open Design calls are now
+audited like any other tool.
 
 ### 6d. deep_think MCP (parallel perspective reasoning)
 
@@ -933,7 +971,9 @@ rules/quality.md               — verification and correctness rules
 rules/infra.md                 — infrastructure and security rules
 rules/knowledge.md             — skill/knowledge management rules
 skills/                        — 186 skill files across 26 categories
-mcp/server.py                  — loci-mcp server (hermes_memory MCP, 25 tools)
+mcp/server.py                  — loci-mcp server (hermes_memory MCP, 60 tools)
+mcp/graph_tools.py             — 11 code-graph tools registered onto the same
+                                 server (71 tools total at runtime)
 scripts/grounding_client.py    — pre_llm_call hook entry (UNIX socket client)
 scripts/grounding_daemon.py    — persistent daemon (systemd --user)
 scripts/hooks/pre_llm_grounding.py  — grounding logic v3
@@ -943,7 +983,9 @@ scripts/state_db_qdrant_sync.py     — 5-min catch-all cron sync
 scripts/mnemosyne_qdrant_sync.py    — 30-min Mnemosyne → Qdrant sync
 scripts/mnemosyne_activity_check.py — gate script for consolidation crons
 scripts/mnemosyne_sleep_all.sh      — CLI-level sleep script
-cron/jobs.json                 — all 5 cron job definitions
+scripts/dtl_harvest.sh              — deep-think-loci harvest (ships disabled)
+cron/jobs.json                 — all 6 cron job definitions (5 enabled, plus
+                                 deep-think-loci-harvest, disabled by default)
 state.db                       — SQLite session store (session_search queries this)
 mnemosyne/data/                — Mnemosyne SQLite + embeddings (local)
 hermes.db                      — Hermes internal state
@@ -994,13 +1036,15 @@ vectors. If `MNEMOSYNE_EMBEDDING_DIM` is set to 768 (the default) and Ollama
 becomes unavailable, fastembed upserts will fail silently with a dimension
 mismatch. Either set `EMBED_DIM=384` when using fastembed, or restore Ollama.
 
-**loci-mcp tool index (`mcp/server.py` — 25 `@mcp.tool()` functions):**
+**loci-mcp tool index (`mcp/server.py` — 60 `@mcp.tool()` functions, plus 11
+registered by `mcp/graph_tools.py` for 71 total at runtime; the 24 core
+investigation/memory tools are indexed below):**
 
 | Tool | Brief description |
 |------|------------------|
 | `investigation_start` | Create or resume an investigation by ID. Idempotent — resuming returns the current manifest without overwriting. |
 | `investigation_load` | Retrieve manifest and recent findings for context recovery at session start. Retracted findings excluded by default. |
-| `investigation_store` | Record a finding (observed/inferred/assumed/gap). Writes to JSONL, Mnemosyne, and Qdrant `hermes_memory`. |
+| `investigation_store` | Record a finding (observed/inferred/assumed/gap/procedure). Writes to JSONL, Mnemosyne, and Qdrant `hermes_memory`. |
 | `investigation_note` | Update manifest fields: context, hypothesis, next_step, open questions, checked sources, or close the investigation. |
 | `investigation_reflect` | Synthesize current investigation state — finding breakdown, open questions, gaps, and advisory self-check. |
 | `investigation_search` | Hybrid Mnemosyne+Qdrant search over findings with cross-encoder reranking. Retracted findings excluded by default. |
@@ -1033,7 +1077,7 @@ HOOK_RULES_MAX_CHARS=1200     total chars budget for rules injection
 HOOK_EMBED_TIMEOUT=3.0        Ollama embed call timeout (seconds)
 HOOK_QDRANT_TIMEOUT=2.0       per-collection Qdrant query timeout
 HOOK_QDRANT_WORKERS=8         parallel workers for fan-out
-BLOCK_MODE=0                  0=log only, 1=block dangerous commands
+HOOK_BLOCK_MODE=0             0=log only, 1=block dangerous commands
 ```
 
 ---
@@ -1103,10 +1147,12 @@ outside the hook (manual runs, cron) use shell env, not the hook's .env.
 Always pass env vars explicitly when running hook scripts manually.
 
 ### 13. Dangerous command detection is advisory by default
-`BLOCK_MODE=0` means the pre_tool_call hook logs dangerous commands but does
+`HOOK_BLOCK_MODE=0` means the pre_tool_call hook logs dangerous commands but does
 NOT block them. An `rm -rf` or `kubectl delete` will proceed. This is intentional
 for development flexibility but means the "dangerous command detection" is a
-record, not a safety net. Set `BLOCK_MODE=1` if you want enforcement.
+record, not a safety net. Set `HOOK_BLOCK_MODE=1` if you want enforcement.
+(One case blocks even at the default: writing injection-flagged or supply-chain-IOC
+content to an agent config file such as CLAUDE.md, AGENTS.md, or `.cursorrules`.)
 
 ### 14. fastembed fallback produces 384-dim vectors
 When Ollama is unavailable, the loci-mcp server falls back to

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -15,15 +15,15 @@ query
   → fastembed Qdrant/bm25                 [sparse]
   → Qdrant RRF fusion (dense + sparse prefetch)
   → candidate pool (limit×5 overfetch)
-  → cross-encoder ms-marco-MiniLM-L-6-v2 rerank
+  → cross-encoder BAAI/bge-reranker-v2-m3 rerank (pin MiniLM via `RERANK_MODEL`)
   → top-K results
   + Mnemosyne recall merged + deduped (optional)
   + JSONL fallback when Qdrant unavailable
 ```
 
-Collections created on first run:
-- `hermes_memory` — findings (named vectors: dense=768 cosine + sparse=BM25 IDF)
-- `hermes_verdicts` — pre-answer claim check verdicts
+Collections:
+- `hermes_memory` — findings (named vectors: dense=768 cosine + sparse=BM25 IDF); created on first Qdrant connection
+- `hermes_verdicts` — pre-answer claim check verdicts; created lazily on the first verdict write
 
 ## Requirements
 
@@ -51,10 +51,10 @@ With optional Mnemosyne:
 
 | Variable | Default | Description |
 |---|---|---|
-| `QDRANT_URL` | `http://localhost:6333` | Qdrant instance URL |
+| `QDRANT_URL` | _(unset — Qdrant search disabled)_ | Qdrant instance URL, e.g. `http://localhost:6333` |
 | `QDRANT_API_KEY` | _(none)_ | Qdrant API key if required |
-| `QDRANT_COLLECTION_PREFIX` | `hermes_memory` | Prefix for Qdrant collections |
-| `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama instance URL |
+| `QDRANT_COLLECTION_PREFIX` | `hermes_memory` | Name of the shared findings collection (used verbatim, nothing is appended) |
+| `OLLAMA_BASE_URL` | _(unset — no dense embeddings; batch falls back to fastembed)_ | Ollama instance URL, e.g. `http://localhost:11434` |
 | `EMBED_MODEL` | `nomic-embed-text` | Ollama embedding model |
 | `HERMES_MEMORY_DIR` | `~/.hermes/memory-sessions` | Local JSONL storage root |
 | `HERMES_MNEMO_BANK` | `default` | Mnemosyne bank name (optional) |
@@ -81,46 +81,109 @@ Add to `~/.claude/settings.json` under `mcpServers`:
 }
 ```
 
-## Tools (24)
+## Tools (71)
+
+71 tools are registered at runtime: 60 defined in `server.py`, plus 11 code-graph
+tools registered from `graph_tools.py` via `graph_tools.register(mcp, _get_kuzu)` at
+server startup — which is why they do not appear as `@mcp.tool()` in `server.py`.
+The same inventory is listed in the [top-level README](../README.md#mcp-tools-71).
 
 **Session management:**
 - `investigation_start(investigation_id, title, context?)` — create or resume a session
 - `investigation_load(investigation_id, last_n_findings?, include_retracted?)` — load manifest + recent findings
-- `investigation_note(investigation_id, field, value)` — update hypothesis/next_step/open_questions/checked_source
+- `investigation_note(investigation_id, field, value)` — update context/hypothesis/next_step/open_question_add/open_question_remove/checked_source/closed_summary
 - `investigation_reflect(investigation_id)` — synthesize current investigation state
 - `investigation_list(limit?, offset?, summary?)` — list sessions, most-recent first; paginated (`limit=30`, `offset=0`) and compact (`summary=True`) by default. Pass `summary=False` for full records, `limit=0` (or any value `<=0`) for all — `offset` is still honored in no-limit mode, so it returns all *remaining* records starting at `offset`. Returns `{investigations, total, limit, offset}`
+- `investigation_as_of(investigation_id, as_of_timestamp)` — findings as they were believed at a point in time
+- `investigation_share(investigation_id, agent_ids)` — grant access to one or more agents
+- `investigation_unshare(investigation_id, agent_ids)` — revoke access
 
 **Finding storage:**
 - `investigation_store(investigation_id, finding_type, text, source, confidence?, tags?, derived_from?)` — store a finding
   - `finding_type`: one of `observed | inferred | assumed | gap`
   - Returns: `{"stored": true, "finding_id": "<uuid>", "type": "<finding_type>", "mnemo_stored": true}`
-- `memory_retract(investigation_id, finding_id, reason?)` — soft-delete a finding
-- `memory_restore(investigation_id, finding_id, reason?)` — undo a retraction
+- `memory_retract(investigation_id, target, reason?, dry_run?, scope_semantic?)` — soft-delete findings matching `target`; `dry_run=True` by default, pass `dry_run=False` to actually retract
+- `memory_restore(investigation_id, finding_id?, retraction_id?, reason?)` — undo a retraction
+- `finding_resolve(investigation_id, finding_id, resolution, note?)` — mark a finding fixed/intentional/wontfix
+- `procedure_attempt(investigation_id, finding_id, success)` — record a pass/fail attempt against a procedure-type finding
+- `procedure_search(query, investigation_id?, limit?)` — search procedure-type findings
 
 **Search & retrieval:**
 - `investigation_search(query, investigation_id?, ...)` — hybrid RAG search
-- `investigation_related_cases(investigation_id)` — find related past investigations
+- `investigation_related_cases(entities, entity_type?, limit_per_entity?)` — find past investigations sharing the given entities
 - `rag_context_search(query, ...)` — cross-collection RAG search
+- `memory_surface(context, investigation_id?, top_k?)` — proactively surface prior findings for the current working context
+- `memory_route(query, agent_id?, top_k?, deduplicate?)` — agent-mesh search across all investigations
+- `memory_hints(investigation_id, limit?, since_ts?)` — recent findings as lightweight hints
+- `memory_confidence(query, top_k?)` — metamemory: how reliably memory knows a topic
+- `ground(title, focus?, case_ids?, entities?, code_refs?, budget_chars?, allow_keyword?, graph_available?)` — assemble a char-budgeted, provenance-tagged grounding block
 
 **Claim validation:**
 - `investigation_pre_answer_check(investigation_id, claims, ...)` — validate claims against evidence before answering
-- `investigation_evidence_precheck(investigation_id, claim)` — lightweight duplicate/evidence check
+- `investigation_evidence_precheck(investigation_id, proposed_query, min_similarity?)` — lightweight duplicate/evidence check
+- `verify_finding(claim, context?, investigation_id?)` — adversarially verify a claim with the local model
+- `investigation_verify_all(investigation_id, limit?)` — batch adversarial-verify the open findings
+- `investigation_reason(investigation_id, question, perspectives?, ground_threshold?, persist?)` — grounded multi-perspective reasoning over findings
+- `conflict_list(investigation_id)` — list detected conflicts
+- `conflict_resolve(investigation_id, conflict_id, verdict)` — record a verdict on a conflict
 
 **Entity & provenance:**
 - `investigation_entity_lookup(entity, entity_type?, investigation_id?, limit?)` — find findings by entity
-- `investigation_finding_provenance(investigation_id, finding_id)` — trace finding lineage
+- `investigation_finding_provenance(finding_id, investigation_id)` — trace finding lineage
+- `entity_list(investigation_id, entity_type?)` — list entities extracted from findings
+- `entity_timeline(investigation_id, entity_id)` — chronological findings mentioning an entity
+- `causal_edges_list(investigation_id)` — list causal edges inferred for an investigation
+
+**Memory tiering:**
+- `memory_promote(investigation_id, finding_id, tier)` — promote a finding to a higher tier
+- `memory_demote(investigation_id, finding_id, tier)` — demote a finding to a lower tier
+
+**Contracts & wiring obligations:**
+- `contract_declare(investigation_id, entity, role, fields, protocol?)` — store a cross-boundary contract declaration
+- `contract_query(investigation_id, entity, role?)` — query stored contract declarations
+- `contract_check(investigation_id, field_name, entity?)` — check a field name against stored contracts
+- `wiring_obligation_declare(investigation_id, class_name, method_name, expected_effect)` — declare an unverified integration point
+- `wiring_obligation_list(investigation_id, resolved?)` — list wiring obligations
+- `wiring_obligation_resolve(investigation_id, finding_id, evidence)` — resolve one with evidence of fulfillment
+
+**Local model offload:**
+- `llm_local(prompt, model?, fmt?, max_tokens?, temperature?, keep_alive?)` — generate with the local GPU model
+- `generate_batch(prompts, model?, max_tokens?, fmt?)` — generate for many prompts at once
+- `query_expand(query, n_queries?, n_keywords?)` — HyDE-lite query expansion
+- `classify_text(text, labels)` — pick the best label for a text
+- `compress_text(text, max_chars?)` — semantically condense text to a char budget
+- `semantic_dedup(items, threshold?, text_key?)` — cluster near-duplicate items by embedding similarity
+- `semantic_relevance(texts, topic)` — cosine relevance of each text to a topic
 
 **Audit & health:**
-- `audit_log(investigation_id, event_type, detail)` — log an event
+- `audit_log(tool_name, inputs_json, output, investigation_id?, embedding_text?)` — record a tool call in the audit trail
 - `memory_self_check()` — provenance + contradiction self-check over stored findings
 - `memory_health()` — Qdrant + Mnemosyne + embedder status
-- `code_memory_correlate(investigation_id, code_snippet)` — correlate code with findings
+- `loci_health()` — read-only self-diagnosis snapshot of the server
+- `code_memory_correlate(investigation_id, target_file?, entity?)` — correlate code files/entities with findings
 - `memory_consolidate()` — run Mnemosyne sleep consolidation over all sessions
 
+**Portability:**
+- `investigation_export(investigation_id, include_embeddings?)` — export an investigation as a portable JSON bundle
+- `investigation_import(bundle_json, new_title?)` — import a bundle produced by `investigation_export`
+
 **Reflection loop:**
-- `reflection_loop_seed(paths, kind?)` — enqueue process logs / session events for bounded self-reflection
-- `reflection_loop_tick(batch_size?, max_lines?, max_bytes?)` — process a batch: tail-read, classify, dedupe, store findings
+- `reflection_loop_seed(investigation_id?, session_events_limit?, process_logs_limit?, reset_queue?)` — enqueue process logs / session events for bounded self-reflection
+- `reflection_loop_tick(max_items?, max_lines_per_file?, store_item_findings?)` — process a batch: tail-read, classify, dedupe, store findings
 - `reflection_loop_status()` — inspect queue depth and processing stats
+
+**Code graph** (registered from `graph_tools.py`):
+- `code_graph_ingest(path, max_files?, replace?)` — parse with tree-sitter and ingest the symbol graph
+- `code_graph_query(cypher, params?)` — read-only Cypher over the code + findings graph
+- `code_memory_relink()` — rebuild all Finding → CodeSymbol edges
+- `code_memory_map(anchor, anchor_type?, hops?)` — code↔memory neighbourhood around an anchor
+- `symbol_impact(symbol, hops?)` — blast radius of a symbol across code and memory
+- `impact_report(symbol, hops?)` — change blast radius: transitive callers and callees
+- `finding_code_context(finding_id)` — the code a finding references, with callers/callees
+- `investigation_code_briefing(investigation_id, top?)` — the code story of an investigation
+- `subsystem_report(anchor, limit?)` — full picture of the code under a path or package prefix
+- `related_investigations_via_code(investigation_id, limit?)` — other investigations touching the same symbols
+- `dead_code_candidates(lang?, limit?)` — functions with no caller and no finding reference
 
 ### investigation_start return shape
 
@@ -147,10 +210,10 @@ Add to `~/.claude/settings.json` under `mcpServers`:
 
 ## Performance notes
 
-- `EMBED_BATCH_SIZE=32` hard ceiling — Ollama stalls silently above this
+- Embed batching hard-capped at 32 (`_EMBED_BATCH_SIZE` in `server.py`, not an env var) — Ollama stalls silently above this
 - Named vectors `dense`+`sparse` in same Qdrant point — hybrid RRF without extra collections
 - Payload indexes on `investigation_id`, `confidence`, `record_type`, `tags` — O(log N) filter at scale
-- BM25 kept in RAM (`SparseIndexParams(on_disk=False, modifier=Modifier.IDF)`)
+- BM25 kept in RAM (`SparseVectorParams(index=SparseIndexParams(on_disk=False), modifier=Modifier.IDF)`)
 - 30-day TTL purge on `hermes_memory` applied at startup
 
 ## memcheck module

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -54,7 +54,7 @@ With optional Mnemosyne:
 | `QDRANT_URL` | _(unset — Qdrant search disabled)_ | Qdrant instance URL, e.g. `http://localhost:6333` |
 | `QDRANT_API_KEY` | _(none)_ | Qdrant API key if required |
 | `QDRANT_COLLECTION_PREFIX` | `hermes_memory` | Name of the shared findings collection (used verbatim, nothing is appended) |
-| `OLLAMA_BASE_URL` | _(unset — no dense embeddings; batch falls back to fastembed)_ | Ollama instance URL, e.g. `http://localhost:11434` |
+| `OLLAMA_BASE_URL` | _(unset — falls back to 384-dim fastembed, which mismatches the 768-dim collection unless `EMBED_DIM=384`)_ | Ollama instance URL, e.g. `http://localhost:11434` |
 | `EMBED_MODEL` | `nomic-embed-text` | Ollama embedding model |
 | `HERMES_MEMORY_DIR` | `~/.hermes/memory-sessions` | Local JSONL storage root |
 | `HERMES_MNEMO_BANK` | `default` | Mnemosyne bank name (optional) |


### PR DESCRIPTION
Docs-only. No code touched.

## The headline

Every document that stated the MCP tool count stated a **different, wrong** number:

| file | claimed | actual |
|---|---|---|
| `README.md:30`, `README.md:230` | 24 | **71** |
| `mcp/README.md:84` | 24 | **71** |
| `docs/ARCHITECTURE.md:179` | 18 | **71** |
| `docs/memory-and-code-review-tools.md:70` | 25 | **71** |

71 = 60 functions decorated `@mcp.tool()` in `server.py`, plus 11 attached by `graph_tools.register()` at import. Confirmed two ways — AST over the committed tree, and `mcp.list_tools()` at runtime.

Fixing the digit alone would leave a correct number sitting above a stale list, so the inventories were completed as well: the README table goes 24 → 71 rows, and `mcp/README.md`'s grouped list 23 → 71. Every description is condensed from that tool's own docstring, not invented.

## Also corrected

All verified against `git show HEAD:<path>`:

- reranker default is `BAAI/bge-reranker-v2-m3`, not `ms-marco-MiniLM-L-6-v2`
- documented defaults for `QDRANT_URL` and `OLLAMA_BASE_URL` were wrong — both are unset
- hook env vars are `HOOK_`-prefixed (`HOOK_RANKER_W_*`, `HOOK_MMR_LAMBDA`, `HOOK_PHERO_*`)
- stale signatures: `memory_retract`, `audit_log`, `code_memory_correlate`, `reflection_loop_seed`/`tick`, `investigation_note`, `investigation_related_cases`, `investigation_finding_provenance`, `investigation_evidence_precheck`, `memory_restore`
- `hermes_verdicts` is created lazily, not on first run
- `docs/ARCHITECTURE.md` claimed `graph_edges` and `conflicts` are unqueried; they are (writes and reads cited in `scripts/amem_consolidation.py`, `glymphatic_sweep.py`, `spreading_activation.py`). Only `annotations` is genuinely unqueried.

## Deliberately left alone

`FastMCP` references. `mcp[cli]` is pinned `<2`, so they describe the API you're actually on. Rewriting them to `MCPServer` would make accurate docs wrong.

## Method

Facts were sourced from the **committed** tree via `git show HEAD:<path>`, never the working tree — a refactor is running concurrently against `mcp/**/*.py`, so working-tree reads could have caught a half-applied edit.

106 claims were flagged, then independently re-checked by adversarial verifiers defaulting to "the doc is fine". **9 were rejected** as aspirational prose or auditor misreads; 97 were confirmed and applied.

## Worth a reviewer's eye

- The `docs/img/loci-tools.svg` diagram still shows the older 24-tool grouping. The groupings remain valid, so it's annotated inline rather than removed — but it should be regenerated at some point.
- `mcp/README.md:89` links to `../README.md#mcp-tools-71`; verified that anchor resolves against the new `## MCP tools (71)` heading in this same PR.
- One out-of-scope fix was made and self-reported: `memory_restore`'s signature was documented as `(investigation_id, finding_id, reason?)` but is actually `(investigation_id, finding_id=None, retraction_id=None, reason="")`. Easy to drop if you want strict scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_