### PR TITLE
contract: rename the graph-store wire keys to ladybug, and fix graph_facts

### DIFF
--- a/mcp/graph/queries.py
+++ b/mcp/graph/queries.py
@@ -95,7 +95,8 @@ def _meta(node: dict, name: str) -> Any:
     """Read an internal key off a returned node/rel dict.
 
     ladybug returns these upper-cased (``_ID``/``_LABEL``/``_SRC``/``_DST``);
-    kuzu used lower-case. Accept either so the reader survives the rename.
+    its predecessor used lower-case. Accept either so the reader survives
+    the rename.
     """
     up = f"_{name.upper()}"
     return node[up] if up in node else node.get(f"_{name.lower()}")

--- a/mcp/ladybug_ops.py
+++ b/mcp/ladybug_ops.py
@@ -5,7 +5,7 @@ entity-lookup projection, the symbol-index cache, and the one-time backfill. The
 LadybugStore singleton itself — ``_ladybug_store`` / ``_ladybug_failed`` /
 ``_ladybug_last_attempt`` / ``_LADYBUG_RETRY_SECONDS`` / ``_ladybug_lock`` and the
 ``_get_ladybug`` accessor built on them, plus ``_ladybug_health_state`` /
-``_ladybug_writer_pid`` which feed the frozen ``kuzu`` / ``kuzu_writer_pid`` wire
+``_ladybug_writer_pid`` which feed the ``ladybug`` / ``ladybug_writer_pid`` wire
 keys — DELIBERATELY stay in server.py: several tests monkeypatch those latches on
 the server module and assert on ``server._get_ladybug()``, so moving them here
 would make every one of those patches a silent no-op.

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -666,7 +666,7 @@ def _entity_lookup_cascade(
     the findings.  A total miss reports the last tier tried (``jsonl_fallback``).
     """
     findings = _entity_lookup_ladybug(entity, investigation_id, limit)
-    method = "kuzu"
+    method = "ladybug"
     if not findings:
         findings = _entity_lookup_qdrant(entity, entity_type, investigation_id, limit)
         method = "qdrant"
@@ -5664,12 +5664,11 @@ def loci_health() -> str:
 
     Returns JSON:
       code_version:      short git SHA of the running code ('' if not a git checkout)
-      kuzu:              'available' | 'contended' | 'unavailable' | 'latched' | 'backoff'
-                         (key name retained for wire compatibility; the backend is LadybugDB)
+      ladybug:           'available' | 'contended' | 'unavailable' | 'latched' | 'backoff'
                          — reflects the graph store state via a READ-ONLY probe (never
                          grabs the writer lock). 'contended' = another process holds the
                          writer lock right now (transient with per-op leasing).
-      kuzu_writer_pid:   (optional) PID stamped as the current write-lease holder
+      ladybug_writer_pid: (optional) PID stamped as the current write-lease holder
       ollama_reachable:  TCP reachability of the resolved Ollama endpoint
       vllm_reachable:    TCP reachability of the resolved vLLM endpoint
       qdrant_reachable:  TCP reachability of the resolved Qdrant endpoint
@@ -5679,7 +5678,7 @@ def loci_health() -> str:
     """
     out: dict = {
         "code_version": "",
-        "kuzu": "unavailable",
+        "ladybug": "unavailable",
         "ollama_reachable": False,
         "vllm_reachable": False,
         "qdrant_reachable": False,
@@ -5693,10 +5692,10 @@ def loci_health() -> str:
         logger.debug("loci_health: code_version probe failed: %r", exc)
         pass
     try:
-        out["kuzu"] = _ladybug_health_state()
+        out["ladybug"] = _ladybug_health_state()
         pid = _ladybug_writer_pid()
         if pid is not None:
-            out["kuzu_writer_pid"] = pid
+            out["ladybug_writer_pid"] = pid
     except Exception as exc:
         logger.debug("loci_health: ladybug health-state probe failed: %r", exc)
         pass

--- a/mcp/tests/test_analytics.py
+++ b/mcp/tests/test_analytics.py
@@ -7,7 +7,7 @@ from graph import analytics as A
 
 @pytest.fixture
 def ks(tmp_path):
-    s = LadybugStore(str(tmp_path / "g.kuzu"))
+    s = LadybugStore(str(tmp_path / "g.ladybug"))
     assert s.available()
     e = s._exec
     e("MERGE (c:CodeFile {path:'a.java'}) SET c.lang='java'")
@@ -90,7 +90,7 @@ def test_investigation_code_briefing(ks):
 
 def test_dead_code_candidates(tmp_path):
     from graph.ladybug_store import LadybugStore
-    s = LadybugStore(str(tmp_path / "dc.kuzu"))
+    s = LadybugStore(str(tmp_path / "dc.ladybug"))
     e = s._exec
     # `referenced` is the usage signal now (name occurs more than it's defined).
     def sym(sid, name, kind="function", decs="", referenced=False):

--- a/mcp/tests/test_graph_facts.py
+++ b/mcp/tests/test_graph_facts.py
@@ -46,7 +46,7 @@ def test_main_no_graph_is_fail_open(monkeypatch, capsys):
 
 
 def test_main_dispatches_per_request(monkeypatch, capsys):
-    monkeypatch.setattr(GF, "_find_graph", lambda: "/fake/graph.kuzu")
+    monkeypatch.setattr(GF, "_find_graph", lambda: "/fake/graph.ladybug")
 
     class FakeKS:
         def __init__(self, *a, **k):
@@ -71,3 +71,25 @@ def test_main_dispatches_per_request(monkeypatch, capsys):
     assert out["a"]["kind"] == "impact" and "foo" in out["a"]["text"]
     assert out["b"]["kind"] == "subsystem"
     assert out["c"]["kind"] == "dead_code"
+
+
+def test_find_graph_looks_where_the_server_actually_writes(tmp_path, monkeypatch):
+    """_find_graph must glob the same directory name mcp/server.py creates.
+
+    Regression: the server opens MEMORY_DIR / "graph.ladybug", but _find_graph
+    globbed "~/.hermes/**/graph.kuzu" -- the pre-rename name. Nothing matched, so
+    every graph_facts request reported "code graph not found" while a populated
+    graph sat beside it. Both sides pass their own tests in isolation; only the
+    agreement between them was broken.
+    """
+    home = tmp_path / "home"
+    (home / ".hermes" / "memory-sessions" / "graph.ladybug").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    found = GF._find_graph()
+
+    assert found is not None, (
+        "_find_graph did not locate the server's graph directory — it is globbing "
+        "a name the server does not create"
+    )
+    assert found.endswith("graph.ladybug")

--- a/mcp/tests/test_graph_integration.py
+++ b/mcp/tests/test_graph_integration.py
@@ -45,7 +45,7 @@ def test_entity_lookup_is_graph_primary_and_cross_case(srv):
     S.investigation_start("inv-b", "B")
     _store(S, "inv-b", "observed", "prior sighting of 203.0.113.9", "edr", "high")
     el = json.loads(S.investigation_entity_lookup("203.0.113.9"))
-    assert el["retrieval"] == "kuzu"
+    assert el["retrieval"] == "ladybug"
     assert el["total_findings"] == 2
     assert el["investigations_count"] == 2  # cross-case
 
@@ -57,7 +57,7 @@ def test_related_cases_graph_primary(srv):
     S.investigation_start("inv-b", "B")
     _store(S, "inv-b", "observed", "callback to evil.example.com", "proxy", "high")
     rc = json.loads(S.investigation_related_cases("evil.example.com"))["results"][0]
-    assert rc["retrieval"] == "kuzu"
+    assert rc["retrieval"] == "ladybug"
     assert rc["related_investigation_count"] >= 1
 
 
@@ -98,7 +98,7 @@ def test_backfill_of_preexisting_findings(srv, tmp_path):
     # drop the graph + its file, reset singleton -> next _get_ladybug triggers backfill
     import shutil
     ks = S._get_ladybug()
-    graph_path = tmp_path / "mem" / "graph.kuzu"
+    graph_path = tmp_path / "mem" / "graph.ladybug"
     del ks
     S._ladybug_store = None
     S._ladybug_failed = False
@@ -133,7 +133,6 @@ def test_relink_invalidates_the_symbol_index_cache(tmp_path, monkeypatch):
         def relink_all(ks):
             return {"relinked": 0}
 
-    monkeypatch.setattr(graph_tools, "_get_kuzu", lambda: object(), raising=False)
     monkeypatch.setattr(graph_tools, "_get_ladybug", lambda: object(), raising=False)
     import sys, types
     fake_graph = types.ModuleType("graph")

--- a/mcp/tests/test_health_warm.py
+++ b/mcp/tests/test_health_warm.py
@@ -18,7 +18,7 @@ import server  # noqa: E402
 
 
 _EXPECTED_KEYS = {
-    "code_version", "kuzu", "ollama_reachable", "vllm_reachable",
+    "code_version", "ladybug", "ollama_reachable", "vllm_reachable",
     "qdrant_reachable", "embed_model", "rerank_model", "warm",
 }
 
@@ -28,8 +28,8 @@ def test_loci_health_returns_expected_keys():
     assert isinstance(out, dict)
     # Subset (not ==) so additive fields don't break this contract.
     assert _EXPECTED_KEYS <= set(out.keys())
-    # the "kuzu" key name is retained for wire compatibility (backend is LadybugDB)
-    assert out["kuzu"] in (
+    # the graph-store health state is one of the documented values
+    assert out["ladybug"] in (
         "available", "contended", "unavailable", "latched", "backoff"
     )
     # booleans for reachability, strings for model names / version

--- a/scripts/graph_facts.py
+++ b/scripts/graph_facts.py
@@ -23,10 +23,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."
 
 def _find_graph() -> str | None:
     import glob
-    # "graph.kuzu" is the ON-DISK database directory name. It predates the
-    # Kuzu -> LadybugDB rename and is deliberately NOT renamed: every existing
-    # deployment has its database at this path, and changing it would orphan them.
-    for p in glob.glob(os.path.expanduser("~/.hermes/**/graph.kuzu"), recursive=True):
+    # Must match what the server actually opens: mcp/server.py creates
+    # MEMORY_DIR / "graph.ladybug". Globbing the historical "graph.kuzu" name
+    # found nothing, so every graph_facts request reported "code graph not
+    # found" while a populated graph sat next to it.
+    for p in glob.glob(os.path.expanduser("~/.hermes/**/graph.ladybug"), recursive=True):
         return p
     return None
 
@@ -98,7 +99,7 @@ def main() -> int:
         for req in spec:
             out[req.get("key", "?")] = {"kind": "unavailable", "text": "code graph not found", "raw": {}}
         print(json.dumps(out, indent=2))
-        print("[graph_facts: no graph.kuzu found]", file=sys.stderr)
+        print("[graph_facts: no graph.ladybug found]", file=sys.stderr)
         return 0
 
     from graph.ladybug_store import LadybugStore


### PR DESCRIPTION
**Stacked on #159** → #158. Two changes, both consequences of the Kuzu → LadybugDB migration being half-finished.

## 1. The wire keys ⚠️ breaking

| | before | after |
|---|---|---|
| `loci_health()` | `"kuzu"` | `"ladybug"` |
| `loci_health()` | `"kuzu_writer_pid"` | `"ladybug_writer_pid"` |
| `_entity_lookup_cascade` → `"retrieval"` | `"kuzu"` | `"ladybug"` |

#156 froze these deliberately for compatibility; that freeze is now lifted on request.

**This breaks anything reading `health["kuzu"]`.** Worth being explicit about the failure mode: it breaks *loudly* at the point of use — the key is simply gone, so `health["kuzu"]` raises `KeyError`. The one thing to watch is a consumer using `.get("kuzu")`, which returns `None` and reads as "unavailable" rather than "renamed". If you have such a consumer, that's the one to grep for.

No aliasing period, per your call. The `retrieval` field was an extra I'd missed in my earlier inventory — it carries the same `method` value and is asserted in the integration tests.

## 2. `graph_facts` could never find the graph 🐛

`mcp/server.py` opens `MEMORY_DIR / "graph.ladybug"`. `scripts/graph_facts.py` globbed `~/.hermes/**/graph.kuzu`. Nothing matched, so `_find_graph()` returned `None` and **every** request reported `"code graph not found"` while a populated graph sat beside it.

Demonstrated:

```
server created  : .../.hermes/memory-sessions/graph.ladybug
graph_facts finds: NOTHING
```

### This corrects a claim I made in #156

I justified freezing the on-disk name by asserting *"every existing deployment has its database at `graph.kuzu`, and changing it would orphan them."* **That was wrong.** The server has written `graph.ladybug` since before that PR — I checked the path across history and it was already `graph.ladybug` at `d6b9ef2`. So the glob was already pointing at a path nothing creates, and the comment I added claiming the name was "deliberately NOT renamed" documented a consistency that did not exist. Removed.

Because the server only ever opens `graph.ladybug`, there is no fallback to add: a `graph.kuzu` directory would be data the server never reads, and reporting facts from it would be worse than reporting none.

## Why nothing caught it

Both sides passed their own tests in isolation. Only the *agreement* between them was broken, and no test exercised `_find_graph` against a real directory layout. Added one, mutation-checked:

```
old glob restored -> FAILED test_find_graph_looks_where_the_server_actually_writes
fix applied       -> 6 passed
```

## Verification

- `mcp/tests` → **490 passed, 0 skipped** (up from 489)
- `scripts+hooks` → 556 passed
- lint clean · tool invariant **71/71 unique, all re-exported**
- `loci_health()` health keys now: `['ladybug']`

No `kuzu` identifiers or wire strings remain anywhere in the Python tree. `graph_facts.py` keeps a single comment naming the historical path, so the reason for the change stays discoverable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXxdYGrh3VrNrHVLELsBa)_