### PR TITLE
chore: gitignore Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ backends.toml
 # A2A deploy env (holds PEER_A2A_TOKENS_JSON / PEER_A2A_TOTP_SEEDS_JSON)
 .a2a-deploy.env
 .a2a-deploy.env.bak-*
+
+# Claude Code agent worktrees (transient; created by workflow isolation)
+.claude/worktrees/


### PR DESCRIPTION
One line. Adds `.claude/worktrees/` to `.gitignore`.

Workflow agents that need to mutate source safely — mutation testing, parallel refactors — run inside isolated git worktrees created under `.claude/worktrees/`. They're transient scratch space, frequently several at once, and some are held under a git lock while their agent is live:

```
/home/user/loci/.claude/worktrees/wf_a6adfbc1-416-11   2b963f6
/home/user/loci/.claude/worktrees/wf_a6adfbc1-416-12   2b963f6  locked
/home/user/loci/.claude/worktrees/wf_a6adfbc1-416-13   2b963f6
/home/user/loci/.claude/worktrees/wf_a6adfbc1-416-14   2b963f6  locked
```

Nothing ignored them, so any `git add -A` during a workflow run would have swept four nested checkouts into a commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_