### PR TITLE
observability: give every fail-open handler a diagnostic

### DIFF
--- a/mcp/backends.py
+++ b/mcp/backends.py
@@ -31,11 +31,14 @@ See backends.toml.example. Resolutions are memoized (the probe runs once per pro
 """
 from __future__ import annotations
 
+import logging
 import functools
 import os
 import socket
 from pathlib import Path
 from urllib.parse import urlparse
+
+logger = logging.getLogger("loci-mcp.backends")
 
 _CONFIG_PATH = os.environ.get("LOCI_CONFIG") or str(Path.home() / ".loci" / "backends.toml")
 
@@ -53,8 +56,8 @@ def _config() -> dict:
         p = Path(_CONFIG_PATH)
         if p.exists():
             return tomllib.loads(p.read_text())
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("_config: fail-open swallow: %r", exc)
     return {}
 
 

--- a/mcp/embed_ops.py
+++ b/mcp/embed_ops.py
@@ -17,9 +17,12 @@ embed function is injectable so callers can reuse a warm client and tests can st
 """
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from typing import Callable, Optional
+
+logger = logging.getLogger("loci-mcp.embed_ops")
 
 _OLLAMA = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_URL") or ""
 _EMBED_MODEL = os.environ.get("EMBED_MODEL", "")   # empty -> resolved via backends at call time
@@ -112,8 +115,8 @@ def warm(embed_fn: Optional[Callable[[list[str]], list[list[float]]]] = None) ->
         def _run() -> None:
             try:
                 ef(["warm"])
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("_run: fail-open swallow: %r", exc)
 
         try:
             threading.Thread(target=_run, name="embed-warm", daemon=True).start()

--- a/mcp/graph/code_parse.py
+++ b/mcp/graph/code_parse.py
@@ -239,8 +239,8 @@ def _node_name(node, lang: str) -> Optional[str]:
         for c in node.named_children:
             if c.type in _NAME_LEAVES:
                 return _text(c)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("_node_name: fail-open swallow: %r", exc)
     return None
 
 
@@ -776,13 +776,13 @@ def _collect_decls(root, lang, def_types, enclosing_symbol_src, in_method, add_d
                                 nm = _first_child_type(c, {"identifier"})
                             if nm is not None:
                                 add_decl(_text(nm), None, enclosing_symbol_src(node), "param")
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_collect_decls: fail-open swallow: %r", exc)
 
         try:
             stack.extend(node.children)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_collect_decls: fail-open swallow: %r", exc)
 
 
 def _python_is_class_field(assign_node, def_types) -> bool:

--- a/mcp/graph/ladybug_store.py
+++ b/mcp/graph/ladybug_store.py
@@ -356,8 +356,8 @@ class LadybugStore:
                     try:
                         if c is not None:
                             c.close()
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug("_session: fail-open swallow: %r", exc)
                 try:
                     if got:
                         fcntl.flock(fd, fcntl.LOCK_UN)
@@ -370,8 +370,8 @@ class LadybugStore:
         try:
             os.ftruncate(fd, 0)
             os.pwrite(fd, f"{os.getpid()} {int(time.time())}\n".encode(), 0)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_stamp_holder: fail-open swallow: %r", exc)
 
     def writable_probe(self) -> bool:
         """True if a RW connection can be opened right now (lease free AND LadybugDB's own
@@ -439,8 +439,8 @@ class LadybugStore:
                     "ALTER TABLE CodeSymbol ADD referenced BOOL DEFAULT false"):
             try:
                 conn.execute(alt)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("_ensure_schema: fail-open swallow: %r", exc)
         self._schema_ready = True
 
     # ------------------------------------------------------------------ #
@@ -454,8 +454,8 @@ class LadybugStore:
         result is drained+closed INSIDE the session, before _session tears it down."""
         try:
             res.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_close_result: fail-open swallow: %r", exc)
 
     def _exec(self, cypher: str, params: Optional[dict] = None):
         """Execute a WRITE statement in a leased RW session; returns None (writes have no

--- a/mcp/inv_store.py
+++ b/mcp/inv_store.py
@@ -110,8 +110,8 @@ def _atomic_write_text(path: Path, data: str) -> None:
     except Exception:
         try:
             os.unlink(tmp_path)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_atomic_write_text: fail-open swallow: %r", exc)
         raise
 
 
@@ -136,8 +136,8 @@ def _append_jsonl(path: Path, entry: dict) -> None:
         finally:
             try:
                 fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("_append_jsonl: fail-open swallow: %r", exc)
 
 
 def _read_jsonl(path: Path) -> list[dict]:

--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -608,8 +608,8 @@ def investigation_finding_provenance(
                 nc = node_entry.get("numeric_confidence", 1.0)
                 try:
                     aggregate_confidence *= float(nc)
-                except (TypeError, ValueError):
-                    pass
+                except (TypeError, ValueError) as exc:
+                    logger.debug("investigation_finding_provenance: fail-open swallow: %r", exc)
         aggregate_confidence = round(aggregate_confidence, 6)
     except Exception:
         aggregate_confidence = None

--- a/mcp/memcheck/checks/code_hallucination.py
+++ b/mcp/memcheck/checks/code_hallucination.py
@@ -31,6 +31,8 @@ from ..code_rules import (
 )
 from ..verdict import Verdict, make_signature, new_verdict, redact_excerpt
 
+logger = logging.getLogger("loci-mcp.code_hallucination")
+
 __all__ = ["run_code_checks"]
 
 # Advisory confidence for a vendored static code smell (LH00x) — surfaced, not
@@ -63,8 +65,8 @@ def _relpath(path: Path, repo_root: str | None) -> str:
     if repo_root:
         try:
             return path.resolve().relative_to(Path(repo_root).resolve()).as_posix()
-        except (ValueError, OSError):
-            pass
+        except (ValueError, OSError) as exc:
+            logger.debug("_relpath: fail-open swallow: %r", exc)
     return path.name
 
 

--- a/mcp/memcheck/checks/contradiction_llm.py
+++ b/mcp/memcheck/checks/contradiction_llm.py
@@ -92,8 +92,8 @@ def extract_json(text: str) -> dict | None:
     t = text.strip()
     try:
         return json.loads(t)
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("extract_json: fail-open swallow: %r", exc)
     if "```" in t:
         inner = t.split("```", 1)[1]
         if inner.startswith("json"):
@@ -101,8 +101,8 @@ def extract_json(text: str) -> dict | None:
         inner = inner.split("```", 1)[0].strip()
         try:
             return json.loads(inner)
-        except Exception:
-            pass
+        except Exception as exc:
+            _log.debug("extract_json: fail-open swallow: %r", exc)
     start = t.find("{")
     if start != -1:
         depth = 0
@@ -149,7 +149,8 @@ def _gate_and_judge(
         for j in range(i + 1, len(prepared)):
             try:
                 c = cosine_fn(vectors[i], vectors[j])
-            except Exception:
+            except Exception as exc:
+                _log.debug("_gate_and_judge: fail-open swallow: %r", exc)
                 continue
             if c >= subject_threshold:
                 candidates.append((c, i, j))

--- a/mcp/memcheck/cli.py
+++ b/mcp/memcheck/cli.py
@@ -25,6 +25,7 @@ not on the hook path).
 
 from __future__ import annotations
 
+import logging
 import hashlib
 import json
 import os
@@ -38,6 +39,8 @@ from typing import Any, Optional
 # for it only when qdrant is actually reachable.
 from .backend import VerdictBackend
 from .verdict import make_signature, new_verdict, redact_excerpt
+
+logger = logging.getLogger("loci-mcp.cli")
 
 __all__ = [
     "EMBED_DIM",
@@ -184,8 +187,8 @@ def _append_audit_line(record: dict) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, default=str) + "\n")
-    except Exception:  # noqa: BLE001 — logging must never break the hook
-        pass
+    except Exception as exc:  # noqa: BLE001 — logging must never break the hook
+        logger.debug("_append_audit_line: fail-open swallow: %r", exc)
 
 
 def _now_iso() -> str:
@@ -398,8 +401,8 @@ def process_code(payload: dict, engine, *, repo_root: Optional[str] = None) -> d
         if repo_root:
             try:
                 return p.resolve().relative_to(Path(repo_root).resolve()).as_posix()
-            except (ValueError, OSError):
-                pass
+            except (ValueError, OSError) as exc:
+                logger.debug("_audit_relpath: fail-open swallow: %r", exc)
         return p.name
 
     # Skip: no path, not a .py file, or the file doesn't exist.
@@ -505,9 +508,9 @@ def _check_action_from_stdin() -> int:
             )
 
         check_action(payload, backend)
-    except Exception:  # noqa: BLE001 — absolute fail-open boundary
+    except Exception as exc:  # noqa: BLE001 — absolute fail-open boundary
         # Never let anything escape to stdout or a non-zero exit.
-        pass
+        logger.debug("_check_action_from_stdin: fail-open swallow: %r", exc)
     return 0
 
 
@@ -625,8 +628,8 @@ def _cmd_check_code(argv: list[str]) -> int:
                     {"tool_name": "Write", "tool_input": {"file_path": f}},
                     _BackendEngine(backend),
                 )
-            except Exception:  # noqa: BLE001 — recording must never break the CLI
-                pass
+            except Exception as exc:  # noqa: BLE001 — recording must never break the CLI
+                logger.debug("_cmd_check_code: fail-open swallow: %r", exc)
 
     if total_issues == 0:
         print("no code-hallucination issues found")

--- a/mcp/memcheck/daemon.py
+++ b/mcp/memcheck/daemon.py
@@ -25,6 +25,7 @@ Socket: ``MEMCHECK_SOCKET`` env, default ``~/.hermes/memcheck.sock`` (perms 0600
 
 from __future__ import annotations
 
+import logging
 import json
 import os
 import signal
@@ -36,6 +37,8 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from . import cli
+
+logger = logging.getLogger("loci-mcp.daemon")
 
 __all__ = [
     "DEFAULT_SOCKET",
@@ -164,8 +167,8 @@ class _Handler(socketserver.BaseRequestHandler):
                 self._write_response(
                     {"would_flag": False, "occurrences": 0, "qdrant": "unavailable"}
                 )
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("handle: fail-open swallow: %r", exc)
 
     def _read_all(self) -> bytes:
         chunks: list[bytes] = []
@@ -184,8 +187,8 @@ class _Handler(socketserver.BaseRequestHandler):
         line = (json.dumps(obj, separators=(",", ":")) + "\n").encode("utf-8")
         try:
             self.request.sendall(line)
-        except Exception:  # noqa: BLE001 — client may have already gone away
-            pass
+        except Exception as exc:  # noqa: BLE001 — client may have already gone away
+            logger.debug("_write_response: fail-open swallow: %r", exc)
 
 
 class MemcheckDaemon(socketserver.ThreadingUnixStreamServer):
@@ -220,8 +223,8 @@ def _prepare_socket_path(path: Path) -> None:
     if path.exists() or path.is_symlink():
         try:
             path.unlink()
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("_prepare_socket_path: fail-open swallow: %r", exc)
 
 
 def serve(
@@ -244,8 +247,8 @@ def serve(
     # User-only access to the socket (0600).
     try:
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.debug("serve: fail-open swallow: %r", exc)
 
     def _shutdown(_signum, _frame) -> None:
         # shutdown() must run off the serve thread; spawn a tiny stopper.
@@ -256,9 +259,9 @@ def serve(
         try:
             signal.signal(sig, _shutdown)
             installed_signals.append(sig)
-        except (ValueError, OSError):
+        except (ValueError, OSError) as exc:
             # Not on the main thread (e.g. under a test) — skip signal install.
-            pass
+            logger.debug("serve: fail-open swallow: %r", exc)
 
     if ready_event is not None:
         ready_event.set()
@@ -270,8 +273,8 @@ def serve(
         try:
             if path.exists() or path.is_symlink():
                 path.unlink()
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("serve: fail-open swallow: %r", exc)
     return 0
 
 

--- a/mcp/memcheck/hook_client.py
+++ b/mcp/memcheck/hook_client.py
@@ -22,9 +22,12 @@ Importing this module must not connect to anything — only ``main()`` /
 ``run()`` do I/O, so it stays ``python -m memcheck.hook_client`` friendly.
 """
 
+import logging
 import os
 import socket
 import sys
+
+logger = logging.getLogger("loci-mcp.hook_client")
 
 # Keep stdlib-only and lazy: ``subprocess`` is imported inside the spawn path so
 # the common (daemon-up) case never pays for it.
@@ -58,9 +61,9 @@ def _spawn_daemon():
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-    except Exception:
+    except Exception as exc:
         # Spawning is opportunistic; failure just means the next call retries.
-        pass
+        logger.debug("_spawn_daemon: fail-open swallow: %r", exc)
 
 
 def run(stdin_bytes):
@@ -88,13 +91,13 @@ def run(stdin_bytes):
             try:
                 while sock.recv(65536):
                     pass
-            except (TimeoutError, OSError):
-                pass
+            except (TimeoutError, OSError) as exc:
+                logger.debug("run: fail-open swallow: %r", exc)
         finally:
             sock.close()
-    except Exception:
+    except Exception as exc:
         # Absolute fail-open boundary: timeout, reset, anything — exit 0.
-        pass
+        logger.debug("run: fail-open swallow: %r", exc)
     return 0
 
 

--- a/mcp/memcheck/mnemosyne.py
+++ b/mcp/memcheck/mnemosyne.py
@@ -146,8 +146,9 @@ class MnemosyneBackend(VerdictBackend):
                 continue
             try:
                 verdict = Verdict.from_payload(metadata)
-            except (KeyError, TypeError, ValueError):
+            except (KeyError, TypeError, ValueError) as exc:
                 # Malformed payload — skip rather than fail the whole recall.
+                _log.debug("recall: fail-open swallow: %r", exc)
                 continue
             scored.append(
                 ScoredVerdict(verdict=verdict, similarity=_extract_score(result))

--- a/mcp/model_json.py
+++ b/mcp/model_json.py
@@ -9,9 +9,12 @@ wrapper over Ollama; this is a pure parser with no backend of its own.
 """
 from __future__ import annotations
 
+import logging
 import json
 import re
 from typing import Optional
+
+logger = logging.getLogger("loci-mcp.model_json")
 
 
 def extract_json_object(text: str) -> Optional[dict]:
@@ -27,8 +30,8 @@ def extract_json_object(text: str) -> Optional[dict]:
         obj = json.loads(text)
         if isinstance(obj, dict):
             return obj
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("extract_json_object: fail-open swallow: %r", exc)
     # 2) strip code fences and retry
     fenced = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL | re.IGNORECASE)
     if fenced:
@@ -36,8 +39,8 @@ def extract_json_object(text: str) -> Optional[dict]:
             obj = json.loads(fenced.group(1))
             if isinstance(obj, dict):
                 return obj
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("extract_json_object: fail-open swallow: %r", exc)
     # 3) brace-match scan: first '{' whose balanced span parses as an object
     depth = 0
     start = -1

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -314,8 +314,8 @@ def _ladybug_writer_pid() -> Optional[int]:
         if _ladybug_store is not None:
             fn = getattr(_ladybug_store, "lock_holder_pid", None)
             return fn() if fn is not None else None
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("_ladybug_writer_pid: fail-open swallow: %r", exc)
     return None
 
 
@@ -717,8 +717,8 @@ def _embed_sparse(text: str):
         try:
             from qdrant_client.models import SparseVector
             return SparseVector(indices=list(cached[0]), values=list(cached[1]))
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_embed_sparse: fail-open swallow: %r", exc)
     model = _get_sparse_embedder()
     if model is None:
         return None
@@ -2038,8 +2038,8 @@ def _session_hints_push(investigation_id: str, hint: dict) -> None:
         buf.append(hint)
         if len(buf) > _SESSION_HINTS_MAX_PER_INV:
             del buf[0]
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("_session_hints_push: fail-open swallow: %r", exc)
 
 
 _REFLECTION_ERROR_RE = re.compile(r"\b(error|exception|traceback|failed|failure|timeout|conflict)\b", re.I)
@@ -2377,8 +2377,8 @@ def _normalize_claims(claims: str | list[str]) -> list[str]:
             parsed = json.loads(raw)
             if isinstance(parsed, list):
                 return [str(c).strip() for c in parsed if str(c).strip()]
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("_normalize_claims: fail-open swallow: %r", exc)
 
     lines = [line.strip(" -\t") for line in raw.splitlines() if line.strip()]
     if len(lines) > 1:
@@ -2567,8 +2567,8 @@ def _compute_aggregate_confidence(
             nc = node.get("numeric_confidence", 1.0)
             try:
                 product *= float(nc)
-            except (TypeError, ValueError):
-                pass
+            except (TypeError, ValueError) as exc:
+                logger.debug("_compute_aggregate_confidence: fail-open swallow: %r", exc)
             parents = node.get("derived_from") or []
             current_id = str(parents[0]) if parents else None
             depth += 1
@@ -3397,8 +3397,8 @@ def procedure_attempt(
         except Exception:
             try:
                 os.unlink(tmp_path)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("procedure_attempt: fail-open swallow: %r", exc)
             raise
 
         # Update Qdrant payload for the finding
@@ -6262,7 +6262,8 @@ def contract_check(
             continue
         try:
             declared = json.loads(m.group(1))
-        except Exception:
+        except Exception as exc:
+            logger.debug("contract_check: fail-open swallow: %r", exc)
             continue
         for stored_field, stored_type in declared.items():
             sf = stored_field.lower()
@@ -7119,7 +7120,8 @@ def _run_causal_inference(investigation_id: str, findings: list[dict]) -> int:
                         if m:
                             try:
                                 obj = json.loads(m.group(0))
-                            except Exception:
+                            except Exception as exc:
+                                logger.debug("_run_causal_inference: fail-open swallow: %r", exc)
                                 continue
                         else:
                             continue
@@ -8229,8 +8231,8 @@ def main() -> None:
     try:
         import embed_ops
         embed_ops.warm()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("main: fail-open swallow: %r", exc)
     transport = os.environ.get("HERMES_MCP_TRANSPORT", "stdio")
     if transport in ("sse", "streamable-http"):
         host = os.environ.get("HERMES_MCP_HOST", "0.0.0.0")

--- a/mcp/tests/test_graph_facts.py
+++ b/mcp/tests/test_graph_facts.py
@@ -1,5 +1,4 @@
 """Tests for scripts/graph_facts.py — the deterministic code-graph fact producer."""
-import io
 import json
 import os
 import sys

--- a/mcp/tests/test_ladybug_lease.py
+++ b/mcp/tests/test_ladybug_lease.py
@@ -35,7 +35,9 @@ def test_no_lock_held_between_ops_two_instances(tmp_path):
     assert a.upsert_finding({"id": "f1", "investigation": "inv1", "text": "x"}) is True
 
     # Each instance sees the other's committed writes (fresh leased read sessions).
-    ids = {r[0] for r in b.related_investigations("inv1")} if False else None
+    # (A previous `... if False else None` stub called related_investigations here
+    # but could never execute and asserted nothing. Cross-instance visibility is
+    # proven by the _rows assertion below, which is the point of this test.)
     rows = a._rows("MATCH (i:Investigation) RETURN i.id ORDER BY i.id")
     assert [r[0] for r in rows] == ["inv1", "inv2"]
 


### PR DESCRIPTION
**Stacked on #156** → #154 → #153 → #151.

Silent exception handlers across `mcp/` (non-test): **44 → 3**.

## Why this one matters

A handler whose entire body is `pass` or `continue` is indistinguishable from a correct empty result. This session hit that exact failure **twice**:

- `subgraph()` returned `{}` for **every** input against ladybug — it read `_id` where ladybug writes `_ID`. Nothing raised, nothing logged.
- `ground()` reported `degraded: False` on total grounding failure (#154), so downstream agents consumed a lookup that consulted nothing as full coverage.

Both were reachable, both were covered by tests, both were silently wrong. A `logger.debug` would have turned each into a one-line grep.

## What changed

42 handlers now emit `logger.debug` naming the enclosing function. **Fail-open behaviour is bit-for-bit unchanged** — every `pass` stays a no-op, every `continue` still continues (the log is inserted *before* it, not in place of it), every fallback value untouched. The only difference is that a swallowed failure is greppable.

Eight modules had no logger and gained one. Handlers with no exception binding gained `as exc`.

## Three are deliberately left silent

`server.py:90`, `server.py:95`, `graph/__init__.py:18` — all optional-dependency import guards at module scope. No logger can exist at that point in module execution, and the fallback is explicit and handled.

I encoded this as a **rule** — a module-scope `try` whose body contains only imports — rather than judging case by case, so the boundary is reproducible rather than a matter of taste.

## Two pre-existing test defects fixed

CI's mandated ruff gate doesn't lint `mcp/tests/`, so these were invisible:

- **`test_ladybug_lease.py`** — `ids = {r[0] for r in b.related_investigations("inv1")} if False else None`. A stub that could never execute and asserted nothing. I checked whether it could be made live: the call works, but the only assertion available is vacuous — `related_investigations` legitimately returns `[]` for two investigations sharing nothing, since the `RELATED` lane has no writer (already documented at `ladybug_store.py:1013`). A fake assertion would be worse than none, so the dead line is removed; cross-instance visibility is already proven by the `_rows` assertion below it.
- **`test_graph_facts.py`** — unused `import io`.

## Verification

- `pytest tests/` → **488 passed, 0 skipped**
- ruff → `All checks passed!` across **all** of `mcp/` including `tests/` (previously 2 errors there)
- `mcp.list_tools()` → **71**, unique
- `loci_health()["kuzu"]` → still present, wire format intact

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_