### PR TITLE
grounding: report degraded when the server module fails to import

### DIFF
--- a/mcp/grounding.py
+++ b/mcp/grounding.py
@@ -195,6 +195,12 @@ def ground(task: dict, opts: Optional[dict] = None) -> dict:
     except Exception as exc:
         logger.warning("grounding: server module unavailable, all lanes disabled: %s", exc)
         S = None
+        # Every server-backed lane (1, 2, 3, 6) short-circuits on S is None, and only
+        # lanes 4 and 5 set this flag. Without marking it here, a total grounding
+        # failure returns {block:"", chars:0, degraded:False} -- byte-identical to a
+        # healthy "nothing stored for this task" result, so callers consume a lookup
+        # that consulted nothing as full coverage.
+        degraded = True
 
     # 1. Named cases -> investigation_load (structured, retracted excluded). Fail-open per
     # case: a raising server tool (or malformed finding) skips that case, never aborts ground().

--- a/mcp/tests/test_grounding.py
+++ b/mcp/tests/test_grounding.py
@@ -154,3 +154,30 @@ def test_ground_budget_respected(tmp_path, monkeypatch):
                  {"budgetChars": 800, "memoryDir": str(tmp_path)})
     # block stays within budget + bounded header/footer overhead
     assert r["chars"] <= 800 + 500
+
+
+def test_ground_marks_degraded_when_server_import_fails(monkeypatch):
+    """A total grounding failure must be distinguishable from 'nothing stored'.
+
+    Regression: `degraded` was set only in lanes 4 and 5. When `import server`
+    failed, every server-backed lane short-circuited without touching the flag, so
+    ground() returned {block:"", chars:0, degraded:False} -- identical to a healthy
+    empty result. Downstream fan-out agents read that as full coverage.
+    """
+    import importlib
+    real = importlib.import_module
+
+    def _boom(name, *a, **k):
+        if name == "server":
+            raise ImportError("simulated: server module unavailable")
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(importlib, "import_module", _boom)
+    r = G.ground({"title": "why is auth failing", "caseIds": ["c1"], "entities": ["auth"]},
+                 {"budgetChars": 500, "memoryDir": "/nonexistent"})
+
+    assert r["chars"] == 0                    # nothing was assembled...
+    assert r["degraded"] is True, (           # ...and the caller must be told why
+        "total grounding failure reported degraded=False — indistinguishable "
+        "from a healthy 'no prior context' result"
+    )


### PR DESCRIPTION
**Stacked on #153** (which is itself stacked on #151). One line of production code plus a regression test.

## The bug

`ground()` set `degraded = True` only in lanes 4 and 5. When `import server` raised, `S` became `None` and every server-backed lane (1, 2, 3, 6) short-circuited **without touching the flag**. A total grounding failure returned:

```python
{"block": "", "sources": [], "chars": 0, "degraded": False}
```

Byte-identical to a healthy *"nothing stored for this task"* result.

Reproduced by forcing the import to raise:

| | `chars` | `degraded` |
|---|---|---|
| `import server` broken — every lane dead | 0 | **`False`** |
| genuinely no stored context | 0 | `True`* |

<sub>\* `True` only because RAG happened to be down in the test environment. On a healthy deployment lane 5 succeeds, the flag stays `False`, and the two become indistinguishable.</sub>

The flag was effectively **inverted against severity** — the worst outcome reported cleanest. Every downstream fan-out agent consumed a lookup that had consulted nothing as full coverage.

## Why it survived

`tests/test_grounding.py` asserts the returned dict's *keys*:

```python
assert set(r) == {"block", "sources", "chars", "degraded"}   # well-formed, never raised
```

Shape, not value. The function was reachable, called, and covered — and still wrong. Exactly the class of defect that reachability analysis and line coverage both miss.

## The test is mutation-checked

A regression test that passes with and without the fix is worthless, so I verified it both ways:

```
fix reverted   -> FAILED tests/test_grounding.py::test_ground_marks_degraded_when_server_import_fails
fix applied    -> 13 passed
```

## Verification

- `cd mcp && .venv/bin/pytest tests/` → **488 passed, 0 skipped** (487 + this regression test)
- ruff gate on `grounding.py` → `All checks passed!`

## Scope note

This **changes a return value**, which is why it was deliberately excluded from the refactor that found it — that pass was contractually behaviour-preserving. It belongs in its own reviewable commit, not buried in a 1,900-line diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_