### PR TITLE
chore: check in .mcp.json so the loci server registers per-checkout

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "loci": {
+      "type": "stdio",
+      "command": "mcp/.venv/bin/python",
+      "args": ["mcp/server.py"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ cp ../.env.example .env   # fill in QDRANT_URL and OLLAMA_BASE_URL at minimum
 .venv/bin/python server.py
 ```
 
-Wire into Claude Code (`~/.claude/settings.json`):
+A Claude Code session started **inside this checkout** picks the server up from
+the checked-in `.mcp.json` — no wiring needed once the venv above exists. To use
+it from anywhere else, add absolute paths to `~/.claude/settings.json`:
 
 ```json
 "loci": {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,7 +118,7 @@ Configure Claude Code (`~/.claude/settings.json`):
 ```json
 {
   "mcpServers": {
-    "hermes_memory": {
+    "loci": {
       "command": "/path/to/mcp/.venv/bin/python",
       "args": ["/path/to/mcp/server.py"],
       "env": {
@@ -139,7 +139,7 @@ Configure Claude Code to use HTTP transport:
 ```json
 {
   "mcpServers": {
-    "hermes_memory": {
+    "loci": {
       "transport": "sse",
       "url": "http://your-host:8000/sse"
     }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -177,7 +177,7 @@ All hook paths and infra addresses are driven by env vars. To stand up on a new 
 3. Update `~/.claude/settings.json` hook paths (currently hardcoded — no env expansion in JSON)
 4. Create `~/.claude/hook-state/` directory
 5. Ensure Qdrant API key is in `~/.claude/settings.json` at
-   `mcpServers.hermes_memory.env.QDRANT_API_KEY`
+   `mcpServers.loci.env.QDRANT_API_KEY` (or the legacy `mcpServers.hermes_memory.env.QDRANT_API_KEY`)
 
 ---
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -62,14 +62,40 @@ With optional Mnemosyne:
 
 ## Claude Code / MCP wiring
 
-Add to `~/.claude/settings.json` under `mcpServers`:
+The repo checks in a `.mcp.json` at its root, so a Claude Code session started
+**inside this checkout** registers the server as `loci` with no per-machine
+setup. Its paths are relative — Claude Code launches stdio servers with the
+project directory as cwd, so they resolve in any clone:
 
 ```json
 {
   "mcpServers": {
-    "hermes_memory": {
-      "command": "/path/to/loci-mcp/.venv/bin/python",
-      "args": ["/path/to/loci-mcp/server.py"],
+    "loci": {
+      "type": "stdio",
+      "command": "mcp/.venv/bin/python",
+      "args": ["mcp/server.py"]
+    }
+  }
+}
+```
+
+It carries no `env` block: `server.py` loads the repo-root `.env` and then
+`mcp/.env` (override) at import, so credentials and host-specific endpoints stay
+in gitignored files rather than a committed config. Complete [Setup](#setup)
+first — the interpreter it names does not exist until you create `mcp/.venv`,
+and Claude Code will report the server as failed to start until you do.
+
+To use the server from **outside** this checkout, register it by absolute path
+in `~/.claude/settings.json` instead. Keep the name `loci`; registering the same
+server twice under two names publishes every tool twice:
+
+```json
+{
+  "mcpServers": {
+    "loci": {
+      "type": "stdio",
+      "command": "/path/to/loci/mcp/.venv/bin/python",
+      "args": ["/path/to/loci/mcp/server.py"],
       "env": {
         "QDRANT_URL": "http://localhost:6333",
         "QDRANT_API_KEY": "",

--- a/scripts/ebbinghaus_consolidation.py
+++ b/scripts/ebbinghaus_consolidation.py
@@ -55,7 +55,11 @@ def _load_qdrant_api_key() -> str:
     try:
         with open(settings_path) as fh:
             cfg = json.load(fh)
-        return cfg["mcpServers"]["hermes_memory"]["env"]["QDRANT_API_KEY"]
+        servers = cfg["mcpServers"]
+        # "loci" is the current registration name; "hermes_memory" is what older
+        # settings.json files used. Accept either.
+        entry = servers.get("loci") or servers["hermes_memory"]
+        return entry["env"]["QDRANT_API_KEY"]
     except (KeyError, FileNotFoundError, json.JSONDecodeError) as exc:
         print(f"[warn] could not read QDRANT_API_KEY from settings.json: {exc}")
         return ""

--- a/scripts/qdrant_payload_indexes.py
+++ b/scripts/qdrant_payload_indexes.py
@@ -29,7 +29,11 @@ if not QDRANT_KEY:
     try:
         import json as _json
         _cfg = _json.load(open(os.path.join(_HOME, ".claude", "settings.json")))
-        QDRANT_KEY = _cfg["mcpServers"]["hermes_memory"]["env"]["QDRANT_API_KEY"]
+        _servers = _cfg["mcpServers"]
+        # "loci" is the current registration name; "hermes_memory" is what older
+        # settings.json files used. Accept either.
+        _entry = _servers.get("loci") or _servers["hermes_memory"]
+        QDRANT_KEY = _entry["env"]["QDRANT_API_KEY"]
     except Exception:
         pass
 

--- a/scripts/reembed_daemon.md
+++ b/scripts/reembed_daemon.md
@@ -44,7 +44,7 @@ Always run the dry-run first, eyeball `targeted`, then re-run with `--apply`.
 | var | purpose | default |
 |-----|---------|---------|
 | `QDRANT_URL` | Qdrant endpoint (separate k3s host, CPU) | — (required) |
-| `QDRANT_API_KEY` | Qdrant key; falls back to `~/.claude/settings.json` `mcpServers.hermes_memory.env` | "" |
+| `QDRANT_API_KEY` | Qdrant key; falls back to `~/.claude/settings.json` `mcpServers.loci.env` (or the legacy `mcpServers.hermes_memory.env`) | "" |
 | `OLLAMA_BASE_URL` / `OLLAMA_URL` | Ollama for the warm-GPU nomic embed path | — |
 | `EMBED_MODEL` | current embed model tag | `nomic-embed-text` |
 | `EMBED_VERSION` | current embed version marker | `1` |

--- a/scripts/reembed_daemon.py
+++ b/scripts/reembed_daemon.py
@@ -72,7 +72,11 @@ def _resolve_qdrant():
             import json
             home = os.path.expanduser("~")
             cfg = json.load(open(os.path.join(home, ".claude", "settings.json")))
-            key = cfg["mcpServers"]["hermes_memory"]["env"]["QDRANT_API_KEY"]
+            servers = cfg["mcpServers"]
+            # "loci" is the current registration name; "hermes_memory" is what
+            # older settings.json files used. Accept either.
+            entry = servers.get("loci") or servers["hermes_memory"]
+            key = entry["env"]["QDRANT_API_KEY"]
         except Exception:
             key = ""
     if not url:

--- a/scripts/tests/test_settings_qdrant_key.py
+++ b/scripts/tests/test_settings_qdrant_key.py
@@ -1,0 +1,141 @@
+"""The QDRANT_API_KEY fallback must read whichever name the MCP server is registered under.
+
+Three scripts fall back to ``~/.claude/settings.json`` when QDRANT_API_KEY is unset in the
+environment, and each indexes ``mcpServers`` by the server's registration name. That name is
+now ``loci`` (what the checked-in ``.mcp.json`` and the READMEs use); it used to be
+``hermes_memory``. A lookup pinned to one name fails soft on the other -- the scripts swallow
+the KeyError and connect with no api-key, which surfaces as an auth error from Qdrant far from
+the actual cause, or as a silent unauthenticated connection against an open instance.
+
+These assert both names resolve, and that a settings file with neither still fails soft.
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    """Import a scripts/ module under a private name, fresh each call.
+
+    qdrant_payload_indexes resolves the key at module scope, so it has to be re-imported
+    per case rather than reused.
+    """
+    spec = importlib.util.spec_from_file_location(f"_t_{name}", SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeHome:
+    """Point ~ at a temp dir holding a .claude/settings.json with the given mcpServers block."""
+
+    def __init__(self, servers):
+        self._servers = servers
+
+    def __enter__(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        home = pathlib.Path(self._tmp.name)
+        claude = home / ".claude"
+        claude.mkdir()
+        if self._servers is not None:
+            (claude / "settings.json").write_text(json.dumps({"mcpServers": self._servers}))
+        self._env = mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False)
+        self._env.start()
+        # os.path.expanduser consults USERPROFILE first on Windows and caches nothing,
+        # but it also honours an explicit HOME everywhere pytest runs here.
+        return home
+
+    def __exit__(self, *exc):
+        self._env.stop()
+        self._tmp.cleanup()
+        return False
+
+
+def _entry(key):
+    return {"env": {"QDRANT_API_KEY": key}}
+
+
+class TestEbbinghausKeyLookup(unittest.TestCase):
+    def test_reads_loci_registration(self):
+        with _FakeHome({"loci": _entry("key-loci")}):
+            mod = _load("ebbinghaus_consolidation")
+            self.assertEqual(mod._load_qdrant_api_key(), "key-loci")
+
+    def test_reads_legacy_hermes_memory_registration(self):
+        with _FakeHome({"hermes_memory": _entry("key-legacy")}):
+            mod = _load("ebbinghaus_consolidation")
+            self.assertEqual(mod._load_qdrant_api_key(), "key-legacy")
+
+    def test_loci_wins_when_both_are_present(self):
+        with _FakeHome({"loci": _entry("key-new"), "hermes_memory": _entry("key-old")}):
+            mod = _load("ebbinghaus_consolidation")
+            self.assertEqual(mod._load_qdrant_api_key(), "key-new")
+
+    def test_returns_empty_when_neither_name_is_registered(self):
+        with _FakeHome({"something_else": _entry("nope")}):
+            mod = _load("ebbinghaus_consolidation")
+            self.assertEqual(mod._load_qdrant_api_key(), "")
+
+
+class TestPayloadIndexesKeyLookup(unittest.TestCase):
+    """This one resolves at import time, so the assertion is on the module global."""
+
+    def _key_with(self, servers):
+        with mock.patch.dict(os.environ, {"QDRANT_API_KEY": ""}, clear=False):
+            with _FakeHome(servers):
+                return _load("qdrant_payload_indexes").QDRANT_KEY
+
+    def test_reads_loci_registration(self):
+        self.assertEqual(self._key_with({"loci": _entry("key-loci")}), "key-loci")
+
+    def test_reads_legacy_hermes_memory_registration(self):
+        self.assertEqual(
+            self._key_with({"hermes_memory": _entry("key-legacy")}), "key-legacy")
+
+    def test_returns_empty_when_neither_name_is_registered(self):
+        self.assertEqual(self._key_with({"something_else": _entry("nope")}), "")
+
+
+class TestReembedDaemonKeyLookup(unittest.TestCase):
+    """_resolve_qdrant builds a real QdrantClient; stub the constructor and read api_key back."""
+
+    def _api_key_with(self, servers):
+        captured = {}
+
+        class _Client:
+            def __init__(self, url=None, api_key=None):
+                captured["url"] = url
+                captured["api_key"] = api_key
+
+        stub = types.ModuleType("qdrant_client")
+        stub.QdrantClient = _Client
+        env = {"QDRANT_URL": "http://qdrant.invalid:6333", "QDRANT_API_KEY": ""}
+        with mock.patch.dict(sys.modules, {"qdrant_client": stub}):
+            with mock.patch.dict(os.environ, env, clear=False):
+                with _FakeHome(servers):
+                    _load("reembed_daemon")._resolve_qdrant()
+        return captured["api_key"]
+
+    def test_reads_loci_registration(self):
+        self.assertEqual(self._api_key_with({"loci": _entry("key-loci")}), "key-loci")
+
+    def test_reads_legacy_hermes_memory_registration(self):
+        self.assertEqual(
+            self._api_key_with({"hermes_memory": _entry("key-legacy")}), "key-legacy")
+
+    def test_passes_none_when_neither_name_is_registered(self):
+        # No key found -> `api_key=key or None`, i.e. an unauthenticated client.
+        self.assertIsNone(self._api_key_with({"something_else": _entry("nope")}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Registers mcp/server.py as the stdio MCP server "loci" for any Claude Code
session started in this checkout, replacing per-machine `claude mcp add`.

Paths are relative: Claude Code launches stdio servers with the project
directory as cwd, so `mcp/.venv/bin/python` and `mcp/server.py` resolve in
any clone regardless of where it lives. mcp/.venv is the venv path the
repo already gitignores and that mcp/README.md documents.

No env block. server.py already loads .env from the repo root and mcp/.env
(override) at import, and falls back to ~/.hermes/memory-sessions when
HERMES_MEMORY_DIR is unset -- so secrets and host-specific endpoints stay
in gitignored .env files rather than a committed config. Nested
${VAR:-${VAR2}} expansion was tried first and does not resolve; the server
silently read the wrong memory directory as a result.

Requires the venv to exist: python3 -m venv mcp/.venv && mcp/.venv/bin/pip
install -r mcp/requirements.txt

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQTzDE8LXMx4vZHXtuh1DM