### PR TITLE
graph: make code_memory_relink actually invalidate the symbol-index cache

### DIFF
--- a/mcp/graph_tools.py
+++ b/mcp/graph_tools.py
@@ -132,9 +132,11 @@ def code_memory_relink() -> str:
         from graph import linker
         result = linker.relink_all(ks)
         # A relink can change the symbol set relationship; drop the cached index
-        # so subsequent auto-links rebuild against the current graph.
-        global _symbol_index_cache, _symbol_index_count
-        _symbol_index_cache, _symbol_index_count = None, -1
+        # so subsequent auto-links rebuild against the current graph. Must go
+        # through ladybug_ops -- assigning the names here would bind graph_tools'
+        # own globals and leave the real cache stale.
+        import ladybug_ops
+        ladybug_ops.invalidate_symbol_index()
         return json.dumps(result, indent=2)
     except Exception as exc:
         logger.debug("code_memory_relink failed: %r", exc)

--- a/mcp/ladybug_ops.py
+++ b/mcp/ladybug_ops.py
@@ -107,6 +107,18 @@ _symbol_index_cache = None             # built graph.linker index
 _symbol_index_count = -1               # CodeSymbol count the cache was built at
 
 
+def invalidate_symbol_index() -> None:
+    """Drop the cached symbol index so the next auto-link rebuilds it.
+
+    Callers outside this module MUST use this rather than assigning the module
+    globals themselves: a `global _symbol_index_cache` in another module binds
+    names in THAT module's namespace and leaves this cache untouched, which is
+    exactly the dead write that made code_memory_relink's invalidation a no-op.
+    """
+    global _symbol_index_cache, _symbol_index_count
+    _symbol_index_cache, _symbol_index_count = None, -1
+
+
 def _get_symbol_index(ks):
     """Return a cached graph.linker symbol index, rebuilding it when the graph's
     CodeSymbol count changes. Returns None (fail-open) if unavailable/empty."""

--- a/mcp/tests/test_graph_integration.py
+++ b/mcp/tests/test_graph_integration.py
@@ -106,3 +106,44 @@ def test_backfill_of_preexisting_findings(srv, tmp_path):
         shutil.rmtree(graph_path, ignore_errors=True)
     ks2 = S._get_ladybug()  # empty graph -> backfill runs
     assert ks2.code_query("MATCH (f:Finding) RETURN count(f)")[0][0] == 2
+
+
+def test_relink_invalidates_the_symbol_index_cache(tmp_path, monkeypatch):
+    """code_memory_relink must actually drop the cached symbol index.
+
+    Regression: graph_tools.code_memory_relink declared
+    `global _symbol_index_cache, _symbol_index_count` and assigned None/-1. Those
+    names are not defined in graph_tools, so the `global` bound them in
+    graph_tools' OWN namespace and the real cache -- which lives in ladybug_ops --
+    was never touched. Auto-linking after a relink kept using a stale index until
+    the CodeSymbol count happened to change; a relink that rewires edges without
+    changing the symbol count never triggered a rebuild, producing wrong or
+    missing REFERENCES edges on findings stored afterwards.
+    """
+    import graph_tools
+    import ladybug_ops
+
+    # Prime the cache with a recognisable value.
+    ladybug_ops._symbol_index_cache = {"sentinel": True}
+    ladybug_ops._symbol_index_count = 7
+
+    # Force relink_all to succeed without needing a live graph.
+    class _FakeLinker:
+        @staticmethod
+        def relink_all(ks):
+            return {"relinked": 0}
+
+    monkeypatch.setattr(graph_tools, "_get_kuzu", lambda: object(), raising=False)
+    monkeypatch.setattr(graph_tools, "_get_ladybug", lambda: object(), raising=False)
+    import sys, types
+    fake_graph = types.ModuleType("graph")
+    fake_graph.linker = _FakeLinker
+    monkeypatch.setitem(sys.modules, "graph.linker", _FakeLinker)
+
+    graph_tools.code_memory_relink()
+
+    assert ladybug_ops._symbol_index_cache is None, (
+        "relink did not clear the real cache — the invalidation wrote to the "
+        "wrong namespace"
+    )
+    assert ladybug_ops._symbol_index_count == -1


### PR DESCRIPTION
**Stacked on #158.** A live bug, pre-existing at `HEAD`.

## The bug

`code_memory_relink()` invalidated the cached symbol index like this:

```python
global _symbol_index_cache, _symbol_index_count
_symbol_index_cache, _symbol_index_count = None, -1
```

But `graph_tools.py` **never defines those names at module level**. So the `global` statement bound them in `graph_tools`' own namespace, and the real cache — which lives in `ladybug_ops` (previously `server.py`) — was never touched.

Demonstrated at runtime:

```
graph_tools has _symbol_index_cache before: False
graph_tools has it AFTER the global write:  True     # phantom names created
real ladybug_ops cache untouched:  {'a': 1}  5       # never invalidated
```

## Why it matters

Auto-linking after a relink keeps using the **stale** symbol index. The cache only rebuilds when the `CodeSymbol` *count* changes — so a relink that rewires edges without changing the symbol count, or replaces symbols one-for-one, never triggers a rebuild. The result is wrong or missing `REFERENCES` edges on every finding stored afterwards.

## Why nothing caught it

- **Lint:** `F824` (dead global) isn't in the mandated `--select` list.
- **Tests:** nothing exercised invalidation.
- **Reachability:** the function is called and covered. It just writes somewhere nobody reads — the statically-live/semantically-inert shape.

## The fix

`ladybug_ops` gains `invalidate_symbol_index()`; `graph_tools` calls it. Its docstring states plainly why external callers must not assign the globals themselves, since that is exactly what went wrong.

## The test is mutation-checked

A regression test that passes either way would be worthless, so I verified both directions:

```
old dead-global code restored -> FAILED test_relink_invalidates_the_symbol_index_cache
fix applied                   -> 7 passed
```

## Verification

**489 passed / 0 skipped** (up from 488), lint clean, tool invariant **71/71 unique, all re-exported**.

Worth knowing for anyone running this file alone: `pytest tests/test_graph_integration.py` dies at collection with `ModuleNotFoundError: No module named 'server'` — nothing puts the package root on `sys.path` for a single-file invocation. It passes in the full-directory run CI uses, and standalone with `PYTHONPATH=/home/user/loci/mcp`. Pre-existing, not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_