### PR TITLE
refactor: decompose every oversized function; add a call-graph debugging tool

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1946,6 +1946,174 @@ def _update_entities_jsonl(investigation_id: str, finding_id: str, text: str) ->
 
 # ---- Tool: investigation_store ----
 
+# --------------------------------------------------------------------------- #
+# investigation_store internals
+#
+# Split out of the tool body so each stage is separately readable and testable.
+# Every helper preserves the tool's original behaviour exactly, including the
+# verbatim error strings, which are part of the tool's response contract.
+# --------------------------------------------------------------------------- #
+_STORE_FINDING_TYPES = {"observed", "inferred", "assumed", "gap", "procedure"}
+_STORE_CONFIDENCES = {"high", "medium", "low"}
+_STORE_TIERS = {"hot", "warm", "cold"}
+_CONFIDENCE_TO_NUMERIC = {"high": 0.9, "medium": 0.6, "low": 0.3}
+
+
+def _store_validate(finding_type: str, confidence: str, tier: str, resolution: str) -> Optional[str]:
+    """Return the tool's error JSON for the first invalid argument, else None."""
+    if finding_type not in _STORE_FINDING_TYPES:
+        return json.dumps({"error": "finding_type must be one of: observed, inferred, assumed, gap, procedure"})
+    if confidence not in _STORE_CONFIDENCES:
+        return json.dumps({"error": "confidence must be one of: high, medium, low"})
+    if tier not in _STORE_TIERS:
+        return json.dumps({"error": "tier must be one of: hot, warm, cold"})
+    if resolution not in _RESOLUTION_STATES:
+        return json.dumps({"error": "resolution must be one of: open, fixed, intentional, wontfix, superseded"})
+    return None
+
+
+def _store_numeric_confidence(confidence: str, numeric_confidence: float | None) -> float:
+    """Caller-supplied confidence (clamped to 0..1), else derived from the label."""
+    if numeric_confidence is None:
+        return _CONFIDENCE_TO_NUMERIC.get(confidence, 0.6)
+    try:
+        return max(0.0, min(1.0, float(numeric_confidence)))
+    except (TypeError, ValueError):
+        return _CONFIDENCE_TO_NUMERIC.get(confidence, 0.6)
+
+
+def _store_build_finding(investigation_id, finding_type, text, source, confidence, tags,
+                         derived_from, numeric_confidence, procedure_preconditions,
+                         procedure_steps, procedure_postconditions, valid_from,
+                         valid_until, authored_by, tier, resolution, code_refs):
+    """Build the finding record. Returns (finding, error_json); one is always None.
+
+    The only failure mode is a derived_from id with no matching parent, which the
+    tool reports rather than storing a dangling lineage link.
+    """
+    ts_now = _now()
+    finding = {
+        "id": str(uuid.uuid4()),
+        "investigation_id": investigation_id,
+        "ts": ts_now,
+        "created_at_ts": int(datetime.now(timezone.utc).timestamp()),
+        "record_type": finding_type,   # "observed" | "inferred" | "assumed" | "gap"
+        "type": finding_type,          # kept for backwards compat with existing JSONL
+        "text": text,
+        "source": source,
+        "confidence": confidence,
+        "numeric_confidence": _store_numeric_confidence(confidence, numeric_confidence),
+        "tags": [t.strip() for t in (
+            ",".join(tags) if isinstance(tags, list) else (tags or "")
+        ).split(",") if t.strip()],
+        "valid_from": valid_from if valid_from is not None else ts_now,
+        "valid_until": valid_until,
+        "authored_by": authored_by or "",
+        "tier": tier,
+        "resolution": resolution,
+    }
+
+    derived = _normalize_derived_from(derived_from)
+    if derived:
+        existing_ids = {f["id"] for f in _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl") if "id" in f}
+        unknown = [pid for pid in derived if pid not in existing_ids]
+        if unknown:
+            return None, json.dumps({"error": f"derived_from contains unknown parent id(s): {unknown}. Verify the parent findings exist before linking."})
+        finding["derived_from"] = derived
+
+    finding["entities"] = _extract_entities(text)
+
+    # Staleness: stamp sha256 of any referenced code file so a later re-hash can flag
+    # the finding stale once that file changes. Best-effort + fail-open (no refs / an
+    # unreadable file -> omit; never error).
+    try:
+        refs = _compute_code_refs(text, code_refs)
+        if refs:
+            finding["code_refs"] = refs
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("investigation_store: code-ref hashing failed (fail-open): %r", exc)
+
+    if finding_type == "procedure":
+        finding["procedure_meta"] = {
+            "preconditions": procedure_preconditions or "",
+            "steps": procedure_steps or "",
+            "postconditions": procedure_postconditions or "",
+            "success_count": 0,
+            "attempt_count": 0,
+        }
+    return finding, None
+
+
+def _store_commit(investigation_id: str, manifest: dict, finding: dict,
+                  finding_type: str, text: str, tier: str) -> None:
+    """Append the finding and update the manifest under the per-investigation lock."""
+    lock_path = _inv_dir(investigation_id) / ".lock"
+    with open(lock_path, "w") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            _append_jsonl(_inv_dir(investigation_id) / "findings.jsonl", finding)
+            manifest["finding_counts"][finding_type] = manifest["finding_counts"].get(finding_type, 0) + 1
+            # Update hot-tier manifest notes
+            if tier == "hot":
+                snippet = text[:200]
+                notes = manifest.get("notes") or ""
+                manifest["notes"] = (notes + "; " + snippet) if notes else snippet
+            _save_manifest(manifest)
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+
+def _store_index(investigation_id: str, finding: dict, finding_type: str,
+                 text: str, source: str, confidence: str, tier: str) -> bool:
+    """Fan the finding out to Mnemosyne, Qdrant, the event log and the graph.
+
+    Returns whether Mnemosyne accepted it. Cold tier skips Qdrant indexing; the
+    graph mirror is tier-agnostic, since the relationship graph carries findings
+    regardless of index tier.
+    """
+    mnemo_stored = _mnemo_remember(
+        text,
+        importance={"high": 0.9, "medium": 0.7, "low": 0.5}.get(confidence, 0.6),
+        metadata={
+            "investigation_id": investigation_id,
+            "record_type": finding_type,
+            "source": source,
+            "confidence": confidence,
+            "tags": finding["tags"],
+            "finding_id": finding["id"],
+        },
+    )
+    if tier != "cold":
+        _qdrant_upsert(finding["id"], text, finding)
+    _event_log_append({
+        "op": "store",
+        "investigation_id": investigation_id,
+        "finding_id": finding["id"],
+        "finding_type": finding_type,
+        "confidence": confidence,
+        "tier": tier,
+    })
+    _mirror_finding_to_ladybug(finding, investigation_id)
+    _autolink_finding_to_ladybug(finding)
+    return mnemo_stored
+
+
+def _store_conflicts(investigation_id: str, finding: dict) -> tuple:
+    """Detect conflicts with existing findings. Fail-open: never blocks a store.
+
+    Returns (detected, conflicting_finding_id, conflict_id).
+    """
+    try:
+        conflicts = _detect_conflicts(investigation_id, finding)
+        if conflicts:
+            first = conflicts[0]
+            conflict_id = _write_conflict(investigation_id, finding["id"], first["neighbor_id"])
+            return True, first["neighbor_id"], conflict_id
+    except Exception as exc:
+        logger.debug("investigation_store: conflict detection failed (fail-open): %s", exc)
+    return False, None, None
+
+
 @mcp.tool()
 def investigation_store(
     investigation_id: str,
@@ -2040,132 +2208,23 @@ def investigation_store(
     if not manifest:
         return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
 
-    if finding_type not in {"observed", "inferred", "assumed", "gap", "procedure"}:
-        return json.dumps({"error": "finding_type must be one of: observed, inferred, assumed, gap, procedure"})
-    if confidence not in {"high", "medium", "low"}:
-        return json.dumps({"error": "confidence must be one of: high, medium, low"})
-    if tier not in {"hot", "warm", "cold"}:
-        return json.dumps({"error": "tier must be one of: hot, warm, cold"})
     resolution = str(resolution or "open").lower()
-    if resolution not in _RESOLUTION_STATES:
-        return json.dumps({"error": "resolution must be one of: open, fixed, intentional, wontfix, superseded"})
+    invalid = _store_validate(finding_type, confidence, tier, resolution)
+    if invalid:
+        return invalid
 
-    # Resolve numeric_confidence: caller-supplied (clamped) or derived from string confidence.
-    _confidence_to_numeric = {"high": 0.9, "medium": 0.6, "low": 0.3}
-    if numeric_confidence is None:
-        resolved_numeric_confidence = _confidence_to_numeric.get(confidence, 0.6)
-    else:
-        try:
-            resolved_numeric_confidence = max(0.0, min(1.0, float(numeric_confidence)))
-        except (TypeError, ValueError):
-            resolved_numeric_confidence = _confidence_to_numeric.get(confidence, 0.6)
-
-    _ts_now = _now()
-    finding = {
-        "id": str(uuid.uuid4()),
-        "investigation_id": investigation_id,
-        "ts": _ts_now,
-        "created_at_ts": int(datetime.now(timezone.utc).timestamp()),
-        "record_type": finding_type,   # "observed" | "inferred" | "assumed" | "gap"
-        "type": finding_type,          # kept for backwards compat with existing JSONL
-        "text": text,
-        "source": source,
-        "confidence": confidence,
-        "numeric_confidence": resolved_numeric_confidence,
-        "tags": [t.strip() for t in (
-            ",".join(tags) if isinstance(tags, list) else (tags or "")
-        ).split(",") if t.strip()],
-        "valid_from": valid_from if valid_from is not None else _ts_now,
-        "valid_until": valid_until,
-        "authored_by": authored_by or "",
-        "tier": tier,
-        "resolution": resolution,
-    }
-    derived = _normalize_derived_from(derived_from)
-    if derived:
-        existing_ids = {f["id"] for f in _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl") if "id" in f}
-        unknown = [pid for pid in derived if pid not in existing_ids]
-        if unknown:
-            return json.dumps({"error": f"derived_from contains unknown parent id(s): {unknown}. Verify the parent findings exist before linking."})
-        finding["derived_from"] = derived
-    finding["entities"] = _extract_entities(text)
-
-    # Staleness: stamp sha256 of any referenced code file so a later re-hash can flag
-    # the finding stale once that file changes. Best-effort + fail-open (no refs / an
-    # unreadable file -> omit; never error).
-    try:
-        _refs = _compute_code_refs(text, code_refs)
-        if _refs:
-            finding["code_refs"] = _refs
-    except Exception as _cr_exc:  # noqa: BLE001
-        logger.debug("investigation_store: code-ref hashing failed (fail-open): %r", _cr_exc)
-
-    if finding_type == "procedure":
-        finding["procedure_meta"] = {
-            "preconditions": procedure_preconditions or "",
-            "steps": procedure_steps or "",
-            "postconditions": procedure_postconditions or "",
-            "success_count": 0,
-            "attempt_count": 0,
-        }
-
-    _lock_path = _inv_dir(investigation_id) / ".lock"
-    with open(_lock_path, "w") as _lock_fh:
-        fcntl.flock(_lock_fh, fcntl.LOCK_EX)
-        try:
-            _append_jsonl(_inv_dir(investigation_id) / "findings.jsonl", finding)
-            manifest["finding_counts"][finding_type] = manifest["finding_counts"].get(finding_type, 0) + 1
-            # Update hot-tier manifest notes
-            if tier == "hot":
-                snippet = text[:200]
-                notes = manifest.get("notes") or ""
-                manifest["notes"] = (notes + "; " + snippet) if notes else snippet
-            _save_manifest(manifest)
-        finally:
-            fcntl.flock(_lock_fh, fcntl.LOCK_UN)
-
-    mnemo_stored = _mnemo_remember(
-        text,
-        importance={"high": 0.9, "medium": 0.7, "low": 0.5}.get(confidence, 0.6),
-        metadata={
-            "investigation_id": investigation_id,
-            "record_type": finding_type,
-            "source": source,
-            "confidence": confidence,
-            "tags": finding["tags"],
-            "finding_id": finding["id"],
-        },
+    finding, invalid = _store_build_finding(
+        investigation_id, finding_type, text, source, confidence, tags, derived_from,
+        numeric_confidence, procedure_preconditions, procedure_steps,
+        procedure_postconditions, valid_from, valid_until, authored_by, tier,
+        resolution, code_refs,
     )
+    if invalid:
+        return invalid
 
-    # cold tier: skip Qdrant indexing; hot and warm: index normally
-    if tier != "cold":
-        _qdrant_upsert(finding["id"], text, finding)
-    _event_log_append({
-        "op": "store",
-        "investigation_id": investigation_id,
-        "finding_id": finding["id"],
-        "finding_type": finding_type,
-        "confidence": confidence,
-        "tier": tier,
-    })
-    # graph store: mirror into Kuzu + auto-link to code symbols (fail-open, tier-agnostic —
-    # the relationship graph carries findings regardless of index tier).
-    _mirror_finding_to_ladybug(finding, investigation_id)
-    _autolink_finding_to_ladybug(finding)
-
-    # Conflict detection — fail-open; never blocks a successful store.
-    conflict_detected = False
-    conflicting_finding_id = None
-    conflict_id = None
-    try:
-        conflicts = _detect_conflicts(investigation_id, finding)
-        if conflicts:
-            first = conflicts[0]
-            conflict_id = _write_conflict(investigation_id, finding["id"], first["neighbor_id"])
-            conflict_detected = True
-            conflicting_finding_id = first["neighbor_id"]
-    except Exception as _cd_exc:
-        logger.debug("investigation_store: conflict detection failed (fail-open): %s", _cd_exc)
+    _store_commit(investigation_id, manifest, finding, finding_type, text, tier)
+    mnemo_stored = _store_index(investigation_id, finding, finding_type, text, source, confidence, tier)
+    conflict_detected, conflicting_finding_id, conflict_id = _store_conflicts(investigation_id, finding)
 
     # Update the in-process session hints ring buffer so memory_hints can
     # surface this finding immediately without re-scanning JSONL.
@@ -2177,8 +2236,7 @@ def investigation_store(
         "ts": finding["ts"],
         "created_at_ts": finding["created_at_ts"],
     })
-
-        # Background entity extraction — fail-open, never blocks the response
+    # Background entity extraction — fail-open, never blocks the response
     _update_entities_jsonl(investigation_id, finding["id"], text)
 
     result = {
@@ -2661,6 +2719,59 @@ def _reflection_store_finding(
 
 # ---- Tool: reflection_loop_tick ----
 
+def _reflection_item_finding(kind, path, summary, raw_errors, raw_warnings,
+                             error_observations, warning_observations, stats,
+                             investigation_id, low_signal_session_events) -> bool:
+    """Store one reflection finding for a processed queue item.
+
+    Returns True when a finding was written. Session events with no errors or
+    warnings are recorded as low-signal for the batched roll-up instead, and
+    return False -- this was a `continue` at the tail of the caller's loop, so
+    returning early is equivalent.
+
+    Mutates `stats` (suppression counters) and `low_signal_session_events` in
+    place, matching the original inline behaviour.
+    """
+    if kind == "session_event" and not raw_errors and not raw_warnings:
+        low_signal_session_events.append({
+            "path": path,
+            "lines_scanned": int(summary.get("lines_scanned") or 0),
+            "bytes_scanned": int(summary.get("bytes_scanned") or 0),
+            "events": summary.get("events") or {},
+            "tools": summary.get("tools") or {},
+        })
+        return False
+
+    visible_errors, suppressed_error_hits, suppressed_error_signatures = (
+        _reflection_filter_signatures(raw_errors, error_observations)
+    )
+    visible_warnings, suppressed_warning_hits, suppressed_warning_signatures = (
+        _reflection_filter_signatures(raw_warnings, warning_observations)
+    )
+    stats["error_signatures_suppressed"] += suppressed_error_hits
+    stats["warning_signatures_suppressed"] += suppressed_warning_hits
+    top_error = _reflection_signature_summary(
+        visible_errors, suppressed_error_signatures, suppressed_error_hits
+    )
+    top_warning = _reflection_signature_summary(
+        visible_warnings, suppressed_warning_signatures, suppressed_warning_hits
+    )
+    finding_text = (
+        f"reflection_loop_tick processed {kind} target={path}; "
+        f"lines={summary.get('lines_scanned', 0)} bytes={summary.get('bytes_scanned', 0)}; "
+        f"sampling={summary.get('sampling_mode', 'full')}; "
+        f"top_events={summary.get('events', {})}; top_tools={summary.get('tools', {})}; "
+        f"errors={top_error}; warnings={top_warning}."
+    )
+    return bool(_reflection_store_finding(
+        investigation_id=investigation_id,
+        finding_type="observed",
+        text=finding_text,
+        confidence="low",
+        tags="self-reflection,loop-tick,artifact-mining,unreceipted-observed",
+    ))
+
+
 @mcp.tool()
 def reflection_loop_tick(
     max_items: int = 3,
@@ -2745,45 +2856,11 @@ def reflection_loop_tick(
         batch_error_signatures.update(raw_errors)
         batch_warning_signatures.update(raw_warnings)
 
-        if store_item_findings:
-            if kind == "session_event" and not raw_errors and not raw_warnings:
-                low_signal_session_events.append({
-                    "path": path,
-                    "lines_scanned": int(summary.get("lines_scanned") or 0),
-                    "bytes_scanned": int(summary.get("bytes_scanned") or 0),
-                    "events": summary.get("events") or {},
-                    "tools": summary.get("tools") or {},
-                })
-                continue
-            visible_errors, suppressed_error_hits, suppressed_error_signatures = (
-                _reflection_filter_signatures(raw_errors, error_observations)
-            )
-            visible_warnings, suppressed_warning_hits, suppressed_warning_signatures = (
-                _reflection_filter_signatures(raw_warnings, warning_observations)
-            )
-            stats["error_signatures_suppressed"] += suppressed_error_hits
-            stats["warning_signatures_suppressed"] += suppressed_warning_hits
-            top_error = _reflection_signature_summary(
-                visible_errors, suppressed_error_signatures, suppressed_error_hits
-            )
-            top_warning = _reflection_signature_summary(
-                visible_warnings, suppressed_warning_signatures, suppressed_warning_hits
-            )
-            finding_text = (
-                f"reflection_loop_tick processed {kind} target={path}; "
-                f"lines={summary.get('lines_scanned', 0)} bytes={summary.get('bytes_scanned', 0)}; "
-                f"sampling={summary.get('sampling_mode', 'full')}; "
-                f"top_events={summary.get('events', {})}; top_tools={summary.get('tools', {})}; "
-                f"errors={top_error}; warnings={top_warning}."
-            )
-            if _reflection_store_finding(
-                investigation_id=investigation_id,
-                finding_type="observed",
-                text=finding_text,
-                confidence="low",
-                tags="self-reflection,loop-tick,artifact-mining,unreceipted-observed",
-            ):
-                findings_written += 1
+        if store_item_findings and _reflection_item_finding(
+            kind, path, summary, raw_errors, raw_warnings, error_observations,
+            warning_observations, stats, investigation_id, low_signal_session_events,
+        ):
+            findings_written += 1
 
     if store_item_findings and low_signal_session_events:
         event_counts: Counter[str] = Counter()
@@ -4130,6 +4207,62 @@ def _correlate_memories(
     }
 
 
+def _correlate_scan_target_file(target_file: str):
+    """Scan a target .py file for suspected entities and code-hallucination verdicts.
+
+    Returns (suspected_entities, code_findings, code_note). Every stage is
+    fail-open: a missing, non-Python, unreadable, or checker-failing file yields
+    an advisory note rather than an error, and correlation proceeds on whatever
+    entities were extracted.
+    """
+    tf = str(target_file).strip()
+    path = Path(tf)
+    if not path.exists() or not path.is_file():
+        return set(), None, f"target_file {tf!r} does not exist or is not a file — skipped"
+    if path.suffix != ".py":
+        return set(), None, f"target_file {tf!r} is not a .py file — skipped"
+
+    code_note = None
+    try:
+        content = path.read_text()
+    except Exception as exc:  # fail-open — unreadable file is advisory
+        logger.debug("could not read target_file %s: %r", tf, exc)
+        return set(), None, f"target_file {tf!r} could not be read — skipped"
+
+    suspected = _suspected_entities_from_text(content)
+
+    # tree-sitter: ingest the file's AST into the code graph (fail-open) so its
+    # symbols/calls are queryable via code_graph_query and linkable to the memory
+    # graph. Targeted symbol suspicion still comes from the code checker's flagged
+    # identifiers below, not every symbol.
+    try:
+        from graph.code_parse import parse_source, detect_lang
+        lang = detect_lang(tf)
+        ks = _get_ladybug()
+        if lang and ks:
+            ks.ingest_code([parse_source(tf, content.encode("utf-8", "replace"), lang)])
+    except Exception as exc:
+        logger.debug("AST ingest for %s failed (fail-open): %r", tf, exc)
+
+    try:
+        verdicts = run_code_checks(path)
+    except Exception as exc:  # fail-open — checker errors are advisory
+        logger.debug("run_code_checks failed for %s, degrading: %r", tf, exc)
+        verdicts = []
+
+    lh_verdicts = [
+        v for v in verdicts
+        if str(getattr(v, "verdict_type", "")) in _CODE_HALLUCINATION_CODES
+    ]
+    suspected |= _verdict_symbols(lh_verdicts)
+    if not lh_verdicts:
+        code_note = (
+            f"no code-hallucination issues found in {path.name} — "
+            "correlating on its extracted entities only (advisory)"
+        )
+    return suspected, _code_findings_from_verdicts(lh_verdicts), code_note
+
+
 @mcp.tool()
 def code_memory_correlate(
     investigation_id: str,
@@ -4195,50 +4328,9 @@ def code_memory_correlate(
 
     # --- Resolve suspected entities from the target file (+ confirm LH issues). ---
     if str(target_file or "").strip():
-        tf = str(target_file).strip()
-        source["target_file"] = tf
-        p = Path(tf)
-        if not p.exists() or not p.is_file():
-            code_note = f"target_file {tf!r} does not exist or is not a file — skipped"
-        elif p.suffix != ".py":
-            code_note = f"target_file {tf!r} is not a .py file — skipped"
-        else:
-            try:
-                content = p.read_text()
-            except Exception as exc:  # fail-open — unreadable file is advisory note
-                logger.debug("could not read target_file %s: %r", tf, exc)
-                content = ""
-                code_note = f"target_file {tf!r} could not be read — skipped"
-            if content or code_note is None:
-                suspected |= _suspected_entities_from_text(content)
-                # tree-sitter: ingest the file's AST into the code graph (fail-open) so
-                # its symbols/calls are queryable via code_graph_query and linkable to
-                # the memory graph. Targeted symbol suspicion still comes from the code
-                # checker's flagged identifiers (_verdict_symbols) below, not every symbol.
-                try:
-                    from graph.code_parse import parse_source, detect_lang
-                    _lang = detect_lang(tf)
-                    _ks = _get_ladybug()
-                    if _lang and _ks:
-                        _ks.ingest_code([parse_source(tf, content.encode("utf-8", "replace"), _lang)])
-                except Exception as exc:
-                    logger.debug("AST ingest for %s failed (fail-open): %r", tf, exc)
-                try:
-                    verdicts = run_code_checks(p)
-                except Exception as exc:  # fail-open — checker errors are advisory
-                    logger.debug("run_code_checks failed for %s, degrading: %r", tf, exc)
-                    verdicts = []
-                lh_verdicts = [
-                    v for v in verdicts
-                    if str(getattr(v, "verdict_type", "")) in _CODE_HALLUCINATION_CODES
-                ]
-                suspected |= _verdict_symbols(lh_verdicts)
-                code_findings = _code_findings_from_verdicts(lh_verdicts)
-                if not lh_verdicts:
-                    code_note = (
-                        f"no code-hallucination issues found in {p.name} — "
-                        "correlating on its extracted entities only (advisory)"
-                    )
+        source["target_file"] = str(target_file).strip()
+        _tf_suspected, code_findings, code_note = _correlate_scan_target_file(target_file)
+        suspected |= _tf_suspected
 
     suspected = {s for s in suspected if s}
     if not suspected:
@@ -5740,6 +5832,127 @@ def loci_health() -> str:
     return json.dumps(out, indent=2)
 
 
+# --------------------------------------------------------------------------- #
+# rag_context_search internals
+#
+# Each stage is independently fail-open, matching the tool's contract: a dead
+# expander, collection, decay pass or access-log write never aborts the search.
+# --------------------------------------------------------------------------- #
+def _rag_expand_queries(query: str) -> tuple[list[str], dict]:
+    """Widen the recall pool with HyDE-lite expansion.
+
+    Returns (search_queries, expansion_info). The original query always leads, so
+    a degraded expander costs nothing. The cross-encoder re-pass ranks against the
+    ORIGINAL query, so expansion widens recall without diluting precision.
+    """
+    try:
+        import query_expand as _qe
+        exp = _qe.expand(query, n_queries=3, n_keywords=6)
+        sq = list(exp.get("queries") or [query])
+        kw = exp.get("keywords") or []
+        if kw:
+            sq.append(" ".join(kw))
+        seen: set = set()
+        queries = [q for q in sq if q and not (q in seen or seen.add(q))] or [query]
+        return queries, {"enabled": True, "degraded": bool(exp.get("degraded")),
+                         "n_queries": len(queries), "keywords": kw}
+    except Exception as exc:
+        logger.debug("rag_context_search: query expansion failed (fail-open): %s", exc)
+        return [query], {"enabled": True, "degraded": True, "error": str(exc)}
+
+
+def _rag_search_collections(collections, search_queries, limit, agent_filter, errors) -> list[dict]:
+    """Union hits across (collection x expanded query), deduped by (origin, id).
+
+    Keeps the best bi-encoder score per key. A failing collection is recorded in
+    `errors` and skipped rather than aborting the search.
+    """
+    best: dict = {}
+    for col in collections:
+        qf = agent_filter if col == "agent_core_chunks" else None
+        for sq in search_queries:
+            try:
+                hits = _qdrant_search_collection(sq, collection_name=col, limit=limit, query_filter=qf)
+            except Exception as exc:
+                errors.append(f"{col}: {exc}")
+                logger.warning("rag_context_search: collection %s failed: %s", col, exc)
+                continue
+            for h in hits:
+                key = (h.get("origin"), h.get("id"))
+                prev = best.get(key)
+                if prev is None or float(h.get("score") or 0.0) > float(prev.get("score") or 0.0):
+                    best[key] = h
+    return list(best.values())
+
+
+def _rag_apply_decay(results: list[dict]) -> None:
+    """Rescore findings in place with Ebbinghaus exponential time decay.
+
+    Only touches rows from the main findings collection; rows without a usable
+    timestamp keep their raw score.
+    """
+    try:
+        now_ts = time.time()
+        for r in results:
+            if r.get("origin") != QDRANT_COLLECTION_PREFIX:
+                continue
+            ts_val = r.get("created_at_ts") or r.get("ts")
+            if ts_val is None:
+                continue
+            # ts may be an ISO string; created_at_ts is always an int epoch
+            try:
+                age_days = max(0.0, (now_ts - float(ts_val)) / 86400.0)
+                raw_score = float(r.get("score") or 0.0)
+                r["score"] = round(raw_score * math.exp(-_MEMORY_DECAY_LAMBDA * age_days), 4)
+                r["decay_applied"] = True
+            except Exception as exc:
+                logger.debug("rag_context_search: recency decay scoring failed (fail-open): %r", exc)
+    except Exception as exc:
+        logger.debug("rag_context_search: decay rescoring failed: %s", exc)
+
+
+def _rag_cross_encode(results: list[dict], query: str) -> None:
+    """Re-rank the top 20 in place against the ORIGINAL query, for consistent
+    cross-collection ordering. No-op when the cross-encoder is unavailable."""
+    ce = _get_cross_encoder()
+    if ce is None or len(results) <= 1:
+        return
+    try:
+        pairs = [(query, str(r.get('text', r.get('content', '')))[:512]) for r in results[:20]]
+        for r, sc in zip(results[:20], ce.predict(pairs)):
+            r['final_ce_score'] = round(float(sc), 4)
+        results[:20] = sorted(results[:20], key=lambda r: r.get('final_ce_score', -999), reverse=True)
+    except Exception as exc:
+        logger.debug('Final CE re-pass failed: %s', exc)
+
+
+def _rag_record_access(results: list[dict], query: str) -> None:
+    """Append a last_accessed marker to each returned finding's JSONL.
+
+    Best-effort per row: this must never block the response.
+    """
+    access_ts = int(time.time())
+    for r in results:
+        try:
+            if r.get("origin") != QDRANT_COLLECTION_PREFIX:
+                continue
+            finding_id, inv_id = r.get("id"), r.get("investigation_id")
+            if not finding_id or not inv_id:
+                continue
+            findings_path = _inv_dir(inv_id) / "findings.jsonl"
+            if not findings_path.exists():
+                continue
+            _append_jsonl(findings_path, {
+                "id": finding_id,
+                "investigation_id": inv_id,
+                "record_type": "access",
+                "last_accessed": access_ts,
+                "query": query[:200],
+            })
+        except Exception as exc:
+            logger.debug("rag access-log write-back failed for %s: %r", r.get("id"), exc)
+
+
 @mcp.tool()
 def rag_context_search(
     query: str,
@@ -5810,23 +6023,7 @@ def rag_context_search(
         _do_expand = os.environ.get("LOCI_RAG_EXPAND", "1").strip().lower() not in ("0", "false", "no", "off", "")
     search_queries = [query]
     if _do_expand:
-        try:
-            import query_expand as _qe
-            _exp = _qe.expand(query, n_queries=3, n_keywords=6)
-            # `queries` already leads with the original; append keywords as one extra recall probe.
-            _sq = list(_exp.get("queries") or [query])
-            _kw = _exp.get("keywords") or []
-            if _kw:
-                _sq.append(" ".join(_kw))
-            # De-dup search strings, preserving order (original stays first).
-            _seen_q: set = set()
-            search_queries = [q for q in _sq if q and not (q in _seen_q or _seen_q.add(q))] or [query]
-            expansion_info = {"enabled": True, "degraded": bool(_exp.get("degraded")),
-                              "n_queries": len(search_queries), "keywords": _kw}
-        except Exception as _exp_exc:
-            logger.debug("rag_context_search: query expansion failed (fail-open): %s", _exp_exc)
-            search_queries = [query]
-            expansion_info = {"enabled": True, "degraded": True, "error": str(_exp_exc)}
+        search_queries, expansion_info = _rag_expand_queries(query)
 
     # Build the GPS-exclusion filter for agent_core_chunks (only).
     _agent_filter = None
@@ -5837,87 +6034,22 @@ def rag_context_search(
     # Retrieve per (collection x expanded query), unioning hits deduped by (origin, id) keeping
     # the best bi-encoder score. The cross-encoder re-pass below re-ranks against the ORIGINAL
     # query, so expansion only widens the candidate pool (recall) without diluting precision.
-    _best: dict = {}
-    for col in _collections:
-        qf = _agent_filter if col == "agent_core_chunks" else None
-        for _sq in search_queries:
-            try:
-                hits = _qdrant_search_collection(_sq, collection_name=col, limit=limit, query_filter=qf)
-            except Exception as exc:
-                errors.append(f"{col}: {exc}")
-                logger.warning("rag_context_search: collection %s failed: %s", col, exc)
-                continue
-            for h in hits:
-                key = (h.get("origin"), h.get("id"))
-                prev = _best.get(key)
-                if prev is None or float(h.get("score") or 0.0) > float(prev.get("score") or 0.0):
-                    _best[key] = h
-    all_results.extend(_best.values())
+    all_results.extend(_rag_search_collections(_collections, search_queries, limit, _agent_filter, errors))
 
     # Apply Ebbinghaus exponential time-decay rescoring to findings from the main
     # investigation collection only (agent_core_chunks is static knowledge, not time-sensitive).
     if decay:
-        try:
-            _now_ts = time.time()
-            for r in all_results:
-                if r.get("origin") != QDRANT_COLLECTION_PREFIX:
-                    continue
-                ts_val = r.get("created_at_ts") or r.get("ts")
-                if ts_val is None:
-                    continue
-                # ts field may be an ISO string; created_at_ts is always an int epoch
-                try:
-                    age_days = (_now_ts - float(ts_val)) / 86400.0
-                    if age_days < 0:
-                        age_days = 0.0
-                    raw_score = float(r.get("score") or 0.0)
-                    r["score"] = round(raw_score * math.exp(-_MEMORY_DECAY_LAMBDA * age_days), 4)
-                    r["decay_applied"] = True
-                except Exception as exc:
-                    logger.debug("rag_context_search: recency decay scoring failed (fail-open): %r", exc)
-                    pass
-        except Exception as _decay_exc:
-            logger.debug("rag_context_search: decay rescoring failed: %s", _decay_exc)
+        _rag_apply_decay(all_results)
 
     # Merge-sort by score descending across all collections
     all_results.sort(key=lambda r: float(r.get("score") or 0.0), reverse=True)
 
     # Final cross-encoder re-pass for consistent cross-collection ranking
-    ce = _get_cross_encoder()
-    if ce is not None and len(all_results) > 1:
-        try:
-            pairs = [(query, str(r.get('text', r.get('content', '')))[:512]) for r in all_results[:20]]
-            ce_scores = ce.predict(pairs)
-            for r, s in zip(all_results[:20], ce_scores):
-                r['final_ce_score'] = round(float(s), 4)
-            all_results[:20] = sorted(all_results[:20], key=lambda r: r.get('final_ce_score', -999), reverse=True)
-        except Exception as _ce_exc:
-            logger.debug('Final CE re-pass failed: %s', _ce_exc)
+    _rag_cross_encode(all_results, query)
 
     # Best-effort access tracking: append last_accessed timestamp to each returned finding's JSONL.
     # Failures are silently ignored — this must never block the response.
-    _access_ts = int(time.time())
-    for r in all_results:
-        try:
-            if r.get("origin") != QDRANT_COLLECTION_PREFIX:
-                continue
-            finding_id = r.get("id")
-            inv_id = r.get("investigation_id")
-            if not finding_id or not inv_id:
-                continue
-            _findings_path = _inv_dir(inv_id) / "findings.jsonl"
-            if not _findings_path.exists():
-                continue
-            _access_entry = {
-                "id": finding_id,
-                "investigation_id": inv_id,
-                "record_type": "access",
-                "last_accessed": _access_ts,
-                "query": query[:200],
-            }
-            _append_jsonl(_findings_path, _access_entry)
-        except Exception as exc:
-            logger.debug("rag access-log write-back failed for %s: %r", r.get("id"), exc)
+    _rag_record_access(all_results, query)
 
     ctx = context_assemble(all_results, query, budget_chars=budget_chars)
     ctx["mode"] = "rag_hybrid"

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -56,6 +56,7 @@ import threading
 import time
 import uuid
 from collections import Counter
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -214,6 +215,15 @@ from inv_store import (  # noqa: E402,F401
 
 _investigation_locks: dict[str, threading.Lock] = {}  # per-investigation lock for atomic JSONL appends
 _investigation_locks_lock = threading.Lock()          # guards _investigation_locks dict itself
+
+
+def _investigation_lock(investigation_id: str) -> threading.Lock:
+    """Return the per-investigation lock, creating it under the dict-guard lock if absent.
+
+    Returns the lock UNACQUIRED — callers are responsible for `with` on the result.
+    """
+    with _investigation_locks_lock:
+        return _investigation_locks.setdefault(investigation_id, threading.Lock())
 
 # ---------------------------------------------------------------------------
 # LadybugDB graph store (primary relationship/graph backend) — fail-open like Qdrant.
@@ -1107,6 +1117,134 @@ def _ensure_investigation_exists(investigation_id: str, *, title: str, context: 
     _save_manifest(manifest)
 
 
+@dataclass
+class _ReflectionScan:
+    event_counts: Counter = field(default_factory=Counter)
+    tool_counts: Counter = field(default_factory=Counter)
+    error_counts: Counter = field(default_factory=Counter)
+    warning_counts: Counter = field(default_factory=Counter)
+    lines_scanned: int = 0
+    bytes_scanned: int = 0
+    sampling_mode: str = "full"
+
+    def scan_line(self, line: str) -> None:
+        canon = _canonicalize_reflection_signature(line)
+        if _REFLECTION_ERROR_RE.search(line):
+            self.error_counts[canon] += 1
+        elif _REFLECTION_WARN_RE.search(line):
+            self.warning_counts[canon] += 1
+
+
+def _scan_temp_ingest(file_path: Path, scan: "_ReflectionScan") -> None:
+    content = file_path.read_text(encoding="utf-8", errors="ignore")
+    scan.bytes_scanned += len(content.encode("utf-8", errors="ignore"))
+    scan.lines_scanned = 1
+    try:
+        payload = json.loads(content)
+        if isinstance(payload, dict):
+            for key in list(payload.keys())[:30]:
+                scan.event_counts[f"payload_key:{key}"] += 1
+        scan.scan_line(json.dumps(payload)[:20000])
+    except Exception:
+        scan.scan_line(content[:20000])
+
+
+def _scan_session_event(file_path: Path, scan: "_ReflectionScan", max_lines: int) -> None:
+    with file_path.open("r", encoding="utf-8", errors="ignore") as fh:
+        for raw in fh:
+            if scan.lines_scanned >= max_lines:
+                break
+            scan.lines_scanned += 1
+            scan.bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except Exception:
+                scan.scan_line(line)
+                continue
+            event_type = str(event.get("type") or event.get("event") or "unknown")
+            scan.event_counts[event_type] += 1
+            tool_name = event.get("tool_start_name") or event.get("tool_complete_name") or event.get("tool_name")
+            if tool_name:
+                scan.tool_counts[str(tool_name)] += 1
+            joined = " ".join([
+                str(event.get("user_content") or ""),
+                str(event.get("assistant_content") or ""),
+                str(event.get("tool_complete_result_content") or ""),
+            ])
+            scan.scan_line(joined)
+
+
+def _scan_claude_code_event(file_path: Path, scan: "_ReflectionScan", max_lines: int) -> None:
+    with file_path.open("r", encoding="utf-8", errors="ignore") as fh:
+        for raw in fh:
+            if scan.lines_scanned >= max_lines:
+                break
+            scan.lines_scanned += 1
+            scan.bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except Exception:
+                scan.scan_line(line)
+                continue
+            # Claude Code event schema: {"type": "...", "message": {...}, "attachments": [...]}
+            event_type = str(event.get("type") or "unknown")
+            scan.event_counts[event_type] += 1
+            # Tool names appear in attachments list as {"toolName": "..."} entries
+            for attachment in (event.get("attachments") or []):
+                if isinstance(attachment, dict):
+                    tool_name = attachment.get("toolName") or attachment.get("tool_name")
+                    if tool_name:
+                        scan.tool_counts[str(tool_name)] += 1
+            # Message content is nested under "message" with role/content structure
+            message = event.get("message") or {}
+            if isinstance(message, dict):
+                content = message.get("content") or ""
+                if isinstance(content, list):
+                    # content may be a list of blocks: [{"type": "text", "text": "..."}]
+                    content = " ".join(
+                        str(block.get("text") or "") for block in content
+                        if isinstance(block, dict)
+                    )
+                joined = str(content)
+            else:
+                joined = str(message)
+            scan.scan_line(joined)
+
+
+def _scan_process_log(file_path: Path, scan: "_ReflectionScan", max_lines: int) -> None:
+    file_bytes = int(file_path.stat().st_size)
+    if file_bytes > REFLECTION_LOG_TAIL_MIN_FILE_BYTES:
+        scan.sampling_mode = "tail"
+        for raw in _read_tail_lines(
+            file_path,
+            max_lines=max_lines,
+            max_bytes=REFLECTION_LOG_TAIL_READ_BYTES,
+        ):
+            scan.lines_scanned += 1
+            scan.bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
+            scan.scan_line(raw)
+            m = re.search(r"\btool(?:Name)?[=:\"]+([a-zA-Z0-9_.:-]+)", raw)
+            if m:
+                scan.tool_counts[m.group(1)] += 1
+    else:
+        with file_path.open("r", encoding="utf-8", errors="ignore") as fh:
+            for raw in fh:
+                if scan.lines_scanned >= max_lines:
+                    break
+                scan.lines_scanned += 1
+                scan.bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
+                scan.scan_line(raw)
+                m = re.search(r"\btool(?:Name)?[=:\"]+([a-zA-Z0-9_.:-]+)", raw)
+                if m:
+                    scan.tool_counts[m.group(1)] += 1
+
+
 def _process_reflection_item(kind: str, path: str, max_lines: int) -> dict:
     file_path = Path(path)
     if not file_path.exists():
@@ -1122,123 +1260,16 @@ def _process_reflection_item(kind: str, path: str, max_lines: int) -> dict:
             "warnings": {},
         }
 
-    event_counts: Counter[str] = Counter()
-    tool_counts: Counter[str] = Counter()
-    error_counts: Counter[str] = Counter()
-    warning_counts: Counter[str] = Counter()
-    lines_scanned = 0
-    bytes_scanned = 0
-    sampling_mode = "full"
-
-    def _scan_line(line: str) -> None:
-        canon = _canonicalize_reflection_signature(line)
-        if _REFLECTION_ERROR_RE.search(line):
-            error_counts[canon] += 1
-        elif _REFLECTION_WARN_RE.search(line):
-            warning_counts[canon] += 1
+    scan = _ReflectionScan()
 
     if kind == "temp_ingest":
-        content = file_path.read_text(encoding="utf-8", errors="ignore")
-        bytes_scanned += len(content.encode("utf-8", errors="ignore"))
-        lines_scanned = 1
-        try:
-            payload = json.loads(content)
-            if isinstance(payload, dict):
-                for key in list(payload.keys())[:30]:
-                    event_counts[f"payload_key:{key}"] += 1
-            _scan_line(json.dumps(payload)[:20000])
-        except Exception:
-            _scan_line(content[:20000])
+        _scan_temp_ingest(file_path, scan)
     elif kind == "session_event":
-        with file_path.open("r", encoding="utf-8", errors="ignore") as fh:
-            for raw in fh:
-                if lines_scanned >= max_lines:
-                    break
-                lines_scanned += 1
-                bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
-                line = raw.strip()
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except Exception:
-                    _scan_line(line)
-                    continue
-                event_type = str(event.get("type") or event.get("event") or "unknown")
-                event_counts[event_type] += 1
-                tool_name = event.get("tool_start_name") or event.get("tool_complete_name") or event.get("tool_name")
-                if tool_name:
-                    tool_counts[str(tool_name)] += 1
-                joined = " ".join([
-                    str(event.get("user_content") or ""),
-                    str(event.get("assistant_content") or ""),
-                    str(event.get("tool_complete_result_content") or ""),
-                ])
-                _scan_line(joined)
+        _scan_session_event(file_path, scan, max_lines)
     elif kind == "claude_code_event":
-        with file_path.open("r", encoding="utf-8", errors="ignore") as fh:
-            for raw in fh:
-                if lines_scanned >= max_lines:
-                    break
-                lines_scanned += 1
-                bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
-                line = raw.strip()
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except Exception:
-                    _scan_line(line)
-                    continue
-                # Claude Code event schema: {"type": "...", "message": {...}, "attachments": [...]}
-                event_type = str(event.get("type") or "unknown")
-                event_counts[event_type] += 1
-                # Tool names appear in attachments list as {"toolName": "..."} entries
-                for attachment in (event.get("attachments") or []):
-                    if isinstance(attachment, dict):
-                        tool_name = attachment.get("toolName") or attachment.get("tool_name")
-                        if tool_name:
-                            tool_counts[str(tool_name)] += 1
-                # Message content is nested under "message" with role/content structure
-                message = event.get("message") or {}
-                if isinstance(message, dict):
-                    content = message.get("content") or ""
-                    if isinstance(content, list):
-                        # content may be a list of blocks: [{"type": "text", "text": "..."}]
-                        content = " ".join(
-                            str(block.get("text") or "") for block in content
-                            if isinstance(block, dict)
-                        )
-                    joined = str(content)
-                else:
-                    joined = str(message)
-                _scan_line(joined)
+        _scan_claude_code_event(file_path, scan, max_lines)
     elif kind == "process_log":
-        file_bytes = int(file_path.stat().st_size)
-        if file_bytes > REFLECTION_LOG_TAIL_MIN_FILE_BYTES:
-            sampling_mode = "tail"
-            for raw in _read_tail_lines(
-                file_path,
-                max_lines=max_lines,
-                max_bytes=REFLECTION_LOG_TAIL_READ_BYTES,
-            ):
-                lines_scanned += 1
-                bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
-                _scan_line(raw)
-                m = re.search(r"\btool(?:Name)?[=:\"]+([a-zA-Z0-9_.:-]+)", raw)
-                if m:
-                    tool_counts[m.group(1)] += 1
-        else:
-            with file_path.open("r", encoding="utf-8", errors="ignore") as fh:
-                for raw in fh:
-                    if lines_scanned >= max_lines:
-                        break
-                    lines_scanned += 1
-                    bytes_scanned += len(raw.encode("utf-8", errors="ignore"))
-                    _scan_line(raw)
-                    m = re.search(r"\btool(?:Name)?[=:\"]+([a-zA-Z0-9_.:-]+)", raw)
-                    if m:
-                        tool_counts[m.group(1)] += 1
+        _scan_process_log(file_path, scan, max_lines)
     else:
         return {
             "status": "unsupported_kind",
@@ -1256,13 +1287,13 @@ def _process_reflection_item(kind: str, path: str, max_lines: int) -> dict:
         "status": "processed",
         "kind": kind,
         "path": path,
-        "lines_scanned": lines_scanned,
-        "bytes_scanned": bytes_scanned,
-        "sampling_mode": sampling_mode,
-        "events": dict(event_counts.most_common(8)),
-        "tools": dict(tool_counts.most_common(8)),
-        "errors": dict(error_counts.most_common(8)),
-        "warnings": dict(warning_counts.most_common(8)),
+        "lines_scanned": scan.lines_scanned,
+        "bytes_scanned": scan.bytes_scanned,
+        "sampling_mode": scan.sampling_mode,
+        "events": dict(scan.event_counts.most_common(8)),
+        "tools": dict(scan.tool_counts.most_common(8)),
+        "errors": dict(scan.error_counts.most_common(8)),
+        "warnings": dict(scan.warning_counts.most_common(8)),
     }
 
 
@@ -2772,6 +2803,88 @@ def _reflection_item_finding(kind, path, summary, raw_errors, raw_warnings,
     ))
 
 
+def _reflection_batch_low_signal(investigation_id: str, low_signal_session_events: list[dict]) -> int:
+    """Store the batched low-signal session_event roll-up finding.
+
+    Returns the number to add to ``findings_written`` (0 or 1). Caller must
+    only invoke this when ``store_item_findings and low_signal_session_events``.
+    """
+    event_counts: Counter[str] = Counter()
+    tool_counts: Counter[str] = Counter()
+    for entry in low_signal_session_events:
+        event_counts.update(entry.get("events") or {})
+        tool_counts.update(entry.get("tools") or {})
+    sample_paths = [e["path"] for e in low_signal_session_events[:3]]
+    low_signal_text = (
+        f"reflection_loop_tick batched low-signal session_event files count={len(low_signal_session_events)}; "
+        f"total_lines={sum(e['lines_scanned'] for e in low_signal_session_events)} "
+        f"total_bytes={sum(e['bytes_scanned'] for e in low_signal_session_events)}; "
+        f"top_events={dict(event_counts.most_common(8))}; top_tools={dict(tool_counts.most_common(8))}; "
+        f"sample_paths={sample_paths}."
+    )
+    if _reflection_store_finding(
+        investigation_id=investigation_id,
+        finding_type="observed",
+        text=low_signal_text,
+        confidence="low",
+        tags="self-reflection,loop-tick,artifact-mining,unreceipted-observed,batched-low-signal",
+    ):
+        return 1
+    return 0
+
+
+def _reflection_batch_error_signature(investigation_id: str, batch_error_signatures: Counter) -> int:
+    """Store the batch dominant-error-signature inference finding.
+
+    Returns the number to add to ``findings_written`` (0 or 1). Caller must
+    only invoke this when ``store_item_findings and batch_error_signatures``.
+    """
+    sig, count = batch_error_signatures.most_common(1)[0]
+    infer_text = (
+        "Batch dominant error signature suggests reliability hotspot: "
+        f"{sig} (count={count}) in latest processed artifacts."
+    )
+    if _reflection_store_finding(
+        investigation_id=investigation_id,
+        finding_type="inferred",
+        text=infer_text,
+        confidence="medium",
+        tags="self-reflection,error-cluster,inference",
+    ):
+        return 1
+    return 0
+
+
+def _reflection_requeue_dropped(
+    queue: list, dropped_items: list[dict], investigation_id: str, store_item_findings: bool
+) -> int:
+    """Re-queue dropped items and record a gap finding for each, in place.
+
+    Mutates ``queue`` via ``.append`` -- never rebinds it, since the caller
+    persists the same list object via ``state["queue"] = queue``. Returns the
+    number to add to ``findings_written``.
+    """
+    added = 0
+    for dropped in dropped_items:
+        queue.append(dropped)
+        if store_item_findings:
+            d_kind = str(dropped.get("kind") or "")
+            d_path = str(dropped.get("path") or "")
+            gap_text = (
+                f"reflection_loop_tick could not process item kind={d_kind} path={d_path}; "
+                "item re-queued for future processing."
+            )
+            if _reflection_store_finding(
+                investigation_id=investigation_id,
+                finding_type="gap",
+                text=gap_text,
+                confidence="low",
+                tags="self-reflection,loop-tick,dropped-item,re-queued",
+            ):
+                added += 1
+    return added
+
+
 @mcp.tool()
 def reflection_loop_tick(
     max_items: int = 3,
@@ -2863,42 +2976,10 @@ def reflection_loop_tick(
             findings_written += 1
 
     if store_item_findings and low_signal_session_events:
-        event_counts: Counter[str] = Counter()
-        tool_counts: Counter[str] = Counter()
-        for entry in low_signal_session_events:
-            event_counts.update(entry.get("events") or {})
-            tool_counts.update(entry.get("tools") or {})
-        sample_paths = [e["path"] for e in low_signal_session_events[:3]]
-        low_signal_text = (
-            f"reflection_loop_tick batched low-signal session_event files count={len(low_signal_session_events)}; "
-            f"total_lines={sum(e['lines_scanned'] for e in low_signal_session_events)} "
-            f"total_bytes={sum(e['bytes_scanned'] for e in low_signal_session_events)}; "
-            f"top_events={dict(event_counts.most_common(8))}; top_tools={dict(tool_counts.most_common(8))}; "
-            f"sample_paths={sample_paths}."
-        )
-        if _reflection_store_finding(
-            investigation_id=investigation_id,
-            finding_type="observed",
-            text=low_signal_text,
-            confidence="low",
-            tags="self-reflection,loop-tick,artifact-mining,unreceipted-observed,batched-low-signal",
-        ):
-            findings_written += 1
+        findings_written += _reflection_batch_low_signal(investigation_id, low_signal_session_events)
 
     if store_item_findings and batch_error_signatures:
-        sig, count = batch_error_signatures.most_common(1)[0]
-        infer_text = (
-            "Batch dominant error signature suggests reliability hotspot: "
-            f"{sig} (count={count}) in latest processed artifacts."
-        )
-        if _reflection_store_finding(
-            investigation_id=investigation_id,
-            finding_type="inferred",
-            text=infer_text,
-            confidence="medium",
-            tags="self-reflection,error-cluster,inference",
-        ):
-            findings_written += 1
+        findings_written += _reflection_batch_error_signature(investigation_id, batch_error_signatures)
 
     stats["last_error_signatures"] = [
         {"signature": sig, "count": count}
@@ -2911,23 +2992,9 @@ def reflection_loop_tick(
     stats["error_signature_observations"] = _prune_signature_observations(error_observations)
     stats["warning_signature_observations"] = _prune_signature_observations(warning_observations)
 
-    for dropped in dropped_items:
-        queue.append(dropped)
-        if store_item_findings:
-            d_kind = str(dropped.get("kind") or "")
-            d_path = str(dropped.get("path") or "")
-            gap_text = (
-                f"reflection_loop_tick could not process item kind={d_kind} path={d_path}; "
-                "item re-queued for future processing."
-            )
-            if _reflection_store_finding(
-                investigation_id=investigation_id,
-                finding_type="gap",
-                text=gap_text,
-                confidence="low",
-                tags="self-reflection,loop-tick,dropped-item,re-queued",
-            ):
-                findings_written += 1
+    findings_written += _reflection_requeue_dropped(
+        queue, dropped_items, investigation_id, store_item_findings
+    )
 
     state["stats"] = stats
     state["processed"] = processed
@@ -3049,6 +3116,98 @@ def _search_row_is_retracted(
     return False
 
 
+def _search_normalize_filters(min_confidence: str, resolution: Optional[str]) -> tuple[str, Optional[str]]:
+    """Fail-open normalisation of investigation_search's resolution and
+    min_confidence filters. An unknown value logs a warning and falls back
+    (resolution -> None, min_confidence -> "low") rather than raising.
+    """
+    # Normalise resolution filter (fail-open: an unknown value disables the filter).
+    resolution = str(resolution).lower() if resolution else None
+    if resolution is not None and resolution not in _RESOLUTION_STATES:
+        logger.warning(
+            "investigation_search: unknown resolution %r — ignoring filter; valid "
+            "values: %s", resolution, ", ".join(sorted(_RESOLUTION_STATES))
+        )
+        resolution = None
+
+    # Normalise confidence floor so callers passing "High" or "MEDIUM" are not
+    # silently ignored by the lowercase dict lookup downstream.
+    min_confidence = str(min_confidence or "low").lower()
+    if min_confidence not in _CONFIDENCE_RANK:
+        logger.warning(
+            "investigation_search: unknown min_confidence %r — ignoring filter; "
+            "valid values: low, medium, high", min_confidence
+        )
+        min_confidence = "low"
+
+    return min_confidence, resolution
+
+
+def _search_apply_confidence_floor(rows: list[dict], min_confidence: str) -> list[dict]:
+    """Apply the confidence floor post-hoc so mnemosyne rows — which carry no
+    "confidence" field — don't silently undermine the caller's filter when
+    mnemosyne satisfies the result limit before Qdrant is queried.
+    """
+    if min_confidence and min_confidence in _CONFIDENCE_RANK and min_confidence != "low":
+        floor = _CONFIDENCE_RANK[min_confidence]
+        return [
+            r for r in rows
+            # Normalise stored confidence to lowercase — mnemosyne-sourced rows may
+            # carry mixed-case values; without .lower() "High" maps to rank 0.
+            if _CONFIDENCE_RANK.get(str(r.get("confidence", "low")).lower(), 0) >= floor
+        ]
+    return rows
+
+
+def _search_annotate_rows(rows: list[dict]) -> None:
+    """Surface each row's resolution and staleness in place.
+
+    Rows sourced from mnemosyne carry no resolution, so we build an authoritative
+    finding_id -> resolution map from JSONL — scoped to only the investigations
+    that actually produced rows, so cost is bounded regardless of how many
+    investigations exist. Absent record -> "open". Fail-open (a failed map build
+    just falls back to the per-row payload value, defaulting to "open").
+    """
+    _resolution_map, _coderefs_map = _search_resolution_maps(rows)
+
+    for r in rows:
+        r["resolution"] = _search_row_resolution(r, _resolution_map)
+        # Staleness: rows from mnemo/qdrant don't carry code_refs, so consult the
+        # JSONL-derived map. Only set ``stale`` when the finding has usable refs.
+        _rfid = str(r.get("finding_id") or r.get("id") or "")
+        _refs = _coderefs_map.get(_rfid)
+        if _refs:
+            _st = _finding_is_stale({"code_refs": _refs})
+            if _st is not None:
+                r["stale"] = _st
+
+
+def _search_empty_response(qdrant: dict, mnemo_enabled: bool) -> str:
+    """Build the JSON payload for an empty investigation_search result set."""
+    qdrant_avail = bool(os.environ.get("QDRANT_URL", ""))
+    # Only use rag_required mode when Qdrant itself is unavailable.
+    # Empty results with Qdrant available is a normal no-match response.
+    if not qdrant_avail or (qdrant.get("reason") == "qdrant_unavailable"):
+        return json.dumps({
+            "mode": "rag_required",
+            "reason": "qdrant_unavailable",
+            "results": [],
+            "qdrant_enabled": qdrant_avail,
+            "error": "RAG_REQUIRED: Qdrant unavailable. Check QDRANT_URL and QDRANT_API_KEY.",
+        }, indent=2)
+    return json.dumps({
+        "mode": "no_matches",
+        "reason": str(qdrant.get("reason") or "no_matches"),
+        "results": [],
+        "qdrant_enabled": qdrant_avail,
+        "mnemo_status": {
+            "enabled": mnemo_enabled,
+            "bank": _mnemo_bank() if mnemo_enabled else None,
+            "match_count": 0,
+        },
+    }, indent=2)
+
+
 @mcp.tool()
 def investigation_search(
     query: str,
@@ -3081,24 +3240,7 @@ def investigation_search(
     Returns:
         JSON list of matching findings with investigation context.
     """
-    # Normalise resolution filter (fail-open: an unknown value disables the filter).
-    resolution = str(resolution).lower() if resolution else None
-    if resolution is not None and resolution not in _RESOLUTION_STATES:
-        logger.warning(
-            "investigation_search: unknown resolution %r — ignoring filter; valid "
-            "values: %s", resolution, ", ".join(sorted(_RESOLUTION_STATES))
-        )
-        resolution = None
-
-    # Normalise confidence floor so callers passing "High" or "MEDIUM" are not
-    # silently ignored by the lowercase dict lookup downstream.
-    min_confidence = str(min_confidence or "low").lower()
-    if min_confidence not in _CONFIDENCE_RANK:
-        logger.warning(
-            "investigation_search: unknown min_confidence %r — ignoring filter; "
-            "valid values: low, medium, high", min_confidence
-        )
-        min_confidence = "low"
+    min_confidence, resolution = _search_normalize_filters(min_confidence, resolution)
 
     # Precompute retracted finding ids per investigation in scope. A row is
     # filtered when it names a finding id (or matches text of one) that is
@@ -3149,62 +3291,15 @@ def investigation_search(
                 if len(deduped) >= limit:
                     break
 
-    # Apply confidence floor post-hoc so mnemosyne rows — which carry no
-    # "confidence" field — don't silently undermine the caller's filter when
-    # mnemosyne satisfies the result limit before Qdrant is queried.
-    if min_confidence and min_confidence in _CONFIDENCE_RANK and min_confidence != "low":
-        floor = _CONFIDENCE_RANK[min_confidence]
-        deduped = [
-            r for r in deduped
-            # Normalise stored confidence to lowercase — mnemosyne-sourced rows may
-            # carry mixed-case values; without .lower() "High" maps to rank 0.
-            if _CONFIDENCE_RANK.get(str(r.get("confidence", "low")).lower(), 0) >= floor
-        ]
+    deduped = _search_apply_confidence_floor(deduped, min_confidence)
 
-    # Surface each row's resolution and optionally filter by it. Rows sourced from
-    # mnemosyne carry no resolution, so we build an authoritative finding_id ->
-    # resolution map from JSONL — scoped to only the investigations that actually
-    # produced rows, so cost is bounded regardless of how many investigations exist.
-    # Absent record -> "open". Fail-open (a failed map build just falls back to the
-    # per-row payload value, defaulting to "open").
-    _resolution_map, _coderefs_map = _search_resolution_maps(deduped)
-
-    for r in deduped:
-        r["resolution"] = _search_row_resolution(r, _resolution_map)
-        # Staleness: rows from mnemo/qdrant don't carry code_refs, so consult the
-        # JSONL-derived map. Only set ``stale`` when the finding has usable refs.
-        _rfid = str(r.get("finding_id") or r.get("id") or "")
-        _refs = _coderefs_map.get(_rfid)
-        if _refs:
-            _st = _finding_is_stale({"code_refs": _refs})
-            if _st is not None:
-                r["stale"] = _st
+    # Surface each row's resolution and optionally filter by it.
+    _search_annotate_rows(deduped)
     if resolution is not None:
         deduped = [r for r in deduped if r.get("resolution") == resolution]
 
     if not deduped:
-        qdrant_avail = bool(os.environ.get("QDRANT_URL", ""))
-        # Only use rag_required mode when Qdrant itself is unavailable.
-        # Empty results with Qdrant available is a normal no-match response.
-        if not qdrant_avail or (qdrant.get("reason") == "qdrant_unavailable"):
-            return json.dumps({
-                "mode": "rag_required",
-                "reason": "qdrant_unavailable",
-                "results": [],
-                "qdrant_enabled": qdrant_avail,
-                "error": "RAG_REQUIRED: Qdrant unavailable. Check QDRANT_URL and QDRANT_API_KEY.",
-            }, indent=2)
-        return json.dumps({
-            "mode": "no_matches",
-            "reason": str(qdrant.get("reason") or "no_matches"),
-            "results": [],
-            "qdrant_enabled": qdrant_avail,
-            "mnemo_status": {
-                "enabled": mnemo_enabled,
-                "bank": _mnemo_bank() if mnemo_enabled else None,
-                "match_count": 0,
-            },
-        }, indent=2)
+        return _search_empty_response(qdrant, mnemo_enabled)
 
     mode = "mnemo_primary"
     if qdrant.get("ok"):
@@ -3232,6 +3327,31 @@ def investigation_search(
 
 
 # ---- Tool: investigation_pre_answer_check ----
+
+def _pre_answer_lexical_refs(
+    claim_tokens, claim_negated: bool, evidence_pool: list[dict]
+) -> tuple[list[dict], list[dict]]:
+    """Score a claim's tokens against the evidence pool via lexical matching.
+
+    Returns ``(support_refs, contradiction_refs)`` in the append order produced
+    by iterating ``evidence_pool`` -- callers rely on this order for the
+    downstream ``[:8]`` slice and for reference deduplication.
+    """
+    claim_support_refs: list[dict] = []
+    claim_contradiction_refs: list[dict] = []
+    for evid in evidence_pool:
+        score = _lexical_match_score(claim_tokens, evid.get("tokens", set()))
+        if score < 0.45:
+            continue
+        evidence_negated = bool(_NEGATION_RE.search(str(evid.get("text", ""))))
+        if claim_negated != evidence_negated and score >= 0.5:
+            ref = _make_ref(evid, "contradiction", score=score)
+            claim_contradiction_refs.append(ref)
+        else:
+            ref = _make_ref(evid, "support", score=score)
+            claim_support_refs.append(ref)
+    return claim_support_refs, claim_contradiction_refs
+
 
 def _pre_answer_chain_confidence(
     investigation_id: str, matched_ids: set[str]
@@ -3316,20 +3436,9 @@ def investigation_pre_answer_check(
     for claim in normalized_claims:
         claim_tokens = tokenize(claim)
         claim_negated = bool(_NEGATION_RE.search(claim))
-        claim_support_refs: list[dict] = []
-        claim_contradiction_refs: list[dict] = []
-
-        for evid in evidence_pool:
-            score = _lexical_match_score(claim_tokens, evid.get("tokens", set()))
-            if score < 0.45:
-                continue
-            evidence_negated = bool(_NEGATION_RE.search(str(evid.get("text", ""))))
-            if claim_negated != evidence_negated and score >= 0.5:
-                ref = _make_ref(evid, "contradiction", score=score)
-                claim_contradiction_refs.append(ref)
-            else:
-                ref = _make_ref(evid, "support", score=score)
-                claim_support_refs.append(ref)
+        claim_support_refs, claim_contradiction_refs = _pre_answer_lexical_refs(
+            claim_tokens, claim_negated, evidence_pool
+        )
 
         qdrant_refs, qdrant_status = _search_qdrant_claim_evidence(claim, investigation_id, limit=5)
         qdrant_available = qdrant_available or bool(qdrant_status.get("available"))
@@ -4988,6 +5097,103 @@ def _forget_finding_verdicts(finding: dict) -> int:
         return 0
 
 
+def _retract_cluster(
+    seed_ids: list[str], findings: list[dict], semantic_ids: list[str]
+) -> tuple[list[str], dict, dict, list[dict]]:
+    """Compute the contamination cluster for a retraction and its dry-run items."""
+    cluster = find_contamination(
+        seed_ids,
+        findings,
+        entities_of=_extract_entities,
+        semantic_neighbor_ids=semantic_ids,
+        min_shared_entities=1,
+    )
+    contaminated_ids = cluster["contaminated_ids"]
+    reasons = cluster["reasons"]
+    by_id = {str(f.get("id", "")): f for f in findings}
+
+    items = [
+        {
+            "finding_id": fid,
+            "text_excerpt": redact_excerpt(str(by_id.get(fid, {}).get("text", "") or "")),
+            "reasons": reasons.get(fid, []),
+        }
+        for fid in contaminated_ids
+    ]
+    return contaminated_ids, reasons, by_id, items
+
+
+def _retract_write_tombstones(
+    retractions_path,
+    contaminated_ids: list[str],
+    by_id: dict,
+    reasons: dict,
+    seed_anchor: str,
+    reason: str,
+    ts: str,
+) -> tuple[list[dict], int]:
+    """Append one retraction tombstone per contaminated finding, forgetting verdicts."""
+    retracted_records: list[dict] = []
+    verdicts_forgotten = 0
+    for fid in contaminated_ids:
+        retraction_id = str(uuid.uuid4())
+        entry = {
+            "retraction_id": retraction_id,
+            "finding_id": fid,
+            "seed_id": seed_anchor,
+            "reason": reason or "hallucination retraction",
+            "ts": ts,
+            "active": True,
+        }
+        _append_jsonl(retractions_path, entry)
+        verdicts_forgotten += _forget_finding_verdicts(by_id.get(fid, {}))
+        retracted_records.append({
+            "retraction_id": retraction_id,
+            "finding_id": fid,
+            "reasons": reasons.get(fid, []),
+        })
+    return retracted_records, verdicts_forgotten
+
+
+def _retract_stamp_valid_until(investigation_id: str, contaminated_ids: list[str], ts: str) -> None:
+    """Bi-temporal hook: stamp valid_until on retracted findings so that
+    investigation_as_of queries exclude them from any future as-of view.
+    Fails open — never propagates."""
+    try:
+        findings_path = _inv_dir(investigation_id) / "findings.jsonl"
+        _rewrite_jsonl_set_field(
+            findings_path,
+            set(contaminated_ids),
+            "valid_until",
+            ts,
+        )
+    except Exception as exc:  # fail-open
+        logger.debug("bi-temporal valid_until stamp failed, degrading: %r", exc)
+
+
+def _retract_quarantine_verdict(
+    seeds: list[dict], seed_anchor: str, reason: str, contaminated_ids: list[str]
+) -> bool:
+    """Record a quarantine verdict to the store (fail-open) for recall."""
+    try:
+        seed_text = str(seeds[0].get("text", "") or "")
+        quarantine_verdict = new_verdict(
+            subject_kind="memory",
+            subject_signature=make_signature("memory", seed_anchor),
+            subject_excerpt=redact_excerpt(seed_text),
+            verdict_type="retracted",
+            decision="quarantine",
+            confidence=0.9,
+            rationale=reason or "hallucination retracted with contaminated lineage",
+            source="human",
+            refs=list(contaminated_ids),
+        )
+        return _record_verdicts([quarantine_verdict])
+    except Exception as exc:  # fail-open
+        logger.debug("quarantine verdict record failed, degrading: %r", exc)
+        return False
+
+
 @mcp.tool()
 def memory_retract(
     investigation_id: str,
@@ -5051,25 +5257,7 @@ def memory_retract(
     if scope_semantic:
         semantic_ids = _semantic_neighbor_ids(seeds, investigation_id)
 
-    cluster = find_contamination(
-        seed_ids,
-        findings,
-        entities_of=_extract_entities,
-        semantic_neighbor_ids=semantic_ids,
-        min_shared_entities=1,
-    )
-    contaminated_ids = cluster["contaminated_ids"]
-    reasons = cluster["reasons"]
-    by_id = {str(f.get("id", "")): f for f in findings}
-
-    items = [
-        {
-            "finding_id": fid,
-            "text_excerpt": redact_excerpt(str(by_id.get(fid, {}).get("text", "") or "")),
-            "reasons": reasons.get(fid, []),
-        }
-        for fid in contaminated_ids
-    ]
+    contaminated_ids, reasons, by_id, items = _retract_cluster(seed_ids, findings, semantic_ids)
 
     if dry_run:
         return json.dumps({
@@ -5087,47 +5275,19 @@ def memory_retract(
     retractions_path = _inv_dir(investigation_id) / "retractions.jsonl"
     audit_path = _inv_dir(investigation_id) / "retraction_audit.jsonl"
     seed_anchor = seed_ids[0]
-    retracted_records: list[dict] = []
-    verdicts_forgotten = 0
 
     # Acquire a per-investigation lock so that the retractions.jsonl appends
     # and the matching retraction_audit.jsonl append are observed atomically
     # by concurrent readers (no window where a retraction exists without its
     # audit record).
-    with _investigation_locks_lock:
-        inv_lock = _investigation_locks.setdefault(investigation_id, threading.Lock())
+    inv_lock = _investigation_lock(investigation_id)
 
     with inv_lock:
-        for fid in contaminated_ids:
-            retraction_id = str(uuid.uuid4())
-            entry = {
-                "retraction_id": retraction_id,
-                "finding_id": fid,
-                "seed_id": seed_anchor,
-                "reason": reason or "hallucination retraction",
-                "ts": ts,
-                "active": True,
-            }
-            _append_jsonl(retractions_path, entry)
-            verdicts_forgotten += _forget_finding_verdicts(by_id.get(fid, {}))
-            retracted_records.append({
-                "retraction_id": retraction_id,
-                "finding_id": fid,
-                "reasons": reasons.get(fid, []),
-            })
+        retracted_records, verdicts_forgotten = _retract_write_tombstones(
+            retractions_path, contaminated_ids, by_id, reasons, seed_anchor, reason, ts
+        )
 
-        # Bi-temporal hook: stamp valid_until on retracted findings so that
-        # investigation_as_of queries exclude them from any future as-of view.
-        try:
-            findings_path = _inv_dir(investigation_id) / "findings.jsonl"
-            _rewrite_jsonl_set_field(
-                findings_path,
-                set(contaminated_ids),
-                "valid_until",
-                ts,
-            )
-        except Exception as exc:  # fail-open
-            logger.debug("bi-temporal valid_until stamp failed, degrading: %r", exc)
+        _retract_stamp_valid_until(investigation_id, contaminated_ids, ts)
 
         _append_jsonl(audit_path, {
             "action": "retract",
@@ -5141,24 +5301,7 @@ def memory_retract(
             "scope_semantic": scope_semantic,
         })
 
-    # Record a quarantine verdict to the store (fail-open) for recall.
-    try:
-        seed_text = str(seeds[0].get("text", "") or "")
-        quarantine_verdict = new_verdict(
-            subject_kind="memory",
-            subject_signature=make_signature("memory", seed_anchor),
-            subject_excerpt=redact_excerpt(seed_text),
-            verdict_type="retracted",
-            decision="quarantine",
-            confidence=0.9,
-            rationale=reason or "hallucination retracted with contaminated lineage",
-            source="human",
-            refs=list(contaminated_ids),
-        )
-        quarantine_recorded = _record_verdicts([quarantine_verdict])
-    except Exception as exc:  # fail-open
-        logger.debug("quarantine verdict record failed, degrading: %r", exc)
-        quarantine_recorded = False
+    quarantine_recorded = _retract_quarantine_verdict(seeds, seed_anchor, reason, contaminated_ids)
 
     _event_log_append({
         "op": "retract",
@@ -5901,7 +6044,9 @@ def _rag_apply_decay(results: list[dict]) -> None:
                 continue
             # ts may be an ISO string; created_at_ts is always an int epoch
             try:
-                age_days = max(0.0, (now_ts - float(ts_val)) / 86400.0)
+                age_days = (now_ts - float(ts_val)) / 86400.0
+                if age_days < 0:
+                    age_days = 0.0
                 raw_score = float(r.get("score") or 0.0)
                 r["score"] = round(raw_score * math.exp(-_MEMORY_DECAY_LAMBDA * age_days), 4)
                 r["decay_applied"] = True
@@ -6066,6 +6211,77 @@ def rag_context_search(
 # Tool: memory_surface — proactive context surfacing
 # ---------------------------------------------------------------------------
 
+def _surface_query_filter(investigation_id: Optional[str]) -> Optional[object]:
+    """Build an investigation-scoped Qdrant filter for memory_surface.
+
+    Fail-open: on any construction error, logs a warning and returns None so
+    the caller falls back to an unscoped (wider) search rather than erroring.
+    """
+    if not investigation_id:
+        return None
+    try:
+        from qdrant_client.models import Filter, FieldCondition, MatchValue
+        return Filter(
+            must=[FieldCondition(key="investigation_id", match=MatchValue(value=investigation_id))]
+        )
+    except Exception as exc:
+        logger.warning(
+            "memory_surface: investigation filter construction failed for %s "
+            "- search will NOT be scoped: %r", investigation_id, exc,
+        )
+        return None
+
+
+def _surface_apply_decay(rows: list[dict]) -> None:
+    """Rescore memory_surface rows in place with Ebbinghaus exponential time decay.
+
+    Applies decay only if _MEMORY_DECAY_LAMBDA is defined on this module. Unlike
+    _rag_apply_decay, this defaults created_at_ts to now (no-op decay) rather than
+    skipping rows without a timestamp, and does not restrict to the findings collection.
+    Fail-open — decay is an optional enhancement and never breaks the tool.
+    """
+    _decay_lambda = globals().get("_MEMORY_DECAY_LAMBDA")
+    now_ts = time.time()
+    if _decay_lambda is not None:
+        try:
+            for r in rows:
+                created_ts = float(r.get("created_at_ts") or now_ts)
+                age_days = (now_ts - created_ts) / 86400.0
+                decay = math.exp(-float(_decay_lambda) * age_days)
+                r["score"] = round(float(r.get("score") or 0.0) * decay, 4)
+        except Exception as exc:
+            logger.debug("memory_surface: recency decay scoring failed (fail-open): %r", exc)
+            pass  # decay is optional enhancement; never break the tool
+
+
+def _surface_rows(top_results: list[dict], ctx_prefix: str, investigation_id: Optional[str]) -> list[dict]:
+    """Build the memory_surface 'surfaced' response rows from top_results.
+
+    ctx_prefix is the pre-computed first-8-whitespace-split-words prefix of the
+    original context, used verbatim in the relevance_note fallback label.
+    """
+    surfaced = []
+    for r in top_results:
+        finding_id = r.get("id") or r.get("finding_id") or ""
+        text = str(r.get("text") or r.get("content") or "")
+        source = str(r.get("source") or r.get("origin") or "")
+        inv_id = r.get("investigation_id") or investigation_id or ""
+        score = round(float(r.get("score") or 0.0), 4)
+
+        # Generate relevance_note: simple label based on context prefix
+        relevance_note = f"Related to: {ctx_prefix}"
+
+        surfaced.append({
+            "finding_id": finding_id,
+            "text": text[:300] if len(text) > 300 else text,
+            "source": source,
+            "relevance_note": relevance_note,
+            "score": score,
+            "investigation_id": inv_id,
+        })
+    return surfaced
+
+
 @mcp.tool()
 def memory_surface(
     context: str,
@@ -6090,8 +6306,6 @@ def memory_surface(
         JSON with {surfaced: [{finding_id, text, source, relevance_note, score,
                                investigation_id}], context_used, count}
     """
-    import math as _math
-
     if not context or not context.strip():
         return json.dumps({
             "error": "context must not be empty",
@@ -6111,19 +6325,7 @@ def memory_surface(
             })
 
         # Build investigation filter if requested
-        query_filter = None
-        if investigation_id:
-            try:
-                from qdrant_client.models import Filter, FieldCondition, MatchValue
-                query_filter = Filter(
-                    must=[FieldCondition(key="investigation_id", match=MatchValue(value=investigation_id))]
-                )
-            except Exception as exc:
-                logger.warning(
-                    "memory_surface: investigation filter construction failed for %s "
-                    "- search will NOT be scoped: %r", investigation_id, exc,
-                )
-                pass
+        query_filter = _surface_query_filter(investigation_id)
 
         # Fetch top_k * 3 candidates with a lower threshold via _qdrant_search_collection
         fetch_limit = top_k * 3
@@ -6157,18 +6359,7 @@ def memory_surface(
         filtered = [r for r in candidates if float(r.get("score") or 0.0) >= _SURFACE_SCORE_THRESHOLD]
 
         # Apply Ebbinghaus decay if _MEMORY_DECAY_LAMBDA is defined on this module
-        _decay_lambda = globals().get("_MEMORY_DECAY_LAMBDA")
-        now_ts = time.time()
-        if _decay_lambda is not None:
-            try:
-                for r in filtered:
-                    created_ts = float(r.get("created_at_ts") or now_ts)
-                    age_days = (now_ts - created_ts) / 86400.0
-                    decay = _math.exp(-float(_decay_lambda) * age_days)
-                    r["score"] = round(float(r.get("score") or 0.0) * decay, 4)
-            except Exception as exc:
-                logger.debug("memory_surface: recency decay scoring failed (fail-open): %r", exc)
-                pass  # decay is optional enhancement; never break the tool
+        _surface_apply_decay(filtered)
 
         # Re-sort after possible decay adjustment, then take top_k
         filtered.sort(key=lambda r: float(r.get("score") or 0.0), reverse=True)
@@ -6178,25 +6369,7 @@ def memory_surface(
         _ctx_words = context.strip().split()
         _ctx_prefix = " ".join(_ctx_words[:8])
 
-        surfaced = []
-        for r in top_results:
-            finding_id = r.get("id") or r.get("finding_id") or ""
-            text = str(r.get("text") or r.get("content") or "")
-            source = str(r.get("source") or r.get("origin") or "")
-            inv_id = r.get("investigation_id") or investigation_id or ""
-            score = round(float(r.get("score") or 0.0), 4)
-
-            # Generate relevance_note: simple label based on context prefix
-            relevance_note = f"Related to: {_ctx_prefix}"
-
-            surfaced.append({
-                "finding_id": finding_id,
-                "text": text[:300] if len(text) > 300 else text,
-                "source": source,
-                "relevance_note": relevance_note,
-                "score": score,
-                "investigation_id": inv_id,
-            })
+        surfaced = _surface_rows(top_results, _ctx_prefix, investigation_id)
 
         return json.dumps({
             "surfaced": surfaced,
@@ -6473,48 +6646,24 @@ def causal_edges_list(investigation_id: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()
-def memory_confidence(
-    query: str,
-    top_k: int = 8,
-) -> str:
+def _confidence_retrieve(query: str, top_k: int) -> tuple[list, Optional[str]]:
     """
-    Estimate how reliably hermes_memory knows about a topic (metamemory).
+    Run the retrieval steps for memory_confidence: empty-query guard, Qdrant
+    availability check, embedding, and vector search.
 
-    Combines five evidence cues into a calibrated confidence score:
-      fluency        — cosine similarity of top hit to query (retrieval ease)
-      accessibility  — mean score of top-4 hits (amount of partial info recalled)
-      source_div     — number of distinct sources/investigations in top results
-      corroboration  — max occurrences across top hits (repeated evidence)
-      trust          — mean confidence tier (high/medium/low) of top hits
-
-    Fluency is down-weighted relative to source_div and trust because it tracks
-    retrieval ease, not correctness (Koriat 1993 over-confidence mechanism).
-
-    Use this before asserting a memory-derived claim to get a calibrated estimate
-    of reliability. Low confidence → verify with investigation tools first.
-
-    Args:
-        query: The claim or topic to estimate confidence for.
-        top_k: Number of results to base the estimate on (default 8).
-
-    Returns:
-        JSON with {confidence, basis, cues, top_hit_preview, recommendation}.
+    Returns (results, hard_stop_basis). When hard_stop_basis is not None the
+    caller should short-circuit with a hard-stop payload using that basis
+    string ("empty_query" / "qdrant_unavailable" / "embed_failed") and
+    results is always []. When hard_stop_basis is None, results holds the
+    (possibly empty) search hits — an empty list there means "no_trace",
+    which the caller handles separately.
     """
-    import math as _math
-
     if not query:
-        return json.dumps({
-            "confidence": 0.0, "basis": "empty_query",
-            "cues": {}, "top_hit_preview": "", "recommendation": "verify",
-        })
+        return [], "empty_query"
 
     client, col = _get_qdrant()
     if client is None:
-        return json.dumps({
-            "confidence": 0.0, "basis": "qdrant_unavailable",
-            "cues": {}, "top_hit_preview": "", "recommendation": "verify",
-        })
+        return [], "qdrant_unavailable"
 
     try:
         emb = _embed(query)
@@ -6522,10 +6671,7 @@ def memory_confidence(
         logger.debug("memory_confidence embed failed: %r", exc)
         emb = None
     if not emb:
-        return json.dumps({
-            "confidence": 0.0, "basis": "embed_failed",
-            "cues": {}, "top_hit_preview": "", "recommendation": "verify",
-        })
+        return [], "embed_failed"
 
     try:
         results = client.search(
@@ -6538,15 +6684,18 @@ def memory_confidence(
         logger.debug("memory_confidence search failed: %r", exc)
         results = []
 
-    if not results:
-        return json.dumps({
-            "confidence": 0.0, "basis": "no_trace",
-            "cues": {"fluency": 0.0, "accessibility": 0.0, "source_div": 0,
-                     "corroboration": 0, "trust": 0.0},
-            "top_hit_preview": "",
-            "recommendation": "no memory found — investigate before asserting",
-        })
+    return results, None
 
+
+def _confidence_cues(results: list) -> dict:
+    """
+    Compute the five metamemory cues for memory_confidence from a list of
+    Qdrant search results.
+
+    Returns {fluency, accessibility, source_div, corroboration, trust,
+    top_text}. top_text is the truncated text/content of the first result
+    that has any (not necessarily results[0]) — "" if none do.
+    """
     scores = [float(getattr(r, "score", 0.0) or 0.0) for r in results]
 
     # Cue 1: Fluency — cosine of top hit (retrieval ease proxy)
@@ -6577,10 +6726,31 @@ def memory_confidence(
     source_div = len(sources)
 
     # Cue 4: Corroboration — log-saturated occurrence count
-    corroboration = _math.log1p(max_occurrences) / _math.log1p(20)  # saturates ~20
+    corroboration = math.log1p(max_occurrences) / math.log1p(20)  # saturates ~20
 
     # Cue 5: Trust — mean confidence tier of top hits
     trust = sum(conf_vals) / max(1, len(conf_vals))
+
+    return {
+        "fluency": fluency,
+        "accessibility": accessibility,
+        "source_div": source_div,
+        "corroboration": corroboration,
+        "trust": trust,
+        "top_text": top_text,
+    }
+
+
+def _confidence_verdict(cues: dict) -> tuple[float, str, str]:
+    """
+    Combine the five metamemory cues into a calibrated (confidence, basis,
+    recommendation) verdict for memory_confidence. Pure function of `cues`.
+    """
+    fluency = cues["fluency"]
+    accessibility = cues["accessibility"]
+    source_div = cues["source_div"]
+    corroboration = cues["corroboration"]
+    trust = cues["trust"]
 
     # Weighted combination (weights: source_div and trust dominate fluency;
     # this ordering follows Fleming 2010 — source/recollection > familiarity/fluency).
@@ -6600,7 +6770,7 @@ def memory_confidence(
            + W["corroboration"] * corroboration
            + W["trust"]         * trust)
     # Sigmoid to keep in (0,1); shift so 0.5 raw → ~0.5 output.
-    confidence = 1.0 / (1.0 + _math.exp(-8 * (raw - 0.5)))
+    confidence = 1.0 / (1.0 + math.exp(-8 * (raw - 0.5)))
 
     # Basis: prefer recollection (source_div) over familiarity (fluency).
     if source_div >= 2:
@@ -6620,6 +6790,63 @@ def memory_confidence(
         recommendation = "low — verify with investigation tools before asserting"
     else:
         recommendation = "unreliable — investigate fresh before asserting"
+
+    return confidence, basis, recommendation
+
+
+@mcp.tool()
+def memory_confidence(
+    query: str,
+    top_k: int = 8,
+) -> str:
+    """
+    Estimate how reliably hermes_memory knows about a topic (metamemory).
+
+    Combines five evidence cues into a calibrated confidence score:
+      fluency        — cosine similarity of top hit to query (retrieval ease)
+      accessibility  — mean score of top-4 hits (amount of partial info recalled)
+      source_div     — number of distinct sources/investigations in top results
+      corroboration  — max occurrences across top hits (repeated evidence)
+      trust          — mean confidence tier (high/medium/low) of top hits
+
+    Fluency is down-weighted relative to source_div and trust because it tracks
+    retrieval ease, not correctness (Koriat 1993 over-confidence mechanism).
+
+    Use this before asserting a memory-derived claim to get a calibrated estimate
+    of reliability. Low confidence → verify with investigation tools first.
+
+    Args:
+        query: The claim or topic to estimate confidence for.
+        top_k: Number of results to base the estimate on (default 8).
+
+    Returns:
+        JSON with {confidence, basis, cues, top_hit_preview, recommendation}.
+    """
+    results, hard_stop_basis = _confidence_retrieve(query, top_k)
+    if hard_stop_basis is not None:
+        return json.dumps({
+            "confidence": 0.0, "basis": hard_stop_basis,
+            "cues": {}, "top_hit_preview": "", "recommendation": "verify",
+        })
+
+    if not results:
+        return json.dumps({
+            "confidence": 0.0, "basis": "no_trace",
+            "cues": {"fluency": 0.0, "accessibility": 0.0, "source_div": 0,
+                     "corroboration": 0, "trust": 0.0},
+            "top_hit_preview": "",
+            "recommendation": "no memory found — investigate before asserting",
+        })
+
+    cues = _confidence_cues(results)
+    fluency = cues["fluency"]
+    accessibility = cues["accessibility"]
+    source_div = cues["source_div"]
+    corroboration = cues["corroboration"]
+    trust = cues["trust"]
+    top_text = cues["top_text"]
+
+    confidence, basis, recommendation = _confidence_verdict(cues)
 
     return json.dumps({
         "confidence": round(confidence, 3),
@@ -7234,6 +7461,94 @@ def memory_hints_resource(investigation_id: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _route_filter_by_agent(hits: list[dict], agent_id: str) -> list[dict]:
+    """
+    Filter memory_route hits down to those authored by `agent_id` or whose
+    investigation ACL includes `agent_id`. Fail-open: ACL lookup errors are
+    logged and treated as "no match" for that hit.
+    """
+    filtered = []
+    for hit in hits:
+        authored_by = hit.get("authored_by", "")
+        if authored_by == agent_id:
+            filtered.append(hit)
+            continue
+        # Check if the investigation ACL includes this agent
+        inv_id = hit.get("investigation_id", "")
+        if inv_id:
+            try:
+                manifest = _load_manifest(inv_id)
+                if manifest:
+                    acl = manifest.get("acl", [])
+                    if isinstance(acl, list) and agent_id in acl:
+                        filtered.append(hit)
+                        continue
+            except Exception as exc:
+                logger.debug("memory_route: ACL check failed for %s: %r", inv_id, exc)
+                pass  # graceful skip
+    return filtered
+
+
+def _route_dedup_by_overlap(hits: list[dict]) -> list[dict]:
+    """
+    Deduplicate memory_route hits by word-overlap (>80% overlap → keep the
+    highest-scoring hit). Assumes `hits` is already sorted by score
+    (descending), so among an overlapping pair the later one in iteration
+    order is always the lower-scoring one to suppress.
+    """
+    kept = []
+    suppressed = set()
+    for i, hit_a in enumerate(hits):
+        if i in suppressed:
+            continue
+        words_a = set(str(hit_a.get("text", "")).lower().split())
+        for j, hit_b in enumerate(hits):
+            if j <= i or j in suppressed:
+                continue
+            words_b = set(str(hit_b.get("text", "")).lower().split())
+            union = words_a | words_b
+            if not union:
+                continue
+            overlap = len(words_a & words_b) / max(len(union), 1)
+            if overlap > 0.80:
+                # Suppress the lower-scoring one (raw_hits already sorted by score)
+                suppressed.add(j)
+        kept.append(hit_a)
+    return kept
+
+
+def _route_rows(hits: list[dict]) -> list[dict]:
+    """
+    Build memory_route response rows from raw Qdrant hits, resolving each
+    hit's investigation title via the manifest. Fail-open: manifest lookup
+    errors are logged and the row keeps an empty title.
+    """
+    routed = []
+    for hit in hits:
+        inv_id = hit.get("investigation_id", "")
+        inv_title = ""
+        if inv_id:
+            try:
+                manifest = _load_manifest(inv_id)
+                if manifest:
+                    inv_title = manifest.get("title", "")
+            except Exception as exc:
+                logger.debug("memory_route: manifest title lookup failed for %s: %r", inv_id, exc)
+                pass
+
+        routed.append({
+            "finding_id": hit.get("finding_id") or hit.get("id", ""),
+            "investigation_id": inv_id,
+            "investigation_title": inv_title,
+            "text": hit.get("text", ""),
+            "source": hit.get("source", ""),
+            "authored_by": hit.get("authored_by", ""),
+            "score": hit.get("score", 0.0),
+            "tier": hit.get("tier") or hit.get("record_type", "finding"),
+        })
+    return routed
+
+
 @mcp.tool()
 def memory_route(
     query: str,
@@ -7298,77 +7613,18 @@ def memory_route(
 
         # Step 3: Filter by agent_id if provided
         if agent_id:
-            filtered = []
-            for hit in raw_hits:
-                authored_by = hit.get("authored_by", "")
-                if authored_by == agent_id:
-                    filtered.append(hit)
-                    continue
-                # Check if the investigation ACL includes this agent
-                inv_id = hit.get("investigation_id", "")
-                if inv_id:
-                    try:
-                        manifest = _load_manifest(inv_id)
-                        if manifest:
-                            acl = manifest.get("acl", [])
-                            if isinstance(acl, list) and agent_id in acl:
-                                filtered.append(hit)
-                                continue
-                    except Exception as exc:
-                        logger.debug("memory_route: ACL check failed for %s: %r", inv_id, exc)
-                        pass  # graceful skip
-            raw_hits = filtered
+            raw_hits = _route_filter_by_agent(raw_hits, agent_id)
 
         # Step 4: Deduplicate by word-overlap (>80% overlap → keep highest score)
         if deduplicate and len(raw_hits) > 1:
-            kept = []
-            suppressed = set()
-            for i, hit_a in enumerate(raw_hits):
-                if i in suppressed:
-                    continue
-                words_a = set(str(hit_a.get("text", "")).lower().split())
-                for j, hit_b in enumerate(raw_hits):
-                    if j <= i or j in suppressed:
-                        continue
-                    words_b = set(str(hit_b.get("text", "")).lower().split())
-                    union = words_a | words_b
-                    if not union:
-                        continue
-                    overlap = len(words_a & words_b) / max(len(union), 1)
-                    if overlap > 0.80:
-                        # Suppress the lower-scoring one (raw_hits already sorted by score)
-                        suppressed.add(j)
-                kept.append(hit_a)
-            raw_hits = kept
+            raw_hits = _route_dedup_by_overlap(raw_hits)
 
         # Step 5: Trim to top_k
         raw_hits = raw_hits[:top_k]
         total_after_dedup = len(raw_hits)
 
         # Step 6: Build response with provenance
-        routed = []
-        for hit in raw_hits:
-            inv_id = hit.get("investigation_id", "")
-            inv_title = ""
-            if inv_id:
-                try:
-                    manifest = _load_manifest(inv_id)
-                    if manifest:
-                        inv_title = manifest.get("title", "")
-                except Exception as exc:
-                    logger.debug("memory_route: manifest title lookup failed for %s: %r", inv_id, exc)
-                    pass
-
-            routed.append({
-                "finding_id": hit.get("finding_id") or hit.get("id", ""),
-                "investigation_id": inv_id,
-                "investigation_title": inv_title,
-                "text": hit.get("text", ""),
-                "source": hit.get("source", ""),
-                "authored_by": hit.get("authored_by", ""),
-                "score": hit.get("score", 0.0),
-                "tier": hit.get("tier") or hit.get("record_type", "finding"),
-            })
+        routed = _route_rows(raw_hits)
 
         return json.dumps({
             "routed": routed,

--- a/scripts/callgraph/README.md
+++ b/scripts/callgraph/README.md
@@ -1,0 +1,232 @@
+# callgraph
+
+A dependency-light, stdlib-only static call-graph tool for the loci corpus
+(`mcp/`, `scripts/`, `a2a_server/`, `mlops/`, `eval/`). No LadybugDB, no
+network, no third-party imports — it runs during debugging when nothing
+else in the stack is up, and it can read a specific git revision so it
+stays correct even while another workflow is mid-editing a file it needs
+to look at.
+
+It complements `mcp/graph_tools.py` / `mcp/graph/*` (which need a live
+LadybugDB and model symbols + CALLS) by modelling the things this codebase
+actually does for dispatch that a symbol graph doesn't capture:
+`@mcp.tool()` registration, `register(mcp, deps)` injection, dict-of-callables
+dispatch, module-global reads/writes across files, and path/key literal
+agreement between producers and consumers. See `docs/DESIGN.md` for the
+full node/edge model and the `CALLS` resolution ladder, and `cg limits`
+(or `docs/LIMITS.md`) for the honest failure-mode catalogue.
+
+## 60-second tour
+
+```
+PYTHONPATH=scripts python3 -m callgraph.cli build --rev HEAD
+PYTHONPATH=scripts python3 -m callgraph.cli modules --rev HEAD --scope mcp/
+PYTHONPATH=scripts python3 -m callgraph.cli defs --rev HEAD --scope mcp/graph_tools.py --all
+PYTHONPATH=scripts python3 -m callgraph.cli imports --rev HEAD --unresolved
+PYTHONPATH=scripts python3 -m callgraph.cli imports --rev HEAD --lazy
+PYTHONPATH=scripts python3 -m callgraph.cli aliases --rev HEAD mcp/server.py::symbol_impact
+PYTHONPATH=scripts python3 -m callgraph.cli callers _get_ladybug --rev HEAD --conf proven
+PYTHONPATH=scripts python3 -m callgraph.cli reach _get_ladybug --rev HEAD --depth 2
+PYTHONPATH=scripts python3 -m callgraph.cli registry --rev HEAD
+PYTHONPATH=scripts python3 -m callgraph.cli name _get_ladybug --rev HEAD
+PYTHONPATH=scripts python3 -m callgraph.cli dead --rev HEAD --scope mcp/
+PYTHONPATH=scripts python3 -m callgraph.cli holes --rev HEAD
+PYTHONPATH=scripts python3 -m callgraph.cli writes-dead --rev HEAD --scope mcp/
+PYTHONPATH=scripts python3 -m callgraph.cli literals --rev HEAD --paths --orphans
+PYTHONPATH=scripts python3 -m callgraph.cli flags --rev HEAD mcp/grounding.py::ground
+PYTHONPATH=scripts python3 -m callgraph.cli reach _get_ladybug --rev HEAD --depth 2 --format dot > reach.dot
+PYTHONPATH=scripts python3 -m callgraph.cli selftest
+PYTHONPATH=scripts python3 -m callgraph.cli limits
+```
+
+Always pass `--rev HEAD` (or any commit-ish) when another workflow might be
+editing a file you're about to query — the working tree is the default
+source, but a mid-edit file can have lines that don't exist yet. Every
+report prints which source it read.
+
+## What's implemented (build_steps 1-13 — the full design, minus `whatchanged`)
+
+- **config.py** — the corpus definition: `mcp/`, `scripts/`, `a2a_server/`,
+  `mlops/`, `eval/`, non-test `.py` files only (114 files at HEAD),
+  excluding `tests/`, `__pycache__`, `.venv`, `*.egg-info`, and this
+  package itself.
+- **ingest.py** — `ast.parse` over the corpus, either the working tree or a
+  specific git revision (`git ls-tree` + `git show`). A SyntaxError on one
+  file degrades that file to a stub and never aborts the build.
+- **resolve.py** — the module resolution table: which dotted names each
+  file answers to, given (a) the implicit repo-root namespace, (b) a
+  literal `sys.path.insert(0, <expr>)` this tool can constant-fold, or (c)
+  a directory containing a `__main__` entry point (Python auto-adds a
+  script's own directory to `sys.path[0]` when run directly — this is how
+  `import harness` resolves from `eval/grounding_gate_eval.py`, purely
+  because `eval/harness.py` has a `__main__` guard). Every resolution
+  records which insert (or which fact) made it work, preferring a root the
+  *importing file itself* established over one some other file happened to
+  set up first.
+- **model.py** — `Node`/`Edge`/`Confidence`/`GraphStore`, the shared
+  representation every later extractor and query reads and writes.
+- **scopes.py** — one AST pass per module: qualnames (class/closure/lambda
+  nesting), decorator source text, params, module-global `NAME` slots
+  (including idents that are `global`-declared but never bound at module
+  level — the raw signal behind BUG C), and import statements.
+- **extract/defs.py** — MODULE / CLASS / FUNCTION / NAME nodes, `DEFINES`
+  edges, and `DECORATED_BY` classification (registering / wrapping /
+  unknown), driven by `rules.toml`.
+- **extract/imports.py** — `IMPORTS` edges (module-level vs function-local,
+  with `resolved_via` provenance) and `ALIASES` edges for `from X import Y`
+  re-exports and bare `A = B` module-level aliasing — so
+  `mcp/server.py`'s `from graph_tools import symbol_impact` and
+  `mcp/graph_tools.py`'s own `def symbol_impact` are the same node, not two.
+
+- **extract/walk.py** — one shared whole-module AST walk (module-level vs
+  "inside which FUNCTION") that extract/calls.py, extract/names.py and
+  extract/registry.py's REG-FN pass all build their per-node callback on
+  top of, instead of each re-deriving enclosing-scope from scratch.
+- **extract/calls.py** — `CALLSITE` nodes (one per `ast.Call` in the
+  corpus, ~11,600 of them) and rungs 1-3 of the `CALLS` resolution ladder
+  (all PROVEN-tier): a plain module-level def/class, an attribute call
+  through a module-level *or* function-local import, one-or-more `ALIASES`
+  hops, Python builtins, and a nested-function's own bare name. Anything
+  else — attribute calls on an unknown-type receiver, calls through
+  dict/getattr/subscript results, calls on a bare parameter — lands on the
+  single `?` UNRESOLVED sink with a `reason`, never silently dropped
+  (rungs 4-6, the PROBABLE tier, are a later slice's job).
+- **extract/names.py** — `READS_NAME` / `WRITES_NAME` edges, with a precise
+  `via` per occurrence (`module-level-assign` | `global-stmt` |
+  `import-binding` | `def-binding` | `augmented`) and cross-module reads
+  (`mod.X` through a module-level import). This is the data BUG C's
+  diagnosis needs: a `global`-declared write with no module-level binding
+  anywhere in the OWNING module.
+- **extract/registry.py** — `REGISTRY` / `REGISTERS` / `ENTERS` /
+  `ENTRYPOINT` for every registration surface this corpus uses: `DEC`
+  (`@mcp.tool()`, `@mcp.resource()`, `@mcp.custom_route()`,
+  `@app.get/post/...`), `MAN-LOOP` (`for fn in (a, b, c): mcp.tool()(fn)`),
+  `MAN-DICT` (a module-level dict-of-bare-callables, e.g. `_SKILL_MAP`),
+  `ROOT-CLI` (`if __name__ == "__main__":`), and `ROOT-EXT` (rules.toml's
+  hand-maintained `[[roots]]` table for systemd/cron/shell triggers). Also
+  `INJECTS`: `register()`'s parameter-or-`deps["key"]` → `global` binding
+  pattern, correlated against every call site of that `register()`
+  anywhere in the corpus.
+- **analyze/reach.py**, **analyze/deadcode.py** — the closures `cg
+  callers`/`cg reach`/`cg dead` run on top of. `cg dead`'s hard-gate
+  contract (build_steps step 5): **zero** `@mcp.tool()`/manifest-registered
+  function may ever be reported dead — every `ENTRYPOINT` enters its
+  registered `FUNCTION` directly, independent of any module-execution
+  modelling, specifically so this can't slip. Measured at HEAD: **0 false
+  positives across all 92 registered functions**, 66 rows total
+  (down from 165 before the validator pass). A callsite
+  inside a `lambda` body is additionally attributed to the scope that
+  BUILDS the lambda, since a lambda is consumed where it is written.
+
+- **extract/flow.py** — escaping-local detection (`LOCALBINDING`/`ESCAPES`)
+  and the lightweight per-function control-flow summary (a linear walk with
+  a context stack — if-branch / loop-body / except-handler / with-body —
+  deliberately not a real CFG) that `cg flags` ranks over, including the
+  ASSIGNMENT FORM (plain rebind vs `+=` vs for-target) each update used.
+  **analyze/flags.py** turns that into the partial-assignment ranker:
+  `cg flags mcp/grounding.py::ground` finds BUG B's `degraded` flag exactly
+  (init constant, 3 guarded reassignments, 11 guard exits that skip it).
+  `classify()` splits accumulators (counters, correct by construction) off
+  from flags — they were 16 of 23 rows and outranked BUG B itself until the
+  validator pass; pass `--include-accumulators` to see them.
+
+- **extract/funcrefs.py** — `REFERENCES` edges for a bare function name in
+  any value position (passed as an argument, returned, stored). Generalizes
+  the registration-specific REFERENCES `extract/registry.py` already
+  emitted. This is what keeps callbacks like
+  `_health_check("x", _health_probe_embeddings_sparse)` off `cg dead`.
+- **extract/literals.py** — `LITERAL`/`PATHEXPR` nodes and
+  `PRODUCES_LITERAL`/`CONSUMES_LITERAL` edges for path- and key-like string
+  literals, including composed paths (`MEMORY_DIR / "x"`, `os.path.join`,
+  f-strings). **analyze/literalaudit.py** is the producer/consumer table,
+  orphan detection, and the fenced `--near-miss` pairing: `cg literals
+  --paths --orphans` finds BUG D's `graph.ladybug`/`graph.kuzu` split
+  exactly, and `--near-miss` pairs them on the shared `graph` stem.
+- **analyze/nameaudit.py** — `cg writes-dead`'s two checks:
+  DANGLING-GLOBAL (near-zero false positives — finds BUG C's
+  `_symbol_index_cache`/`_symbol_index_count` and names the real slot in
+  `mcp/ladybug_ops.py`) and the weaker WRITE-WITH-NO-READ triage list
+  (`--include-tests` re-checks against a textual scan of `tests/` source).
+
+CLI subcommands available now: `build`, `modules`, `defs`, `imports`,
+`aliases`, `callers`, `reach`, `paths`, `entrypoints`, `registry`, `name`,
+`writes-dead`, `literals`, `flags`, `dead`, `holes`, `explain`, `selftest`,
+`limits`. `--format` accepts `text` (default), `json` (every command), and
+`dot` (a Graphviz export — full graph on `build`, the traversed subgraph on
+`reach`/`callers`/`paths`; solid/dashed/dotted edges encode
+proven/probable/unproven). `whatchanged` (diff-to-blast-radius) is the one
+query from the design not yet built — everything else in `docs/DESIGN.md`'s
+query list is live.
+
+- **selftest.py** / **`cg selftest`** — the standalone health check: builds
+  the graph once over `fixtures/` (no git, no network — one dedicated
+  assertion per dispatch shape the design lists) and once over the real
+  corpus at `--rev HEAD` (the hard gate + registration-surface counts),
+  and prints PASS/FAIL per check with a nonzero exit on any failure. Same
+  checks run under `pytest` via `tests/test_selftest.py`. Full run
+  (fixture build + the one real-corpus build + all 15 assertions) finishes
+  in ~3.5s on this box, comfortably inside the design's 5s ceiling.
+- **`cg limits`** — prints `docs/LIMITS.md` verbatim: the measured
+  false-positive rates and orphan/row counts behind
+  `writes-dead`/`literals`/`flags`, refreshed at every HEAD this package
+  moves to. A new false-positive class discovered in use is meant to be
+  appended there in the same commit that finds it.
+- **`--rev` under a concurrent edit** — `ingest.py`'s git-rev path now
+  reads the whole corpus in ONE `git ls-tree` + ONE `git cat-file --batch`
+  subprocess pair (previously one `git show` per file), which is both
+  faster and, more importantly, structurally incapable of touching the
+  working tree at all when `--rev` is given — verified directly in
+  `tests/test_rev_freshness.py` by monkeypatching `Path.read_text` to
+  raise during a `--rev` build. That's the property that matters while
+  this package was built alongside another workflow mid-editing
+  `mcp/server.py`: `--rev HEAD` never sees whatever that workflow has
+  sitting in the working tree at the moment it runs. `tests/
+  test_rev_freshness.py` also covers the "cache invalidation" half of
+  step 13's brief: there is no parse cache (see `ingest.py`'s own
+  docstring for why, and `--no-cache`'s documented no-op status), so what
+  gets tested instead is the absence of a staleness bug — back-to-back
+  builds at different revisions never leak content into each other, and
+  rebuilding the same rev twice is byte-identical.
+
+## Validation (does it catch bugs that were REAL?)
+
+`tests/test_regression_real_bugs.py` and `tests/test_dead_false_positives.py`
+are the gate that decides whether this tool is worth keeping.
+
+The regression tests do NOT use hand-written miniatures. They run the
+analyzers against the ACTUAL pre-fix source of three shipped bugs, copied
+verbatim out of git history into `fixtures/regress/`, with a provenance test
+that re-checks each fixture against `git show` so it cannot be quietly edited
+into something easier to pass.
+
+| bug | query that surfaces it | result on the real pre-fix code |
+|---|---|---|
+| **B** `grounding.py`'s `degraded` set on only some paths | `cg flags` | sole row for the file; **rank 3 of 7** corpus-wide |
+| **C** `graph_tools.py`'s dead `global` | `cg writes-dead` (DANGLING-GLOBAL) | exactly 2 findings, names the real slot in `ladybug_ops` |
+| **D** `graph.ladybug` vs `graph.kuzu` | `cg literals --paths --orphans --near-miss` | both orphans found and paired on stem `graph` |
+| **A** `node["_id"]` vs `"_ID"` | — | **out of reach, by design.** A data-format mismatch with a value produced inside a driver this tool never parses. No structural signal exists; see `docs/LIMITS.md`. |
+
+`cg dead`'s false-positive rate is documented and gated the same way — see
+`docs/LIMITS.md`'s audit section for the hand-verified breakdown of every
+row it still reports.
+
+Run the tests:
+
+```
+PYTHONPATH=scripts python3 -m pytest scripts/callgraph/tests -q
+```
+
+227 tests, full corpus (114 files) parsed repeatedly at several different
+`--rev`s along the way — expect roughly two minutes wall time for the
+whole suite (dominated by those repeated real-corpus builds, not by
+`cg selftest`'s own ~3.5s fixture-plus-one-HEAD-build budget).
+
+## Provenance
+
+`docs/census.txt` is the original hand-written census of dispatch patterns
+in this corpus (40 `@mcp.tool()` decorators, ~30 `register()` functions,
+288 local imports, ...) that this tool's design was built against.
+`docs/legacy/` holds the one-off AST-walking scanners (`census.py`,
+`extended_census.py`, `PATTERNS_SUMMARY.json`) that produced it — they are
+superseded by `extract/*` and must not be imported by it; keeping two AST
+walkers alive is how rule drift starts.

--- a/scripts/callgraph/__init__.py
+++ b/scripts/callgraph/__init__.py
@@ -1,0 +1,13 @@
+"""callgraph — a dependency-light, stdlib-only static call-graph tool for the
+loci corpus (mcp/, scripts/, a2a_server/, mlops/, eval/).
+
+No LadybugDB, no network, no third-party imports. Designed to run during
+debugging when nothing else in the stack is up, and to read a specific git
+revision (``--rev``) so it stays correct while another workflow is mid-edit
+in a file it needs to look at.
+
+See scripts/callgraph/README.md for the tour and scripts/callgraph/docs/ for
+the design notes and known limitations.
+"""
+
+__version__ = "0.1.0"

--- a/scripts/callgraph/analyze/__init__.py
+++ b/scripts/callgraph/analyze/__init__.py
@@ -1,0 +1,2 @@
+"""analyze/* modules read a built GraphStore and answer a specific question
+(reachability, dead code, name audits, ...). They never mutate the store."""

--- a/scripts/callgraph/analyze/deadcode.py
+++ b/scripts/callgraph/analyze/deadcode.py
@@ -1,0 +1,65 @@
+"""`cg dead`'s verdicts. Deliberately conservative: a function is reported
+only if it is unreachable under the MOST generous closure this tool can
+build (PROBABLE floor — proven + probable). See analyze/reach.py's own
+docstring for why every MODULE is treated as a trivial root.
+
+Only two verdicts are implemented this slice — UNREACHABLE and (a stub for)
+TEST-ONLY/REACHABLE-ONLY-VIA-UNPROVEN are left for a later slice once test
+roots and the probable-tier CALLS rungs (4-6) exist; every row here is
+already reachable-under-PROBABLE-or-better, so nothing is misreported as
+dead, it is simply less finely triaged than the full design calls for.
+
+Per the design's own rule: never wire this to a non-zero exit code, and
+never delete on the strength of this alone — the footer says so on every
+run.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..model import Confidence, GraphStore, Node
+from .reach import reachable_functions
+
+
+def _is_protocol_dunder(node: Node) -> bool:
+    """`__enter__`, `__exit__`, `__init__`, `__iter__`, `__len__`, ... are
+    invoked by LANGUAGE MACHINERY (`with`, `for`, `len()`, an operator, a
+    constructor call), not by name, so no call graph will ever find a
+    reference to them and every one of them is noise on a dead-code list.
+
+    Validated at HEAD: 5 of the 71 rows were protocol dunders, including
+    `scripts/glymphatic_sweep.py`'s `_Mutex.__enter__`/`__exit__`, which are
+    invoked one screen away by `with _Mutex(MUTEX_FLAG):`.
+
+    A never-instantiated class is a real thing to want to know, but the right
+    unit for that is the CLASS, not its `__init__` — reporting the method
+    tells the reader something misleading about the method.
+    """
+    name = node.attrs.get("qualname", "").rsplit(".", 1)[-1]
+    return name.startswith("__") and name.endswith("__") and len(name) > 4
+
+
+def dead_functions(store: GraphStore, scope_prefixes: Optional[list[str]] = None) -> list[Node]:
+    reachable = reachable_functions(store, conf_floor=Confidence.PROBABLE)
+    out: list[Node] = []
+    for n in store.nodes_of_kind("FUNCTION"):
+        if n.attrs.get("is_lambda"):
+            continue  # a lambda's "identity" is its call site; not a useful dead-code unit on its own
+        if _is_protocol_dunder(n):
+            continue
+        if n.id in reachable:
+            continue
+        if scope_prefixes and not any((n.path or "").startswith(p) for p in scope_prefixes):
+            continue
+        out.append(n)
+    return out
+
+
+def registered_but_dead(store: GraphStore, scope_prefixes: Optional[list[str]] = None) -> list[Node]:
+    """The hard-gate check: every function some REGISTERS edge names as
+    externally callable, that this build's `dead_functions` would still
+    report dead. Must be empty on the real corpus — see docs/LIMITS.md and
+    build_steps' step 5 gate."""
+    dead_ids = {n.id for n in dead_functions(store, scope_prefixes)}
+    registered_ids = {e.dst for e in store.edges_of_kind("REGISTERS")}
+    return [store.get(nid) for nid in sorted(registered_ids & dead_ids) if store.get(nid) is not None]

--- a/scripts/callgraph/analyze/flags.py
+++ b/scripts/callgraph/analyze/flags.py
@@ -1,0 +1,108 @@
+"""The partial-assignment ranker behind `cg flags`.
+
+A RANKER, not a detector: every conditional flag in Python matches the
+shape "initialized to a constant, reassigned on some paths, escapes" — see
+docs/LIMITS.md for the measured rows-per-function rate. Scoped to one
+function or file by design; never wire this to a non-zero exit code or a
+CI gate (the design's own rule, restated here because it's the one rule
+this module could tempt someone into breaking).
+
+THIS IS BUG B: `mcp/grounding.py:ground`'s `degraded` LOCALBINDING has a
+constant `False` init, two-to-three guarded reassignments to `True`
+(if/except branches), and several `if not S: break`-shaped guard_exits
+that skip it entirely — a high ratio of "guards that skip" to "guards that
+assign" is exactly the ranking signal.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..model import GraphStore, Node
+
+
+@dataclass
+class FlagCandidate:
+    binding: Node
+    fn_id: str
+    escape_form: str
+    score: float           # guard_exits skipping / max(1, constant rebinds made)
+    pattern: str = "flag"  # "flag" | "accumulator"
+
+    @property
+    def ident(self) -> str:
+        return self.binding.attrs.get("ident", self.binding.id.rsplit("::", 1)[-1])
+
+
+def _in_scope(node: Node, scope_prefixes: Optional[list[str]]) -> bool:
+    if not scope_prefixes:
+        return True
+    return any((node.path or "").startswith(p) for p in scope_prefixes)
+
+
+def classify(binding: Node) -> str:
+    """"accumulator" when the local IS reassigned but never by a plain
+    rebind-to-a-constant — i.e. every update is `+=`/a for-target/a rebind to
+    a computed expression. Counters and running totals live here, and scoring
+    them by guard-exit ratio is a false positive by construction: a counter is
+    SUPPOSED to be updated on only some paths.
+
+    Measured on this corpus at rev d359e9a (the commit where BUG B was live),
+    this is what separated `mcp/grounding.py::ground`'s real `degraded` flag
+    from `link_findings`'s `created` and `measure_drift`'s `n_drifted`, which
+    both outranked it while being entirely correct code.
+
+    A local with ZERO reassignments is NOT an accumulator — it is a flag that
+    is simply never flipped (score 0), which is a different and much weaker
+    signal but still a flag by shape.
+    """
+    contexts = binding.attrs.get("assign_contexts", [])
+    if not contexts:
+        return "flag"
+    forms = set(binding.attrs.get("assign_forms", []))
+    if "augmented" in forms:
+        # HYBRID counter: `n = 0` ... `n = 1` ... `n += 1`. The constant
+        # rebind is a RESET, not a flag flip, so the presence of any `+=`
+        # decides. Found by validation: mcp/server.py::_process_reflection_item's
+        # `lines_scanned` outranked BUG B itself on the constant-rebind
+        # denominator alone (9 guard exits / 1 reset = 9.00).
+        return "accumulator"
+    if binding.attrs.get("constant_rebind_lines"):
+        return "flag"
+    return "accumulator"
+
+
+def rank_flags(store: GraphStore, scope_prefixes: Optional[list[str]] = None,
+                fn_filter: Optional[str] = None,
+                include_accumulators: bool = False) -> list[FlagCandidate]:
+    out: list[FlagCandidate] = []
+    for n in store.nodes_of_kind("LOCALBINDING"):
+        if not n.attrs.get("init_is_constant"):
+            continue
+        if not _in_scope(n, scope_prefixes):
+            continue
+        # local:<fn-id>::<ident> -> fn-id is everything between "local:" and the LAST "::"
+        fn_id = n.id[len("local:"):].rsplit("::", 1)[0]
+        if fn_filter and fn_id != fn_filter:
+            continue
+        pattern = classify(n)
+        if pattern == "accumulator" and not include_accumulators:
+            continue
+        guard_exits = n.attrs.get("guard_exits", [])
+        # Denominator counts only the rebinds that could actually flip the
+        # flag; falling back to assign_lines would re-admit the counter noise
+        # this classification exists to remove.
+        rebinds = n.attrs.get("constant_rebind_lines", n.attrs.get("assign_lines", []))
+        score = len(guard_exits) / max(1, len(rebinds))
+        escapes_edges = store.out_edges(fn_id, "ESCAPES")
+        escape_form = "?"
+        for e in escapes_edges:
+            if e.dst == n.id:
+                escape_form = e.attrs.get("escape_form", "?")
+                break
+        out.append(FlagCandidate(binding=n, fn_id=fn_id, escape_form=escape_form,
+                                  score=score, pattern=pattern))
+    out.sort(key=lambda c: (-c.score, c.binding.path or "", c.binding.line or 0))
+    return out

--- a/scripts/callgraph/analyze/literalaudit.py
+++ b/scripts/callgraph/analyze/literalaudit.py
@@ -1,0 +1,182 @@
+"""Producer/consumer tables, orphan detection, and the fenced near-miss
+pairing behind `cg literals`.
+
+THIS IS BUG D: `mcp/server.py:261`'s `LadybugStore(str(MEMORY_DIR /
+"graph.ladybug"))` PRODUCES a PATHEXPR whose tail literal is
+`graph.ladybug`, with zero CONSUMES anywhere in the corpus; a sibling
+`scripts/graph_facts.py:33`'s `glob.glob(os.path.expanduser("~/.hermes/**/
+graph.kuzu"), recursive=True)` CONSUMES the bare literal
+`~/.hermes/*/graph.kuzu` (normalized), with zero PRODUCES. Both are
+"orphans" — a literal with occurrences only in one direction. Neither half
+proves the other is the bug; the orphan pair is the LEAD, and --near-miss
+is only the convenience of printing them next to each other because they
+share a stem ("graph") across a module boundary.
+
+Matching is keyed on `tail` text (LITERAL's own tail segment, or a
+PATHEXPR's `tail_literal`) rather than node identity, precisely so a
+PATHEXPR producer and a bare-literal consumer with the same tail text are
+recognized as the same "thing" even though they're different node kinds.
+
+NEAR_MISS is capped at PROBABLE and never influences reachability or
+dead-code — see docs/LIMITS.md.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ..model import Confidence, Edge, GraphStore, Node
+
+
+@dataclass
+class LiteralSite:
+    node_id: str            # LITERAL or PATHEXPR id
+    match_text: str         # the tail text sites are grouped/matched on
+    flavour: str
+    direction: str          # "produce" | "consume"
+    src: str                # FUNCTION|MODULE id
+    path: Optional[str]
+    line: Optional[int]
+    col: Optional[int]
+    role: str
+
+
+def _dest_match_text(node: Node) -> Optional[str]:
+    if node.kind == "LITERAL":
+        return node.attrs.get("tail") or node.attrs.get("normalized")
+    if node.kind == "PATHEXPR":
+        return node.attrs.get("tail_literal")
+    return None
+
+
+def _dest_flavour(node: Node) -> str:
+    # PATHEXPR is composed from segments (BinOp `/`, os.path.join, f-string,
+    # `+` concat) that CAN be used in a key-lookup position too (e.g. an
+    # f-string dict key) — its flavour is stamped by extract/literals.py at
+    # the call site that first classified it, same field name as LITERAL.
+    return node.attrs.get("flavour", "path")
+
+
+def collect_sites(store: GraphStore, flavour: Optional[str] = None) -> list[LiteralSite]:
+    out: list[LiteralSite] = []
+    for kind, direction in (("PRODUCES_LITERAL", "produce"), ("CONSUMES_LITERAL", "consume")):
+        for e in store.edges_of_kind(kind):
+            node = store.get(e.dst)
+            if node is None or node.kind not in ("LITERAL", "PATHEXPR"):
+                continue
+            text = _dest_match_text(node)
+            if text is None:
+                continue
+            node_flavour = _dest_flavour(node)
+            if flavour and node_flavour != flavour:
+                continue
+            src_node = store.get(e.src)
+            out.append(LiteralSite(
+                node_id=node.id, match_text=text, flavour=node_flavour, direction=direction,
+                src=e.src, path=(src_node.path if src_node is not None else None),
+                line=e.attrs.get("line"), col=e.attrs.get("col"), role=e.attrs.get("role", "?"),
+            ))
+    return out
+
+
+@dataclass
+class LiteralGroup:
+    match_text: str
+    flavour: str
+    produce_sites: list[LiteralSite] = field(default_factory=list)
+    consume_sites: list[LiteralSite] = field(default_factory=list)
+
+    @property
+    def sites(self) -> list[LiteralSite]:
+        return self.produce_sites + self.consume_sites
+
+
+def group_sites(sites: list[LiteralSite]) -> dict[tuple[str, str], LiteralGroup]:
+    groups: dict[tuple[str, str], LiteralGroup] = {}
+    for s in sites:
+        key = (s.match_text, s.flavour)
+        g = groups.setdefault(key, LiteralGroup(match_text=s.match_text, flavour=s.flavour))
+        (g.produce_sites if s.direction == "produce" else g.consume_sites).append(s)
+    return groups
+
+
+def literal_table(store: GraphStore, flavour: Optional[str] = None) -> list[LiteralGroup]:
+    groups = group_sites(collect_sites(store, flavour))
+    return sorted(groups.values(), key=lambda g: g.match_text)
+
+
+def orphans(store: GraphStore, flavour: Optional[str] = None) -> tuple[list[LiteralGroup], list[LiteralGroup]]:
+    """Returns (producer_only, consumer_only) — path-like literals (by
+    default: pass flavour="path"/"key" to narrow) with occurrences in
+    exactly one direction."""
+    groups = group_sites(collect_sites(store, flavour))
+    producer_only = sorted(
+        (g for g in groups.values() if g.produce_sites and not g.consume_sites),
+        key=lambda g: g.match_text,
+    )
+    consumer_only = sorted(
+        (g for g in groups.values() if g.consume_sites and not g.produce_sites),
+        key=lambda g: g.match_text,
+    )
+    return producer_only, consumer_only
+
+
+def _stem(tail: str) -> str:
+    base = tail.rstrip("/").rsplit("/", 1)[-1]
+    if "." in base and not base.startswith("."):
+        return base.rsplit(".", 1)[0].lower()
+    return base.lower()
+
+
+@dataclass
+class NearMiss:
+    producer: LiteralGroup
+    consumer: LiteralGroup
+    shared_stem: str
+    distance: float
+
+
+def near_miss_pairs(producer_only: list[LiteralGroup], consumer_only: list[LiteralGroup]) -> list[NearMiss]:
+    """Fenced pairing: same stem (tail text minus extension, case-folded),
+    cross-module, capped at PROBABLE, and — per the design's own rule —
+    never wired into reachability or dead-code. `distance` is a plain
+    difflib ratio, reported as a lead's supporting detail, not a threshold
+    this function filters on beyond the stem match."""
+    out: list[NearMiss] = []
+    for p in producer_only:
+        p_stem = _stem(p.match_text)
+        p_paths = {s.path for s in p.produce_sites}
+        for c in consumer_only:
+            if _stem(c.match_text) != p_stem:
+                continue
+            if p.match_text == c.match_text:
+                continue  # exact match is not a "near" miss — it wouldn't be an orphan pair anyway
+            c_paths = {s.path for s in c.consume_sites}
+            if p_paths <= c_paths and c_paths <= p_paths:
+                continue  # same module(s) only — design requires a module boundary
+            ratio = difflib.SequenceMatcher(None, p.match_text, c.match_text).ratio()
+            out.append(NearMiss(producer=p, consumer=c, shared_stem=p_stem, distance=round(ratio, 3)))
+    out.sort(key=lambda nm: (-nm.distance, nm.shared_stem))
+    return out
+
+
+def materialize_near_miss_edges(store: GraphStore, pairs: list[NearMiss]) -> list[Edge]:
+    """Adds the derived NEAR_MISS LITERAL->LITERAL/PATHEXPR edges to the
+    live store so `cg explain` can show them too. Idempotent-ish: callers
+    (the CLI) call this once per invocation on a freshly built store, so
+    duplicate edges across repeated calls within one process are the only
+    risk, which this function does not need to guard against here."""
+    edges: list[Edge] = []
+    for nm in pairs:
+        for p_site in nm.producer.produce_sites:
+            for c_site in nm.consumer.consume_sites:
+                e = Edge(src=p_site.node_id, dst=c_site.node_id, kind="NEAR_MISS", confidence=Confidence.PROBABLE,
+                         attrs={"distance": nm.distance, "shared_stem": nm.shared_stem,
+                                "producer_site": f"{p_site.path}:{p_site.line}",
+                                "consumer_site": f"{c_site.path}:{c_site.line}"})
+                store.add_edge(e)
+                edges.append(e)
+    return edges

--- a/scripts/callgraph/analyze/nameaudit.py
+++ b/scripts/callgraph/analyze/nameaudit.py
@@ -1,0 +1,122 @@
+"""`cg writes-dead` — two checks over NAME/WRITES_NAME/READS_NAME, reported
+separately because their false-positive rates are wildly different.
+
+(a) DANGLING-GLOBAL: an ident declared `global` inside some function of
+    module M, where M has no module-level binding (assign/def/import) of
+    that ident anywhere. scopes.py already computed this exactly —
+    `binding_kind` contains "global-only" precisely when a `global`
+    statement named the ident and nothing in the module's own top-level
+    body ever bound it — so this check is a lookup, not a heuristic.
+    THIS IS BUG C: mcp/graph_tools.py's `global _symbol_index_cache,
+    _symbol_index_count` binds a slot graph_tools.py never defines at
+    module level; the real slot is module-level in mcp/ladybug_ops.py. The
+    diagnosis names that real slot by finding every OTHER module's NAME
+    node with the same ident that IS module-level-bound — near-zero false
+    positives, because a typo or a stale cross-module assumption is almost
+    the only way to end up here.
+
+(b) WRITE-WITH-NO-READ: a NAME slot with >=1 WRITES_NAME edge and 0
+    READS_NAME edges anywhere in the corpus. Much weaker: a slot read only
+    via `getattr(mod, "x")`, `from mod import *`, or only from test code
+    (excluded from the default corpus) reads as a false positive here.
+    Reported as a triage list, never a diagnosis — see docs/LIMITS.md for
+    the measured false-positive rate on this corpus.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ..model import Edge, GraphStore, Node
+
+
+def _ident_of(name_id: str) -> str:
+    return name_id.rsplit("::", 1)[-1]
+
+
+def _in_scope(node: Node, scope_prefixes: Optional[list[str]]) -> bool:
+    if not scope_prefixes:
+        return True
+    return any((node.path or "").startswith(p) for p in scope_prefixes)
+
+
+@dataclass
+class DanglingGlobalFinding:
+    slot: Node
+    global_writes: list[Edge]              # WRITES_NAME edges with via="global-stmt"
+    real_slots: list[Node] = field(default_factory=list)   # module-level-bound NAME nodes,
+                                                             # same ident, a DIFFERENT module
+
+
+@dataclass
+class WriteNoReadFinding:
+    slot: Node
+    writes: list[Edge]
+
+
+def _module_level_bound_index(store: GraphStore) -> dict[str, list[Node]]:
+    """ident -> every NAME node, across the whole corpus, that IS bound at
+    module level (assign/def/import) — the candidate pool for "where does
+    the real slot live" in a dangling-global diagnosis."""
+    idx: dict[str, list[Node]] = {}
+    for n in store.nodes_of_kind("NAME"):
+        bk = set(n.attrs.get("binding_kind", []))
+        if bk & {"assign", "def", "import"}:
+            idx.setdefault(_ident_of(n.id), []).append(n)
+    return idx
+
+
+def dangling_globals(store: GraphStore, scope_prefixes: Optional[list[str]] = None) -> list[DanglingGlobalFinding]:
+    real_slot_index = _module_level_bound_index(store)
+    out: list[DanglingGlobalFinding] = []
+    for n in store.nodes_of_kind("NAME"):
+        if "global-only" not in set(n.attrs.get("binding_kind", [])):
+            continue
+        if not _in_scope(n, scope_prefixes):
+            continue
+        ident = _ident_of(n.id)
+        writes = [e for e in store.in_edges(n.id, "WRITES_NAME") if e.attrs.get("via") == "global-stmt"]
+        real = sorted(
+            (rn for rn in real_slot_index.get(ident, []) if rn.path != n.path),
+            key=lambda rn: (rn.path or "", rn.line or 0),
+        )
+        out.append(DanglingGlobalFinding(slot=n, global_writes=writes, real_slots=real))
+    out.sort(key=lambda f: (f.slot.path or "", f.slot.line or 0))
+    return out
+
+
+def write_no_read(store: GraphStore, scope_prefixes: Optional[list[str]] = None) -> list[WriteNoReadFinding]:
+    out: list[WriteNoReadFinding] = []
+    for n in store.nodes_of_kind("NAME"):
+        if not _in_scope(n, scope_prefixes):
+            continue
+        writes = store.in_edges(n.id, "WRITES_NAME")
+        if not writes:
+            continue
+        if store.in_edges(n.id, "READS_NAME"):
+            continue
+        out.append(WriteNoReadFinding(slot=n, writes=writes))
+    out.sort(key=lambda f: (f.slot.path or "", f.slot.line or 0))
+    return out
+
+
+def read_by_tests(idents: set[str], test_sources) -> dict[str, list[str]]:
+    """Cheap `--include-tests` mitigation for the weak check: a whole-word
+    textual scan of test file SOURCE (not a full parse/resolve — tests are
+    intentionally excluded from the modelled corpus, see config.py) for
+    each candidate ident. Returns ident -> sorted list of test rel_paths
+    where the token appears at least once. A textual hit is not proof the
+    ident is genuinely read there (it could be a coincidental substring
+    match on a docstring, or the ident used as an unrelated local), which
+    is exactly why this is a `--include-tests` RE-CHECK, not baked into the
+    default write-with-no-read result."""
+    import re
+    hits: dict[str, list[str]] = {ident: [] for ident in idents}
+    patterns = {ident: re.compile(r"\b" + re.escape(ident) + r"\b") for ident in idents}
+    for sf in test_sources:
+        for ident, pat in patterns.items():
+            if pat.search(sf.source):
+                hits[ident].append(sf.rel_path)
+    return {ident: sorted(paths) for ident, paths in hits.items() if paths}

--- a/scripts/callgraph/analyze/reach.py
+++ b/scripts/callgraph/analyze/reach.py
@@ -1,0 +1,321 @@
+"""Forward/backward closures over the graph, at whatever confidence tier the
+caller asks for. This is deliberately small: it backs `cg callers`, `cg
+reach`, `cg entrypoints`, and `cg dead`'s "what does an ENTRYPOINT actually
+reach" question, without inventing a second traversal per command.
+
+A MODULE-level statement executes automatically the instant the module is
+imported — Python doesn't wait for anyone to "call" module top level. Since
+this corpus is one monolithic MCP server where every module IS imported
+(directly or transitively) by server.py, every MODULE node is treated as a
+trivially-reachable root for `reachable_functions()`'s closure (NOT for
+`callers`/`reach`, which answer a narrower question about one symbol). This
+is what keeps `register()` helper functions — never externally callable by
+name, but executed unconditionally at import time — off the dead list
+without requiring a full import-order simulation. It is also exactly the
+kind of approximation `cg dead`'s own footer says out loud: this tool
+reports "no path it can model", not "safe to delete".
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from ..model import Confidence, Edge, GraphStore, Node
+
+# DISPATCHES joined CALLS/REFERENCES once extract/dispatch.py's probable
+# tier existed: a callsite this tool cannot pin to one target (dict-of-
+# callables fan-out, a widened injected global) still names every real
+# candidate, and those candidates are exactly as "reachable" as a proven
+# call for dead-code/reach purposes — just at PROBABLE confidence, same as
+# any other rung-4+ edge.
+CALL_EDGE_KINDS = ("CALLS", "REFERENCES", "DISPATCHES")
+CLOSURE_EDGE_KINDS = ("ENTERS", "REGISTERS")
+
+
+def _lambda_host(store: GraphStore, fn_id: str) -> Optional[str]:
+    """The nearest enclosing NON-lambda FUNCTION of a lambda, or its MODULE.
+
+    A lambda has no name to be called by: it is always consumed in place --
+    passed, returned, or stored -- at the point it is written. So its body
+    is reachable exactly when the scope that CONSTRUCTS it is reachable, and
+    attributing its callsites to that scope is precise, not a widening.
+
+    Without this, everything called only from inside a lambda is reported
+    dead. Measured on the real corpus at HEAD: mcp/server.py's health block
+    dispatches nine `_health_probe_*` functions through
+    `lambda: _health_probe_qdrant_reachable(qdrant_url, qd)` and every one of
+    them was a false positive on `cg dead`.
+    """
+    node = store.get(fn_id)
+    if node is None or not node.attrs.get("is_lambda"):
+        return None
+    qual = node.attrs.get("qualname", "")
+    path = node.path or ""
+    while ".<locals>." in qual:
+        qual = qual.rsplit(".<locals>.", 1)[0]
+        host_id = f"fn:{path}::{qual}"
+        host = store.get(host_id)
+        if host is not None and host.kind == "FUNCTION" and not host.attrs.get("is_lambda"):
+            return host_id
+    mod_id = f"mod:{path}"
+    return mod_id if mod_id in store else None
+
+
+def _callsites_by_enclosing(store: GraphStore) -> dict[Optional[str], list[Node]]:
+    idx: dict[Optional[str], list[Node]] = {}
+    for n in store.nodes_of_kind("CALLSITE"):
+        encl = n.attrs.get("enclosing_fn")
+        idx.setdefault(encl, []).append(n)
+        # A callsite inside a lambda ALSO belongs to the scope that builds
+        # the lambda — see _lambda_host.
+        if encl is not None:
+            host = _lambda_host(store, encl)
+            if host is not None and host != encl:
+                idx.setdefault(host, []).append(n)
+    return idx
+
+
+def reachable_functions(store: GraphStore, conf_floor: Confidence = Confidence.PROBABLE,
+                         extra_roots: Iterable[str] = ()) -> set[str]:
+    """Every FUNCTION id reachable from any ENTRYPOINT, or trivially via
+    module-execution, following CALLS/REFERENCES (through CALLSITEs) and
+    REGISTERS/ENTERS edges at or above conf_floor."""
+    callsites = _callsites_by_enclosing(store)
+    visited: set[str] = set()
+    frontier: list[str] = []
+
+    def seed(node_id: str) -> None:
+        if node_id not in visited:
+            visited.add(node_id)
+            frontier.append(node_id)
+
+    for n in store.nodes_of_kind("ENTRYPOINT"):
+        seed(n.id)
+    for n in store.nodes_of_kind("MODULE"):
+        seed(n.id)
+    for rid in extra_roots:
+        seed(rid)
+
+    while frontier:
+        nxt: list[str] = []
+        for nid in frontier:
+            for kind in CLOSURE_EDGE_KINDS:
+                for e in store.out_edges(nid, kind):
+                    if e.confidence >= conf_floor and e.dst not in visited:
+                        visited.add(e.dst)
+                        nxt.append(e.dst)
+            for cs in callsites.get(nid, []):
+                for kind in CALL_EDGE_KINDS:
+                    for e in store.out_edges(cs.id, kind):
+                        if e.confidence >= conf_floor and e.dst not in visited:
+                            visited.add(e.dst)
+                            nxt.append(e.dst)
+            # REFERENCES whose src is a FUNCTION/MODULE directly (MAN-LOOP's
+            # register()-body tuple, MAN-DICT's module-level dict literal),
+            # not routed via a CALLSITE.
+            for e in store.out_edges(nid, "REFERENCES"):
+                if e.confidence >= conf_floor and e.dst not in visited:
+                    visited.add(e.dst)
+                    nxt.append(e.dst)
+        frontier = nxt
+
+    return {nid for nid in visited if (nd := store.get(nid)) is not None and nd.kind == "FUNCTION"}
+
+
+@dataclass
+class CallerRow:
+    kind: str          # "CALLS" | "REFERENCES" | "DISPATCHES"
+    edge: Edge
+    site_node: Optional[Node]   # the CALLSITE (for CALLS/DISPATCHES) or None (REFERENCES)
+
+
+def direct_callers(store: GraphStore, target_id: str) -> list[CallerRow]:
+    rows: list[CallerRow] = []
+    for e in store.in_edges(target_id, "CALLS"):
+        rows.append(CallerRow("CALLS", e, store.get(e.src)))
+    for e in store.in_edges(target_id, "DISPATCHES"):
+        rows.append(CallerRow("DISPATCHES", e, store.get(e.src)))
+    for e in store.in_edges(target_id, "REFERENCES"):
+        rows.append(CallerRow("REFERENCES", e, None))
+    return rows
+
+
+def resolve_symbol(store: GraphStore, symbol: str) -> list[str]:
+    """A FUNCTION id, a `module::qualname` shorthand, or a bare name (which
+    may be ambiguous — every module-level FUNCTION with that exact
+    qualname is returned so the caller can print the candidate set rather
+    than silently pick one)."""
+    if symbol in store and store.get(symbol).kind == "FUNCTION":
+        return [symbol]
+    if "::" in symbol and not symbol.startswith("fn:"):
+        cand = f"fn:{symbol}"
+        if cand in store:
+            return [cand]
+    exact = sorted({n.id for n in store.nodes_of_kind("FUNCTION") if n.attrs.get("qualname") == symbol})
+    if exact:
+        return exact
+    suffix = sorted({
+        n.id for n in store.nodes_of_kind("FUNCTION")
+        if n.id.endswith(f"::{symbol}") or n.id.endswith(f".{symbol}")
+    })
+    return suffix
+
+
+def function_at_line(store: GraphStore, path: str, line: int) -> Optional[str]:
+    """The innermost FUNCTION at `path` whose [lineno, end_lineno] span
+    contains `line`, or the MODULE id if no function's span does (the line
+    is top-level module code). Ties among nested functions are broken by
+    picking the one with the LARGEST start line — the most specific,
+    innermost span containing the target line."""
+    best: Optional[Node] = None
+    for n in store.nodes_of_kind("FUNCTION"):
+        if n.path != path or n.line is None:
+            continue
+        end = n.attrs.get("end_lineno", n.line)
+        if n.line <= line <= end:
+            if best is None or n.line > best.line:
+                best = n
+    if best is not None:
+        return best.id
+    mod_id = f"mod:{path}"
+    return mod_id if mod_id in store else None
+
+
+def forward_calls(store: GraphStore, fn_id: str, depth: int = 3,
+                   conf_floor: Confidence = Confidence.PROBABLE) -> list[tuple[int, Edge, Node]]:
+    """BFS out from fn_id's own CALLSITEs, depth-limited. Returns
+    (hop_depth, CALLS-or-REFERENCES edge, callsite-or-None) tuples in
+    discovery order; a target visited at a shallower depth is not repeated
+    at a deeper one."""
+    callsites = _callsites_by_enclosing(store)
+    out: list[tuple[int, Edge, Node]] = []
+    seen_targets: set[str] = {fn_id}
+    frontier = [fn_id]
+    d = 0
+    while frontier and d < depth:
+        d += 1
+        nxt: list[str] = []
+        for nid in frontier:
+            for cs in callsites.get(nid, []):
+                for kind in CALL_EDGE_KINDS:
+                    for e in store.out_edges(cs.id, kind):
+                        if e.confidence < conf_floor or e.dst in seen_targets:
+                            continue
+                        seen_targets.add(e.dst)
+                        out.append((d, e, cs))
+                        tnode = store.get(e.dst)
+                        if tnode is not None and tnode.kind == "FUNCTION":
+                            nxt.append(e.dst)
+            for kind in CALL_EDGE_KINDS:
+                for e in store.out_edges(nid, kind):
+                    if e.confidence < conf_floor or e.dst in seen_targets:
+                        continue
+                    seen_targets.add(e.dst)
+                    out.append((d, e, None))
+                    tnode = store.get(e.dst)
+                    if tnode is not None and tnode.kind == "FUNCTION":
+                        nxt.append(e.dst)
+        frontier = nxt
+    return out
+
+
+# ---------------------------------------------------------------------------
+# `cg paths` / `cg reach --to` / `cg entrypoints`
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PathHop:
+    edge: Edge
+    site: Optional[Node]   # the CALLSITE this hop travelled through, or None (a REFERENCES/DISPATCHES-off-a-FUNCTION hop)
+
+
+def path_confidence(hops: list["PathHop"]) -> Confidence:
+    """A path's confidence is the MINIMUM over its hops, never an average —
+    one PROBABLE link in an otherwise-PROVEN chain demotes the whole
+    answer, because the chain is only as trustworthy as its weakest edge."""
+    return Confidence.combine(h.edge.confidence for h in hops)
+
+
+def shortest_path(store: GraphStore, src_id: str, dst_id: str,
+                   conf_floor: Confidence = Confidence.UNPROVEN, max_depth: int = 20) -> Optional[list[PathHop]]:
+    """BFS shortest hop-chain from src_id to dst_id, over the same edge set
+    forward_calls/reachable_functions use (CALLS/REFERENCES/DISPATCHES,
+    through each source function's own CALLSITEs). Returns the hop list in
+    call order (empty list if src_id == dst_id), or None if dst_id is not
+    reachable within max_depth hops at conf_floor or better. Breadth-first
+    so the FIRST path found is shortest by hop count — ties are broken by
+    store iteration order, not by confidence (callers wanting the highest-
+    confidence path should raise conf_floor and re-run, not sort after)."""
+    if src_id == dst_id:
+        return []
+    callsites = _callsites_by_enclosing(store)
+    visited = {src_id}
+    queue: deque = deque([(src_id, [])])
+    while queue:
+        nid, path = queue.popleft()
+        if len(path) >= max_depth:
+            continue
+        candidates: list[tuple[Edge, Optional[Node]]] = []
+        for cs in callsites.get(nid, []):
+            for kind in CALL_EDGE_KINDS:
+                for e in store.out_edges(cs.id, kind):
+                    candidates.append((e, cs))
+        for kind in CALL_EDGE_KINDS:
+            for e in store.out_edges(nid, kind):
+                candidates.append((e, None))
+        for e, cs in candidates:
+            if e.confidence < conf_floor or e.dst in visited:
+                continue
+            new_path = path + [PathHop(e, cs)]
+            if e.dst == dst_id:
+                return new_path
+            visited.add(e.dst)
+            tnode = store.get(e.dst)
+            if tnode is not None and tnode.kind == "FUNCTION":
+                queue.append((e.dst, new_path))
+    return None
+
+
+def entrypoints_reaching(store: GraphStore, start_id: str,
+                          conf_floor: Confidence = Confidence.PROBABLE) -> dict[str, Confidence]:
+    """Reverse closure from a FUNCTION (or MODULE) id back to every
+    ENTRYPOINT that can reach it — the backward mirror of
+    reachable_functions' forward walk, over the identical edge set (ENTERS/
+    REGISTERS/REFERENCES walked directly; CALLS/DISPATCHES walked back via
+    each CALLSITE's own `enclosing_fn`, since those edges originate at a
+    CALLSITE, not a FUNCTION). Returns {entrypoint_id: best confidence seen
+    on any path to it} — `cg entrypoints` prints this as "reachable from N
+    entry points", one line per key."""
+    visited = {start_id}
+    frontier = [start_id]
+    entrypoints: dict[str, Confidence] = {}
+    while frontier:
+        nxt: list[str] = []
+        for nid in frontier:
+            for e in store.in_edges(nid, "ENTERS"):
+                if e.confidence < conf_floor:
+                    continue
+                best = entrypoints.get(e.src)
+                if best is None or e.confidence > best:
+                    entrypoints[e.src] = e.confidence
+            for e in store.in_edges(nid, "REGISTERS"):
+                if e.confidence >= conf_floor and e.src not in visited:
+                    visited.add(e.src)
+                    nxt.append(e.src)
+            for e in store.in_edges(nid, "REFERENCES"):
+                if e.confidence >= conf_floor and e.src not in visited:
+                    visited.add(e.src)
+                    nxt.append(e.src)
+            for kind in ("CALLS", "DISPATCHES"):
+                for e in store.in_edges(nid, kind):
+                    if e.confidence < conf_floor:
+                        continue
+                    site = store.get(e.src)
+                    encl = site.attrs.get("enclosing_fn") if site is not None else None
+                    if encl is not None and encl not in visited:
+                        visited.add(encl)
+                        nxt.append(encl)
+        frontier = nxt
+    return entrypoints

--- a/scripts/callgraph/cli.py
+++ b/scripts/callgraph/cli.py
@@ -1,0 +1,1072 @@
+"""argparse front end for `cg`.
+
+Slice 1 implements: build, modules, defs, imports, aliases.
+Slice 2 adds: callers, reach, registry, name, dead, holes — on the CALLSITE/
+CALLS resolution ladder (rungs 1-3), REGISTRY/REGISTERS/ENTERS/ENTRYPOINT,
+and READS_NAME/WRITES_NAME/INJECTS extract/* modules built alongside it.
+Slice 3 (build steps 7-9) adds: the probable tier (extract/dispatch.py's
+CALLS rungs 4-6 + DISPATCHES), `--why` on callers/reach rows, and the
+traversal commands `reach --to`/`paths`/`entrypoints`/`explain`, all riding
+the same pipeline.build_graph() — no new node/edge kind needed a schema
+change, this slice only adds resolution power and ways to see it.
+Slice 4/step 13 (hardening) adds: `selftest` (build_steps step 13's
+standalone health check, see selftest.py) and `limits` (prints
+docs/LIMITS.md), plus `--format dot` on build/reach/callers/paths.
+`whatchanged` (diff -> blast radius) is the one query from the design not
+yet built.
+
+Exit codes: 0 clean, 1 findings present (`selftest` uses this for a failed
+check; the design's other analysis commands are lead generators and are
+deliberately never wired to a nonzero exit — see docs/LIMITS.md), 2 tool
+error (bad args, git failure, etc).
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Optional
+
+from . import config
+from .analyze.deadcode import dead_functions
+from .analyze.flags import rank_flags
+from .analyze.literalaudit import literal_table, materialize_near_miss_edges, near_miss_pairs, orphans
+from .analyze.nameaudit import dangling_globals, read_by_tests, write_no_read
+from .analyze.reach import (
+    Confidence, direct_callers, entrypoints_reaching, forward_calls, function_at_line,
+    path_confidence, resolve_symbol, shortest_path,
+)
+from .ingest import load_test_sources
+from .model import GraphStore
+from .pipeline import BuildResult, build_graph
+from .selftest import run_selftest
+
+
+def _add_common_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--rev", default=None, help="git rev to read instead of the working tree (e.g. HEAD)")
+    p.add_argument("--scope", action="append", default=None, metavar="PATH_PREFIX",
+                    help="restrict to files whose repo-relative path starts with this prefix; repeatable")
+    p.add_argument("--format", choices=["text", "json", "dot"], default="text")
+    p.add_argument("--no-cache", action="store_true", help="currently a no-op (see ingest.py)")
+    p.add_argument("--conf", choices=["proven", "probable", "all"], default="probable",
+                    help="confidence floor for edges considered (default: probable)")
+    p.add_argument("--depth", type=int, default=None, help="traversal depth limit (command-specific default if omitted)")
+    p.add_argument("--why", action="store_true", help="print the rule/because behind each row")
+
+
+def _conf_floor(args: argparse.Namespace) -> Optional[Confidence]:
+    return None if args.conf == "all" else Confidence.parse(args.conf)
+
+
+def _build(args: argparse.Namespace) -> BuildResult:
+    try:
+        return build_graph(rev=args.rev, scope_prefixes=args.scope, no_cache=args.no_cache)
+    except Exception as exc:  # tool error, not a finding
+        print(f"callgraph: build failed: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def _footer(result: BuildResult) -> str:
+    m = result.meta
+    scope_note = f" scope={'+'.join(m.scope_prefixes)}" if m.scope_prefixes else ""
+    return (f"# source: {m.source}{scope_note}  files: {m.file_count}  "
+            f"parse errors: {m.error_count}  built in {m.elapsed_s:.3f}s")
+
+
+# -- build ------------------------------------------------------------------
+
+def cmd_build(args: argparse.Namespace) -> int:
+    result = _build(args)
+    if args.format == "dot":
+        print(result.store.to_dot())
+        return 0
+    if args.format == "json":
+        print(json.dumps({
+            "source": result.meta.source, "file_count": result.meta.file_count,
+            "error_count": result.meta.error_count, "errors": result.meta.errors,
+            "elapsed_s": result.meta.elapsed_s, "stats": result.store.stats(),
+        }, indent=2, sort_keys=True))
+        return 0
+    print(_footer(result))
+    print()
+    stats = result.store.stats()
+    for key in sorted(stats):
+        if key in ("nodes", "edges"):
+            continue
+        print(f"  {key:28s} {stats[key]:6d}")
+    print(f"  {'TOTAL nodes':28s} {stats['nodes']:6d}")
+    print(f"  {'TOTAL edges':28s} {stats['edges']:6d}")
+    if result.meta.errors:
+        print("\nparse errors:")
+        for path, err in result.meta.errors:
+            print(f"  {path}: {err}")
+    return 0
+
+
+# -- modules ------------------------------------------------------------------
+
+def cmd_modules(args: argparse.Namespace) -> int:
+    result = _build(args)
+    rows = []
+    for node in sorted(result.store.nodes_of_kind("MODULE"), key=lambda n: n.path or ""):
+        rows.append({
+            "path": node.path, "kind": node.attrs.get("kind"),
+            "importable_as": node.attrs.get("importable_as"),
+            "has_main": node.attrs.get("has_main"),
+        })
+    if args.format == "json":
+        print(json.dumps(rows, indent=2, sort_keys=True))
+        return 0
+    print(_footer(result))
+    print()
+    for r in rows:
+        names = ", ".join(r["importable_as"])
+        main_flag = " [__main__]" if r["has_main"] else ""
+        print(f"  {r['path']:45s} {r['kind']:15s} {{{names}}}{main_flag}")
+    print(f"\n  {len(rows)} modules")
+    return 0
+
+
+# -- defs ------------------------------------------------------------------
+
+def cmd_defs(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    functions = sorted(store.nodes_of_kind("FUNCTION"), key=lambda n: (n.path or "", n.line or 0))
+    classes = sorted(store.nodes_of_kind("CLASS"), key=lambda n: (n.path or "", n.line or 0))
+    names = list(store.nodes_of_kind("NAME"))
+
+    if args.filter:
+        functions = [n for n in functions if args.filter in (n.path or "")]
+        classes = [n for n in classes if args.filter in (n.path or "")]
+
+    module_level_fns = [n for n in functions if not n.attrs.get("is_nested") and not n.attrs.get("is_method")]
+    function_local_imports = sum(
+        1 for e in store.edges_of_kind("IMPORTS") if e.attrs.get("scope") == "function-local"
+    )
+    dangling_globals = sum(
+        1 for n in names if "global-only" in n.attrs.get("binding_kind", [])
+    )
+
+    if args.format == "json":
+        payload = {
+            "functions": [
+                {"id": n.id, "path": n.path, "line": n.line, "qualname": n.attrs.get("qualname"),
+                 "is_method": n.attrs.get("is_method"), "is_nested": n.attrs.get("is_nested"),
+                 "is_lambda": n.attrs.get("is_lambda"), "decorators": n.attrs.get("decorators")}
+                for n in functions
+            ],
+            "classes": [
+                {"id": n.id, "path": n.path, "line": n.line, "qualname": n.attrs.get("qualname"),
+                 "bases": n.attrs.get("bases")}
+                for n in classes
+            ],
+            "summary": {
+                "functions_total": len(functions), "functions_module_level": len(module_level_fns),
+                "classes_total": len(classes), "names_total": len(names),
+                "function_local_imports": function_local_imports, "dangling_globals": dangling_globals,
+            },
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print()
+    if args.filter or args.all:
+        for n in functions:
+            deco = f"  @{', @'.join(_decorator_heads(n))}" if n.attrs.get("decorators") else ""
+            print(f"  {n.path}:{n.line}  fn  {n.attrs.get('qualname')}{deco}")
+        for n in classes:
+            print(f"  {n.path}:{n.line}  cls {n.attrs.get('qualname')}  bases=({', '.join(n.attrs.get('bases', []))})")
+    print()
+    print(f"  functions: {len(functions)} total, {len(module_level_fns)} module-level (not nested/method)")
+    print(f"  classes:   {len(classes)}")
+    print(f"  NAME slots: {len(names)}  (dangling-global candidates: {dangling_globals})")
+    print(f"  function-local imports: {function_local_imports}")
+    unmatched = [
+        e for n in functions for e in store.out_edges(n.id, "DECORATED_BY")
+        if e.attrs.get("classification") == "unknown"
+    ]
+    if unmatched:
+        print(f"\n  {len(unmatched)} decorator(s) not classified by rules.toml:")
+        for e in unmatched:
+            print(f"    {e.attrs.get('raw')}  (line {e.attrs.get('line')})")
+    return 0
+
+
+def _decorator_heads(fn_node) -> list[str]:
+    return [d.split("(")[0] for d in fn_node.attrs.get("decorators", [])]
+
+
+# -- imports ------------------------------------------------------------------
+
+def cmd_imports(args: argparse.Namespace) -> int:
+    result = _build(args)
+    edges = list(result.store.edges_of_kind("IMPORTS"))
+    if args.lazy:
+        edges = [e for e in edges if e.attrs.get("scope") == "function-local"]
+    if args.unresolved:
+        edges = [e for e in edges if e.attrs.get("resolved_via") == "unresolved"]
+
+    edges.sort(key=lambda e: (e.src, e.attrs.get("line") or 0))
+
+    if args.format == "json":
+        print(json.dumps([
+            {"src": e.src, "dst": e.dst, "confidence": e.confidence.name, **e.attrs}
+            for e in edges
+        ], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print()
+    for e in edges:
+        src_path = e.src.split(":", 1)[1] if e.src.startswith("mod:") else e.src
+        loc = f"{src_path}:{e.attrs.get('line')}"
+        scope_tag = "[local]" if e.attrs.get("scope") == "function-local" else "        "
+        fn_tag = f" in {e.attrs.get('enclosing_fn')}" if e.attrs.get("enclosing_fn") else ""
+        print(f"  {loc:38s} {scope_tag} {e.attrs.get('module') or '(bare)':30s} "
+              f"-> {e.dst:45s} {e.confidence.name:9s} via={e.attrs.get('resolved_via')}{fn_tag}")
+    print(f"\n  {len(edges)} import edges")
+    if args.unresolved and not edges:
+        print("  (none — every import resolves to a corpus module, stdlib, or a third-party package in the venv)")
+    return 0
+
+
+# -- aliases (debug/verification command for step 3) ------------------------
+
+def cmd_aliases(args: argparse.Namespace) -> int:
+    result = _build(args)
+    edges = list(result.store.edges_of_kind("ALIASES"))
+    if args.filter:
+        edges = [e for e in edges if args.filter in e.src]
+    edges.sort(key=lambda e: (e.src, e.attrs.get("line") or 0))
+    if args.format == "json":
+        print(json.dumps([
+            {"src": e.src, "dst": e.dst, "confidence": e.confidence.name, **e.attrs} for e in edges
+        ], indent=2, sort_keys=True))
+        return 0
+    print(_footer(result))
+    print()
+    for e in edges:
+        print(f"  {e.src}  --[{e.attrs.get('form')}]-->  {e.dst}  ({e.confidence.name})")
+    print(f"\n  {len(edges)} alias edges")
+    return 0
+
+
+# -- callers ------------------------------------------------------------------
+
+
+def _row_conf_name(conf: Confidence) -> str:
+    return conf.name
+
+
+def cmd_callers(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    targets = resolve_symbol(store, args.symbol)
+    if not targets:
+        print(f"# no FUNCTION found matching '{args.symbol}'", file=sys.stderr)
+        return 2
+    if len(targets) > 1:
+        print(f"# ambiguous symbol '{args.symbol}' — {len(targets)} candidates (pass one of these ids to disambiguate):")
+        for t in sorted(targets):
+            print(f"  {t}")
+        return 0
+
+    target = targets[0]
+    conf_floor = _conf_floor(args)
+    rows = direct_callers(store, target)
+    if conf_floor is not None:
+        rows = [r for r in rows if r.edge.confidence >= conf_floor]
+
+    if args.format == "dot":
+        node_ids = {target} | {r.edge.src for r in rows} | {r.edge.dst for r in rows}
+        print(store.to_dot(node_ids, [r.edge for r in rows]))
+        return 0
+    if args.format == "json":
+        print(json.dumps([
+            {"kind": r.kind, "src": r.edge.src, "confidence": r.edge.confidence.name, **r.edge.attrs}
+            for r in rows
+        ], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print(f"# callers of {target}")
+    print()
+    for tier in (Confidence.PROVEN, Confidence.PROBABLE, Confidence.UNPROVEN):
+        tier_rows = [r for r in rows if r.edge.confidence == tier]
+        if not tier_rows:
+            continue
+        print(f"-- {tier.name} " + "-" * (60 - len(tier.name)))
+        for r in tier_rows:
+            _print_caller_row(store, r, tier, args.why)
+        print()
+    print(f"  {len(rows)} caller row(s)")
+    return 0
+
+
+def _print_caller_row(store: GraphStore, r, tier: Confidence, why: bool) -> None:
+    if r.kind == "CALLS":
+        site = r.site_node
+        loc = f"{site.path}:{site.line}:{site.col}" if site is not None else r.edge.src
+        extra = f"  because={r.edge.attrs['because']}" if "because" in r.edge.attrs else ""
+        rung = r.edge.attrs.get("rung", "")
+        callee = site.attrs.get("callee", "") if site is not None else ""
+        print(f"  {loc:42s} {tier.name:9s} call[{rung}]  {callee}(){extra}")
+    elif r.kind == "DISPATCHES":
+        site = r.site_node
+        loc = f"{site.path}:{site.line}:{site.col}" if site is not None else r.edge.src
+        fanout = r.edge.attrs.get("fanout", "?")
+        selector = r.edge.attrs.get("selector", "")
+        callee = site.attrs.get("callee", "") if site is not None else ""
+        print(f"  {loc:42s} {tier.name:9s} dispatch  1 of {fanout}  {callee}(){f' on {selector}' if selector else ''}")
+    else:  # REFERENCES
+        src_node = store.get(r.edge.src)
+        loc = f"{src_node.path}:{r.edge.attrs.get('line', '?')}" if src_node is not None else r.edge.src
+        print(f"  {loc:42s} {tier.name:9s} passed-by-ref  form={r.edge.attrs.get('form')}")
+    if why:
+        rule = r.edge.attrs.get("rung") or r.edge.attrs.get("reason") or r.edge.attrs.get("form") or r.kind
+        because = r.edge.attrs.get("because")
+        registry = r.edge.attrs.get("registry")
+        extra_bits = [f"rule={rule}"]
+        if because:
+            extra_bits.append(f"because={because}")
+        if registry:
+            extra_bits.append(f"registry={registry}")
+        print(f"      -- why: {'  '.join(extra_bits)}")
+
+
+# -- reach --------------------------------------------------------------------
+
+
+def cmd_reach(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    targets = resolve_symbol(store, args.symbol)
+    if not targets:
+        print(f"# no FUNCTION found matching '{args.symbol}'", file=sys.stderr)
+        return 2
+    if len(targets) > 1:
+        print(f"# ambiguous symbol '{args.symbol}' — {len(targets)} candidates:")
+        for t in sorted(targets):
+            print(f"  {t}")
+        return 0
+    target = targets[0]
+    conf_floor = _conf_floor(args) or Confidence.UNPROVEN
+
+    if args.to:
+        return _print_path(args, result, target, args.to, conf_floor)
+
+    depth = args.depth or 3
+    hops = forward_calls(store, target, depth=depth, conf_floor=conf_floor)
+
+    if args.format == "dot":
+        node_ids = {target} | {e.src for _d, e, _s in hops} | {e.dst for _d, e, _s in hops}
+        print(store.to_dot(node_ids, [e for _d, e, _s in hops]))
+        return 0
+    if args.format == "json":
+        print(json.dumps([
+            {"depth": d, "dst": e.dst, "confidence": e.confidence.name, **e.attrs} for d, e, _ in hops
+        ], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print(f"# forward reach from {target} (depth<={depth})")
+    print()
+    for d, e, site in hops:
+        loc = f"{site.path}:{site.line}:{site.col}" if site is not None else "(passed-by-ref)"
+        tag = "dispatch" if e.kind == "DISPATCHES" else e.kind.lower()
+        print(f"  depth={d}  {loc:38s} {e.confidence.name:9s} {tag:10s} -> {e.dst}")
+    print(f"\n  {len(hops)} node(s) reached")
+    return 0
+
+
+# -- paths ----------------------------------------------------------------
+
+
+def _print_path(args: argparse.Namespace, result: BuildResult, src: str, to_symbol: str, conf_floor: Confidence) -> int:
+    store = result.store
+    dst_targets = resolve_symbol(store, to_symbol)
+    if not dst_targets:
+        print(f"# no FUNCTION found matching '{to_symbol}'", file=sys.stderr)
+        return 2
+    if len(dst_targets) > 1:
+        print(f"# ambiguous symbol '{to_symbol}' — {len(dst_targets)} candidates:")
+        for t in sorted(dst_targets):
+            print(f"  {t}")
+        return 0
+    dst = dst_targets[0]
+    hops = shortest_path(store, src, dst, conf_floor=conf_floor, max_depth=args.depth or 20)
+
+    if args.format == "dot":
+        if not hops:
+            print(store.to_dot({src}, []))
+            return 0
+        node_ids = {src} | {h.edge.src for h in hops} | {h.edge.dst for h in hops}
+        print(store.to_dot(node_ids, [h.edge for h in hops]))
+        return 0
+    if args.format == "json":
+        if hops is None:
+            print(json.dumps({"reachable": False}))
+            return 0
+        print(json.dumps({
+            "reachable": True, "confidence": path_confidence(hops).name,
+            "hops": [
+                {"dst": h.edge.dst, "confidence": h.edge.confidence.name,
+                 "site": (f"{h.site.path}:{h.site.line}:{h.site.col}" if h.site is not None else None), **h.edge.attrs}
+                for h in hops
+            ],
+        }, indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print(f"# path {src} -> {dst}")
+    print()
+    if hops is None:
+        print(f"  UNREACHABLE within depth={args.depth or 20} at --conf {args.conf}")
+        return 0
+    if not hops:
+        print("  (src == dst)")
+        return 0
+    for i, h in enumerate(hops, start=1):
+        loc = f"{h.site.path}:{h.site.line}:{h.site.col}" if h.site is not None else "(passed-by-ref)"
+        tag = "dispatch" if h.edge.kind == "DISPATCHES" else h.edge.kind.lower()
+        because = f"  because={h.edge.attrs['because']}" if "because" in h.edge.attrs else ""
+        print(f"  hop {i}: {loc:38s} {h.edge.confidence.name:9s} {tag:10s} -> {h.edge.dst}{because}")
+    print(f"\n  path confidence: {path_confidence(hops).name}  ({len(hops)} hop(s))")
+    return 0
+
+
+def cmd_paths(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    src_targets = resolve_symbol(store, args.src)
+    if not src_targets:
+        print(f"# no FUNCTION found matching '{args.src}'", file=sys.stderr)
+        return 2
+    if len(src_targets) > 1:
+        print(f"# ambiguous symbol '{args.src}' — {len(src_targets)} candidates:")
+        for t in sorted(src_targets):
+            print(f"  {t}")
+        return 0
+    conf_floor = _conf_floor(args) or Confidence.UNPROVEN
+    return _print_path(args, result, src_targets[0], args.dst, conf_floor)
+
+
+# -- registry -----------------------------------------------------------------
+
+
+def cmd_registry(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+
+    if args.unmatched:
+        unmatched = [e for e in store.edges_of_kind("DECORATED_BY") if e.attrs.get("classification") == "unknown"]
+        if args.format == "json":
+            print(json.dumps([{"src": e.src, "raw": e.attrs.get("raw"), "line": e.attrs.get("line")} for e in unmatched],
+                              indent=2, sort_keys=True))
+            return 0
+        print(_footer(result))
+        print()
+        for e in unmatched:
+            print(f"  {e.src}  @{e.attrs.get('raw')}  (line {e.attrs.get('line')})")
+        print(f"\n  {len(unmatched)} unclassified registering-looking decorator(s)")
+        return 0
+
+    regs = sorted(store.nodes_of_kind("REGISTRY"), key=lambda n: (n.path or "", n.id))
+    if args.tool:
+        regs = [r for r in regs if args.tool in r.attrs.get("keys", [])]
+
+    if args.format == "json":
+        print(json.dumps([
+            {
+                "id": r.id, "path": r.path, "mechanism": r.attrs.get("mechanism"),
+                "member_count": r.attrs.get("member_count"), "keys": r.attrs.get("keys"),
+                "declaration_line": r.attrs.get("declaration_line"),
+            } for r in regs
+        ], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print()
+    total_members = 0
+    for r in regs:
+        members = store.out_edges(r.id, "REGISTERS")
+        total_members += len(members)
+        print(f"  {r.id:45s} mechanism={r.attrs.get('mechanism'):15s} members={len(members):3d}  declared={r.path}:{r.attrs.get('declaration_line')}")
+        if args.tool:
+            for m in sorted(members, key=lambda e: e.attrs.get("key", "")):
+                print(f"      {m.attrs.get('key'):40s} -> {m.dst}")
+    print(f"\n  {len(regs)} registries, {total_members} total REGISTERS edges")
+    return 0
+
+
+# -- name ---------------------------------------------------------------------
+
+
+def cmd_name(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    ident = args.ident
+    name_nodes = [n for n in store.nodes_of_kind("NAME") if n.id.endswith(f"::{ident}")]
+    if args.module:
+        name_nodes = [n for n in name_nodes if n.path == args.module]
+    if not name_nodes:
+        print(f"# no NAME slot found for '{ident}'" + (f" in {args.module}" if args.module else ""), file=sys.stderr)
+        return 2
+
+    rows = []
+    for n in name_nodes:
+        for e in store.in_edges(n.id, "WRITES_NAME"):
+            rows.append(("WRITE", n, e, e.src))
+        for e in store.in_edges(n.id, "READS_NAME"):
+            rows.append(("READ", n, e, e.src))
+        for e in store.in_edges(n.id, "INJECTS"):
+            rows.append(("INJECT", n, e, e.src))
+
+    if args.format == "json":
+        print(json.dumps([
+            {"slot": n.id, "kind": k, "src": src, **e.attrs} for (k, n, e, src) in rows
+        ], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print(f"# NAME slots matching '::{ident}'" + (f" (module={args.module})" if args.module else ""))
+    print()
+    slot_modules = {n.path for n in name_nodes}
+    touching_modules = {store.get(src).path if store.get(src) is not None else src for (_k, _n, _e, src) in rows}
+    for n in sorted(name_nodes, key=lambda n: n.path or ""):
+        print(f"  slot {n.id}  binding_kind={n.attrs.get('binding_kind')}")
+        for (kind, slot_n, e, src) in sorted(rows, key=lambda r: (r[1].id != n.id, r[3])):
+            if slot_n.id != n.id:
+                continue
+            src_node = store.get(src)
+            loc = f"{src_node.path}:{e.attrs.get('line', src_node.line)}" if src_node is not None else src
+            if kind == "WRITE":
+                print(f"    WRITE  {loc:42s} via={e.attrs.get('via')}")
+            elif kind == "READ":
+                cross = "  (cross-module)" if e.attrs.get("cross_module") else ""
+                print(f"    READ   {loc:42s} in_call={e.attrs.get('in_call_position')}{cross}")
+            else:
+                print(f"    INJECT {loc:42s} value={e.attrs.get('value')} param={e.attrs.get('param')} key={e.attrs.get('key')}")
+        print()
+    if len(touching_modules | slot_modules) > 1:
+        print(f"  WARNING: this global is written in one module and touched from {len(touching_modules)} module(s) total"
+              f" — cross-module coupling via {'global-stmt/INJECTS' if any(r[0]=='INJECT' for r in rows) else 'global-stmt'}.")
+    print(f"  {len(rows)} row(s) across {len(name_nodes)} slot(s)")
+    return 0
+
+
+# -- dead ---------------------------------------------------------------------
+
+
+def cmd_dead(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    dead = dead_functions(store, args.scope)
+    dead.sort(key=lambda n: (n.path or "", n.line or 0))
+
+    if args.format == "json":
+        print(json.dumps([{"id": n.id, "path": n.path, "line": n.line} for n in dead], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    roots_count = sum(1 for _ in store.nodes_of_kind("ENTRYPOINT"))
+    print(f"# dead here means no path this tool can model; it does NOT mean safe to delete —")
+    print(f"# check roots.toml, shell scripts, systemd units and cron first. ({roots_count} entrypoint(s) known)")
+    print()
+    for n in dead:
+        print(f"  UNREACHABLE  {n.path}:{n.line}  {n.attrs.get('qualname')}")
+    print(f"\n  {len(dead)} unreachable function(s)")
+    return 0
+
+
+# -- holes --------------------------------------------------------------------
+
+
+def cmd_holes(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    edges = list(store.in_edges("?", "CALLS"))
+    if args.scope:
+        edges = [e for e in edges if any(e.src.split(":", 2)[1].startswith(p) for p in args.scope if e.src.startswith("call:"))]
+    by_reason: dict[str, int] = {}
+    for e in edges:
+        by_reason[e.attrs.get("reason", "unknown")] = by_reason.get(e.attrs.get("reason", "unknown"), 0) + 1
+
+    if args.format == "json":
+        print(json.dumps({"total": len(edges), "by_reason": by_reason}, indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print()
+    for reason, count in sorted(by_reason.items(), key=lambda kv: -kv[1]):
+        print(f"  {count:6d}  {reason}")
+    print(f"\n  {len(edges)} unresolved callsite(s) total / {len(list(store.nodes_of_kind('CALLSITE')))} callsites")
+    return 0
+
+
+# -- writes-dead -------------------------------------------------------------
+
+
+def _ident_of(name_id: str) -> str:
+    return name_id.rsplit("::", 1)[-1]
+
+
+def cmd_writes_dead(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    dangling = dangling_globals(store, args.scope)
+    weak = write_no_read(store, args.scope)
+
+    tests_hits: dict[str, list[str]] = {}
+    if args.include_tests:
+        idents = {_ident_of(f.slot.id) for f in weak}
+        test_sources = load_test_sources(rev=args.rev)
+        tests_hits = read_by_tests(idents, test_sources)
+        weak = [f for f in weak if _ident_of(f.slot.id) not in tests_hits]
+
+    if args.format == "json":
+        print(json.dumps({
+            "dangling_global": [
+                {
+                    "slot": f.slot.id, "path": f.slot.path,
+                    "write_sites": [{"src": e.src, "line": e.attrs.get("line")} for e in f.global_writes],
+                    "real_slots": [{"id": rn.id, "path": rn.path, "line": rn.line} for rn in f.real_slots],
+                } for f in dangling
+            ],
+            "write_no_read": [
+                {"slot": f.slot.id, "path": f.slot.path,
+                 "write_sites": [{"src": e.src, "line": e.attrs.get("line"), "via": e.attrs.get("via")} for e in f.writes]}
+                for f in weak
+            ],
+            "include_tests": args.include_tests,
+            "tests_excluded_idents": sorted(tests_hits) if args.include_tests else None,
+        }, indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print()
+    print("-- DANGLING-GLOBAL (near-zero false positives) " + "-" * 30)
+    for f in dangling:
+        ident = _ident_of(f.slot.id)
+        write_lines = ", ".join(str(e.attrs.get("line")) for e in f.global_writes) or "?"
+        print(f"  {f.slot.path}:{write_lines}  DANGLING-GLOBAL  {ident}"
+              f" — declared global here, never bound at module level in this module")
+        if f.real_slots:
+            real = f.real_slots[0]
+            others = f" (+{len(f.real_slots) - 1} more)" if len(f.real_slots) > 1 else ""
+            print(f"      real slot: {real.path}:{real.line}{others}  (different slot — same ident, different module)")
+        else:
+            print("      no module-level binding of this ident found anywhere else in the corpus either")
+    print(f"\n  {len(dangling)} dangling-global finding(s)")
+
+    print()
+    print("-- WRITE-WITH-NO-READ (weak check, see docs/LIMITS.md) " + "-" * 24)
+    for f in weak:
+        ident = _ident_of(f.slot.id)
+        write_lines = ", ".join(str(e.attrs.get("line")) for e in f.writes)
+        print(f"  {f.slot.path}:{write_lines}  WRITE-NO-READ  {ident}")
+    print(f"\n  {len(weak)} write-with-no-read finding(s)"
+          + (f"  ({len(tests_hits)} ident(s) excluded via --include-tests)" if args.include_tests else ""))
+    return 0
+
+
+# -- entrypoints ----------------------------------------------------------
+
+
+def cmd_entrypoints(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    try:
+        path, line_str = args.location.rsplit(":", 1)
+        line = int(line_str)
+    except ValueError:
+        print(f"# expected <file>:<line>, got '{args.location}'", file=sys.stderr)
+        return 2
+    start_id = function_at_line(store, path, line)
+    if start_id is None:
+        print(f"# no module or function found at {path}:{line}", file=sys.stderr)
+        return 2
+    conf_floor = _conf_floor(args) or Confidence.UNPROVEN
+    entries = entrypoints_reaching(store, start_id, conf_floor=conf_floor)
+
+    if args.format == "json":
+        print(json.dumps({
+            "location": f"{path}:{line}", "start": start_id,
+            "entrypoints": [{"id": eid, "confidence": c.name} for eid, c in sorted(entries.items())],
+        }, indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    node = store.get(start_id)
+    label = node.attrs.get("qualname", start_id) if (node is not None and start_id.startswith("fn:")) else start_id
+    print(f"# {path}:{line}  ->  {label}")
+    print()
+    if not entries:
+        print("  reachable from 0 known entry points")
+        print("  # dead here means no path this tool can model, not proven unreachable — see docs/LIMITS.md")
+        return 0
+    print(f"  reachable from {len(entries)} entry point(s):")
+    for eid, conf in sorted(entries.items(), key=lambda kv: (-kv[1], kv[0])):
+        enode = store.get(eid)
+        trust = enode.attrs.get("trust") if enode is not None else "?"
+        print(f"    {eid:55s} {conf.name:9s} trust={trust}")
+    return 0
+
+
+# -- explain ----------------------------------------------------------------
+
+
+def _explain_target_sites(store: GraphStore, target: str):
+    node = store.get(target)
+    if node is not None and node.kind == "CALLSITE":
+        return [node]
+    parts = target.rsplit(":", 2)
+    path = line = col = None
+    if len(parts) == 3 and parts[1].lstrip("-").isdigit() and parts[2].lstrip("-").isdigit():
+        path, line, col = parts[0], int(parts[1]), int(parts[2])
+    elif len(parts) >= 2 and parts[-1].lstrip("-").isdigit():
+        path, line = target.rsplit(":", 1)
+        line = int(line)
+    if path is None:
+        return []
+    return [
+        n for n in store.nodes_of_kind("CALLSITE")
+        if n.path == path and n.line == line and (col is None or n.col == col)
+    ]
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    sites = _explain_target_sites(store, args.target)
+    if not sites:
+        print(f"# no CALLSITE found for '{args.target}' (pass a CALLSITE id, or <file>:<line>[:<col>])", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        out = []
+        for site in sites:
+            out.append({
+                "callsite": site.id, "form": site.attrs.get("form"), "callee": site.attrs.get("callee"),
+                "enclosing_fn": site.attrs.get("enclosing_fn"),
+                "calls": [{"dst": e.dst, "confidence": e.confidence.name, **e.attrs} for e in store.out_edges(site.id, "CALLS")],
+                "dispatches": [{"dst": e.dst, "confidence": e.confidence.name, **e.attrs} for e in store.out_edges(site.id, "DISPATCHES")],
+            })
+        print(json.dumps(out, indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    for site in sites:
+        print(f"# {site.id}")
+        print(f"  {site.path}:{site.line}:{site.col}  form={site.attrs.get('form')}  callee={site.attrs.get('callee')}()")
+        print(f"  enclosing: {site.attrs.get('enclosing_fn')}")
+        for e in store.out_edges(site.id, "CALLS"):
+            bits = [f"CALLS -> {e.dst}", e.confidence.name]
+            for key in ("rung", "reason", "because", "alternatives"):
+                if key in e.attrs:
+                    bits.append(f"{key}={e.attrs[key]}")
+            print("    " + "  ".join(bits))
+        for e in store.out_edges(site.id, "DISPATCHES"):
+            print(f"    DISPATCHES -> {e.dst}  {e.confidence.name}  1 of {e.attrs.get('fanout')}"
+                  f"  selector={e.attrs.get('selector')}  registry={e.attrs.get('registry')}")
+        print()
+    return 0
+
+
+# -- literals -----------------------------------------------------------------
+
+
+def cmd_literals(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    flavour = "path" if args.paths else ("key" if args.keys else None)
+
+    if args.near_miss:
+        producer_only, consumer_only = orphans(store, flavour)
+        pairs = near_miss_pairs(producer_only, consumer_only)
+        if args.glob:
+            pairs = [p for p in pairs if args.glob in p.producer.match_text or args.glob in p.consumer.match_text]
+        materialize_near_miss_edges(store, pairs)
+        if args.format == "json":
+            print(json.dumps([
+                {"producer": nm.producer.match_text, "consumer": nm.consumer.match_text,
+                 "shared_stem": nm.shared_stem, "distance": nm.distance,
+                 "producer_sites": [f"{s.path}:{s.line}" for s in nm.producer.produce_sites],
+                 "consumer_sites": [f"{s.path}:{s.line}" for s in nm.consumer.consume_sites]}
+                for nm in pairs
+            ], indent=2, sort_keys=True))
+            return 0
+        print(_footer(result))
+        print("# NEAR_MISS pairs — lead, not finding; never influences reachability/dead-code/exit code")
+        print()
+        for nm in pairs:
+            print(f"  {nm.producer.match_text!r}  <~>  {nm.consumer.match_text!r}"
+                  f"  stem={nm.shared_stem}  distance={nm.distance}")
+            for s in nm.producer.produce_sites:
+                print(f"      PRODUCED {s.path}:{s.line}  role={s.role}")
+            for s in nm.consumer.consume_sites:
+                print(f"      CONSUMED {s.path}:{s.line}  role={s.role}")
+        print(f"\n  {len(pairs)} near-miss pair(s)")
+        return 0
+
+    if args.orphans:
+        producer_only, consumer_only = orphans(store, flavour)
+        if args.glob:
+            producer_only = [g for g in producer_only if args.glob in g.match_text]
+            consumer_only = [g for g in consumer_only if args.glob in g.match_text]
+        if args.format == "json":
+            print(json.dumps({
+                "producer_only": [{"text": g.match_text, "sites": [f"{s.path}:{s.line}" for s in g.produce_sites]} for g in producer_only],
+                "consumer_only": [{"text": g.match_text, "sites": [f"{s.path}:{s.line}" for s in g.consume_sites]} for g in consumer_only],
+            }, indent=2, sort_keys=True))
+            return 0
+        print(_footer(result))
+        print()
+        for g in producer_only:
+            sites = ", ".join(f"{s.path}:{s.line}" for s in g.produce_sites)
+            print(f"  {g.match_text}  —  PRODUCED {sites}  —  CONSUMED BY NOBODY")
+        for g in consumer_only:
+            sites = ", ".join(f"{s.path}:{s.line}" for s in g.consume_sites)
+            print(f"  {g.match_text}  —  CONSUMED {sites}  —  PRODUCED BY NOBODY")
+        print(f"\n  {len(producer_only)} producer-only, {len(consumer_only)} consumer-only orphan(s)")
+        return 0
+
+    groups = literal_table(store, flavour)
+    if args.glob:
+        groups = [g for g in groups if args.glob in g.match_text]
+    if args.format == "json":
+        print(json.dumps([
+            {"text": g.match_text, "flavour": g.flavour,
+             "produced_by": [f"{s.path}:{s.line}({s.role})" for s in g.produce_sites],
+             "consumed_by": [f"{s.path}:{s.line}({s.role})" for s in g.consume_sites]}
+            for g in groups
+        ], indent=2, sort_keys=True))
+        return 0
+    print(_footer(result))
+    print()
+    for g in groups:
+        prod = ", ".join(f"{s.path}:{s.line}" for s in g.produce_sites) or "(none)"
+        cons = ", ".join(f"{s.path}:{s.line}" for s in g.consume_sites) or "(none)"
+        print(f"  {g.match_text:40s} [{g.flavour}]  produced: {prod}  consumed: {cons}")
+    print(f"\n  {len(groups)} literal(s)")
+    return 0
+
+
+# -- flags ----------------------------------------------------------------
+
+
+def cmd_flags(args: argparse.Namespace) -> int:
+    result = _build(args)
+    store = result.store
+    fn_filter = None
+    scope = args.scope
+    target = args.target
+    if target:
+        if "::" in target:
+            path, qual = target.split("::", 1)
+            fn_filter = f"fn:{path}::{qual}"
+            scope = None
+        else:
+            scope = [target]
+
+    rows = rank_flags(store, scope, fn_filter,
+                       include_accumulators=getattr(args, "include_accumulators", False))
+
+    if args.format == "json":
+        print(json.dumps([
+            {
+                "ident": r.ident, "fn": r.fn_id, "path": r.binding.path, "score": r.score,
+                "escape_form": r.escape_form, "pattern": r.pattern, **r.binding.attrs,
+            } for r in rows
+        ], indent=2, sort_keys=True))
+        return 0
+
+    print(_footer(result))
+    print("# ranker, not a detector — scope to one file/function; never a CI gate (see docs/LIMITS.md)")
+    print()
+    for r in rows:
+        b = r.binding
+        print(f"  {b.path}  {r.fn_id.split('::', 1)[-1]}::{r.ident}  score={r.score:.2f}  [{r.pattern}]")
+        print(f"      init={b.attrs.get('init_line')} (constant)  escapes as {r.escape_form} at "
+              f"{b.attrs.get('escape_lines')}")
+        for a in b.attrs.get("assign_contexts", []):
+            print(f"      assigned True-ish at :{a['line']}  ({a['context']}, {a.get('form', 'assign')})")
+        for g in b.attrs.get("guard_exits", []):
+            print(f"      guard exit :{g['line']}  {g['kind']}  ({g['context']}) — does NOT assign {r.ident}")
+        print()
+    print(f"  {len(rows)} candidate row(s)")
+    return 0
+
+
+# -- selftest ----------------------------------------------------------------
+
+
+def cmd_selftest(args: argparse.Namespace) -> int:
+    report = run_selftest()
+    if args.format == "json":
+        print(json.dumps({
+            "ok": report.ok, "elapsed_s": report.elapsed_s,
+            "checks": [{"name": c.name, "ok": c.ok, "detail": c.detail} for c in report.checks],
+        }, indent=2, sort_keys=True))
+        return 0 if report.ok else 1
+
+    print(f"# callgraph selftest — fixtures/ (no git) + one real-corpus build --rev HEAD")
+    print()
+    for c in report.checks:
+        status = "PASS" if c.ok else "FAIL"
+        print(f"  [{status}] {c.name}")
+        if not c.ok:
+            print(f"         {c.detail}")
+    print()
+    passed = sum(1 for c in report.checks if c.ok)
+    print(f"  {passed}/{len(report.checks)} checks passed  ({report.elapsed_s:.3f}s)")
+    if not report.ok:
+        print("  SELFTEST FAILED")
+        return 1
+    print("  selftest green")
+    return 0
+
+
+# -- limits -------------------------------------------------------------------
+
+
+def cmd_limits(args: argparse.Namespace) -> int:
+    limits_path = config.PACKAGE_ROOT / "docs" / "LIMITS.md"
+    try:
+        text = limits_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"callgraph: could not read {limits_path}: {exc}", file=sys.stderr)
+        return 2
+    if args.format == "json":
+        print(json.dumps({"path": str(limits_path), "text": text}, indent=2))
+        return 0
+    print(text, end="" if text.endswith("\n") else "\n")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cg", description="Dependency-light static call-graph tool for the loci corpus.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("build", help="parse the corpus and print graph stats")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_build)
+
+    p = sub.add_parser("modules", help="list MODULE nodes and their importable names")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_modules)
+
+    p = sub.add_parser("defs", help="list/summarize FUNCTION, CLASS, NAME nodes")
+    _add_common_args(p)
+    p.add_argument("filter", nargs="?", default=None, help="only show defs whose path contains this substring")
+    p.add_argument("--all", action="store_true", help="list every def, not just the summary")
+    p.set_defaults(func=cmd_defs)
+
+    p = sub.add_parser("imports", help="list IMPORTS edges")
+    _add_common_args(p)
+    p.add_argument("--lazy", action="store_true", help="only function-local imports")
+    p.add_argument("--unresolved", action="store_true", help="only imports that resolve to neither corpus, stdlib, nor a third-party package")
+    p.set_defaults(func=cmd_imports)
+
+    p = sub.add_parser("aliases", help="list ALIASES edges (debug/verification)")
+    _add_common_args(p)
+    p.add_argument("filter", nargs="?", default=None, help="only show aliases whose src id contains this substring")
+    p.set_defaults(func=cmd_aliases)
+
+    p = sub.add_parser("callers", help="who calls this symbol (direct CALLS + REFERENCES)")
+    _add_common_args(p)
+    p.add_argument("symbol", help="a FUNCTION id, module::qualname, or bare name")
+    p.set_defaults(func=cmd_callers)
+
+    p = sub.add_parser("reach", help="forward closure: what does this symbol call, transitively")
+    _add_common_args(p)
+    p.add_argument("symbol", help="a FUNCTION id, module::qualname, or bare name")
+    p.add_argument("--to", default=None, metavar="SYMBOL",
+                    help="degenerate to `cg paths`: print the shortest evidence chain from symbol to this target")
+    p.set_defaults(func=cmd_reach)
+
+    p = sub.add_parser("paths", help="shortest evidence chain between two symbols, hop by hop")
+    _add_common_args(p)
+    p.add_argument("src", help="a FUNCTION id, module::qualname, or bare name")
+    p.add_argument("dst", help="a FUNCTION id, module::qualname, or bare name")
+    p.set_defaults(func=cmd_paths)
+
+    p = sub.add_parser("entrypoints", help="which ENTRYPOINTs can reach a given file:line")
+    _add_common_args(p)
+    p.add_argument("location", help="<repo-relative-path>:<line>")
+    p.set_defaults(func=cmd_entrypoints)
+
+    p = sub.add_parser("registry", help="list REGISTRY surfaces and their REGISTERS members")
+    _add_common_args(p)
+    p.add_argument("--tool", default=None, help="only the registry containing this externally-visible key")
+    p.add_argument("--unmatched", action="store_true", help="list registering-classified decorators rules.toml failed to key")
+    p.set_defaults(func=cmd_registry)
+
+    p = sub.add_parser("name", help="who reads/writes/injects this module-global ident, across the corpus")
+    _add_common_args(p)
+    p.add_argument("ident", help="the bare identifier, e.g. _get_ladybug")
+    p.add_argument("--module", default=None, help="restrict to one module's NAME slot (repo-relative path)")
+    p.set_defaults(func=cmd_name)
+
+    p = sub.add_parser("writes-dead", help="DANGLING-GLOBAL and WRITE-WITH-NO-READ NAME-slot audits")
+    _add_common_args(p)
+    p.add_argument("--include-tests", action="store_true",
+                    help="re-check WRITE-WITH-NO-READ findings against a textual scan of tests/ source; "
+                         "drop any whose ident appears there")
+    p.set_defaults(func=cmd_writes_dead)
+
+    p = sub.add_parser("literals", help="path/key literal producer-consumer table, orphans, and near-miss leads")
+    _add_common_args(p)
+    p.add_argument("glob", nargs="?", default=None, help="only literals whose tail text contains this substring")
+    p.add_argument("--paths", action="store_true", help="restrict to path-like literals")
+    p.add_argument("--keys", action="store_true", help="restrict to key-like literals")
+    p.add_argument("--orphans", action="store_true", help="only literals with occurrences in exactly one direction")
+    p.add_argument("--near-miss", action="store_true", help="pair producer-only/consumer-only orphans by shared stem")
+    p.set_defaults(func=cmd_literals)
+
+    p = sub.add_parser("flags", help="partial-assignment ranker over escaping constant-initialized locals")
+    _add_common_args(p)
+    p.add_argument("target", nargs="?", default=None,
+                    help="a repo-relative path (file scope) or path::qualname (single function)")
+    p.add_argument("--include-accumulators", action="store_true",
+                    help="also list counters/running totals (locals reassigned only by += or "
+                         "to a computed expression). Off by default: they match the flag shape "
+                         "but are correct by construction — see docs/LIMITS.md")
+    p.set_defaults(func=cmd_flags)
+
+    p = sub.add_parser("dead", help="functions unreachable from any known ENTRYPOINT (lead generator, not proof)")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_dead)
+
+    p = sub.add_parser("holes", help="inbound edges to the `?` UNRESOLVED sink, grouped by reason")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_holes)
+
+    p = sub.add_parser("explain", help="the rule/evidence behind one callsite's CALLS/DISPATCHES edges")
+    _add_common_args(p)
+    p.add_argument("target", help="a CALLSITE id (call:<path>:<line>:<col>:...), or <path>:<line>[:<col>]")
+    p.set_defaults(func=cmd_explain)
+
+    p = sub.add_parser("selftest", help="build over fixtures/ + one real HEAD build, assert the full expected finding set")
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.set_defaults(func=cmd_selftest)
+
+    p = sub.add_parser("limits", help="print docs/LIMITS.md — the honest failure-mode catalogue")
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.set_defaults(func=cmd_limits)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/callgraph/config.py
+++ b/scripts/callgraph/config.py
@@ -1,0 +1,170 @@
+"""Corpus definition — the single source of truth for "what is in the corpus".
+
+Every count `cg` prints is only meaningful relative to this answer, so it
+lives in one place and nothing else in the package re-derives it.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# scripts/callgraph/config.py -> scripts/callgraph -> scripts -> <repo root>
+PACKAGE_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = PACKAGE_ROOT.parent.parent
+
+# The five top-level directories that make up the analyzed corpus (non-test
+# Python only). Order matters only for display.
+CORPUS_ROOTS: tuple[str, ...] = ("mcp", "scripts", "a2a_server", "mlops", "eval")
+
+# Directory (path-component) names excluded anywhere they occur under a
+# corpus root.
+EXCLUDE_DIR_NAMES: frozenset[str] = frozenset({
+    "tests",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".git",
+    ".cache",
+    "node_modules",
+})
+EXCLUDE_DIR_SUFFIXES: tuple[str, ...] = (".egg-info",)
+
+# This tool's own package must never be walked as part of the corpus it
+# analyzes — two AST walkers over the same code is how rule drift starts,
+# and self-analysis produces noise no engineer asked for.
+SELF_PACKAGE_REL = "scripts/callgraph"
+
+CACHE_DIR = PACKAGE_ROOT / ".cache"
+
+
+def is_excluded_rel(rel_posix: str) -> bool:
+    """True if a repo-relative POSIX path (file or dir) must be skipped."""
+    if rel_posix == SELF_PACKAGE_REL or rel_posix.startswith(SELF_PACKAGE_REL + "/"):
+        return True
+    parts = rel_posix.split("/")
+    for part in parts:
+        if part in EXCLUDE_DIR_NAMES:
+            return True
+        if part.endswith(EXCLUDE_DIR_SUFFIXES):
+            return True
+    return False
+
+
+def iter_corpus_files_worktree(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Repo-relative POSIX paths of every non-test .py file under the corpus
+    roots, read from the working tree."""
+    out: list[str] = []
+    for root_name in CORPUS_ROOTS:
+        base = repo_root / root_name
+        if not base.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            rel_dir = Path(dirpath).relative_to(repo_root).as_posix()
+            if rel_dir != "." and is_excluded_rel(rel_dir):
+                dirnames[:] = []
+                continue
+            dirnames[:] = [
+                d for d in dirnames
+                if not is_excluded_rel(f"{rel_dir}/{d}" if rel_dir != "." else d)
+            ]
+            for fn in filenames:
+                if not fn.endswith(".py"):
+                    continue
+                rel_file = f"{rel_dir}/{fn}" if rel_dir != "." else fn
+                if is_excluded_rel(rel_file):
+                    continue
+                out.append(rel_file)
+    return sorted(out)
+
+
+def iter_test_files_worktree(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Repo-relative POSIX paths of .py files under any `tests/` directory
+    nested inside a corpus root — the deliberate COMPLEMENT of
+    iter_corpus_files_worktree (which prunes `tests/` on purpose, see
+    EXCLUDE_DIR_NAMES). Used only by `cg writes-dead --include-tests` as a
+    textual mitigation pass over the weak write-with-no-read check; test
+    files are never added to the modelled GraphStore itself."""
+    out: list[str] = []
+    for root_name in CORPUS_ROOTS:
+        base = repo_root / root_name
+        if not base.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            rel_dir = Path(dirpath).relative_to(repo_root).as_posix()
+            parts = [] if rel_dir == "." else rel_dir.split("/")
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in {"__pycache__", ".venv", "venv", ".git", "node_modules"}
+                and not d.endswith(".egg-info")
+            ]
+            if "tests" not in parts:
+                continue
+            for fn in filenames:
+                if fn.endswith(".py"):
+                    out.append(f"{rel_dir}/{fn}")
+    return sorted(out)
+
+
+def in_corpus(rel_posix: str) -> bool:
+    """True if a repo-relative POSIX path falls under a corpus root and is
+    not excluded. Does not check existence."""
+    if not rel_posix.endswith(".py"):
+        return False
+    top = rel_posix.split("/", 1)[0]
+    if top not in CORPUS_ROOTS:
+        return False
+    return not is_excluded_rel(rel_posix)
+
+
+_STDLIB_NAMES: frozenset[str] | None = None
+
+
+def stdlib_module_names() -> frozenset[str]:
+    global _STDLIB_NAMES
+    if _STDLIB_NAMES is None:
+        names = set(getattr(sys, "stdlib_module_names", ()))
+        # A handful of names that show up as top-level import targets but are
+        # not in every interpreter build's stdlib_module_names set.
+        names |= {"_thread", "__future__"}
+        _STDLIB_NAMES = frozenset(names)
+    return _STDLIB_NAMES
+
+
+_THIRD_PARTY_NAMES: frozenset[str] | None = None
+
+
+def third_party_top_level_names() -> frozenset[str]:
+    """Top-level importable names available in the project's venv, used only
+    to classify an external import as 'third-party' (installed) vs 'unknown'
+    (nothing on disk answers to that name) for reporting purposes."""
+    global _THIRD_PARTY_NAMES
+    if _THIRD_PARTY_NAMES is not None:
+        return _THIRD_PARTY_NAMES
+    names: set[str] = set()
+    candidates = [
+        REPO_ROOT / "mcp" / ".venv" / "lib",
+        REPO_ROOT / "a2a_server" / ".venv" / "lib",
+    ]
+    for lib_dir in candidates:
+        if not lib_dir.is_dir():
+            continue
+        for py_dir in lib_dir.glob("python3.*"):
+            site = py_dir / "site-packages"
+            if not site.is_dir():
+                continue
+            for entry in site.iterdir():
+                name = entry.name
+                if name.endswith(".dist-info") or name.endswith(".egg-info"):
+                    name = name.split("-")[0]
+                elif name.endswith(".py"):
+                    name = name[:-3]
+                elif name.endswith(".so"):
+                    name = name.split(".")[0]
+                if not name or name.startswith("_") and name not in {"_distutils_hack"}:
+                    pass
+                names.add(name)
+    _THIRD_PARTY_NAMES = frozenset(names)
+    return _THIRD_PARTY_NAMES

--- a/scripts/callgraph/docs/DESIGN.md
+++ b/scripts/callgraph/docs/DESIGN.md
@@ -1,0 +1,108 @@
+# Design
+
+The node/edge model this package implements, and the confidence contract
+every query is built on. This is documentation of what `extract/*` and
+`analyze/*` actually produce — see `docs/LIMITS.md` for where it falls
+short, and `docs/census.txt` for the dispatch-pattern census the model was
+built against.
+
+## Confidence
+
+Every `CALLS`, `REGISTERS`, `INJECTS`, `DISPATCHES`, `IMPORTS`, and
+`ALIASES` edge carries a `Confidence`: `PROVEN` > `PROBABLE` > `UNPROVEN`,
+ordered so `Confidence.combine(...)` over a chain's hops (see `cg paths`)
+always yields the WEAKEST link, never an average. `UNPROVEN` is the
+confidence stamped on an edge to the `?` sink — a hole made visible, not a
+silent omission (`cg holes` counts and groups these by reason).
+
+## Nodes
+
+- **MODULE** (`mod:<repo-rel-path>`) — one per non-test `.py` file in the
+  corpus. Attrs: `path`, `kind`, `importable_as` (every dotted name the
+  module answers to), `has_main`.
+- **FUNCTION** (`fn:<mod-path>::<qualname>`) — qualname carries class and
+  closure nesting (`register.<locals>.<lambda>@<line>`, `Widget.method`).
+  Lambdas handed to a registering call are real, addressable FUNCTION
+  nodes. Attrs: `lineno`, `end_lineno`, `is_async`, `is_lambda`,
+  `is_method`, `is_nested`, `decorators` (verbatim source), docstring
+  first line.
+- **CLASS** (`cls:<mod-path>::<Name>`) — thin: `bases` (source text) and
+  method ids, so method defs have a parent. No type inference.
+- **NAME** (`name:<mod-path>::<ident>`) — a module-global BINDING SLOT,
+  distinct from any value in it. Created for module-level assigns,
+  `def`/`class` bindings, import bindings, and idents that appear ONLY in a
+  `global` statement with no module-level binding (`binding_kind` includes
+  `"global-only"` — the raw signal BUG C's diagnosis is a lookup over, not
+  a heuristic).
+- **CALLSITE** (`call:<mod-path>:<line>:<col>:<end_line>:<end_col>`) — one
+  per `ast.Call`, first-class because a single syntactic call can resolve
+  to several candidates at different confidences. Attrs: `form`, `callee`,
+  `enclosing_fn`.
+- **REGISTRY** (`reg:<mod-path>::<label>`) — a registration surface:
+  `mechanism` in `{decorator, manifest-tuple, manifest-dict, route-table,
+  register-fn}`. The node that stops registered functions from being
+  reported dead.
+- **ENTRYPOINT** (`entry:<kind>:<key>`) — synthetic reachability roots,
+  the only nodes with no inbound edges by construction. `trust` is
+  `declared-in-source` or `declared-in-roots.toml`.
+- **EXTERNAL** (`ext:<dotted>`) — terminal sink for every call resolving
+  outside the corpus (stdlib, third-party, or the venv). Without this node
+  thousands of calls would vanish silently instead of landing somewhere
+  countable.
+- **UNRESOLVED** — the single sink node `id="?"`. Every callsite this tool
+  genuinely cannot resolve lands here with a `reason` on its inbound edge.
+- **LOCALBINDING** (`local:<fn-id>::<ident>`) — materialized only for
+  locals that ESCAPE the function (returned, packed into a returned
+  container, or captured by an escaping closure). `cg flags`'s ranker
+  reads `init_is_constant`, `assign_lines`/`assign_contexts`, and
+  `guard_exits` off this node.
+- **LITERAL** / **PATHEXPR** — string literals and composed paths
+  (`Path / str`, `os.path.join`, f-strings, `+` concat), tagged
+  `path`-like or `key`-like, with an occurrence list rather than one site.
+
+## Edges
+
+| Edge | Meaning | Confidence |
+|---|---|---|
+| `DEFINES` | this source physically contains that def | always PROVEN |
+| `CALLS` | executing this callsite may transfer control there | 3-tier ladder, see below |
+| `REFERENCES` | the function OBJECT is named here, NOT invoked (passed by reference into a manifest/registrar) | PROVEN |
+| `REGISTERS` | this function becomes callable from outside the Python corpus through this surface | PROVEN if the manifest/decorator is literal, else PROBABLE |
+| `ENTERS` | reachability starts here | trust-tagged, not confidence-tagged |
+| `IMPORTS` | at this statement the target module loads and binds names | PROVEN/UNPROVEN by resolution |
+| `ALIASES` | this NAME slot is another name for that object (re-exports, bare `A = B`) — may chain NAME→NAME→FUNCTION | PROVEN |
+| `READS_NAME` / `WRITES_NAME` | this body loads/rebinds that module-global slot, cross-module included | attrs carry `via`/`in_call_position` |
+| `INJECTS` | an argument at this callsite is written into that module's global slot when the callee runs (`register()`'s `global X = param` / `deps["key"]` shape) | PROBABLE |
+| `DISPATCHES` | this callsite invokes SOME registry member, selected at runtime by a value this tool cannot evaluate — fans out to every candidate, never guesses one | PROBABLE |
+| `DECORATED_BY` | this decorator expression was applied verbatim | classification: registering / wrapping / transparent / unknown |
+| `PRODUCES_LITERAL` / `CONSUMES_LITERAL` | this code constructs / looks up that path or key | role inferred from syntactic context |
+| `NEAR_MISS` | two literals, different modules, one producer-only + one consumer-only, similar text (derived, never syntactic) | capped at PROBABLE, fenced out of reachability/dead-code/exit codes |
+| `ESCAPES` | this local's value leaves the function | `escape_form`: direct-return / dict-value / tuple-element / closure |
+
+### The `CALLS` resolution ladder
+
+Seven rungs, each stamping its own confidence and (for rungs past the
+first three) a `rung`/`because`/`alternatives` attribute so `--why` and
+`cg explain` can show exactly which rule fired:
+
+1. plain module-level `Name` bound by a def/class or module-level import — **PROVEN**
+2. `Attribute` call through a module-level *or* function-local import — **PROVEN**
+3. one-or-more `ALIASES` hops, Python builtins, a nested function's own bare name — **PROVEN**
+4. a module-global written only by an injection site — **PROBABLE**, `because=injected at <file:line>` (fans out to `DISPATCHES` if more than one distinct value was ever injected — the re-entrant-`register()` case)
+5. a value fetched from a dict-of-callables (`.get(...)`/`[...]`) — **PROBABLE**, fans out to every registry member via `DISPATCHES`
+6. an attribute on a value of unknown type, resolved by unique-method-name-in-corpus — **PROBABLE**, `alternatives=N`; ambiguous names stay unresolved with the same `alternatives` count
+7. anything else (param-call, computed getattr, computed dict key, `importlib` with a variable, star-import) — **UNPROVEN**, edge to `?` with a `reason`
+
+## Queries
+
+See `README.md`'s 60-second tour for runnable examples and `cli.py --help`
+for the full flag surface. `cg selftest` exercises one representative
+finding per dispatch shape above, plus the corpus-wide hard gate, and is
+the fastest way to confirm a checkout is healthy without reading this
+whole document.
+
+## Out of scope
+
+BUG A (`node["_id"]` vs a backend's `"_ID"` key-casing mismatch) is
+explicitly not something this tool can catch — see `docs/LIMITS.md`'s
+final section for why, stated once and not re-litigated here.

--- a/scripts/callgraph/docs/LIMITS.md
+++ b/scripts/callgraph/docs/LIMITS.md
@@ -1,0 +1,237 @@
+# Known limits
+
+The honest failure-mode catalogue for `callgraph`. A new false-positive
+class discovered in use gets appended here in the same commit that finds
+it. Numbers below were measured at HEAD (`rev 989942b5`, 2026-08-10) with
+`PYTHONPATH=scripts python3 -m callgraph.cli <cmd> --rev HEAD`, whole
+corpus (114 files) unless a `--scope` is noted.
+
+## `cg writes-dead`
+
+Two checks, reported separately because their false-positive rates are not
+remotely comparable.
+
+- **DANGLING-GLOBAL** (the strong check, worth a CI gate): near-zero false
+  positives — it is almost always either a typo or a cross-module cache
+  invalidation that silently no-ops. At HEAD: **0** findings corpus-wide.
+  At `c1c40a9^` (BUG C): **2** findings, both in `mcp/graph_tools.py`
+  (`_symbol_index_cache`, `_symbol_index_count`), each correctly naming the
+  real module-level slot at `mcp/ladybug_ops.py:106-107`.
+
+- **WRITE-WITH-NO-READ** (the weak check, triage list only): **297**
+  findings corpus-wide at HEAD. Re-running with `--include-tests` (a
+  textual, whole-word scan of `tests/` source for each candidate ident)
+  drops that to **104** — i.e. **123 of 297 (41%)** of the raw findings are
+  read only from test code and are false positives of the default (tests
+  excluded) view. The remaining 104 are dominated by two further known
+  false-positive shapes this check cannot distinguish from a real orphaned
+  write: (a) module-level bindings meant purely as a public re-export
+  surface (`from __future__ import annotations`, `__all__` entries, and
+  plain function/class defs that are never referenced by bare name because
+  every caller goes through `from mod import symbol` — which correctly
+  creates an ALIASES edge, not a READS_NAME, so the origin slot reads as
+  "written, never read" even though it's very much in use); (b) a handful
+  of genuinely internal helpers that exist only for interactive/REPL use.
+  **Conclusion: never gate on WRITE-WITH-NO-READ; always read its output
+  with a file open next to it, and prefer `--include-tests` as a first
+  triage pass.**
+
+## `cg literals`
+
+- **Orphan counts at HEAD** (the haystack size `--orphans`/`--near-miss`
+  work against): path-like — **0** producer-only, **1** consumer-only.
+  Key-like — **83** producer-only, **549** consumer-only. The remaining
+  path-like consumer-only orphan at HEAD is legitimate: a wildcard
+  `glob.glob(".../settings.json")` pattern with no single producer site
+  this tool can attribute to it.
+
+- **BUG D regression**: at `08c9198^`, `cg literals --paths --orphans`
+  reports `graph.ladybug` (produced at `mcp/server.py:261`, consumed by
+  nobody) and `graph.kuzu` (consumed at `scripts/graph_facts.py:29`,
+  produced by nobody) as two separate orphan groups; `--near-miss` pairs
+  them on the shared stem `graph` (distance 0.609). At HEAD both literals
+  are `graph.ladybug`, matched producer+consumer, zero orphans for either
+  text.
+
+- **FALSE POSITIVE — regex over-triggers on short/ambiguous key-like
+  strings.** `looks_key_like`'s identifier-shaped regex matches `_`
+  (Python's throwaway-variable convention) as a KEY-LIKE literal wherever
+  it appears in a lookup position (e.g. an f-string built key like
+  `f"_{name.upper()}"` in `mcp/graph/queries.py`) — it now correctly sorts
+  into the KEY-LIKE bucket (a PATHEXPR's flavour is stamped from its call
+  site, not guessed from node kind — see extract/literals.py) rather than
+  polluting `--paths`, but it is still present as noise inside
+  `--keys --orphans`. A future pass should raise the minimum length or
+  blocklist single-underscore/single-letter strings.
+
+- **FALSE POSITIVE/NEGATIVE — role inference loses track across
+  variables.** A path or key built in one function, stored in a variable,
+  and used three functions later has no PRODUCES/CONSUMES edge at all
+  (silently dropped, not miscounted) — see the design's own note on this;
+  not separately re-measured here beyond the orphan counts above, which
+  are therefore an UNDER-count of true orphans, not an over-count.
+
+- **KEY-LIKE literal counts are dominated by dict-get/dict-subscript
+  noise.** 83+549 = 632 key-like orphan groups out of 732 total LITERAL
+  nodes at HEAD is a strong hint that most `.get("some_word")` calls in
+  this corpus are looking up per-call-site-unique or genuinely
+  producer/consumer-decoupled keys (e.g. reading fields out of a JSON
+  response body) rather than a coordinated cross-module contract —
+  `--keys --orphans` is not a useful lead-generator on its own for this
+  corpus; `--paths --orphans` is where the signal is.
+
+## `cg flags`
+
+- **Row counts at HEAD**: `mcp/` alone — **5** rows. Whole corpus —
+  **7** rows (**28** with `--include-accumulators`; 21 of the 28 are
+  counters, see the next bullet). Given ~558 escaping LOCALBINDINGs
+  corpus-wide, only constant-initialized ones are ranked at all, and the
+  design's own precision statement ("expect roughly one real finding per
+  dozen rows") should be read against these row counts, not against the
+  558 total LOCALBINDINGs — most escaping locals are never
+  constant-initialized flags in the first place and never appear in
+  `cg flags` output at all.
+
+- **FALSE POSITIVE CLASS, now suppressed — accumulators.** A counter
+  (`n = 0` ... `n += 1`) matches "constant init, updated on only some
+  paths" perfectly, because a counter is SUPPOSED to be updated on only
+  some paths. Measured at `d359e9a` (where BUG B was live) this class
+  filled **16 of 23** corpus-wide rows and pushed the real bug down to
+  **rank 7**. `analyze/flags.classify()` now separates them: any local
+  whose reassignments include an augmented assignment, or include no plain
+  rebind-to-a-constant at all, is `pattern="accumulator"` and is excluded
+  unless `--include-accumulators` is passed. Same corpus, same revision,
+  after: **7** rows, BUG B at **rank 3**. The two rows still above it
+  (`canary.py::monitor_live`'s `rollback_recommended`,
+  `server.py::_process_reflection_item`'s `sampling_mode`) are the same
+  shape in CORRECT code — irreducible without knowing intent.
+
+- **BUG B regression**: at `69adfa4^`, `cg flags mcp/grounding.py::ground`
+  reports exactly one row — `degraded` — init `False` (constant) at
+  `:179`, escaping as a dict-value at `:316`, reassigned `True` at 3
+  guarded sites (2 `if-branch`, 1 `except-handler`), and **10** guard exits
+  (`break`/`continue` inside `if-branch`/`except-handler` blocks) that
+  never touch it, for a score of 3.67 — `degraded` is the only (hence
+  top-ranked) row for the function, matching the acceptance criteria. At
+  `69adfa4` (the actual fix, commit message: "grounding: report degraded
+  when the server module fails to import"), a fourth assignment
+  (`degraded = True` inside the `except Exception: S = None` handler that
+  every server-backed lane short-circuits on) is added; re-running the
+  same command against HEAD confirms the fix is visible to this tool as a
+  DROP in score (**3.67 -> 2.75**) from the new guarded assignment, while
+  the same 10 unrelated `if not S: break`/`continue` guard exits remain
+  (they are not about `degraded` at all — they are the lanes' own
+  fail-open behavior, unrelated to the flag). `cg flags` does not, and is
+  not meant to, assert "this is now fixed"; it only ever reports a ratio.
+
+- **RANKER, NOT A DETECTOR.** Every conditional flag in Python matches the
+  shape this check ranks on. Never wire `cg flags` to a non-zero exit
+  code or a CI gate; always scope it to one file or function before
+  reading the output as anything but a lead list.
+
+## `cg dead` — false-positive audit (validator pass, HEAD `989942b5`)
+
+The number that decides whether this query is worth reading. Measured by
+`tests/test_dead_false_positives.py`, which is the permanent gate.
+
+- **HARD GATE: 0 false positives on the registration surface.** All 92
+  registered functions — 40 `@mcp.tool()`, 31 `register()` manifest-tuple
+  members, 13 `_SKILL_MAP` entries, 6 FastAPI routes, 1 `mcp.resource`,
+  1 `mcp.custom_route` — are reachable. None is reported dead. This is an
+  absolute, not a ratio.
+
+- **Total rows: 66** (was **165** before this pass). Five resolution bugs
+  plus one noise class, found by hand-verifying the 165, each now fixed and
+  regression-tested:
+
+  | shape | real site | rows recovered |
+  |---|---|---|
+  | bare name passed as a call argument | `_health_check("x", _health_probe_*)` | ~62 |
+  | call inside a `lambda` body | `lambda: _health_probe_qdrant_reachable(...)` | (same cluster) |
+  | function-local import used from a nested scope | `loci_health`'s `import backends`, called in a lambda | 4 |
+  | nested def called from a SIBLING nested def | `code_parse.py::parse_source` | 2 |
+  | `from . import X` of a sibling submodule | `analytics.py`'s `from . import queries as Q` | 4 |
+  | protocol dunders invoked by language machinery | `with _Mutex(MUTEX_FLAG):` calls `__enter__`/`__exit__` | 5 |
+
+- **Hand-verified breakdown of the remaining 66:**
+
+  - **53 are methods** reached only through an attribute call on a receiver
+    whose type this tool does not infer (`ks.symbol_findings(...)` where
+    `ks` is a parameter or an untyped module global). These are FALSE
+    POSITIVES and they are **out of reach without type inference** — the
+    honest limit, not a bug to be fixed by loosening the gate. Some are
+    additionally reached only via `getattr(obj, "name")` on an untyped
+    receiver (`readable_probe`, `lock_holder_pid`), which is the same
+    problem wearing a different hat.
+  - **1 is a nested closure inside one of those methods**
+    (`related_investigations.<locals>._bump`) — dead purely by
+    transitivity from a false positive above it, not an independent claim.
+  - **12 are module-level functions.** Spot-checked: `queries.py`'s
+    `symbol_findings` / `related_findings_via_code` really are called from
+    nowhere in the non-test corpus — they are `__all__` exports of a library
+    module, exercised only by `mcp/tests/`.
+
+  Cross-checking all 66 rows against a whole-tree `git grep` of each name:
+  **3** are reachable only from test code (`backends.py::_reset_cache`,
+  `ladybug_store.py::writable_probe`, `critic.py::record_label`), which this
+  corpus definition excludes on purpose; **3** are mentioned nowhere in the
+  tree at all and are the rows a reader should open first
+  (`memcheck/daemon.py::MemcheckDaemon.handle_error`,
+  `memcheck/engine.py::VerdictEngine.in_memory`, `::recall_decision`); the
+  remaining 60 are mentioned elsewhere in the corpus, overwhelmingly as the
+  untyped-receiver method calls described above.
+
+- **The trade that bought this.** `extract/funcrefs.py` treats ANY bare
+  function name in a value position as an escape, so a function mentioned
+  once in code that itself never runs will not be reported. `cg dead` is a
+  lead generator, and recall was spent to keep its rows worth reading.
+  `tests/test_dead_false_positives.py::test_genuinely_unreferenced_function_is_still_reported`
+  is the counter-test that keeps this from degenerating into a query that
+  never says anything.
+
+## Validating against real bugs, not shapes
+
+`tests/test_regression_real_bugs.py` runs the analyzers against the actual
+pre-fix source of BUGs B, C and D, copied verbatim out of git history into
+`fixtures/regress/` (a provenance test re-checks each fixture against
+`git show` so it cannot be quietly edited into a toy). This is a different
+and stronger claim than `cg selftest`'s "BUG x shape" checks, which run
+against hand-written miniatures and can keep passing after the analyzer has
+stopped working on real input.
+
+Result on the real code: **B, C and D are all surfaced.** C and D are
+surfaced exactly and with zero noise in their fixtures (2 findings and 1
+orphan pair respectively). B is surfaced as the sole row for its file, but
+only as **rank 3 of 7** corpus-wide — `cg flags` is a ranker, and its BUG B
+result depends on the user already suspecting `mcp/grounding.py`.
+
+None of the three was found by this tool first; all three were already
+fixed when it was pointed at them. What is demonstrated here is that the
+queries surface them from the real source, not that they would have been
+noticed unprompted.
+
+## Carried over from earlier slices (see also `cg holes`, `cg registry
+--unmatched`, `cg dead`'s footer)
+
+- Dynamic dispatch this tool cannot see (`getattr(obj, <var>)`,
+  `importlib.import_module(<var>)`, `globals()[...]`, `exec`/`eval`,
+  monkeypatching) becomes an edge to `?` with a reason, never a fabricated
+  edge.
+- Non-Python entry points (systemd/cron/shell/docker-compose/CI) are only
+  covered by the hand-maintained `[[roots]]` table in `rules.toml`, which
+  WILL go stale — `cg dead`'s footer names the table size for this reason.
+- Method calls on values of unknown type resolve only via a
+  unique-method-name-in-corpus heuristic; common names (`run`, `get`,
+  `predict`, `record`, `close`) fan out or fall to `?`.
+- An unrecognized registrar (a new decorator/manifest shape rules.toml
+  doesn't know) is the single most damaging failure mode this tool can
+  have; `cg registry --unmatched` and `cg selftest`'s known-count
+  assertions are mitigations, not a guarantee.
+- `node["_id"]` vs a graph backend's `"_ID"` key-casing mismatch (BUG A)
+  is explicitly OUT OF SCOPE: the string `"_ID"` is not a literal anywhere
+  in this corpus's own `.py` files (the case mangling happens inside a
+  driver this tool never parses), so there is no producer node for the
+  key-literal audit to pair the consumer against, and the near-miss check
+  cannot fire on a single-sided key. A structural call/reference graph
+  should not be expected to catch this; it needs an executed backend or a
+  typed payload contract instead.

--- a/scripts/callgraph/docs/census.txt
+++ b/scripts/callgraph/docs/census.txt
@@ -1,0 +1,611 @@
+================================================================================
+                    CALL-GRAPH CENSUS REPORT
+            Dispatch patterns and constructs in mcp/ | scripts/ | a2a_server/ | mlops/ | eval/
+
+Generated: 2026-08-10
+Target: Build dependency-light call-graph tool for debugging (no LadybugDB required)
+================================================================================
+
+EXECUTIVE SUMMARY
+─────────────────
+
+A call-graph builder for this codebase MUST handle:
+
+  1. 40 @mcp.tool() decorated functions — never called by name, registered dynamically
+  2. ~30 register(mcp, deps) functions — pass bare function references in tuple/list literals
+  3. 856 bare function references in tuple/list/dict literals (registration manifests)
+  4. 288 local imports (import INSIDE function bodies — not module-level)
+  5. 2 importlib.import_module() calls (dynamic module loading)
+  6. 2,140 direct calls (Name + Attribute chains)
+  7. 280 plain function/method defs across target areas
+  8. 22 decorated defs (decorators other than @mcp.tool)
+  9. 240 module-level imports
+  10. 187 string literals that look like paths or special identifiers
+
+The corpus spans 13,805 files total; focus areas have ~150 "real" .py files. Target
+analysis regions (mcp/graph/** + mcp/memcheck/**): 28 files, 7,277 lines.
+
+================================================================================
+I. PLAIN FUNCTION & METHOD DEFINITIONS
+================================================================================
+
+Census: 280 plain function/method defs across mcp/ + scripts/ + a2a_server/ + mlops/ + eval/
+
+Distribution by directory:
+  mcp/               ~150 functions
+  a2a_server/        ~40 functions
+  scripts/           ~50 functions
+  eval/              ~30 functions
+  mlops/             ~10 functions
+
+Examples (from target areas):
+
+  File: mcp/graph/code_parse.py:66
+    def detect_lang(path: str) -> Optional[str]:
+        """Detect language from file extension."""
+
+  File: mcp/graph/ladybug_store.py:313
+    @contextmanager
+    def _session(self):
+        """Context manager for database sessions."""
+
+  File: mcp/graph/analytics.py:45
+    def impact_report(ks, symbol):
+        """Change blast radius for a symbol."""
+
+  File: mcp/memcheck/checks/code_hallucination.py:57
+    def run_code_checks(llm, code, context: CodeContext) -> list[VerdictReading]:
+        """Check for code hallucinations."""
+
+Methods on classes (mcp/graph/ladybug_store.py has LadybugStore class):
+  - __init__(self, db_path: str)  [line 143]
+  - available(self) -> bool  [line 173]
+  - code_query(self, cypher: str, params: dict = None)  [line 185]
+  - upsert_investigation(self, **fields)  [line 494]
+  - upsert_finding(self, **fields)  [line 508]
+
+================================================================================
+II. DECORATED FUNCTION DEFINITIONS (grouped by decorator)
+================================================================================
+
+Census: 22 decorated defs total, 7 distinct decorator patterns
+
+Distribution:
+  _writes               11 occurrences  (custom LadybugDB write-session decorator)
+  abc.abstractmethod     3 occurrences  (abstract methods)
+  @staticmethod          4 occurrences  (static methods on classes)
+  @classmethod           2 occurrences  (class methods)
+  @contextmanager        1 occurrence   (context manager)
+  functools.wraps        1 occurrence   (wrapper decorator)
+
+Concrete examples:
+
+  1. @mcp.tool() — FastMCP registration decorator
+     File: mcp/server.py:2118
+       @mcp.tool()
+       def investigation_store(investigation_id: str, finding_type: str, ...):
+           """Record an observation, inference, or assumption."""
+
+     File: mcp/server.py:2258
+       @mcp.tool()
+       def finding_resolve(finding_id: str, status: str):
+           """Resolve a finding (mark as fixed/duplicate/wontfix)."""
+
+     TOTAL: 40 @mcp.tool() decorated functions across mcp/server.py
+
+  2. _writes decorator (custom multi-statement write pattern)
+     File: mcp/graph/ladybug_store.py:494
+       @_writes
+       def upsert_investigation(self, **fields):
+           """Atomically write investigation to graph store."""
+
+     File: mcp/graph/ladybug_store.py:508
+       @_writes
+       def upsert_finding(self, **fields):
+           """Record finding node in graph."""
+
+     TOTAL: 11 occurrences; defined at mcp/graph/ladybug_store.py:38
+
+  3. abc.abstractmethod (abstract base class methods)
+     File: mcp/memcheck/backend.py:70
+       @abc.abstractmethod
+       def record(self, verdict: ScoredVerdict) -> bool:
+           """Write a verdict to the backend."""
+
+     File: mcp/memcheck/backend.py:75
+       @abc.abstractmethod
+       def recall(self, finding_id: str) -> Optional[ScoredVerdict]:
+           """Retrieve a stored verdict."""
+
+  4. @staticmethod
+     File: mcp/graph/ladybug_store.py:450
+       @staticmethod
+       def _close_result(result):
+           """Close a database cursor."""
+
+  5. @classmethod
+     File: mcp/memcheck/engine.py:63
+       @classmethod
+       def in_memory(cls):
+           """Create an in-memory verdict engine."""
+
+     File: mcp/memcheck/verdict.py:101
+       @classmethod
+       def from_payload(cls, payload: dict):
+           """Deserialize verdict from JSON."""
+
+  6. @contextmanager
+     File: mcp/graph/ladybug_store.py:313
+       @contextmanager
+       def _session(self):
+           """Lease a database session with bounded timeout."""
+
+================================================================================
+III. DIRECT CALLS (Name + Attribute chains)
+================================================================================
+
+Census: 2,140 direct calls across corpus
+  - Name calls (direct function name):    1,066
+  - Attribute calls (obj.method):         1,074
+
+Call patterns are standard; examples of each:
+
+  File: mcp/graph/code_parse.py:66
+    Name call:
+      lang = LANG_BY_EXT.get(ext)  # lookup in dict
+      Call: get() [Attribute]
+
+  File: mcp/graph/analytics.py:27
+    Name call:
+      bool_result = ks.available()  # method call
+      Call: available() [Attribute]
+
+  File: mcp/graph/code_parse.py:32
+    Module-level call:
+      logger.debug("...")  # logging
+      Call: logger.debug() [Attribute]
+
+Common patterns:
+  - Method calls on self: self.available(), self.code_query()
+  - Dict operations: dict.get(), dict.items(), dict.setdefault()
+  - String operations: str.split(), str.strip(), str.startswith()
+  - Logging: logger.debug(), logger.error()
+  - Object creation: Path(...), dict(...), list(...)
+
+================================================================================
+IV. REGISTRATION ROOTS: @mcp.tool() DECORATED FUNCTIONS
+================================================================================
+
+Census: 40 @mcp.tool() decorated functions (never called by name, only registered)
+
+Location: mcp/server.py (all 40 in a single file)
+
+Key registration roots:
+  Line 2118:  investigation_store(investigation_id, finding_type, text, ...)
+  Line 2258:  finding_resolve(finding_id, status)
+  Line 2327:  procedure_attempt(procedure_id, attempt_text)
+  Line 2420:  procedure_search(investigation_id, query)
+  Line 2538:  reflection_loop_seed(iteration_limit)
+  Line 2635:  reflection_loop_status()
+  Line 2776:  reflection_loop_tick()
+  Line 3053:  investigation_search(investigation_id, query, top_k)
+  Line 3274:  investigation_pre_answer_check(investigation_id, response)
+  Line 3425:  investigation_entity_lookup(investigation_id, entity_name)
+  Line 3490:  entity_list(investigation_id)
+  Line 3541:  entity_timeline(investigation_id, entity_name)
+  Line 3620:  investigation_related_cases(investigation_id)
+  Line 3693:  investigation_evidence_precheck(investigation_id, query)
+  Line 3779:  audit_log(tool_name, result, start_time, error_msg)
+
+These functions are never called by their Python name; FastMCP's introspection
+reads their decorators and signatures, then dispatches via HTTP MCP protocol.
+
+================================================================================
+V. REGISTRATION MANIFESTS: register(mcp, deps) PATTERN
+================================================================================
+
+Census: ~30 register() functions across mcp/ (zero in other directories)
+
+Pattern: Each module defines tools with a bare register() that:
+  1. Accepts a FastMCP instance + dependency injector
+  2. Takes bare function references in a tuple/list (not strings)
+  3. Calls mcp.tool()(fn) for each, registering them on the shared instance
+
+Example: mcp/graph_tools.py
+
+  File: mcp/graph_tools.py (full register function)
+
+    _get_ladybug = None  # module-level, injected by register()
+
+    def register(mcp, get_ladybug):
+        """Inject deps and register every graph tool on the shared FastMCP instance."""
+        global _get_ladybug
+        _get_ladybug = get_ladybug
+
+        for fn in (
+            code_graph_ingest,          # bare function ref (tuple literal)
+            code_graph_query,
+            code_memory_relink,
+            code_memory_map,
+            symbol_impact,
+            impact_report,
+            finding_code_context,
+            investigation_code_briefing,
+            subsystem_report,
+            related_investigations_via_code,
+            dead_code_candidates,
+        ):
+            mcp.tool()(fn)  # register each tool via decorator
+
+Call site (mcp/server.py:7398):
+
+    import graph_tools
+    graph_tools.register(mcp, _get_ladybug)
+
+Other examples:
+  File: mcp/llm_tools.py:register(mcp)
+    Registers: llm_json, llm_extract, llm_rank, llm_rewrite, ...
+
+  File: mcp/investigation_tools.py:register(mcp, get_memory_dir, deps)
+    Registers: investigation_start, investigation_load, investigation_reflect, ...
+
+  File: mcp/ladybug_ops.py:register(get_ladybug, get_memory_dir)
+    Registers: graph_impact, symbol_impact_v2, finding_code_context_v2, ...
+
+================================================================================
+VI. BARE FUNCTION REFERENCES IN TUPLE/LIST/DICT LITERALS
+================================================================================
+
+Census: 856 bare function references in literals (not strings)
+
+This is a KEY pattern for call-graph builders. Examples show why:
+
+  File: mcp/graph_tools.py (shown above):
+    Tuple of bare function refs — each name must resolve to a function definition
+    for fn in (
+        code_graph_ingest,        # <- bare ref, must resolve to function def
+        code_graph_query,
+        symbol_impact,
+        ...
+    ):
+        mcp.tool()(fn)
+
+  File: mcp/backends.py (function-local dict):
+    def _resolve_vllm_model(model_name: str):
+        from backends import models  # local import
+        supported = {
+            "mistral-7b": models.mistral,       # <- bare ref to imported module.attr
+            "llama-2-7b": models.llama2,
+        }
+        return supported.get(model_name)()
+
+  File: a2a_server/server.py (module-level tuple dispatch):
+    # Line 375
+    (str, dict)  # built-in types, not callables but treated as "refs"
+
+  File: a2a_server/server.py (module-level function tuple):
+    # Line 520
+    def _recall_fts_working(query, top_k):
+        ...
+
+    def _recall_fts_episodes(query, top_k):
+        ...
+
+    # used in tuple literal
+    (_recall_fts_working, _recall_fts_episodes)
+
+Distribution:
+  mcp/           394 bare refs
+  scripts/       277 bare refs
+  a2a_server/     50 bare refs
+  mlops/          92 bare refs
+  eval/           43 bare refs
+
+================================================================================
+VII. DICT-OF-CALLABLES DISPATCH
+================================================================================
+
+Census: 23 dict-of-callables assignments (some are test doubles, data, not dispatch)
+
+True dispatch dicts (handlers keyed by string):
+
+  File: mcp/memcheck/checks/code_hallucination.py:46
+    _LH_TO_PATTERN = {
+        'LLM_HALLUCINATION_FUNCTION_CALL': 'suspected_function_call',
+        'LLM_HALLUCINATION_OBJECT_ATTR': 'suspected_attr_access',
+        'LLM_HALLUCINATION_IMPORT': 'suspected_import',
+        'LLM_HALLUCINATION_BUILTIN': 'suspected_builtin',
+    }
+    [Maps string verdict codes to pattern identifiers]
+
+  File: mcp/memcheck/checks/contradiction.py:35
+    _CONF_PROTECTION = {
+        'high': 0.9,
+        'medium': 0.6,
+        'low': 0.3,
+    }
+    [Config dispatch: string confidence level -> float threshold]
+
+  File: mcp/verdict_ops.py (function-local):
+    _VERDICT_MAP = {
+        'HALLUCINATED': VerdictType.HALLUCINATED,
+        'OUTDATED': VerdictType.OUTDATED,
+        'CONTRADICTED': VerdictType.CONTRADICTED,
+    }
+    [Enum-like mapping; string -> function/type]
+
+Data-like dicts (not dispatch):
+  File: mcp/graph/queries.py:38
+    _PK = {
+        'CodeSymbol': 'id',
+        'Finding': 'id',
+        'Entity': 'name',
+        'Investigation': 'id',
+    }
+    [Metadata, not handler dispatch]
+
+  File: eval/grounding_gate_qf_eval.py:42
+    DEFAULT_FOCUS = {
+        'strategy': 'balanced',
+        'diversity': 0.5,
+        'depth': 3,
+    }
+    [Config data]
+
+================================================================================
+VIII. LAZY IMPORTS (module-local, function-scoped)
+================================================================================
+
+Census: 288 local imports across corpus (import INSIDE function body)
+
+Distribution by directory:
+  mcp/               207 local imports
+  scripts/            30 local imports
+  mlops/              41 local imports
+  eval/                8 local imports
+  a2a_server/          2 local imports
+
+These defeat static analysis and are performance optimizations or workarounds for:
+  1. Circular dependencies
+  2. Optional dependencies (fail gracefully if not installed)
+  3. Lazy initialization to delay expensive module setup
+
+Examples:
+
+  File: mcp/batched_gen.py:51 (inside _resolve_vllm function)
+    def _resolve_vllm():
+        import backends  # <- local import
+        return backends.vllm_pipeline()
+
+  File: mcp/backends.py:55 (inside _config function)
+    def _config():
+        import tomllib  # <- local import, only if needed
+        with open(...) as f:
+            return tomllib.load(f)
+
+  File: a2a_server/server.py:1247 (inside skill_docker_status function)
+    def skill_docker_status():
+        import subprocess  # <- local import to avoid top-level dependency
+        result = subprocess.run(...)
+
+  File: eval/grounding_gate_oos_eval.py:32 (inside run function)
+    def run():
+        import np  # NumPy only if OOD check is needed
+        import LogisticRegression  # sklearn only if OOD check is needed
+        ...
+
+Call-graph implications:
+  - These imports cannot be discovered by static analysis of module-level imports
+  - CFG (control-flow graph) analysis needed to find which functions import what
+  - The imported name is only live inside that function's scope
+  - A call-graph must track which function contains the import to resolve intra-function calls
+
+================================================================================
+IX. importlib.import_module() CALLS (dynamic module loading)
+================================================================================
+
+Census: 2 importlib.import_module() calls
+
+These are runtime module loading — must be resolved at call time with string values.
+
+File: mcp/grounding.py:194
+  def _get_server():
+      """Load the server module on first access."""
+      global _server_module
+      if _server_module is None:
+          _server_module = importlib.import_module('server')
+      return _server_module
+
+File: mlops/embedding/tests/test_embedding.py:667
+  import importlib
+  ...
+  module = importlib.import_module('contrastive')
+
+Call-graph implication:
+  - Cannot resolve statically; the module name is only known at runtime
+  - A conservative call-graph might mark the loaded module as "unknown" or skip it
+  - Or defer to a runtime registry of known modules
+
+================================================================================
+X. MODULE-LEVEL ASSIGNMENTS & NAMES READ ACROSS MODULES
+================================================================================
+
+Census: 240+ module-level assignments; tracking cross-module reads is incomplete
+
+Examples of module-level names that are read by other modules:
+
+  File: mcp/graph_tools.py (module-scope injection):
+    _get_ladybug = None
+
+  Then used by every function in that module:
+    ks = _get_ladybug()  # called inside code_graph_ingest, code_graph_query, etc.
+
+  Injected from mcp/server.py:7398:
+    graph_tools.register(mcp, _get_ladybug)
+
+  Similar patterns in:
+    mcp/llm_tools.py:       _mcp, _get_memory_dir
+    mcp/investigation_tools.py:  _mcp, _deps_dict
+    mcp/ladybug_ops.py:     _get_ladybug, _get_memory_dir
+
+  File: mcp/server.py (module-level constants):
+    HERMES_MEMORY_DIR = os.environ.get('HERMES_MEMORY_DIR', '~/.hermes/findings')
+    MNEMOSYNE_DB = os.path.join(_mnem_data_dir, 'mnemosyne.db')
+
+  These are read by tools and dependencies via `from server import HERMES_MEMORY_DIR`.
+
+Call-graph implication:
+  - A complete call-graph must track which names are assigned at module level
+  - And which are imported/read by other modules
+  - This builds a "data-dependency" layer on top of call-graph
+
+================================================================================
+XI. GLOBAL STATEMENTS
+================================================================================
+
+Census: 0 global statements in target areas (mcp/graph/ + mcp/memcheck/)
+
+This is good — no function-level globals in the graph/memcheck modules.
+
+However, other areas use globals:
+  - mcp/graph_tools.py: _get_ladybug = None (module-level, injected)
+  - mcp/llm_tools.py: _mcp = None, _get_memory_dir = None (module-level)
+  - Various __init__.py files: module-level imports and re-exports
+
+================================================================================
+XII. STRING LITERALS THAT LOOK LIKE PATHS OR COLLECTION NAMES
+================================================================================
+
+Census: 187 string literals with special patterns (paths, identifiers, etc.)
+
+Paths:
+  File: mcp/graph/code_parse.py:40
+    '.py'  # file extension
+
+  File: mcp/graph/__init__.py:1
+    'Loci MCP graph package — code symbol/reference extraction + (optional) LadybugDB store.'
+
+Special identifiers:
+  File: mcp/graph/linker.py:87
+    'Build a fast lookup index over ``symbols`` for reference extraction.'
+
+  File: mcp/memcheck/backend.py (config keys read at runtime):
+    Implied patterns like 'file::Qualname' (symbol id format)
+
+Collection names and other literals used by Cypher/database queries:
+  File: mcp/graph/queries.py (database schema references):
+    Implied: 'CodeFile', 'CodeSymbol', 'Finding', 'Entity', 'Investigation'
+    (These appear as quoted strings in Cypher queries)
+
+File paths mentioned in docstrings:
+  File: mcp/graph/ladybug_store.py:1
+    'Embedded LadybugDB graph store...'
+    References layout: '$HERMES_MEMORY_DIR/<investigation_id>/manifest.json'
+
+Call-graph implication:
+  - String patterns may encode node types, collection names, or runtime configs
+  - A conservative call-graph builder might flag these as "unresolvable" data references
+  - Or maintain a separate "string-to-resource" mapping
+
+================================================================================
+XIII. GETATTR / DICT-OF-CALLABLES DISPATCH
+================================================================================
+
+Census: Limited getattr usage in target areas; more dict-based dispatch
+
+Example (getattr for optional attributes):
+  File: mcp/memcheck/backend.py
+    Method resolution is primarily through dict lookups (_VERDICT_MAP) and
+    isinstance() checks, not getattr()
+
+Dict-based dispatch is the primary pattern:
+  File: mcp/memcheck/checks/contradiction.py:35
+    _CONF_PROTECTION = { 'high': 0.9, 'medium': 0.6, 'low': 0.3 }
+    conf_value = _CONF_PROTECTION.get(confidence_level)
+
+This is safer than getattr() and more explicit.
+
+================================================================================
+XIV. CROSS-MODULE CALLS & PATTERNS
+================================================================================
+
+Key integration points where call-graph builder must track:
+
+  1. server.py (orchestration layer)
+     Imports and calls register() on sub-modules:
+       - graph_tools.register(mcp, _get_ladybug)    [line 7398]
+       - investigation_tools.register(mcp, ...)
+       - llm_tools.register(mcp)
+       - ladybug_ops.register(...)
+
+     Then imports functions from those modules:
+       - from graph_tools import (symbol_impact, ...)
+
+  2. graph/ package (code analysis layer)
+     ladybug_store.py defines LadybugStore class
+     queries.py imports and uses LadybugStore
+     code_parse.py standalone utility functions
+     linker.py uses code_parse and LadybugStore
+
+  3. memcheck/ package (verification layer)
+     backend.py defines abstract VerdictBackend
+     engine.py implements Engine (a backend)
+     checks/ subpackage defines specific checks
+     All import from backend
+
+  4. a2a_server/ (FastAPI integration)
+     server.py defines routes via @app.post(), @app.get()
+     Imports and calls skills like skill_memory_recall(), skill_memory_store()
+     Uses FastAPI Depends() for injection
+
+  5. scripts/ (CLI/daemon tools)
+     Many standalone scripts import from mcp/
+     Some use graph_tools, some use memcheck checks
+     Lazy-import patterns common for optional deps
+
+================================================================================
+XV. RECOMMENDATIONS FOR CALL-GRAPH TOOL
+================================================================================
+
+The tool must handle:
+
+  1. @mcp.tool() decorators as registration roots (40 total)
+
+  2. register(mcp, deps) pattern:
+     - Track function refs in tuple/list literals
+     - Resolve bare names to function defs in same module
+     - Model the global variable injection (_get_ladybug, etc.)
+
+  3. Dict-of-callables dispatch:
+     - String key -> handler function/type lookup
+     - Requires constant folding (dict literal analysis)
+
+  4. Local imports:
+     - Cannot resolve statically; require data-flow or CFG analysis
+     - Mark as "potentially reachable" with uncertainty
+
+  5. importlib.import_module():
+     - Cannot resolve without runtime value tracking
+     - Fall back to string literal inspection
+
+  6. Method calls on classes:
+     - LadybugStore, VerdictEngine, etc.
+     - Must resolve class definitions and method defs
+
+  7. Bare function refs in tuples (856 instances):
+     - Most are in register() calls or literal dispatch tables
+     - Must resolve to function defs in same/nearby modules
+
+  8. Cross-module imports and re-exports:
+     - mcp/__init__.py re-exports from submodules
+     - Tools may import from either location
+
+Key weakness to avoid:
+  - Assuming all function calls are direct Name or Attribute references
+  - Missing the bare function refs in tuples
+  - Not handling lazy imports (function-scoped import statements)
+  - Ignoring decorator-based registration (FastMCP's @mcp.tool())
+
+================================================================================
+                              END OF REPORT
+================================================================================

--- a/scripts/callgraph/docs/legacy/PATTERNS_SUMMARY.json
+++ b/scripts/callgraph/docs/legacy/PATTERNS_SUMMARY.json
@@ -1,0 +1,375 @@
+{
+  "census_date": "2026-08-10",
+  "purpose": "Call-graph builder pattern inventory for loci codebase",
+  "scope": "mcp/ + scripts/ + a2a_server/ + mlops/ + eval/",
+  "target_analysis_areas": ["mcp/graph/**", "mcp/memcheck/**"],
+
+  "summary": {
+    "total_files_scanned": 13805,
+    "target_area_files": 28,
+    "target_area_lines": 7277
+  },
+
+  "constructs": {
+    "plain_function_defs": {
+      "total": 280,
+      "description": "Module-level function definitions",
+      "examples": [
+        {
+          "file": "mcp/graph/code_parse.py",
+          "line": 66,
+          "name": "detect_lang",
+          "signature": "def detect_lang(path: str) -> Optional[str]:"
+        },
+        {
+          "file": "mcp/graph/analytics.py",
+          "line": 45,
+          "name": "impact_report",
+          "signature": "def impact_report(ks, symbol):"
+        },
+        {
+          "file": "mcp/memcheck/checks/code_hallucination.py",
+          "line": 57,
+          "name": "run_code_checks",
+          "signature": "def run_code_checks(llm, code, context: CodeContext) -> list[VerdictReading]:"
+        }
+      ]
+    },
+
+    "method_defs": {
+      "total": 100,
+      "description": "Methods on classes",
+      "examples": [
+        {
+          "file": "mcp/graph/ladybug_store.py",
+          "line": 143,
+          "class": "LadybugStore",
+          "name": "__init__",
+          "signature": "def __init__(self, db_path: str):"
+        },
+        {
+          "file": "mcp/graph/ladybug_store.py",
+          "line": 173,
+          "class": "LadybugStore",
+          "name": "available",
+          "signature": "def available(self) -> bool:"
+        },
+        {
+          "file": "mcp/graph/ladybug_store.py",
+          "line": 494,
+          "class": "LadybugStore",
+          "name": "upsert_investigation",
+          "signature": "def upsert_investigation(self, **fields):"
+        }
+      ]
+    },
+
+    "decorated_defs": {
+      "total": 22,
+      "by_decorator": {
+        "_writes": {
+          "count": 11,
+          "description": "Custom multi-statement write decorator (LadybugDB pattern)",
+          "examples": [
+            {
+              "file": "mcp/graph/ladybug_store.py",
+              "line": 494,
+              "func": "upsert_investigation"
+            },
+            {
+              "file": "mcp/graph/ladybug_store.py",
+              "line": 508,
+              "func": "upsert_finding"
+            }
+          ]
+        },
+        "mcp.tool": {
+          "count": 40,
+          "description": "FastMCP tool registration decorator (registration roots)",
+          "examples": [
+            {
+              "file": "mcp/server.py",
+              "line": 2118,
+              "func": "investigation_store"
+            },
+            {
+              "file": "mcp/server.py",
+              "line": 2258,
+              "func": "finding_resolve"
+            },
+            {
+              "file": "mcp/server.py",
+              "line": 3053,
+              "func": "investigation_search"
+            }
+          ]
+        },
+        "abc.abstractmethod": {
+          "count": 3,
+          "description": "Abstract base class methods",
+          "examples": [
+            {
+              "file": "mcp/memcheck/backend.py",
+              "line": 70,
+              "func": "record"
+            }
+          ]
+        },
+        "staticmethod": {
+          "count": 4,
+          "examples": [
+            {
+              "file": "mcp/graph/ladybug_store.py",
+              "line": 450,
+              "func": "_close_result"
+            }
+          ]
+        },
+        "classmethod": {
+          "count": 2,
+          "examples": [
+            {
+              "file": "mcp/memcheck/engine.py",
+              "line": 63,
+              "func": "in_memory"
+            }
+          ]
+        },
+        "contextmanager": {
+          "count": 1,
+          "examples": [
+            {
+              "file": "mcp/graph/ladybug_store.py",
+              "line": 313,
+              "func": "_session"
+            }
+          ]
+        }
+      }
+    },
+
+    "direct_calls": {
+      "total": 2140,
+      "by_type": {
+        "Name": 1066,
+        "Attribute": 1074
+      },
+      "description": "Direct function/method calls",
+      "examples": [
+        {
+          "file": "mcp/graph/code_parse.py",
+          "line": 66,
+          "caller": "detect_lang",
+          "callee": "LANG_BY_EXT.get",
+          "type": "Attribute"
+        },
+        {
+          "file": "mcp/graph/analytics.py",
+          "line": 27,
+          "caller": "_ok",
+          "callee": "ks.available",
+          "type": "Attribute"
+        }
+      ]
+    },
+
+    "bare_function_refs_in_literals": {
+      "total": 856,
+      "description": "Bare function references in tuple/list/dict literals (registration manifests)",
+      "by_directory": {
+        "mcp": 394,
+        "scripts": 277,
+        "a2a_server": 50,
+        "mlops": 92,
+        "eval": 43
+      },
+      "examples": [
+        {
+          "file": "mcp/graph_tools.py",
+          "line": 250,
+          "pattern": "for fn in (code_graph_ingest, code_graph_query, symbol_impact, ...): mcp.tool()(fn)",
+          "context": "register() function - tuple of bare function refs"
+        },
+        {
+          "file": "mcp/batched_gen.py",
+          "line": 51,
+          "pattern": "supported = { 'mistral-7b': models.mistral, 'llama-2-7b': models.llama2 }",
+          "context": "Dict dispatch with bare refs"
+        }
+      ]
+    },
+
+    "dict_of_callables": {
+      "total": 23,
+      "description": "Dictionary assignments that may contain handlers or dispatch tables",
+      "examples": [
+        {
+          "file": "mcp/memcheck/checks/code_hallucination.py",
+          "line": 46,
+          "var": "_LH_TO_PATTERN",
+          "pattern": "{ 'LLM_HALLUCINATION_FUNCTION_CALL': 'suspected_function_call', ... }"
+        },
+        {
+          "file": "mcp/memcheck/checks/contradiction.py",
+          "line": 35,
+          "var": "_CONF_PROTECTION",
+          "pattern": "{ 'high': 0.9, 'medium': 0.6, 'low': 0.3 }"
+        }
+      ]
+    },
+
+    "local_imports": {
+      "total": 288,
+      "description": "Imports inside function bodies (not module-level)",
+      "by_directory": {
+        "mcp": 207,
+        "scripts": 30,
+        "mlops": 41,
+        "eval": 8,
+        "a2a_server": 2
+      },
+      "examples": [
+        {
+          "file": "mcp/batched_gen.py",
+          "line": 51,
+          "function": "_resolve_vllm",
+          "import": "import backends"
+        },
+        {
+          "file": "mcp/backends.py",
+          "line": 55,
+          "function": "_config",
+          "import": "import tomllib"
+        },
+        {
+          "file": "a2a_server/server.py",
+          "line": 1247,
+          "function": "skill_docker_status",
+          "import": "import subprocess"
+        }
+      ]
+    },
+
+    "importlib_calls": {
+      "total": 2,
+      "description": "Dynamic module loading via importlib.import_module()",
+      "examples": [
+        {
+          "file": "mcp/grounding.py",
+          "line": 194,
+          "code": "importlib.import_module('server')"
+        },
+        {
+          "file": "mlops/embedding/tests/test_embedding.py",
+          "line": 667,
+          "code": "importlib.import_module('contrastive')"
+        }
+      ]
+    },
+
+    "module_level_imports": {
+      "total": 240,
+      "description": "Standard module-level import statements"
+    },
+
+    "global_statements": {
+      "total": 0,
+      "note": "No global statements in target areas (mcp/graph/ + mcp/memcheck/)"
+    },
+
+    "string_literals_special": {
+      "total": 187,
+      "description": "String literals that look like paths or special identifiers",
+      "examples": [
+        {
+          "file": "mcp/graph/code_parse.py",
+          "line": 40,
+          "value": "'.py'"
+        },
+        {
+          "file": "mcp/graph/ladybug_store.py",
+          "line": 1,
+          "context": "docstring with path references",
+          "value": "$HERMES_MEMORY_DIR/<investigation_id>/manifest.json"
+        }
+      ]
+    }
+  },
+
+  "registration_patterns": {
+    "mcp_tool_decorators": {
+      "total": 40,
+      "location": "mcp/server.py",
+      "description": "FastMCP @mcp.tool() decorators - these are registration roots, never called by name",
+      "why_hard": "Not callable as regular Python functions; dispatched via HTTP MCP protocol"
+    },
+
+    "register_functions": {
+      "total": 30,
+      "location": "Various mcp/*.py files",
+      "description": "Functions named register(mcp, deps) that take bare function references",
+      "pattern": "for fn in (func1, func2, ...): mcp.tool()(fn)",
+      "files": [
+        "mcp/graph_tools.py",
+        "mcp/llm_tools.py",
+        "mcp/investigation_tools.py",
+        "mcp/ladybug_ops.py",
+        "mcp/inv_store.py"
+      ],
+      "integration_point": "mcp/server.py calls register() on each module after FastMCP instantiation"
+    },
+
+    "module_level_injection": {
+      "description": "Pattern: module-level var set to None, injected by register()",
+      "examples": [
+        {
+          "file": "mcp/graph_tools.py",
+          "var": "_get_ladybug",
+          "injected_by": "register(mcp, get_ladybug)"
+        },
+        {
+          "file": "mcp/llm_tools.py",
+          "var": "_mcp",
+          "var2": "_get_memory_dir",
+          "injected_by": "register(mcp, get_memory_dir)"
+        }
+      ]
+    }
+  },
+
+  "dispatch_mechanisms": {
+    "dict_lookup": {
+      "count": 23,
+      "example": "_CONF_PROTECTION.get(confidence_level)",
+      "why": "Type-safe; preferred over getattr()"
+    },
+    "bare_function_refs": {
+      "count": 856,
+      "mechanism": "Stored in tuple/list/dict, resolved at call time",
+      "why": "Avoids string-based dispatch; dependencies are explicit in literals"
+    },
+    "module_injection": {
+      "count": 5,
+      "mechanism": "Global var set to None, filled by register()",
+      "why": "Decouples tool modules from each other; late binding for server.py"
+    }
+  },
+
+  "critical_for_call_graph": [
+    "Resolve @mcp.tool() decorators to functions they decorate",
+    "Resolve bare function refs in tuple/list literals (856 instances)",
+    "Track register() calls and the dependencies they inject",
+    "Handle local imports (inside function bodies, 288 instances)",
+    "Resolve module-level var assignments and their use",
+    "Detect cross-module imports and re-exports",
+    "Do NOT assume all calls are Name or Attribute chains",
+    "Mark importlib.import_module() as unresolvable (2 instances)"
+  ],
+
+  "known_gaps": [
+    "Cannot statically resolve local imports without CFG analysis",
+    "Cannot statically resolve importlib.import_module() calls",
+    "String-based dynamic dispatch (e.g., getattr with computed names) cannot be resolved",
+    "FastAPI route decorators require introspection to resolve"
+  ]
+}

--- a/scripts/callgraph/docs/legacy/census.py
+++ b/scripts/callgraph/docs/legacy/census.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+AST-based census of call-graph patterns in mcp/graph/** and mcp/memcheck/**
+Counts constructs that a call-graph builder must handle.
+"""
+
+import ast
+import sys
+import subprocess
+from collections import defaultdict
+from typing import List, Dict, Any
+
+def get_committed_file(file_path: str) -> str:
+    """Read file from HEAD commit using git show."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{file_path}"],
+            cwd="/home/user/loci",
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        print(f"Error reading {file_path}: {e.stderr}", file=sys.stderr)
+        return None
+
+def find_target_files() -> List[str]:
+    """Find Python files in mcp/graph and mcp/memcheck."""
+    files = []
+    for root_dir in ["mcp/graph", "mcp/memcheck"]:
+        result = subprocess.run(
+            ["find", root_dir, "-type", "f", "-name", "*.py"],
+            cwd="/home/user/loci",
+            capture_output=True,
+            text=True
+        )
+        for line in result.stdout.strip().split("\n"):
+            if line and line.endswith(".py"):
+                files.append(line)
+    return sorted(set(files))
+
+class CallGraphCensus(ast.NodeVisitor):
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+        self.lineno_offset = 0
+
+        # Census categories
+        self.function_defs = []  # (name, lineno, is_method)
+        self.decorated_defs = defaultdict(list)  # decorator_name -> [(func_name, lineno)]
+        self.direct_calls = []  # (caller_name, callee_name/attr, lineno, call_type)
+        self.bare_refs = []  # (context, name/attr, lineno)
+        self.imports = []  # (module, name, lineno, is_local)
+        self.global_stmts = []  # (names, lineno)
+        self.getattr_calls = []  # (obj, attr_name, lineno)
+        self.dict_dispatch = []  # (var_name, lineno)
+        self.string_literals = []  # (value, lineno)
+
+        self.current_function = None
+        self.current_class = None
+
+    def visit_FunctionDef(self, node):
+        parent_func = self.current_function
+        self.current_function = node.name
+
+        # Record function def
+        is_method = self.current_class is not None
+        self.function_defs.append((node.name, node.lineno, is_method))
+
+        # Record decorators
+        for dec in node.decorator_list:
+            dec_name = self._get_decorator_name(dec)
+            if dec_name:
+                self.decorated_defs[dec_name].append((node.name, node.lineno))
+
+        self.generic_visit(node)
+        self.current_function = parent_func
+
+    def visit_AsyncFunctionDef(self, node):
+        # Treat like FunctionDef
+        self.visit_FunctionDef(node)
+
+    def visit_ClassDef(self, node):
+        parent_class = self.current_class
+        self.current_class = node.name
+
+        self.generic_visit(node)
+        self.current_class = parent_class
+
+    def visit_Call(self, node):
+        # Categorize calls
+        if isinstance(node.func, ast.Name):
+            # Direct function call: foo()
+            self.direct_calls.append((
+                self.current_function or "<module>",
+                node.func.id,
+                node.lineno,
+                "Name"
+            ))
+        elif isinstance(node.func, ast.Attribute):
+            # Method/attr call: obj.method()
+            attr_chain = self._get_attr_chain(node.func)
+            self.direct_calls.append((
+                self.current_function or "<module>",
+                attr_chain,
+                node.lineno,
+                "Attribute"
+            ))
+
+        self.generic_visit(node)
+
+    def visit_Name(self, node):
+        # Track bare Name references (for tuple/list/dict literals later)
+        self.generic_visit(node)
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            self.imports.append((
+                alias.name,
+                alias.asname or alias.name,
+                node.lineno,
+                False  # not local
+            ))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        for alias in node.names:
+            self.imports.append((
+                f"{node.module}.{alias.name}" if node.module else alias.name,
+                alias.asname or alias.name,
+                node.lineno,
+                False
+            ))
+        self.generic_visit(node)
+
+    def visit_Global(self, node):
+        self.global_stmts.append((node.names, node.lineno))
+        self.generic_visit(node)
+
+    def visit_Dict(self, node):
+        # Track dict literals
+        for key in node.keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                self.dict_dispatch.append((key.value, node.lineno))
+        self.generic_visit(node)
+
+    def visit_Tuple(self, node):
+        # Track bare function refs in tuples
+        for elt in node.elts:
+            if isinstance(elt, ast.Name):
+                self.bare_refs.append((
+                    self.current_function or "<module>",
+                    elt.id,
+                    node.lineno
+                ))
+            elif isinstance(elt, ast.Attribute):
+                self.bare_refs.append((
+                    self.current_function or "<module>",
+                    self._get_attr_chain(elt),
+                    node.lineno
+                ))
+        self.generic_visit(node)
+
+    def visit_List(self, node):
+        # Track bare function refs in lists
+        for elt in node.elts:
+            if isinstance(elt, ast.Name):
+                self.bare_refs.append((
+                    self.current_function or "<module>",
+                    elt.id,
+                    node.lineno
+                ))
+        self.generic_visit(node)
+
+    def visit_Constant(self, node):
+        # Track string literals
+        if isinstance(node.value, str):
+            # Look for path-like or collection-name patterns
+            val = node.value
+            if "/" in val or val.endswith(".py") or val.startswith("_"):
+                self.string_literals.append((val, node.lineno))
+        self.generic_visit(node)
+
+    def _get_decorator_name(self, node) -> str:
+        """Extract decorator name."""
+        if isinstance(node, ast.Name):
+            return node.id
+        elif isinstance(node, ast.Attribute):
+            return self._get_attr_chain(node)
+        elif isinstance(node, ast.Call):
+            return self._get_decorator_name(node.func)
+        return None
+
+    def _get_attr_chain(self, node) -> str:
+        """Get full attribute chain."""
+        if isinstance(node, ast.Attribute):
+            return self._get_attr_chain(node.value) + "." + node.attr
+        elif isinstance(node, ast.Name):
+            return node.id
+        else:
+            return "<expr>"
+
+def analyze_file(filepath: str) -> Dict[str, Any]:
+    """Analyze a single Python file."""
+    content = get_committed_file(filepath)
+    if content is None:
+        return None
+
+    try:
+        tree = ast.parse(content, filename=filepath)
+    except SyntaxError as e:
+        print(f"Syntax error in {filepath}: {e}", file=sys.stderr)
+        return None
+
+    census = CallGraphCensus(filepath)
+    census.visit(tree)
+
+    return {
+        "filepath": filepath,
+        "function_defs": census.function_defs,
+        "decorated_defs": dict(census.decorated_defs),
+        "direct_calls": census.direct_calls,
+        "bare_refs": census.bare_refs,
+        "imports": census.imports,
+        "global_stmts": census.global_stmts,
+        "getattr_calls": census.getattr_calls,
+        "dict_dispatch": census.dict_dispatch,
+        "string_literals": census.string_literals,
+    }
+
+def main():
+    files = find_target_files()
+    print(f"Found {len(files)} target files")
+    print("=" * 80)
+
+    all_results = []
+
+    for filepath in files:
+        result = analyze_file(filepath)
+        if result:
+            all_results.append(result)
+
+    # Aggregate stats
+    total_functions = sum(len(r["function_defs"]) for r in all_results)
+    total_decorated = sum(len(defs) for r in all_results for defs in r["decorated_defs"].values())
+    total_calls = sum(len(r["direct_calls"]) for r in all_results)
+    total_bare_refs = sum(len(r["bare_refs"]) for r in all_results)
+    total_imports = sum(len(r["imports"]) for r in all_results)
+    total_globals = sum(len(r["global_stmts"]) for r in all_results)
+    total_strings = sum(len(r["string_literals"]) for r in all_results)
+
+    print(f"\n### CENSUS SUMMARY ###")
+    print(f"Total files analyzed: {len(all_results)}")
+    print(f"Plain function/method defs: {total_functions}")
+    print(f"Decorated function defs: {total_decorated}")
+    print(f"Direct calls (Name + Attribute): {total_calls}")
+    print(f"Bare function references in literals: {total_bare_refs}")
+    print(f"Import statements: {total_imports}")
+    print(f"Global statements: {total_globals}")
+    print(f"String literals (path-like or special): {total_strings}")
+
+    # Decorator breakdown
+    print(f"\n### DECORATORS (by type) ###")
+    all_decorators = defaultdict(list)
+    for r in all_results:
+        for dec_name, defs in r["decorated_defs"].items():
+            all_decorators[dec_name].extend([(r["filepath"], d) for d in defs])
+
+    for dec_name in sorted(all_decorators.keys()):
+        count = len(all_decorators[dec_name])
+        print(f"{dec_name}: {count} occurrences")
+        for filepath, (func_name, lineno) in all_decorators[dec_name][:3]:
+            print(f"  - {filepath}:{lineno} {func_name}")
+
+    # Call types breakdown
+    print(f"\n### CALL TYPES ###")
+    call_counts = defaultdict(int)
+    for r in all_results:
+        for caller, callee, lineno, ctype in r["direct_calls"]:
+            call_counts[ctype] += 1
+
+    for ctype in sorted(call_counts.keys()):
+        print(f"{ctype}: {call_counts[ctype]} calls")
+
+    # Sample direct calls
+    print(f"\n### DIRECT CALL EXAMPLES ###")
+    call_samples = []
+    for r in all_results:
+        for caller, callee, lineno, ctype in r["direct_calls"][:5]:
+            call_samples.append((r["filepath"], lineno, caller, callee, ctype))
+
+    for filepath, lineno, caller, callee, ctype in call_samples[:10]:
+        print(f"{filepath}:{lineno} | {caller}() -> {callee}() [{ctype}]")
+
+    # Sample bare refs
+    print(f"\n### BARE FUNCTION REFERENCES ###")
+    bare_samples = []
+    for r in all_results:
+        for context, name, lineno in r["bare_refs"][:3]:
+            bare_samples.append((r["filepath"], lineno, context, name))
+
+    for filepath, lineno, context, name in bare_samples[:10]:
+        print(f"{filepath}:{lineno} | {context} uses {name} (bare ref)")
+
+    # Import breakdown
+    print(f"\n### IMPORTS ###")
+    import_types = defaultdict(int)
+    for r in all_results:
+        for mod, name, lineno, is_local in r["imports"]:
+            import_types["total"] += 1
+
+    print(f"Total imports: {import_types['total']}")
+
+    # Sample imports
+    print(f"\nSample imports:")
+    for r in all_results:
+        for mod, name, lineno, is_local in r["imports"][:3]:
+            print(f"  {r['filepath']}:{lineno} import {name} (from {mod})")
+
+    # String literals
+    print(f"\n### STRING LITERALS (paths/special) ###")
+    print(f"Total path-like strings: {total_strings}")
+
+    string_samples = []
+    for r in all_results:
+        for val, lineno in r["string_literals"][:2]:
+            string_samples.append((r["filepath"], lineno, val))
+
+    for filepath, lineno, val in string_samples[:10]:
+        print(f"{filepath}:{lineno} | {repr(val)}")
+
+    # Global statements
+    print(f"\n### GLOBAL STATEMENTS ###")
+    print(f"Total global declarations: {total_globals}")
+
+    global_samples = []
+    for r in all_results:
+        for names, lineno in r["global_stmts"]:
+            global_samples.append((r["filepath"], lineno, names))
+
+    for filepath, lineno, names in global_samples[:5]:
+        print(f"{filepath}:{lineno} | global {', '.join(names)}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/callgraph/docs/legacy/extended_census.py
+++ b/scripts/callgraph/docs/legacy/extended_census.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+Extended AST census for dispatch patterns across mcp/, scripts/, a2a_server/, mlops/, eval/
+
+Focus on registration roots and cross-module dispatch mechanisms:
+  - @mcp.tool() decorators
+  - register(mcp, deps) patterns
+  - _SKILL_MAP and dict-of-callables
+  - FastAPI route decorators
+  - lazy/local imports
+  - importlib.import_module calls
+  - module-level name assignments read by other modules
+"""
+
+import ast
+import subprocess
+from collections import defaultdict
+from typing import List, Dict, Any
+
+def get_committed_file(file_path: str) -> str:
+    """Read file from HEAD commit using git show."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{file_path}"],
+            cwd="/home/user/loci",
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        return None
+
+def find_target_files() -> List[str]:
+    """Find Python files in mcp/, scripts/, a2a_server/, mlops/, eval/."""
+    files = set()
+    for root_dir in ["mcp", "scripts", "a2a_server", "mlops", "eval"]:
+        result = subprocess.run(
+            ["find", root_dir, "-type", "f", "-name", "*.py"],
+            cwd="/home/user/loci",
+            capture_output=True,
+            text=True
+        )
+        for line in result.stdout.strip().split("\n"):
+            if line and line.endswith(".py"):
+                files.add(line)
+    return sorted(files)
+
+class DispatchCensus(ast.NodeVisitor):
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+
+        # MCP tool registration
+        self.mcp_tool_defs = []  # (func_name, lineno)
+
+        # register() function calls
+        self.register_calls = []  # (lineno, args_shape)
+
+        # Dict-of-callables assignments
+        self.dict_dispatch_assigns = []  # (var_name, lineno)
+
+        # FastAPI decorators
+        self.fastapi_routes = []  # (method, path, lineno)
+
+        # Local imports (inside functions)
+        self.local_imports = []  # (module, name, func_context, lineno)
+
+        # importlib usage
+        self.importlib_calls = []  # (call_type, module, lineno)
+
+        # Module-level assignments
+        self.module_level_assigns = []  # (var_name, value_type, lineno)
+
+        # _SKILL_MAP or similar patterns
+        self.skill_maps = []  # (var_name, lineno)
+
+        # Bare function refs in tuples (registration manifests)
+        self.tuple_refs = []  # (context, names, lineno)
+
+        self.current_function = None
+
+    def visit_FunctionDef(self, node):
+        parent_func = self.current_function
+        self.current_function = node.name
+
+        # Check for @mcp.tool() decorator
+        for dec in node.decorator_list:
+            if self._is_mcp_tool(dec):
+                self.mcp_tool_defs.append((node.name, node.lineno))
+
+        self.generic_visit(node)
+        self.current_function = parent_func
+
+    def visit_AsyncFunctionDef(self, node):
+        self.visit_FunctionDef(node)
+
+    def visit_Call(self, node):
+        # Look for register() calls
+        if isinstance(node.func, ast.Name) and node.func.id == "register":
+            args_shape = self._analyze_call_args(node)
+            self.register_calls.append((node.lineno, args_shape))
+
+        # Look for importlib.import_module()
+        elif isinstance(node.func, ast.Attribute):
+            chain = self._get_attr_chain(node.func)
+            if "importlib" in chain and "import_module" in chain:
+                module_arg = self._extract_string_arg(node)
+                self.importlib_calls.append(("import_module", module_arg, node.lineno))
+            elif "importlib" in chain and "import_" in chain:
+                module_arg = self._extract_string_arg(node)
+                self.importlib_calls.append((chain.split(".")[-1], module_arg, node.lineno))
+
+        self.generic_visit(node)
+
+    def visit_Assign(self, node):
+        # Module-level assignments (potential dict-of-callables)
+        if self.current_function is None:
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    var_name = target.id
+
+                    # Check if it's a dict
+                    if isinstance(node.value, ast.Dict):
+                        self.dict_dispatch_assigns.append((var_name, node.lineno))
+                        # Check if this looks like _SKILL_MAP
+                        if "_MAP" in var_name or "SKILL" in var_name or "HANDLER" in var_name:
+                            self.skill_maps.append((var_name, node.lineno))
+
+                    # Record all module-level assignments
+                    value_type = self._get_value_type(node.value)
+                    self.module_level_assigns.append((var_name, value_type, node.lineno))
+
+        self.generic_visit(node)
+
+    def visit_Import(self, node):
+        # Check if this is a local import (inside a function)
+        if self.current_function is not None:
+            for alias in node.names:
+                self.local_imports.append((
+                    alias.name,
+                    alias.asname or alias.name,
+                    self.current_function,
+                    node.lineno
+                ))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        # Check if this is a local import
+        if self.current_function is not None:
+            for alias in node.names:
+                self.local_imports.append((
+                    f"{node.module}.{alias.name}" if node.module else alias.name,
+                    alias.asname or alias.name,
+                    self.current_function,
+                    node.lineno
+                ))
+        self.generic_visit(node)
+
+    def visit_Tuple(self, node):
+        # Check for bare function refs (registration manifests)
+        names = []
+        for elt in node.elts:
+            if isinstance(elt, ast.Name):
+                names.append(elt.id)
+            elif isinstance(elt, ast.Attribute):
+                names.append(self._get_attr_chain(elt))
+
+        if names and len(names) >= 2:  # Multi-item tuple (likely registration)
+            self.tuple_refs.append((
+                self.current_function or "<module>",
+                names,
+                node.lineno
+            ))
+
+        self.generic_visit(node)
+
+    def _is_mcp_tool(self, node) -> bool:
+        """Check if decorator is @mcp.tool()."""
+        if isinstance(node, ast.Call):
+            node = node.func
+
+        if isinstance(node, ast.Attribute):
+            chain = self._get_attr_chain(node)
+            return "mcp" in chain and "tool" in chain
+        elif isinstance(node, ast.Name):
+            return node.id == "tool" or "mcp" in node.id
+
+        return False
+
+    def _analyze_call_args(self, node) -> str:
+        """Analyze arguments to a call."""
+        arg_types = []
+        for arg in node.args:
+            if isinstance(arg, ast.Name):
+                arg_types.append(f"Name:{arg.id}")
+            elif isinstance(arg, ast.Tuple):
+                arg_types.append(f"Tuple[{len(arg.elts)}]")
+            elif isinstance(arg, ast.Dict):
+                arg_types.append(f"Dict[{len(arg.keys)}]")
+            else:
+                arg_types.append(type(arg).__name__)
+
+        for kw in node.keywords:
+            if isinstance(kw.value, ast.Name):
+                arg_types.append(f"{kw.arg}=Name:{kw.value.id}")
+            else:
+                arg_types.append(f"{kw.arg}={type(kw.value).__name__}")
+
+        return ", ".join(arg_types) if arg_types else "(no args)"
+
+    def _extract_string_arg(self, node) -> str:
+        """Extract first string argument from a call."""
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                return arg.value
+        return None
+
+    def _get_attr_chain(self, node) -> str:
+        """Get full attribute chain."""
+        if isinstance(node, ast.Attribute):
+            return self._get_attr_chain(node.value) + "." + node.attr
+        elif isinstance(node, ast.Name):
+            return node.id
+        else:
+            return "<expr>"
+
+    def _get_value_type(self, node) -> str:
+        """Get the type of a value."""
+        if isinstance(node, ast.Dict):
+            return "dict"
+        elif isinstance(node, ast.List):
+            return "list"
+        elif isinstance(node, ast.Tuple):
+            return "tuple"
+        elif isinstance(node, ast.Call):
+            return "call"
+        elif isinstance(node, ast.Name):
+            return f"Name:{node.id}"
+        elif isinstance(node, ast.Constant):
+            return f"const:{type(node.value).__name__}"
+        else:
+            return type(node).__name__
+
+def analyze_file(filepath: str) -> Dict[str, Any]:
+    """Analyze a single Python file."""
+    content = get_committed_file(filepath)
+    if content is None:
+        return None
+
+    try:
+        tree = ast.parse(content, filename=filepath)
+    except SyntaxError:
+        return None
+
+    census = DispatchCensus(filepath)
+    census.visit(tree)
+
+    return {
+        "filepath": filepath,
+        "mcp_tools": census.mcp_tool_defs,
+        "register_calls": census.register_calls,
+        "dict_dispatch": census.dict_dispatch_assigns,
+        "fastapi_routes": census.fastapi_routes,
+        "local_imports": census.local_imports,
+        "importlib_calls": census.importlib_calls,
+        "module_assigns": census.module_level_assigns,
+        "skill_maps": census.skill_maps,
+        "tuple_refs": census.tuple_refs,
+    }
+
+def main():
+    files = find_target_files()
+    print(f"Found {len(files)} target files across full corpus")
+    print("=" * 80)
+
+    all_results = []
+
+    for filepath in files:
+        result = analyze_file(filepath)
+        if result:
+            all_results.append(result)
+
+    # Aggregate stats
+    total_mcp_tools = sum(len(r["mcp_tools"]) for r in all_results)
+    total_register = sum(len(r["register_calls"]) for r in all_results)
+    total_dict_dispatch = sum(len(r["dict_dispatch"]) for r in all_results)
+    total_local_imports = sum(len(r["local_imports"]) for r in all_results)
+    total_importlib = sum(len(r["importlib_calls"]) for r in all_results)
+    total_skill_maps = sum(len(r["skill_maps"]) for r in all_results)
+    total_tuple_refs = sum(len(r["tuple_refs"]) for r in all_results)
+
+    print(f"\n### REGISTRATION & DISPATCH PATTERNS ###")
+    print(f"@mcp.tool() decorated functions: {total_mcp_tools}")
+    print(f"register() function calls: {total_register}")
+    print(f"Dict-of-callables assignments: {total_dict_dispatch}")
+    print(f"_SKILL_MAP and similar patterns: {total_skill_maps}")
+    print(f"Bare function refs in tuples: {total_tuple_refs}")
+
+    print(f"\n### LAZY / DYNAMIC IMPORT PATTERNS ###")
+    print(f"Local imports (inside functions): {total_local_imports}")
+    print(f"importlib.import_module() calls: {total_importlib}")
+
+    # Show @mcp.tool() examples
+    print(f"\n### @mcp.tool() DECORATORS ###")
+    mcp_samples = []
+    for r in all_results:
+        for func_name, lineno in r["mcp_tools"]:
+            mcp_samples.append((r["filepath"], lineno, func_name))
+
+    for filepath, lineno, func_name in mcp_samples[:15]:
+        print(f"{filepath}:{lineno} | @mcp.tool() def {func_name}()")
+
+    # Show register() calls
+    print(f"\n### register() FUNCTION CALLS ###")
+    reg_samples = []
+    for r in all_results:
+        for lineno, args_shape in r["register_calls"]:
+            reg_samples.append((r["filepath"], lineno, args_shape))
+
+    for filepath, lineno, args_shape in reg_samples[:10]:
+        print(f"{filepath}:{lineno} | register({args_shape})")
+
+    # Show dict dispatch
+    print(f"\n### DICT-OF-CALLABLES ASSIGNMENTS ###")
+    dict_samples = []
+    for r in all_results:
+        for var_name, lineno in r["dict_dispatch"]:
+            dict_samples.append((r["filepath"], lineno, var_name))
+
+    for filepath, lineno, var_name in dict_samples[:10]:
+        print(f"{filepath}:{lineno} | {var_name} = {{...}}")
+
+    # Show _SKILL_MAP patterns
+    print(f"\n### _SKILL_MAP AND SIMILAR PATTERNS ###")
+    skill_samples = []
+    for r in all_results:
+        for var_name, lineno in r["skill_maps"]:
+            skill_samples.append((r["filepath"], lineno, var_name))
+
+    for filepath, lineno, var_name in skill_samples[:10]:
+        print(f"{filepath}:{lineno} | {var_name} = {{...}}")
+
+    # Show local imports
+    print(f"\n### LOCAL IMPORTS (INSIDE FUNCTIONS) ###")
+    local_samples = []
+    for r in all_results:
+        for mod, name, func, lineno in r["local_imports"][:5]:
+            local_samples.append((r["filepath"], lineno, func, mod, name))
+
+    for filepath, lineno, func, mod, name in local_samples[:15]:
+        print(f"{filepath}:{lineno} | inside {func}(): import {name} (from {mod})")
+
+    # Show importlib usage
+    print(f"\n### importlib USAGE ###")
+    importlib_samples = []
+    for r in all_results:
+        for call_type, module, lineno in r["importlib_calls"]:
+            importlib_samples.append((r["filepath"], lineno, call_type, module))
+
+    for filepath, lineno, call_type, module in importlib_samples[:10]:
+        print(f"{filepath}:{lineno} | importlib.{call_type}('{module}')")
+
+    # Show tuple refs (registration manifests)
+    print(f"\n### BARE FUNCTION REFS IN TUPLES (REGISTRATION MANIFESTS) ###")
+    tuple_samples = []
+    for r in all_results:
+        for context, names, lineno in r["tuple_refs"][:5]:
+            tuple_samples.append((r["filepath"], lineno, context, names))
+
+    for filepath, lineno, context, names in tuple_samples[:10]:
+        names_str = ", ".join(names)
+        print(f"{filepath}:{lineno} | {context}: ({names_str})")
+
+    # Count by directory
+    print(f"\n### PATTERN COUNTS BY DIRECTORY ###")
+    by_dir = defaultdict(lambda: {
+        "mcp_tools": 0, "register": 0, "dict": 0, "skill": 0,
+        "local_import": 0, "importlib": 0, "tuple_ref": 0
+    })
+
+    for r in all_results:
+        dir_name = r["filepath"].split("/")[0]
+        by_dir[dir_name]["mcp_tools"] += len(r["mcp_tools"])
+        by_dir[dir_name]["register"] += len(r["register_calls"])
+        by_dir[dir_name]["dict"] += len(r["dict_dispatch"])
+        by_dir[dir_name]["skill"] += len(r["skill_maps"])
+        by_dir[dir_name]["local_import"] += len(r["local_imports"])
+        by_dir[dir_name]["importlib"] += len(r["importlib_calls"])
+        by_dir[dir_name]["tuple_ref"] += len(r["tuple_refs"])
+
+    for dir_name in sorted(by_dir.keys()):
+        counts = by_dir[dir_name]
+        print(f"\n{dir_name}/:")
+        if counts["mcp_tools"]:
+            print(f"  @mcp.tool(): {counts['mcp_tools']}")
+        if counts["register"]:
+            print(f"  register(): {counts['register']}")
+        if counts["dict"]:
+            print(f"  dict-dispatch: {counts['dict']}")
+        if counts["skill"]:
+            print(f"  skill-maps: {counts['skill']}")
+        if counts["local_import"]:
+            print(f"  local-imports: {counts['local_import']}")
+        if counts["importlib"]:
+            print(f"  importlib: {counts['importlib']}")
+        if counts["tuple_ref"]:
+            print(f"  tuple-refs: {counts['tuple_ref']}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/callgraph/extract/__init__.py
+++ b/scripts/callgraph/extract/__init__.py
@@ -1,0 +1,3 @@
+"""extract/* modules each own one slice of node/edge production from a
+ModuleScope + SourceFile. Nothing here mutates the GraphStore's adjacency
+directly — they only call store.add_node / store.add_edge."""

--- a/scripts/callgraph/extract/calls.py
+++ b/scripts/callgraph/extract/calls.py
@@ -1,0 +1,462 @@
+"""CALLSITE nodes and the CALLS resolution ladder.
+
+This slice implements rungs 1-3 of the design's seven-rung ladder (all
+PROVEN-tier):
+
+  1. callee is a plain Name bound in module scope (a def/class in this same
+     module, a module-level import/alias reachable via one or more ALIASES
+     hops, or a Python builtin).
+  2. callee is an Attribute `m.f` where `m` is a module bound by a
+     module-level import.
+  3. callee is bound by a *function-local* import (either shape) — same
+     resolution as 1/2 but scoped to the enclosing function and tagged
+     scope=function-local.
+
+Everything else (attribute calls on an unknown-type receiver, calls through
+dict/getattr/subscript results, calls on a bare parameter, plain unresolved
+names) is rung 7 territory for THIS slice: parked on the `?` UNRESOLVED sink
+with a `reason`, never dropped. Rungs 4-6 (probable-tier: injected globals,
+dict-dispatch fan-out, unique-method-name) are a later slice's job — see
+extract/registry.py's INJECTS for the data those rungs will consume.
+
+A CALLSITE node is created for every ast.Call in the corpus regardless of
+whether it resolves, so `cg holes` can count what this tool does not (yet)
+understand instead of that call vanishing silently.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+import builtins
+from dataclasses import dataclass
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore, Node
+from ..resolve import ResolutionTable, ResolveResult
+from ..scopes import FunctionInfo, ModuleScope
+from .defs import function_node_id, module_node_id, name_node_id
+from .walk import walk_module
+
+BUILTIN_NAMES = frozenset(dir(builtins))
+UNRESOLVED_ID = "?"
+
+
+def callsite_node_id(rel_path: str, lineno: int, col: int, end_lineno: int, end_col: int) -> str:
+    """Two distinct ast.Call nodes CAN share the same (lineno, col_offset) —
+    a chained call `f(x).g()` has an outer Call node whose start position is
+    identical to its own inner Call's start position. (lineno, col_offset)
+    alone is therefore not a unique key; end position always differs
+    between an outer and inner call sharing a start, and is an intrinsic
+    property of the node (not traversal-order-dependent), so both
+    extract/calls.py and extract/registry.py's REG-FN pass compute the same
+    id for the same call independently, with no coordination needed. `cg`'s
+    own output still displays just path:line:col — the extra precision is
+    an internal disambiguator, not user-facing."""
+    return f"call:{rel_path}:{lineno}:{col}:{end_lineno}:{end_col}"
+
+
+def ensure_unresolved_sink(store: GraphStore) -> None:
+    store.add_node(Node(id=UNRESOLVED_ID, kind="UNRESOLVED", attrs={}))
+
+
+def external_node(store: GraphStore, dotted: str, distribution: str = "unknown") -> str:
+    eid = f"ext:{dotted}"
+    store.add_node(Node(id=eid, kind="EXTERNAL", attrs={"dotted": dotted, "distribution": distribution}))
+    return eid
+
+
+def build_top_level_index(store: GraphStore) -> dict[str, dict[str, str]]:
+    """path -> {qualname: node_id} for every module-level (not nested, not
+    method) FUNCTION and every CLASS. Built once per build and shared by
+    calls.py/registry.py so a same-module or cross-module "does X define an
+    ident called Y" check is an O(1) dict lookup instead of an O(defs in
+    that module) re-scan per callsite — the difference between a build that
+    stays under the 2s budget and one that does not once ~11,600 callsites
+    are in play."""
+    idx: dict[str, dict[str, str]] = {}
+    for n in store.nodes_of_kind("FUNCTION"):
+        if n.attrs.get("is_nested") or n.attrs.get("is_method") or n.path is None:
+            continue
+        idx.setdefault(n.path, {})[n.attrs["qualname"]] = n.id
+    for n in store.nodes_of_kind("CLASS"):
+        if n.path is None:
+            continue
+        idx.setdefault(n.path, {})[n.attrs["qualname"]] = n.id
+    return idx
+
+
+def init_method_id(store: GraphStore, class_id: str) -> Optional[str]:
+    node = store.get(class_id)
+    if node is None:
+        return None
+    for mid in node.attrs.get("method_ids", []):
+        if mid.rsplit("::", 1)[-1].rsplit(".", 1)[-1] == "__init__":
+            return mid
+    return None
+
+
+@dataclass
+class _LocalImportBinding:
+    kind: str            # "module" (`import X [as Y]`) | "from" (`from X import Y [as Z]`)
+    res: ResolveResult
+    display: str          # dotted module text as written
+    imported: Optional[str]   # for kind="from": the original name imported
+    line: int
+
+
+def _build_local_import_index(scope: ModuleScope, table: ResolutionTable) -> dict[str, dict[str, _LocalImportBinding]]:
+    idx: dict[str, dict[str, _LocalImportBinding]] = {}
+    rel_path = scope.sf.rel_path
+    for rec in scope.imports:
+        if rec.scope != "function-local" or rec.enclosing_fn is None:
+            continue
+        bucket = idx.setdefault(rec.enclosing_fn, {})
+        if not rec.is_from:
+            for dotted, asname in rec.names:
+                bound = asname or dotted.split(".")[0]
+                res = table.resolve_dotted(dotted, rel_path)
+                bucket[bound] = _LocalImportBinding("module", res, dotted, None, rec.lineno)
+        else:
+            if rec.level > 0:
+                res = table.resolve_relative(rec.level, rec.module, rel_path)
+                display = ("." * rec.level) + (rec.module or "")
+            else:
+                res = table.resolve_dotted(rec.module or "", rel_path)
+                display = rec.module or ""
+            for imported, asname in rec.names:
+                if imported == "*":
+                    continue
+                bound = asname or imported
+                bucket[bound] = _LocalImportBinding("from", res, display, imported, rec.lineno)
+    return idx
+
+
+def _distribution_for(res: ResolveResult) -> str:
+    return {"stdlib": "stdlib", "third-party": "third-party"}.get(res.status, "unknown")
+
+
+def _lookup_local_import(local_idx, qualname: Optional[str], ident: str):
+    """A function-local `import X` binds a LOCAL name, and Python closures
+    make that binding visible to every nested scope. So resolution has to
+    walk OUTWARD through the `<parent>.<locals>.<child>` chain, not just
+    check the immediately-enclosing function.
+
+    Found by validation: `mcp/server.py::loci_health` does a function-local
+    `import backends`, then calls it from inside a lambda --
+    `lambda: backends.qdrant()[0]`. Keyed on the lambda's own qualname the
+    binding is invisible, the call falls to the `?` sink, and
+    `mcp/backends.py::qdrant` is reported dead despite a live call site.
+    """
+    if qualname is None:
+        return None
+    qual = qualname
+    while True:
+        binding = local_idx.get(qual, {}).get(ident)
+        if binding is not None:
+            return binding
+        if ".<locals>." not in qual:
+            return None
+        qual = qual.rsplit(".<locals>.", 1)[0]
+
+
+def _dotted_call_name(func: ast.AST) -> Optional[str]:
+    parts: list[str] = []
+    node = func
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    else:
+        return None
+    return ".".join(reversed(parts))
+
+
+def _classify_form(func: ast.expr, scope: ModuleScope, fi: Optional[FunctionInfo]) -> str:
+    if isinstance(func, ast.Name):
+        if fi is not None and func.id in scope.locals_of(fi).params:
+            return "param-call"
+        return "name"
+    if isinstance(func, ast.Attribute):
+        return "attribute"
+    if isinstance(func, ast.Subscript):
+        return "subscript-result"
+    if isinstance(func, ast.Call):
+        head = _dotted_call_name(func.func)
+        if head == "getattr" or (head or "").endswith(".getattr"):
+            return "getattr-result"
+        if isinstance(func.func, ast.Attribute) and func.func.attr == "get":
+            return "dict-get-result"
+        return "call-result"
+    return "other"
+
+
+# -- resolution ---------------------------------------------------------
+
+
+def _follow_alias_to_callable(store: GraphStore, name_id: str, depth: int = 0):
+    if depth > 4:
+        return None
+    edges = store.out_edges(name_id, "ALIASES")
+    if not edges:
+        return None
+    edge = edges[0]
+    target = store.get(edge.dst)
+    if target is None:
+        return None
+    if target.kind == "FUNCTION":
+        return edge.dst, edge.confidence, {"rung": "module-alias"}
+    if target.kind == "CLASS":
+        init_id = init_method_id(store, edge.dst)
+        if init_id is not None:
+            return init_id, edge.confidence, {"rung": "module-alias-constructor"}
+        return None
+    if target.kind == "EXTERNAL":
+        return edge.dst, edge.confidence, {"rung": "module-alias-external"}
+    if target.kind == "NAME":
+        return _follow_alias_to_callable(store, edge.dst, depth + 1)
+    return None
+
+
+def _resolve_name(store: GraphStore, sf: SourceFile, scope: ModuleScope, top_level_index, local_idx,
+                   ident: str, fi: Optional[FunctionInfo]):
+    rel = sf.rel_path
+
+    # rung 1a': a nested function/lambda defined INSIDE the enclosing
+    # function, called by its own bare name (shadows module scope, and is
+    # excluded from top_level_index by design since it isn't a top-level
+    # def) — e.g. a helper closure invoked directly by name.
+    # Python resolves a bare name local -> ENCLOSING -> global, so this walks
+    # outward through the `<locals>` chain: a nested def is visible to its
+    # SIBLINGS, not just to itself. Found by validation:
+    # mcp/graph/code_parse.py's `parse_source` defines `enclosing_def_node`
+    # and `_in_method` side by side, and `_in_method` calls
+    # `enclosing_def_node(node)` — checking only fi's own qualname missed it
+    # and reported `enclosing_def_node` dead.
+    if fi is not None:
+        qual = fi.qualname
+        while True:
+            nested_qual = f"{qual}.<locals>.{ident}"
+            nested_fi = scope.function_by_qualname.get(nested_qual)
+            if nested_fi is not None:
+                return function_node_id(rel, nested_qual), Confidence.PROVEN, {"rung": "nested-def-local"}
+            if ".<locals>." not in qual:
+                break
+            qual = qual.rsplit(".<locals>.", 1)[0]
+
+    # rung 1a: module-level def/class in THIS module
+    target = top_level_index.get(rel, {}).get(ident)
+    if target is not None:
+        tnode = store.get(target)
+        if tnode is not None and tnode.kind == "FUNCTION":
+            return target, Confidence.PROVEN, {"rung": "name-def-local"}
+        if tnode is not None and tnode.kind == "CLASS":
+            init_id = init_method_id(store, target)
+            if init_id is not None:
+                return init_id, Confidence.PROVEN, {"rung": "name-constructor"}
+            return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "constructor-no-init"}
+
+    # rung 1b: this NAME slot's own ALIASES edge (from-import or bare A=B),
+    # chased through as many hops as it takes.
+    resolved = _follow_alias_to_callable(store, name_node_id(rel, ident))
+    if resolved is not None:
+        return resolved
+
+    # rung 3 (name form): bound by a function-local import in THIS function.
+    if fi is not None:
+        binding = _lookup_local_import(local_idx, fi.qualname, ident)
+        if binding is not None and binding.kind == "from" and binding.imported:
+            res = binding.res
+            if res.status == "corpus" and res.target_path:
+                found = top_level_index.get(res.target_path, {}).get(binding.imported)
+                if found is not None:
+                    fnode = store.get(found)
+                    if fnode.kind == "FUNCTION":
+                        return found, Confidence.PROVEN, {"rung": "name-local-import", "scope": "function-local",
+                                                            "because": f"local import at {rel}:{binding.line}"}
+                    if fnode.kind == "CLASS":
+                        init_id = init_method_id(store, found)
+                        if init_id is not None:
+                            return init_id, Confidence.PROVEN, {"rung": "name-local-import-constructor",
+                                                                 "scope": "function-local",
+                                                                 "because": f"local import at {rel}:{binding.line}"}
+            elif res.status in ("stdlib", "third-party"):
+                dotted = f"{binding.display}.{binding.imported}" if binding.display else binding.imported
+                eid = external_node(store, dotted, res.status)
+                return eid, Confidence.PROVEN, {"rung": "name-local-import-external", "scope": "function-local",
+                                                 "because": f"local import at {rel}:{binding.line}"}
+
+    if ident in BUILTIN_NAMES:
+        eid = external_node(store, f"builtins.{ident}", "stdlib")
+        return eid, Confidence.PROVEN, {"rung": "builtin"}
+
+    return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "name-not-bound-in-module-scope"}
+
+
+def _resolve_attr_via_module(store: GraphStore, top_level_index, target_module_path: str, attr: str):
+    found = top_level_index.get(target_module_path, {}).get(attr)
+    if found is None:
+        return None
+    fnode = store.get(found)
+    if fnode.kind == "FUNCTION":
+        return found, Confidence.PROVEN, {"rung": "module-attribute"}
+    if fnode.kind == "CLASS":
+        init_id = init_method_id(store, found)
+        if init_id is not None:
+            return init_id, Confidence.PROVEN, {"rung": "module-attribute-constructor"}
+    return None
+
+
+def _resolve_attribute(store: GraphStore, sf: SourceFile, scope: ModuleScope, top_level_index, local_idx,
+                        func: ast.Attribute, fi: Optional[FunctionInfo], table: ResolutionTable):
+    rel = sf.rel_path
+    base = func.value
+    attr = func.attr
+    if not isinstance(base, ast.Name):
+        return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "attribute-unknown-receiver"}
+
+    base_id = base.id
+
+    if base_id == "self" and fi is not None and fi.is_method and fi.parent_class:
+        cls_qual = fi.qualname.rsplit(".", 1)[0]
+        method_id = function_node_id(rel, f"{cls_qual}.{attr}")
+        if method_id in store:
+            return method_id, Confidence.PROVEN, {"rung": "self-attribute"}
+        return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "self-attribute-not-found"}
+
+    if base_id == "cls" and fi is not None and fi.is_method and fi.parent_class:
+        cls_qual = fi.qualname.rsplit(".", 1)[0]
+        method_id = function_node_id(rel, f"{cls_qual}.{attr}")
+        if method_id in store:
+            return method_id, Confidence.PROVEN, {"rung": "cls-attribute"}
+        return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "cls-attribute-not-found"}
+
+    alias_edges = store.out_edges(name_node_id(rel, base_id), "ALIASES")
+    if alias_edges:
+        target = store.get(alias_edges[0].dst)
+        if target is not None and target.kind == "MODULE":
+            resolved = _resolve_attr_via_module(store, top_level_index, target.path, attr)
+            if resolved is not None:
+                return resolved
+            return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "attribute-not-found-in-module"}
+        if target is not None and target.kind == "EXTERNAL":
+            dotted = f"{target.attrs.get('dotted')}.{attr}"
+            eid = external_node(store, dotted, target.attrs.get("distribution", "unknown"))
+            return eid, Confidence.PROVEN, {"rung": "module-attribute-external"}
+
+    if fi is not None:
+        binding = _lookup_local_import(local_idx, fi.qualname, base_id)
+        if binding is not None and binding.kind == "module":
+            res = binding.res
+            if res.status == "corpus" and res.target_path:
+                resolved = _resolve_attr_via_module(store, top_level_index, res.target_path, attr)
+                if resolved is not None:
+                    target_id, conf, extra = resolved
+                    extra = dict(extra)
+                    extra["scope"] = "function-local"
+                    extra["because"] = f"local import at {rel}:{binding.line}"
+                    return target_id, conf, extra
+            elif res.status in ("stdlib", "third-party"):
+                dotted = f"{binding.display}.{attr}"
+                eid = external_node(store, dotted, res.status)
+                return eid, Confidence.PROVEN, {"rung": "module-attribute-external", "scope": "function-local",
+                                                 "because": f"local import at {rel}:{binding.line}"}
+        elif binding is not None and binding.kind == "from" and binding.imported:
+            # `from pkg import submodule` (function-local), then
+            # `submodule.fn()` — the imported name is itself a MODULE, not
+            # a function/class in binding.res.target_path's own top level.
+            # Mirrors extract/imports.py's _emit_alias_from_import submodule
+            # fallback, but scoped to this function's own local import.
+            submodule_res = table.resolve_dotted(f"{binding.display}.{binding.imported}", rel)
+            if submodule_res.status == "corpus" and submodule_res.target_path:
+                resolved = _resolve_attr_via_module(store, top_level_index, submodule_res.target_path, attr)
+                if resolved is not None:
+                    target_id, conf, extra = resolved
+                    extra = dict(extra)
+                    extra["scope"] = "function-local"
+                    extra["because"] = f"local import at {rel}:{binding.line}"
+                    return target_id, conf, extra
+
+    return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": "attribute-unknown-receiver"}
+
+
+_FORM_REASON = {
+    "subscript-result": "computed-subscript-call",
+    "getattr-result": "computed-getattr",
+    "dict-get-result": "dict-with-computed-key",
+    "call-result": "call-result-unresolved",
+    "param-call": "param-call",
+}
+
+
+def _resolve_call(store, sf, scope, table, top_level_index, local_idx, node: ast.Call, fi, form: str):
+    if form == "name":
+        return _resolve_name(store, sf, scope, top_level_index, local_idx, node.func.id, fi)
+    if form == "attribute":
+        return _resolve_attribute(store, sf, scope, top_level_index, local_idx, node.func, fi, table)
+    reason = _FORM_REASON.get(form, "unclassified")
+    return UNRESOLVED_ID, Confidence.UNPROVEN, {"reason": reason}
+
+
+def make_call_visitor(store: GraphStore, sf: SourceFile, scope: ModuleScope,
+                       table: ResolutionTable, top_level_index: dict[str, dict[str, str]]):
+    """Builds the walk_module(node, fi) callback without walking anything
+    itself, so pipeline.py can run it in the SAME whole-module traversal as
+    names.py's visitor — halving the generic-AST-walk overhead across the
+    corpus's ~36k lines instead of paying it twice per file."""
+    ensure_unresolved_sink(store)
+    mod_id = module_node_id(sf.rel_path)
+    local_idx = _build_local_import_index(scope, table)
+    awaited_ids = {id(n.value) for n in ast.walk(sf.tree) if isinstance(n, ast.Await)} if sf.tree is not None else set()
+    call_func_ids = {id(c.func) for c in ast.walk(sf.tree) if isinstance(c, ast.Call)} if sf.tree is not None else set()
+
+    def on_node(node: ast.AST, fi: Optional[FunctionInfo]) -> None:
+        if not isinstance(node, ast.Call):
+            return
+        form = _classify_form(node.func, scope, fi)
+        callsite_id = callsite_node_id(sf.rel_path, node.lineno, node.col_offset,
+                                        getattr(node, "end_lineno", node.lineno),
+                                        getattr(node, "end_col_offset", node.col_offset))
+        enclosing_id = function_node_id(sf.rel_path, fi.qualname) if fi is not None else mod_id
+        receiver_src = None
+        if isinstance(node.func, (ast.Attribute, ast.Subscript)):
+            receiver_src = scope.source_of(node.func.value)
+        attr_name = node.func.attr if isinstance(node.func, ast.Attribute) else None
+        getattr_obj = getattr_attr_literal = None
+        if form == "getattr-result" and isinstance(node.func, ast.Call) and len(node.func.args) >= 2:
+            getattr_obj = scope.source_of(node.func.args[0])
+            lit_arg = node.func.args[1]
+            if isinstance(lit_arg, ast.Constant) and isinstance(lit_arg.value, str):
+                getattr_attr_literal = lit_arg.value
+        store.add_node(Node(
+            id=callsite_id, kind="CALLSITE",
+            attrs={
+                "form": form,
+                "callee": scope.source_of(node.func),
+                "receiver": receiver_src,
+                "attr": attr_name,
+                "getattr_obj": getattr_obj,
+                "getattr_attr_literal": getattr_attr_literal,
+                "argc": len(node.args) + len(node.keywords),
+                "enclosing_fn": enclosing_id,
+                "awaited": id(node) in awaited_ids,
+                "in_call_position": id(node.func) in call_func_ids,
+            },
+            path=sf.rel_path, line=node.lineno, col=node.col_offset,
+        ))
+        target_id, confidence, extra = _resolve_call(store, sf, scope, table, top_level_index, local_idx, node, fi, form)
+        store.add_edge(Edge(src=callsite_id, dst=target_id, kind="CALLS", confidence=confidence, attrs=dict(extra)))
+
+    return on_node
+
+
+def extract_calls(store: GraphStore, sf: SourceFile, scope: ModuleScope,
+                   table: ResolutionTable, top_level_index: dict[str, dict[str, str]]) -> None:
+    """Standalone entry point (unit tests, `cg` debug use) — pipeline.py
+    calls make_call_visitor directly instead, to share one walk_module pass
+    with extract/names.py."""
+    if sf.tree is None:
+        return
+    walk_module(scope, make_call_visitor(store, sf, scope, table, top_level_index))

--- a/scripts/callgraph/extract/defs.py
+++ b/scripts/callgraph/extract/defs.py
@@ -1,0 +1,157 @@
+"""MODULE / CLASS / FUNCTION / NAME nodes, DEFINES and DECORATED_BY edges,
+and decorator classification (registering | wrapping | unknown), driven by
+rules.toml.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore, Node
+from ..resolve import ResolutionTable
+from ..rules import load_rules
+from ..scopes import ModuleScope
+
+
+def module_node_id(rel_path: str) -> str:
+    return f"mod:{rel_path}"
+
+
+def function_node_id(rel_path: str, qualname: str) -> str:
+    return f"fn:{rel_path}::{qualname}"
+
+
+def class_node_id(rel_path: str, qualname: str) -> str:
+    return f"cls:{rel_path}::{qualname}"
+
+
+def name_node_id(rel_path: str, ident: str) -> str:
+    return f"name:{rel_path}::{ident}"
+
+
+def _decorator_head(node: ast.AST) -> str:
+    """Dotted "head" of a decorator expression with call parens stripped:
+    @mcp.tool() -> "mcp.tool"; @app.get("/a2a") -> "app.get"; @staticmethod
+    -> "staticmethod"."""
+    target = node.func if isinstance(node, ast.Call) else node
+    parts: list[str] = []
+    cur = target
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return "<complex>"
+
+
+def extract_module(store: GraphStore, sf: SourceFile, table: Optional[ResolutionTable] = None) -> ModuleScope:
+    """Populate MODULE/CLASS/FUNCTION/NAME nodes and DEFINES/DECORATED_BY
+    edges for one file. Returns the ModuleScope so extract/imports.py (and
+    later slices) can reuse the same single AST pass instead of re-walking."""
+    mod_id = module_node_id(sf.rel_path)
+    info = table.module_for_path(sf.rel_path) if table is not None else None
+    mod_attrs: dict = {
+        "path": sf.rel_path,
+        "kind": info.kind if info is not None else ("package-member" if sf.rel_path.endswith("__init__.py") else "flat-dir"),
+        "importable_as": sorted(info.importable_as.keys()) if info is not None else [],
+        "sys_path_roots": (
+            sorted({p.evidence for provs in info.importable_as.values() for p in provs})
+            if info is not None else []
+        ),
+        "has_main": info.has_main if info is not None else False,
+        "origin": sf.origin,
+    }
+    if sf.error is not None:
+        mod_attrs["parse_error"] = sf.error
+    store.add_node(Node(id=mod_id, kind="MODULE", attrs=mod_attrs, path=sf.rel_path, line=1, col=0))
+
+    scope = ModuleScope(sf)
+    if sf.tree is None:
+        return scope
+
+    rules = load_rules()
+
+    # -- classes -----------------------------------------------------------
+    class_id_by_qualname: dict[str, str] = {}
+    for ci in scope.classes:
+        cid = class_node_id(sf.rel_path, ci.qualname)
+        class_id_by_qualname[ci.qualname] = cid
+        store.add_node(Node(
+            id=cid, kind="CLASS",
+            attrs={"qualname": ci.qualname, "bases": ci.bases, "method_ids": [], "ambiguous_duplicate": ci.ambiguous_duplicate},
+            path=sf.rel_path, line=ci.lineno, col=ci.node.col_offset,
+        ))
+        # DEFINES source is the module for every class here: nested classes
+        # are not exercised by this corpus (~3 real classes total), so a
+        # module-level DEFINES edge is the honest, simple choice rather
+        # than a precise-but-untested nested-class parent lookup.
+        store.add_edge(Edge(src=mod_id, dst=cid, kind="DEFINES", confidence=Confidence.PROVEN,
+                             attrs={"line": ci.lineno}))
+
+    # -- functions -----------------------------------------------------------
+    for fi in scope.functions:
+        fid = function_node_id(sf.rel_path, fi.qualname)
+        param_dicts = [
+            {"name": p.name, "kind": p.kind, "has_default": p.has_default, "default_is_literal": p.default_is_literal}
+            for p in fi.params
+        ]
+        store.add_node(Node(
+            id=fid, kind="FUNCTION",
+            attrs={
+                "qualname": fi.qualname, "is_async": fi.is_async, "is_lambda": fi.is_lambda,
+                "is_method": fi.is_method, "is_nested": fi.is_nested, "params": param_dicts,
+                "decorators": fi.decorators, "docstring_first_line": fi.docstring_first_line,
+                "end_lineno": fi.end_lineno, "ambiguous_duplicate": fi.ambiguous_duplicate,
+            },
+            path=sf.rel_path, line=fi.lineno, col=fi.col,
+        ))
+        if fi.is_method and fi.parent_class:
+            parent_cid = class_id_by_qualname.get(fi.qualname.rsplit(".", 1)[0])
+            if parent_cid is not None:
+                store.add_edge(Edge(src=parent_cid, dst=fid, kind="DEFINES", confidence=Confidence.PROVEN,
+                                     attrs={"line": fi.lineno}))
+                cls_node = store.get(parent_cid)
+                if cls_node is not None:
+                    cls_node.attrs.setdefault("method_ids", []).append(fid)
+            else:
+                store.add_edge(Edge(src=mod_id, dst=fid, kind="DEFINES", confidence=Confidence.PROVEN,
+                                     attrs={"line": fi.lineno}))
+        else:
+            store.add_edge(Edge(src=mod_id, dst=fid, kind="DEFINES", confidence=Confidence.PROVEN,
+                                 attrs={"line": fi.lineno}))
+
+        for dec_node, dec_src in zip(fi.node.decorator_list if not fi.is_lambda else [], fi.decorators):
+            head = _decorator_head(dec_node)
+            classification = rules.classify_decorator(head)
+            # DECORATED_BY targets a REGISTRY node once extract/registry.py
+            # (a later build step) creates one for this decorator site; for
+            # now it targets an EXTERNAL sink named after the decorator's
+            # dotted head so the classification is still recorded and
+            # queryable via `cg defs`.
+            ext_id = f"ext:{head}"
+            store.add_node(Node(id=ext_id, kind="EXTERNAL", attrs={"dotted": head, "role": "decorator"}))
+            store.add_edge(Edge(
+                src=fid, dst=ext_id, kind="DECORATED_BY",
+                confidence=Confidence.PROVEN,
+                attrs={"raw": dec_src, "classification": classification, "line": dec_node.lineno},
+            ))
+
+    # -- module-global NAME slots -------------------------------------------
+    for ident, ninfo in scope.names.items():
+        nid = name_node_id(sf.rel_path, ident)
+        store.add_node(Node(
+            id=nid, kind="NAME",
+            attrs={
+                "binding_kind": sorted(ninfo.binding_kinds),
+                "binding_lines": ninfo.binding_lines,
+                "is_dunder": ninfo.is_dunder,
+                "is_private": ninfo.is_private,
+            },
+            path=sf.rel_path, line=min((min(v) for v in ninfo.binding_lines.values()), default=None),
+        ))
+
+    return scope

--- a/scripts/callgraph/extract/dispatch.py
+++ b/scripts/callgraph/extract/dispatch.py
@@ -1,0 +1,259 @@
+"""The probable tier: CALLS resolution rungs 4-6, plus DISPATCHES.
+
+This is a whole-corpus pass that runs AFTER extract/registry.py has built
+REGISTRY/REGISTERS/INJECTS (registration roots and dependency injection are
+exactly the facts these rungs need), and after extract/calls.py's rungs 1-3
+have already parked every callsite it couldn't resolve on the `?` sink with
+a reason. This pass only ever touches CALLS edges whose dst is still `?` —
+a proven rung-1-3 resolution is never revisited or downgraded.
+
+  rung 4  name-via-injected-global   a bare-name callsite whose ident is a
+          module NAME slot with exactly one distinct INJECTS value (a
+          function) resolves to that function, PROBABLE, because=the
+          register()-call site that performed the injection. Two or more
+          distinct injected values (re-entrant registration) leaves CALLS
+          alone and fans out via DISPATCHES instead (INJECTS is already
+          PROBABLE by construction; this rung does not upgrade it further).
+
+  rung 5  dict-dispatch              a bare-name callsite whose ident is a
+          local variable assigned earlier in the SAME function from
+          `<dict>.get(<key>)` or `<dict>[<key>]`, where `<dict>` is a
+          MAN-DICT REGISTRY in this module (the `_SKILL_MAP` shape). CALLS
+          stays on `?` (no single target is knowable) with its reason
+          upgraded to "dict-dispatch-fanout"; one DISPATCHES edge per
+          registry member is added, each carrying the registry id, the
+          member count as `fanout`, and the key expression's source text
+          as `selector`.
+
+  rung 6  unique-method-name         an attribute callsite whose receiver's
+          type this tool cannot know (rung-1-3 left it at `?` with reason
+          "attribute-unknown-receiver"). If exactly one method anywhere in
+          the corpus shares this call's attribute name, resolve to it,
+          PROBABLE, rung=unique-method-name, alternatives=1. Two or more
+          candidates leaves CALLS at `?` with reason "ambiguous-method-name"
+          and records `alternatives=N` for `cg holes`/`cg explain` — this
+          tool does not guess among same-named methods.
+
+  getattr-literal   `getattr(<module-ish>, "<literal>")(...)` — calls.py
+          already captured the getattr call's own two arguments on the
+          CALLSITE (getattr_obj / getattr_attr_literal) so this pass never
+          re-parses source. If the object resolves to an ALIASES-bound
+          in-corpus MODULE, resolve directly (PROVEN — a literal attribute
+          name on a known module is exactly as certain as any other
+          module-attribute rung); a non-literal attribute argument is left
+          on `?` with reason "computed-getattr" (rung 1-3 already put it
+          there; this pass only revisits it when the literal case applies).
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+
+from ..model import Confidence, Edge, GraphStore, Node
+from ..scopes import ModuleScope
+from .calls import _resolve_attr_via_module
+from .defs import name_node_id
+from .registry import registry_node_id
+
+UNRESOLVED_ID = "?"
+
+
+# -- rung 6 helper: corpus-wide method name index ---------------------------
+
+
+def _build_method_index(store: GraphStore) -> dict[str, list[str]]:
+    """simple method name -> every FUNCTION id anywhere in the corpus whose
+    qualname's last dotted component is that name AND is_method is true.
+    Built once per probable-tier pass; O(functions), not O(callsites)."""
+    idx: dict[str, list[str]] = {}
+    for n in store.nodes_of_kind("FUNCTION"):
+        if not n.attrs.get("is_method"):
+            continue
+        simple = n.attrs.get("qualname", "").rsplit(".", 1)[-1]
+        if not simple:
+            continue
+        idx.setdefault(simple, []).append(n.id)
+    return idx
+
+
+# -- rung 4: name-via-injected-global ----------------------------------------
+
+
+def _try_injected_global(store: GraphStore, site: Node, edge: Edge) -> bool:
+    ident = site.attrs.get("callee")
+    mod_path = site.path
+    if not ident or mod_path is None:
+        return False
+    nid = name_node_id(mod_path, ident)
+    if nid not in store:
+        return False
+    injects = store.in_edges(nid, "INJECTS")
+    values: dict[str, list[Edge]] = {}
+    for inj in injects:
+        if inj.attrs.get("value_kind") == "FUNCTION" and inj.attrs.get("value"):
+            values.setdefault(inj.attrs["value"], []).append(inj)
+    if not values:
+        return False
+    if len(values) == 1:
+        (target_id, inj_list), = values.items()
+        inj_site = store.get(inj_list[0].src)
+        because_loc = f"{inj_site.path}:{inj_site.line}" if inj_site is not None else "unknown"
+        store.retarget_edge(edge, target_id)
+        edge.confidence = Confidence.PROBABLE
+        edge.attrs = {"rung": "name-via-injected-global", "because": f"injected at {because_loc}"}
+        return True
+    # Re-entrant registration: two+ distinct functions have been injected
+    # into the same global — CALLS cannot pick one, but every candidate is
+    # still a real, nameable possibility, so DISPATCHES fans out to all of
+    # them instead of silently guessing the first.
+    edge.attrs = {"reason": "injected-global-multi-value", "alternatives": len(values)}
+    for target_id in values:
+        store.add_edge(Edge(src=site.id, dst=target_id, kind="DISPATCHES", confidence=Confidence.PROBABLE,
+                             attrs={"registry": None, "fanout": len(values), "selector": ident, "via": "injected-global"}))
+    return False
+
+
+# -- rung 5: dict-dispatch ----------------------------------------------------
+
+
+def _find_dict_dispatch_binding(fi_node: ast.AST, ident: str):
+    """Scan `fi_node`'s own body (not descending into nested def/class/
+    lambda scopes) for the LAST `ident = <dict>.get(<key>)` or
+    `ident = <dict>[<key>]` assignment. Returns (dict_name, key_node, line)
+    or None. A linear-walk, last-wins heuristic — matches the rest of this
+    tool's "no CFG" philosophy."""
+    found = None
+
+    def walk(node: ast.AST) -> None:
+        nonlocal found
+        if node is not fi_node and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            return
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name) and node.targets[0].id == ident):
+            value = node.value
+            dict_name = key_node = None
+            if (isinstance(value, ast.Call) and isinstance(value.func, ast.Attribute)
+                    and value.func.attr == "get" and isinstance(value.func.value, ast.Name)
+                    and len(value.args) >= 1):
+                dict_name, key_node = value.func.value.id, value.args[0]
+            elif isinstance(value, ast.Subscript) and isinstance(value.value, ast.Name):
+                dict_name, key_node = value.value.id, value.slice
+            if dict_name is not None:
+                found = (dict_name, key_node, node.lineno)
+        for child in ast.iter_child_nodes(node):
+            walk(child)
+
+    body = [fi_node.body] if isinstance(fi_node, ast.Lambda) else fi_node.body
+    for stmt in body:
+        walk(stmt)
+    return found
+
+
+def _fn_id_to_scope_lookup(fn_id: str) -> tuple[str, str]:
+    rest = fn_id[len("fn:"):]
+    mod_path, qualname = rest.split("::", 1)
+    return mod_path, qualname
+
+
+def _try_dict_dispatch(store: GraphStore, site: Node, edge: Edge, scopes: dict[str, ModuleScope]) -> bool:
+    ident = site.attrs.get("callee")
+    mod_path = site.path
+    enclosing_fn = site.attrs.get("enclosing_fn")
+    if not ident or mod_path is None or enclosing_fn is None or not enclosing_fn.startswith("fn:"):
+        return False
+    fn_mod, qualname = _fn_id_to_scope_lookup(enclosing_fn)
+    scope = scopes.get(fn_mod)
+    if scope is None:
+        return False
+    fi = scope.function_by_qualname.get(qualname)
+    if fi is None:
+        return False
+    binding = _find_dict_dispatch_binding(fi.node, ident)
+    if binding is None:
+        return False
+    dict_name, key_node, _assign_line = binding
+    registry_id = registry_node_id(mod_path, dict_name)
+    reg_node = store.get(registry_id)
+    if reg_node is None or reg_node.attrs.get("mechanism") != "manifest-dict":
+        return False
+    members = store.out_edges(registry_id, "REGISTERS")
+    if not members:
+        return False
+    selector = scope.source_of(key_node) if key_node is not None else dict_name
+    edge.attrs = {"reason": "dict-dispatch-fanout", "registry": registry_id, "fanout": len(members), "selector": selector}
+    for m in members:
+        store.add_edge(Edge(src=site.id, dst=m.dst, kind="DISPATCHES", confidence=Confidence.PROBABLE,
+                             attrs={"registry": registry_id, "fanout": len(members), "selector": selector, "via": "dict-dispatch"}))
+    return True
+
+
+# -- rung 6: unique-method-name ----------------------------------------------
+
+
+def _try_unique_method_name(store: GraphStore, site: Node, edge: Edge, method_index: dict[str, list[str]]) -> bool:
+    if edge.attrs.get("reason") != "attribute-unknown-receiver":
+        return False
+    attr = site.attrs.get("attr")
+    if not attr:
+        return False
+    candidates = method_index.get(attr, [])
+    if len(candidates) == 1:
+        store.retarget_edge(edge, candidates[0])
+        edge.confidence = Confidence.PROBABLE
+        edge.attrs = {"rung": "unique-method-name", "alternatives": 1}
+        return True
+    if len(candidates) > 1:
+        edge.attrs = {"reason": "ambiguous-method-name", "alternatives": len(candidates)}
+    return False
+
+
+# -- getattr-literal ----------------------------------------------------------
+
+
+def _try_getattr_literal(store: GraphStore, site: Node, edge: Edge, top_level_index) -> bool:
+    obj_src = site.attrs.get("getattr_obj")
+    attr_lit = site.attrs.get("getattr_attr_literal")
+    mod_path = site.path
+    if not obj_src or attr_lit is None or mod_path is None:
+        return False
+    if not obj_src.isidentifier():
+        return False  # only a bare Name receiver is modelled; anything else stays a hole
+    alias_edges = store.out_edges(name_node_id(mod_path, obj_src), "ALIASES")
+    if not alias_edges:
+        return False
+    target = store.get(alias_edges[0].dst)
+    if target is None or target.kind != "MODULE" or target.path is None:
+        return False
+    resolved = _resolve_attr_via_module(store, top_level_index, target.path, attr_lit)
+    if resolved is None:
+        return False
+    target_id, _conf, _extra = resolved
+    store.retarget_edge(edge, target_id)
+    edge.confidence = Confidence.PROVEN
+    edge.attrs = {"rung": "getattr-literal", "attr": attr_lit}
+    return True
+
+
+# -- entry point --------------------------------------------------------------
+
+
+def extract_probable_calls(store: GraphStore, scopes: dict[str, ModuleScope], top_level_index) -> None:
+    """Call once per build, after extract_registry_module + extract_injections
+    + extract_external_roots have all run for the whole corpus."""
+    method_index = _build_method_index(store)
+    unresolved = [e for e in store.in_edges(UNRESOLVED_ID, "CALLS")]
+    for edge in unresolved:
+        site = store.get(edge.src)
+        if site is None or site.kind != "CALLSITE":
+            continue
+        form = site.attrs.get("form")
+        if form == "name":
+            if _try_injected_global(store, site, edge):
+                continue
+            if edge.dst == UNRESOLVED_ID:
+                _try_dict_dispatch(store, site, edge, scopes)
+        elif form == "attribute":
+            _try_unique_method_name(store, site, edge, method_index)
+        elif form == "getattr-result":
+            _try_getattr_literal(store, site, edge, top_level_index)

--- a/scripts/callgraph/extract/flow.py
+++ b/scripts/callgraph/extract/flow.py
@@ -1,0 +1,393 @@
+"""Escaping-local detection and the lightweight per-function control-flow
+summary `cg flags` ranks over.
+
+Deliberately NOT a real CFG: a linear walk with a context stack (one tag
+per statement — top-level-of-body | if-branch | loop-body | except-handler
+| with-body; a `try:` body and its `else`/`finally` are pass-through, since
+they don't branch), because a real CFG buys precision this corpus's bug
+shapes do not need. THIS IS BUG B's data: `mcp/grounding.py:ground`'s
+`degraded` is a LOCALBINDING — init'd `False` at the function's top level, a
+dict-value escape at `return {..., "degraded": degraded}`, reassigned
+`True` only inside a couple of `except`/`elif` branches, while several
+`if not S: break`-shaped branches exit the function's enclosing loop
+without ever touching it.
+
+A LOCALBINDING is materialized ONLY for locals that escape (returned
+directly, packed into a returned dict/tuple/list, or captured by a closure
+via `nonlocal` or a Load inside a nested def/lambda that itself escapes) —
+see the design's own framing: "an unassigned local that never escapes is
+nobody's bug."
+
+`guard_exits`: a `return`/`break`/`continue` is counted as a guard-that-
+skips-the-flag when it sits DIRECTLY inside a non-top-level block (an
+if/elif/else/for/while/except/with body) that does not ALSO directly
+assign the ident anywhere in that same block — "directly" meaning at that
+block's own statement list, not further nested inside a sub-branch of it
+(a further-nested sub-branch is its own, separately-judged block). This is
+exactly the shape of `for cid in ...: if not S: break` repeated across
+several lanes in `ground()`.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore, Node
+from ..scopes import FunctionInfo, ModuleScope
+from .defs import function_node_id
+
+TOP_LEVEL = "top-level-of-body"
+_EXIT_TYPES = (ast.Return, ast.Break, ast.Continue)
+_NESTED_SCOPE_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+
+def local_binding_id(fn_id: str, ident: str) -> str:
+    return f"local:{fn_id}::{ident}"
+
+
+# -- block walk: assign/exit events, block-local -----------------------------
+
+
+@dataclass
+class _AssignEvent:
+    ident: str
+    line: int
+    tag: str
+    is_constant: bool
+    block: int
+    form: str = "assign"   # assign | ann-assign | augmented | for-target | with-target
+
+
+@dataclass
+class _ExitEvent:
+    line: int
+    kind: str          # "return" | "break" | "continue"
+    tag: str
+    block: int
+
+
+def _assign_targets(stmt: ast.stmt) -> list[ast.expr]:
+    targets: list[ast.expr] = []
+    if isinstance(stmt, ast.Assign):
+        targets = list(stmt.targets)
+    elif isinstance(stmt, ast.AnnAssign) and stmt.target is not None:
+        targets = [stmt.target]
+    elif isinstance(stmt, ast.AugAssign):
+        targets = [stmt.target]
+    elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+        targets = [stmt.target]
+    elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+        targets = [w.optional_vars for w in stmt.items if w.optional_vars is not None]
+    out: list[ast.expr] = []
+
+    def flatten(t: ast.expr) -> None:
+        if isinstance(t, ast.Name):
+            out.append(t)
+        elif isinstance(t, (ast.Tuple, ast.List)):
+            for e in t.elts:
+                flatten(e)
+        elif isinstance(t, ast.Starred):
+            flatten(t.value)
+
+    for t in targets:
+        flatten(t)
+    return out
+
+
+def _is_constant_value(stmt: ast.stmt) -> bool:
+    value = getattr(stmt, "value", None)
+    return isinstance(value, ast.Constant)
+
+
+def _assign_form(stmt: ast.stmt) -> str:
+    """How the binding was made. The distinction that matters downstream is
+    REBINDING (`x = <const>`) vs ACCUMULATING (`x += ...`): a counter is
+    *supposed* to be updated on only some paths, so scoring it like a
+    conditionally-set flag is a false positive by construction. See
+    analyze/flags.py."""
+    if isinstance(stmt, ast.AugAssign):
+        return "augmented"
+    if isinstance(stmt, ast.AnnAssign):
+        return "ann-assign"
+    if isinstance(stmt, (ast.For, ast.AsyncFor)):
+        return "for-target"
+    if isinstance(stmt, (ast.With, ast.AsyncWith)):
+        return "with-target"
+    return "assign"
+
+
+def _walk_blocks(stmts: list[ast.stmt], tag: str, assigns: list[_AssignEvent], exits: list[_ExitEvent],
+                  block_directly_assigns: dict[int, set[str]]) -> None:
+    bid = id(stmts)
+    directly: set[str] = set()
+    for stmt in stmts:
+        for name_node in _assign_targets(stmt):
+            directly.add(name_node.id)
+            assigns.append(_AssignEvent(ident=name_node.id, line=stmt.lineno, tag=tag,
+                                         is_constant=_is_constant_value(stmt), block=bid,
+                                         form=_assign_form(stmt)))
+        if isinstance(stmt, _EXIT_TYPES):
+            kind = {"Return": "return", "Break": "break", "Continue": "continue"}[type(stmt).__name__]
+            exits.append(_ExitEvent(line=stmt.lineno, kind=kind, tag=tag, block=bid))
+    block_directly_assigns[bid] = directly
+
+    for stmt in stmts:
+        if isinstance(stmt, ast.If):
+            _walk_blocks(stmt.body, "if-branch", assigns, exits, block_directly_assigns)
+            _walk_blocks(stmt.orelse, "if-branch", assigns, exits, block_directly_assigns)
+        elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+            _walk_blocks(stmt.body, "loop-body", assigns, exits, block_directly_assigns)
+            _walk_blocks(stmt.orelse, "loop-body", assigns, exits, block_directly_assigns)
+        elif isinstance(stmt, ast.While):
+            _walk_blocks(stmt.body, "loop-body", assigns, exits, block_directly_assigns)
+            _walk_blocks(stmt.orelse, "loop-body", assigns, exits, block_directly_assigns)
+        elif isinstance(stmt, ast.Try):
+            _walk_blocks(stmt.body, tag, assigns, exits, block_directly_assigns)
+            for h in stmt.handlers:
+                _walk_blocks(h.body, "except-handler", assigns, exits, block_directly_assigns)
+            _walk_blocks(stmt.orelse, tag, assigns, exits, block_directly_assigns)
+            _walk_blocks(stmt.finalbody, tag, assigns, exits, block_directly_assigns)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            _walk_blocks(stmt.body, "with-body", assigns, exits, block_directly_assigns)
+        # nested def/class/lambda: own scope, not walked here (closure
+        # escape detection below handles them separately and deliberately).
+
+
+# -- escape detection ---------------------------------------------------------
+
+
+def _idents_in_expr(expr: ast.expr) -> set[str]:
+    return {n.id for n in ast.walk(expr) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+
+
+def _direct_return_idents(value: ast.expr) -> set[str]:
+    return {value.id} if isinstance(value, ast.Name) else set()
+
+
+def _container_element_idents(value: ast.expr) -> tuple[set[str], set[str]]:
+    """Returns (dict_value_idents, tuple_or_list_element_idents) for a
+    return value shaped like a dict/call-with-kwargs literal, or a
+    tuple/list literal — one level deep, matching the corpus's actual
+    `return {"a": x, "b": y}` / `return (a, b)` shapes."""
+    dict_idents: set[str] = set()
+    seq_idents: set[str] = set()
+    if isinstance(value, ast.Dict):
+        for v in value.values:
+            if isinstance(v, ast.Name):
+                dict_idents.add(v.id)
+    elif isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "dict":
+        for kw in value.keywords:
+            if kw.arg is not None and isinstance(kw.value, ast.Name):
+                dict_idents.add(kw.value.id)
+    elif isinstance(value, (ast.Tuple, ast.List)):
+        for elt in value.elts:
+            if isinstance(elt, ast.Name):
+                seq_idents.add(elt.id)
+    return dict_idents, seq_idents
+
+
+def _find_returns(body: list[ast.stmt]) -> list[ast.Return]:
+    out: list[ast.Return] = []
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, _NESTED_SCOPE_TYPES):
+            return
+        if isinstance(node, ast.Return) and node.value is not None:
+            out.append(node)
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    for stmt in body:
+        visit(stmt)
+    return out
+
+
+def _find_nested_defs(body: list[ast.stmt]) -> list:
+    out = []
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            out.append(node)
+            return  # don't look inside nested-of-nested for THIS function's escape analysis
+        if isinstance(node, ast.ClassDef):
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    for stmt in body:
+        visit(stmt)
+    return out
+
+
+def _nested_def_bound_name(node) -> Optional[str]:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return node.name
+    return None
+
+
+def _escapes(fi: FunctionInfo) -> dict[str, tuple[int, str]]:
+    """ident -> (escape_line, escape_form). form in {direct-return,
+    dict-value, tuple-element, closure}. First escape found wins."""
+    body = fi.node.body if not isinstance(fi.node, ast.Lambda) else [ast.Return(value=fi.node.body, lineno=fi.node.lineno)]
+    out: dict[str, tuple[int, str]] = {}
+
+    escaping_nested_names: set[str] = set()
+
+    for ret in _find_returns(body):
+        value = ret.value
+        for ident in _direct_return_idents(value):
+            out.setdefault(ident, (ret.lineno, "direct-return"))
+        dict_idents, seq_idents = _container_element_idents(value)
+        for ident in dict_idents:
+            out.setdefault(ident, (ret.lineno, "dict-value"))
+        for ident in seq_idents:
+            out.setdefault(ident, (ret.lineno, "tuple-element"))
+        # a nested callable escaping by name (`return inner`, or packed into
+        # the same container shapes) — its free variables escape via closure.
+        candidates = {value.id} if isinstance(value, ast.Name) else set()
+        candidates |= dict_idents | seq_idents
+        escaping_nested_names |= candidates
+
+    # closure: a nested def/lambda whose bound name is in escaping_nested_names
+    # (or a lambda that is itself the direct return value / container element —
+    # matched by identity against the AST nodes found in the return values).
+    nested_defs = _find_nested_defs(body)
+    escaping_lambda_nodes: set[int] = set()
+    for ret in _find_returns(body):
+        value = ret.value
+        if isinstance(value, ast.Lambda):
+            escaping_lambda_nodes.add(id(value))
+        dict_vals = value.values if isinstance(value, ast.Dict) else []
+        seq_elts = value.elts if isinstance(value, (ast.Tuple, ast.List)) else []
+        for v in list(dict_vals) + list(seq_elts):
+            if isinstance(v, ast.Lambda):
+                escaping_lambda_nodes.add(id(v))
+
+    for nd in nested_defs:
+        bound = _nested_def_bound_name(nd)
+        is_escaping = (bound is not None and bound in escaping_nested_names) or id(nd) in escaping_lambda_nodes
+        if not is_escaping:
+            continue
+        inner_locals: set[str] = {a.arg for a in nd.args.args} | {a.arg for a in nd.args.posonlyargs} \
+            | {a.arg for a in nd.args.kwonlyargs}
+        if nd.args.vararg:
+            inner_locals.add(nd.args.vararg.arg)
+        if nd.args.kwarg:
+            inner_locals.add(nd.args.kwarg.arg)
+        nonlocal_names: set[str] = set()
+        for n in ast.walk(nd):
+            if isinstance(n, ast.Nonlocal):
+                nonlocal_names.update(n.names)
+            elif isinstance(n, _NESTED_SCOPE_TYPES) and n is not nd:
+                continue
+        loads: set[str] = set()
+        for n in ast.walk(nd if isinstance(nd, ast.Lambda) else nd):
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load):
+                loads.add(n.id)
+        for ident in loads - inner_locals:
+            out.setdefault(ident, (nd.lineno, "closure"))
+        for ident in nonlocal_names:
+            out.setdefault(ident, (nd.lineno, "closure"))
+
+    return out
+
+
+# -- public entry point --------------------------------------------------
+
+
+def analyze_function(fi: FunctionInfo) -> dict[str, dict]:
+    """Returns ident -> {escape_line, escape_form, init_line, init_is_constant,
+    assign_lines, assign_contexts, guard_exits} for every local that escapes
+    fi. Non-escaping locals are never included — see module docstring."""
+    if fi.is_lambda:
+        body = [ast.Return(value=fi.node.body, lineno=fi.node.lineno)]
+    else:
+        body = fi.node.body
+
+    escapes = _escapes(fi)
+    if not escapes:
+        return {}
+
+    assigns: list[_AssignEvent] = []
+    exits: list[_ExitEvent] = []
+    block_directly_assigns: dict[int, set[str]] = {}
+    _walk_blocks(body, TOP_LEVEL, assigns, exits, block_directly_assigns)
+
+    out: dict[str, dict] = {}
+    for ident, (escape_line, escape_form) in escapes.items():
+        ident_assigns = sorted((a for a in assigns if a.ident == ident), key=lambda a: a.line)
+        if not ident_assigns and escape_form != "closure":
+            # A bare parameter, or a nested def's own name, returned as-is:
+            # never locally (re)bound in THIS function's own body, so it
+            # isn't a "local" in the sense LOCALBINDING models — see
+            # module docstring. A `nonlocal`-captured ident can legitimately
+            # have zero assigns in ITS OWN frame (the assignment lives in
+            # the closure), so escape_form=="closure" is exempted.
+            continue
+        init_line = None
+        init_is_constant = False
+        reassigns: list[_AssignEvent] = ident_assigns
+        if ident_assigns and ident_assigns[0].tag == TOP_LEVEL:
+            init_line = ident_assigns[0].line
+            init_is_constant = ident_assigns[0].is_constant
+            reassigns = ident_assigns[1:]
+
+        guard_exits: list[dict] = []
+        for ex in exits:
+            if ex.tag == TOP_LEVEL:
+                continue
+            if ident in block_directly_assigns.get(ex.block, set()):
+                continue
+            guard_exits.append({"line": ex.line, "kind": ex.kind, "context": ex.tag})
+
+        # A REBIND is a plain `ident = <constant>` reassignment — the only
+        # shape that actually flips a flag. `+=` on a counter, a for-target,
+        # or a rebind to a non-constant expression are all excluded, because
+        # each of them is normal code that the guard-exit ratio would
+        # otherwise score exactly like a conditionally-set flag.
+        constant_rebinds = [a for a in reassigns
+                            if a.form in ("assign", "ann-assign") and a.is_constant]
+
+        out[ident] = {
+            "escape_line": escape_line, "escape_form": escape_form,
+            "init_line": init_line, "init_is_constant": init_is_constant,
+            "assign_lines": [a.line for a in reassigns],
+            "assign_contexts": [{"line": a.line, "context": a.tag, "form": a.form,
+                                  "is_constant": a.is_constant} for a in reassigns],
+            "constant_rebind_lines": [a.line for a in constant_rebinds],
+            "assign_forms": sorted({a.form for a in reassigns}),
+            "guard_exits": guard_exits,
+        }
+    return out
+
+
+def extract_flow(store: GraphStore, sf: SourceFile, scope: ModuleScope) -> None:
+    if sf.tree is None:
+        return
+    for fi in scope.functions:
+        if fi.is_method and fi.qualname.rsplit(".", 1)[-1] == "__init__":
+            pass  # __init__ is analyzed like any other method; no special-case needed
+        summary = analyze_function(fi)
+        if not summary:
+            continue
+        fn_id = function_node_id(sf.rel_path, fi.qualname)
+        for ident, info in summary.items():
+            lid = local_binding_id(fn_id, ident)
+            store.add_node(Node(
+                id=lid, kind="LOCALBINDING",
+                attrs={
+                    "ident": ident, "init_line": info["init_line"], "init_is_constant": info["init_is_constant"],
+                    "assign_lines": info["assign_lines"], "assign_contexts": info["assign_contexts"],
+                    "constant_rebind_lines": info["constant_rebind_lines"],
+                    "assign_forms": info["assign_forms"],
+                    "escape_lines": [info["escape_line"]], "guard_exits": info["guard_exits"],
+                },
+                path=sf.rel_path, line=(info["init_line"] or info["escape_line"]),
+            ))
+            store.add_edge(Edge(src=fn_id, dst=lid, kind="ESCAPES", confidence=Confidence.PROVEN, attrs={
+                "escape_line": info["escape_line"], "escape_form": info["escape_form"],
+            }))

--- a/scripts/callgraph/extract/funcrefs.py
+++ b/scripts/callgraph/extract/funcrefs.py
@@ -1,0 +1,126 @@
+"""Bare function-name ESCAPES -> REFERENCES edges.
+
+A function whose NAME appears anywhere in a value position -- passed as a
+call argument, returned, stored in a container, bound to a variable -- has
+escaped. Whoever holds the reference can call it, and this tool has no way
+to prove they don't. For `cg dead` that is decisive: without this pass such
+a function looks unreachable and gets reported dead, which is a FALSE
+POSITIVE and the single fastest way to make people stop trusting the tool.
+
+Found by validation against the real corpus at HEAD. Two shapes in
+mcp/server.py's health block, both previously reported dead:
+
+    checks.append(_health_check("embeddings_sparse", _health_probe_embeddings_sparse))
+                                                     ^ bare name, call argument
+
+    _collect_decls(root, lang, def_types, enclosing_symbol_src, in_method, add_decl)
+                                                                           ^ nested
+                                                       def, passed down and called
+                                                       through a parameter
+
+extract/registry.py already emitted REFERENCES for the two REGISTRATION
+shapes it models (`manifest-tuple-element`, `manifest-dict-value`). This
+generalizes the same edge to every escape, registration or not.
+
+DELIBERATELY BROAD, and it costs recall: a function referenced only from
+code that itself never runs still counts as referenced here, so genuinely
+dead code can be hidden by a single stale mention. That is the intended
+trade -- `cg dead` is a lead generator whose value is that its rows are
+worth reading, and a tool people suppress is a tool that is not working.
+See docs/LIMITS.md.
+
+Only BARE NAMES are resolved. `mod.func` in a value position is not modelled
+(it would need the same receiver-typing the CALLS ladder gives up on at
+rung 4), so it remains a known blind spot rather than a guess.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore
+from ..scopes import FunctionInfo, ModuleScope
+from .defs import function_node_id, module_node_id
+
+
+def _resolve_local_nested(scope: ModuleScope, fi: Optional[FunctionInfo], name: str) -> Optional[str]:
+    """A nested def visible by bare name from inside `fi` -- i.e. defined in
+    fi itself or in one of its lexical ancestors. Walks outward through the
+    `<parent>.<locals>.<child>` qualname chain the scope builder assigns."""
+    if fi is None:
+        return None
+    qual = fi.qualname
+    while True:
+        cand = f"{qual}.<locals>.{name}"
+        target = scope.function_by_qualname.get(cand)
+        if target is not None and not target.is_lambda:
+            return function_node_id(scope.sf.rel_path, cand)
+        if ".<locals>." not in qual:
+            return None
+        qual = qual.rsplit(".<locals>.", 1)[0]
+
+
+def make_funcrefs_visitor(store: GraphStore, sf: SourceFile, scope: ModuleScope, top_level_index):
+    """Returns (visit, flush).
+
+    `visit` rides along on the ONE shared whole-module walk that calls.py /
+    names.py / literals.py already run (see extract/walk.py) — a separate
+    traversal here measurably blew the build-time budget on this corpus.
+
+    `flush` emits the edges, and must run AFTER extract/registry.py so the
+    specific registration forms win the dedupe below.
+    """
+    mod_path = sf.rel_path
+    module_level = top_level_index.get(mod_path, {})
+    skip: set[int] = set()
+    pending: list[tuple[str, str, int]] = []
+
+    def visit(node: ast.AST, fi: Optional[FunctionInfo]) -> None:
+        # walk_module visits a parent before its children, so a Call is always
+        # seen before its own `.func`, and a def before its decorator list.
+        # Recording the ids here is therefore enough to skip them below.
+        if isinstance(node, ast.Call):
+            skip.add(id(node.func))
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for d in node.decorator_list:
+                skip.add(id(d))          # @foo / @foo(...) is DECORATED_BY, not an escape
+            return
+        if not isinstance(node, ast.Name) or not isinstance(node.ctx, ast.Load):
+            return
+        if id(node) in skip:
+            return
+        target_id = _resolve_local_nested(scope, fi, node.id) or module_level.get(node.id)
+        if target_id is None:
+            return
+        target = store.get(target_id)
+        if target is None or target.kind != "FUNCTION":
+            return
+        src_id = (function_node_id(mod_path, fi.qualname) if fi is not None
+                  else module_node_id(mod_path))
+        if src_id == target_id:
+            return  # a recursive self-mention is not an escape
+        pending.append((src_id, target_id, node.lineno))
+
+    def flush() -> None:
+        for src_id, target_id, line in pending:
+            # extract/registry.py models some of these with a more specific
+            # form (`manifest-tuple-element`, `manifest-dict-value`,
+            # `injected-argument`). Same source, same target, same LINE is the
+            # same syntactic reference — re-emitting it as a generic
+            # name-escape would double-count it in `cg callers`.
+            dup = False
+            for existing in store.out_edges(src_id, "REFERENCES"):
+                if existing.dst == target_id and existing.attrs.get("line") == line:
+                    dup = True
+                    break
+            if dup:
+                continue
+            store.add_edge(Edge(src=src_id, dst=target_id, kind="REFERENCES",
+                                 confidence=Confidence.PROVEN,
+                                 attrs={"form": "name-escape", "line": line}))
+
+    return visit, flush

--- a/scripts/callgraph/extract/imports.py
+++ b/scripts/callgraph/extract/imports.py
@@ -1,0 +1,246 @@
+"""IMPORTS (module-level vs function-local) and ALIASES/re-exports.
+
+Records `importlib.import_module(<literal>)` as a proven import edge;
+`import_module(<variable>)` is deliberately left alone here — an
+unresolvable dynamic import is extract/calls.py's `?` sink territory (a
+later build step), not this module's.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore, Node
+from ..resolve import ResolutionTable, ResolveResult
+from ..scopes import ModuleScope
+from .defs import class_node_id, function_node_id, module_node_id, name_node_id
+
+
+def external_node_id(dotted: str) -> str:
+    return f"ext:{dotted}"
+
+
+def _distribution_for(res: ResolveResult) -> str:
+    return {"stdlib": "stdlib", "third-party": "third-party"}.get(res.status, "unknown")
+
+
+def _ensure_external(store: GraphStore, dotted: str, distribution: str) -> str:
+    eid = external_node_id(dotted)
+    store.add_node(Node(id=eid, kind="EXTERNAL", attrs={"dotted": dotted, "distribution": distribution}))
+    return eid
+
+
+def _resolved_via_confidence(res: ResolveResult) -> Confidence:
+    if res.status in ("corpus", "stdlib", "third-party"):
+        return Confidence.PROVEN
+    return Confidence.UNPROVEN
+
+
+def _emit_imports_edge(store: GraphStore, mod_id: str, display_module: str, res: ResolveResult,
+                        scope_kind: str, enclosing_fn: Optional[str], bound_names: list[str], line: int) -> None:
+    if res.status == "corpus" and res.target_path is not None:
+        dst = module_node_id(res.target_path)
+    else:
+        dst = _ensure_external(store, display_module or "?", _distribution_for(res))
+    attrs = {
+        "scope": scope_kind, "enclosing_fn": enclosing_fn, "bound_names": bound_names,
+        "resolved_via": res.resolved_via, "module": display_module, "line": line,
+    }
+    if res.ambiguous:
+        attrs["ambiguous_candidates"] = res.candidates
+    if res.cross_file_root:
+        attrs["cross_file_root"] = True
+    store.add_edge(Edge(src=mod_id, dst=dst, kind="IMPORTS",
+                         confidence=_resolved_via_confidence(res), attrs=attrs))
+
+
+def _lookup_in_module(all_scopes: dict[str, ModuleScope], target_path: str, ident: str) -> Optional[str]:
+    """A FUNCTION/CLASS/NAME node id for `ident` defined at TOP LEVEL of
+    the module at target_path, or None."""
+    target_scope = all_scopes.get(target_path)
+    if target_scope is None:
+        return None
+    for fi in target_scope.functions:
+        if fi.qualname == ident and not fi.is_nested and not fi.is_method:
+            return function_node_id(target_path, ident)
+    for ci in target_scope.classes:
+        if ci.qualname == ident:
+            return class_node_id(target_path, ident)
+    if ident in target_scope.names:
+        return name_node_id(target_path, ident)
+    return None
+
+
+def extract_imports(store: GraphStore, sf: SourceFile, scope: ModuleScope,
+                     table: ResolutionTable, all_scopes: dict[str, ModuleScope]) -> None:
+    if sf.tree is None:
+        return
+    mod_id = module_node_id(sf.rel_path)
+
+    for rec in scope.imports:
+        if not rec.is_from:
+            for dotted, asname in rec.names:
+                res = table.resolve_dotted(dotted, sf.rel_path)
+                bound = asname or dotted.split(".")[0]
+                _emit_imports_edge(store, mod_id, dotted, res, rec.scope, rec.enclosing_fn, [bound], rec.lineno)
+                if rec.scope == "module-level":
+                    _emit_alias_to_module(store, sf, bound, res, rec.lineno)
+        else:
+            if rec.level > 0:
+                res = table.resolve_relative(rec.level, rec.module, sf.rel_path)
+                display_module = ("." * rec.level) + (rec.module or "")
+            else:
+                res = table.resolve_dotted(rec.module or "", sf.rel_path)
+                display_module = rec.module or ""
+            bound_all = [asname or imported for imported, asname in rec.names if imported != "*"]
+            _emit_imports_edge(store, mod_id, display_module, res, rec.scope, rec.enclosing_fn, bound_all, rec.lineno)
+            if rec.scope == "module-level":
+                for imported, asname in rec.names:
+                    if imported == "*":
+                        continue  # star-import: no per-name alias (a hole, surfaced by later `cg holes`)
+                    bound = asname or imported
+                    _emit_alias_from_import(store, sf, bound, res, display_module, imported, rec.lineno, all_scopes, table)
+
+    _emit_importlib_literal_imports(store, sf, mod_id, table)
+    _emit_module_level_name_aliases(store, sf, scope, all_scopes)
+
+
+def _emit_alias_to_module(store: GraphStore, sf: SourceFile, bound: str, res: ResolveResult, line: int) -> None:
+    """`import X [as Y]` at module level: NAME Y aliases the MODULE object X."""
+    nid = name_node_id(sf.rel_path, bound)
+    if res.status == "corpus" and res.target_path is not None:
+        dst = module_node_id(res.target_path)
+        conf = Confidence.PROVEN
+    else:
+        dst = _ensure_external(store, bound, _distribution_for(res))
+        conf = Confidence.PROVEN if res.status in ("stdlib", "third-party") else Confidence.UNPROVEN
+    store.add_edge(Edge(src=nid, dst=dst, kind="ALIASES", confidence=conf, attrs={"form": "import", "line": line}))
+
+
+def _emit_alias_from_import(store: GraphStore, sf: SourceFile, bound: str, res: ResolveResult,
+                             display_module: str, imported: str, line: int,
+                             all_scopes: dict[str, ModuleScope], table: ResolutionTable) -> None:
+    """`from X import Y [as Z]` at module level: NAME Z aliases whatever Y
+    is inside module X — a function/class/name if X is a corpus module and
+    defines it, a submodule if Y is itself a module, else an external
+    sink."""
+    nid = name_node_id(sf.rel_path, bound)
+    if res.status == "corpus" and res.target_path is not None:
+        target_id = _lookup_in_module(all_scopes, res.target_path, imported)
+        if target_id is not None:
+            store.add_edge(Edge(src=nid, dst=target_id, kind="ALIASES", confidence=Confidence.PROVEN,
+                                 attrs={"form": "from-import", "line": line}))
+            return
+        # `from . import Y` / `from .pkg import Y` where Y is a SIBLING
+        # MODULE FILE. The dotted-name fallback below cannot see it: for a
+        # relative import display_module is just "." (or ".."), so it probes
+        # "..Y" and "Y" and never the package-qualified name. Resolve it
+        # against the filesystem layout instead, which is what Python does.
+        #
+        # Found by validation: `mcp/graph/analytics.py` does
+        # `from . import queries as Q` and then `Q.finding_symbols(...)`.
+        # Without this, `Q` aliased an external sink instead of the MODULE,
+        # so every `Q.*` call fell to the `?` sink and four live
+        # mcp/graph/queries.py functions were reported dead.
+        if res.target_path.endswith("/__init__.py"):
+            pkg_dir = res.target_path[: -len("/__init__.py")]
+            sibling = f"{pkg_dir}/{imported}.py"
+            if sibling in all_scopes:
+                store.add_edge(Edge(src=nid, dst=module_node_id(sibling), kind="ALIASES",
+                                     confidence=Confidence.PROVEN,
+                                     attrs={"form": "from-import-submodule", "line": line}))
+                return
+
+        # Not a name defined in X's top level — maybe X.Y is itself a
+        # submodule (`from mcp import graph_tools` where graph_tools.py is
+        # a sibling file reachable as "mcp.graph_tools" or "graph_tools").
+        for cand in (f"{display_module}.{imported}", imported):
+            matches = table.by_dotted.get(cand) or []
+            if matches:
+                mod_path = matches[0][0]
+                store.add_edge(Edge(src=nid, dst=module_node_id(mod_path), kind="ALIASES",
+                                     confidence=Confidence.PROVEN, attrs={"form": "from-import-submodule", "line": line}))
+                return
+        # Genuinely couldn't find it inside a resolved corpus module (e.g.
+        # re-exported through `__init__.py` `from .x import *`, or a
+        # dynamically-created attribute) — fall back to an external sink
+        # named after the qualified import so it is still queryable.
+        dst = _ensure_external(store, f"{display_module}.{imported}", "unknown")
+        store.add_edge(Edge(src=nid, dst=dst, kind="ALIASES", confidence=Confidence.UNPROVEN,
+                             attrs={"form": "from-import-unresolved-in-module", "line": line}))
+        return
+    dst = _ensure_external(store, f"{display_module}.{imported}" if display_module else imported,
+                            _distribution_for(res))
+    conf = Confidence.PROVEN if res.status in ("stdlib", "third-party") else Confidence.UNPROVEN
+    store.add_edge(Edge(src=nid, dst=dst, kind="ALIASES", confidence=conf,
+                         attrs={"form": "from-import", "line": line}))
+
+
+def _emit_module_level_name_aliases(store: GraphStore, sf: SourceFile, scope: ModuleScope,
+                                     all_scopes: dict[str, ModuleScope]) -> None:
+    """Bare `A = B` at module level, where B is itself a name/function/class
+    already bound in this same module."""
+    for ma in scope.module_assigns:
+        if ma.value_kind != "name" or ma.value_name is None:
+            continue
+        if ma.value_name == ma.target:
+            continue
+        target_id = _lookup_in_module(all_scopes, sf.rel_path, ma.value_name)
+        if target_id is None:
+            continue
+        src_id = name_node_id(sf.rel_path, ma.target)
+        store.add_edge(Edge(src=src_id, dst=target_id, kind="ALIASES", confidence=Confidence.PROVEN,
+                             attrs={"form": "assign", "line": ma.lineno}))
+
+
+def _emit_importlib_literal_imports(store: GraphStore, sf: SourceFile, mod_id: str, table: ResolutionTable) -> None:
+    """`importlib.import_module("literal")` anywhere in the module, at any
+    nesting depth, is treated as a proven import edge (the argument is a
+    literal, so this is not a guess)."""
+    if sf.tree is None:
+        return
+    for node in ast.walk(sf.tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fname = _dotted_call_name(node.func)
+        if fname not in ("importlib.import_module", "import_module"):
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant) or not isinstance(node.args[0].value, str):
+            continue
+        dotted = node.args[0].value
+        res = table.resolve_dotted(dotted, sf.rel_path)
+        enclosing_fn = _enclosing_function_qualname(sf.tree, node)
+        _emit_imports_edge(store, mod_id, dotted, res,
+                            "function-local" if enclosing_fn else "module-level",
+                            enclosing_fn, [], node.lineno)
+
+
+def _dotted_call_name(func: ast.AST) -> Optional[str]:
+    parts: list[str] = []
+    node = func
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    else:
+        return None
+    return ".".join(reversed(parts))
+
+
+def _enclosing_function_qualname(tree: ast.Module, target: ast.AST) -> Optional[str]:
+    """Best-effort: find the nearest enclosing FunctionDef/AsyncFunctionDef
+    of `target` by line range containment. Good enough for attributing an
+    importlib call to a function without a second full scope pass."""
+    best: Optional[tuple[int, str]] = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start, end = node.lineno, getattr(node, "end_lineno", node.lineno)
+            if start <= target.lineno <= end:
+                width = end - start
+                if best is None or width < best[0]:
+                    best = (width, node.name)
+    return best[1] if best else None

--- a/scripts/callgraph/extract/literals.py
+++ b/scripts/callgraph/extract/literals.py
@@ -1,0 +1,385 @@
+"""LITERAL / PATHEXPR extraction, and PRODUCES_LITERAL / CONSUMES_LITERAL
+edges — the data BUG D's diagnosis needs: does any consumer's path/key
+literal agree with a producer's, across the whole corpus?
+
+Two literal flavours (design's own split):
+  PATH-LIKE — contains `/`, starts with `~`, or ends with a recognized file
+              extension.
+  KEY-LIKE  — an identifier-shaped string (env var name, dict lookup key,
+              collection/table name) used in a lookup position.
+
+Role (produce | consume) comes from the syntactic context the literal (or
+the PATHEXPR it's the tail of) sits in — a small, explicit verb table
+matched against the call's dotted name or method name, kept in this module
+rather than rules.toml: unlike the decorator/registrar rules (which grow as
+the corpus adds new frameworks), the verb set here is closed and small
+(open/write_text/mkdir/glob/read_text/exists/environ.get/dict.get) and a
+change to it is a code review of THIS logic, not a data tweak an unrelated
+engineer should be able to make blind.
+
+A composed path (`MEMORY_DIR / "graph.ladybug"`, `os.path.join(...)`, an
+f-string, `+` concat) becomes a PATHEXPR node instead of a bare LITERAL —
+PRODUCES_LITERAL/CONSUMES_LITERAL edges target whichever of the two applies
+at that site. Its `tail_literal` (the last literal segment) is what a
+cross-module orphan/near-miss comparison actually keys on: `graph.ladybug`
+in `mcp/server.py`'s `MEMORY_DIR / "graph.ladybug"` PATHEXPR is compared
+against the bare LITERAL `~/.hermes/**/graph.kuzu` in
+`scripts/graph_facts.py` on exactly that basis (see analyze/literalaudit.py).
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore, Node
+from ..scopes import FunctionInfo, ModuleScope
+from .calls import _dotted_call_name
+from .defs import function_node_id, module_node_id
+from .walk import walk_module
+
+# -- ids ----------------------------------------------------------------
+
+
+def literal_node_id(normalized: str) -> str:
+    digest = hashlib.sha1(normalized.encode("utf-8", errors="surrogateescape")).hexdigest()
+    return f"lit:{digest[:16]}"
+
+
+def pathexpr_node_id(rel_path: str, line: int, col: int) -> str:
+    return f"pathexpr:{rel_path}:{line}:{col}"
+
+
+# -- flavour / normalization ---------------------------------------------
+
+_PATH_EXT_SUFFIXES = (
+    ".py", ".json", ".jsonl", ".toml", ".yaml", ".yml", ".db", ".kuzu", ".ladybug",
+    ".md", ".txt", ".csv", ".service", ".sh", ".log", ".cfg", ".ini", ".pyc", ".lock",
+    ".pid", ".sock",
+)
+_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\-]{0,63}$")
+
+
+def looks_path_like(s: str) -> bool:
+    if not s or "\n" in s or len(s) > 400:
+        return False
+    if "/" in s or s.startswith("~"):
+        return True
+    return s.endswith(_PATH_EXT_SUFFIXES)
+
+
+def looks_key_like(s: str) -> bool:
+    if not s or "\n" in s or len(s) > 128:
+        return False
+    if looks_path_like(s):
+        return False
+    return bool(_KEY_RE.match(s))
+
+
+def classify_flavour(s: str) -> Optional[str]:
+    if looks_path_like(s):
+        return "path"
+    if looks_key_like(s):
+        return "key"
+    return None
+
+
+def normalize_literal(raw: str) -> str:
+    """expanduser-strip's SPIRIT without touching the filesystem: `~` stays
+    a marker (this tool never resolves a real home dir), and a recursive
+    glob's `**` collapses to a single `*` so `~/.hermes/**/graph.kuzu` and a
+    hypothetical single-star sibling normalize the same way. Case is
+    preserved per design."""
+    return raw.replace("**", "*")
+
+
+def tail_segment(s: str) -> str:
+    s2 = s.rstrip("/")
+    if "/" in s2:
+        return s2.rsplit("/", 1)[-1]
+    return s2
+
+
+def _stem(tail: str) -> str:
+    base = tail.rsplit("/", 1)[-1]
+    if "." in base and not base.startswith("."):
+        return base.rsplit(".", 1)[0].lower()
+    return base.lower()
+
+
+# -- node helpers ----------------------------------------------------------
+
+
+def _ensure_literal(store: GraphStore, raw: str, flavour: str) -> str:
+    normalized = normalize_literal(raw)
+    lid = literal_node_id(normalized)
+    node = store.get(lid)
+    if node is None:
+        store.add_node(Node(id=lid, kind="LITERAL", attrs={
+            "raw": raw, "normalized": normalized, "flavour": flavour,
+            "tail": tail_segment(normalized), "occurrences": [],
+        }))
+        node = store.get(lid)
+    return lid
+
+
+def _record_occurrence(store: GraphStore, node_id: str, rel_path: str, line: int, col: int, role: str) -> None:
+    node = store.get(node_id)
+    if node is not None:
+        node.attrs.setdefault("occurrences", []).append(
+            {"path": rel_path, "line": line, "col": col, "role": role}
+        )
+
+
+def _emit_edge(store: GraphStore, src_id: str, dst_id: str, direction: str,
+                rel_path: str, line: int, col: int, role: str) -> None:
+    kind = "PRODUCES_LITERAL" if direction == "produce" else "CONSUMES_LITERAL"
+    store.add_edge(Edge(src=src_id, dst=dst_id, kind=kind, confidence=Confidence.PROVEN,
+                         attrs={"role": role, "line": line, "col": col, "path": rel_path}))
+    _record_occurrence(store, dst_id, rel_path, line, col, role)
+
+
+# -- PATHEXPR composition ---------------------------------------------------
+
+_WRAPPER_TAILS = {"str", "path", "fspath", "repr", "expanduser", "abspath", "normpath", "realpath"}
+
+
+def _unwrap(expr: ast.expr) -> ast.expr:
+    while isinstance(expr, ast.Call) and len(expr.args) == 1 and not expr.keywords:
+        dotted = _dotted_call_name(expr.func) or ""
+        tail = dotted.rsplit(".", 1)[-1].lower()
+        if tail in _WRAPPER_TAILS:
+            expr = expr.args[0]
+            continue
+        break
+    return expr
+
+
+def _flatten_binop(expr: ast.expr, op_type) -> Optional[list[ast.expr]]:
+    if not (isinstance(expr, ast.BinOp) and isinstance(expr.op, op_type)):
+        return None
+    left = _flatten_binop(expr.left, op_type)
+    operands = left if left is not None else [expr.left]
+    operands.append(expr.right)
+    return operands
+
+
+def _segment(expr: ast.expr, scope: ModuleScope) -> dict:
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return {"kind": "literal", "value": expr.value}
+    if isinstance(expr, ast.Name):
+        return {"kind": "name", "value": expr.id}
+    return {"kind": "?", "value": scope.source_of(expr)}
+
+
+def _try_build_pathexpr(store: GraphStore, sf: SourceFile, scope: ModuleScope, expr: ast.expr) -> Optional[str]:
+    segments: Optional[list[dict]] = None
+
+    div_chain = _flatten_binop(expr, ast.Div)
+    if div_chain is not None and len(div_chain) >= 2:
+        segments = [_segment(o, scope) for o in div_chain]
+    else:
+        add_chain = _flatten_binop(expr, ast.Add)
+        if add_chain is not None and len(add_chain) >= 2 and all(
+            isinstance(o, ast.Constant) and isinstance(o.value, str) for o in add_chain
+        ):
+            segments = [_segment(o, scope) for o in add_chain]
+        elif isinstance(expr, ast.Call):
+            dotted = (_dotted_call_name(expr.func) or "").rsplit(".", 1)[-1]
+            if dotted == "join" and expr.args:
+                segments = [_segment(a, scope) for a in expr.args]
+        elif isinstance(expr, ast.JoinedStr):
+            segs = []
+            for v in expr.values:
+                if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                    segs.append({"kind": "literal", "value": v.value})
+                elif isinstance(v, ast.FormattedValue):
+                    segs.append(_segment(v.value, scope))
+            if segs:
+                segments = segs
+
+    if segments is None:
+        return None
+
+    literal_segs = [s for s in segments if s["kind"] == "literal"]
+    if not literal_segs:
+        return None
+    tail_literal = literal_segs[-1]["value"]
+
+    pid = pathexpr_node_id(sf.rel_path, expr.lineno, expr.col_offset)
+    if pid not in store:
+        store.add_node(Node(
+            id=pid, kind="PATHEXPR",
+            attrs={"segments": segments, "tail_literal": tail_literal, "occurrences": []},
+            path=sf.rel_path, line=expr.lineno, col=expr.col_offset,
+        ))
+    return pid
+
+
+def _handle_composed_or_literal(store: GraphStore, sf: SourceFile, scope: ModuleScope,
+                                 candidate: ast.expr, expected_flavour: str, role: str, direction: str,
+                                 src_id: str, site_line: int, site_col: int) -> None:
+    unwrapped = _unwrap(candidate)
+    if isinstance(unwrapped, ast.Constant) and isinstance(unwrapped.value, str):
+        flavour = classify_flavour(unwrapped.value)
+        if flavour != expected_flavour:
+            return
+        lid = _ensure_literal(store, unwrapped.value, flavour)
+        _emit_edge(store, src_id, lid, direction, sf.rel_path, site_line, site_col, role)
+        return
+    pid = _try_build_pathexpr(store, sf, scope, unwrapped)
+    if pid is None:
+        return
+    node = store.get(pid)
+    tail = node.attrs.get("tail_literal") if node is not None else None
+    if tail is None:
+        return
+    flavour = classify_flavour(tail)
+    if expected_flavour == "path" and not looks_path_like(tail):
+        return
+    if expected_flavour == "key" and flavour != "key":
+        return
+    # A PATHEXPR node is keyed by (file, line, col), not by text, so it
+    # never collides across two different call sites — safe to stamp its
+    # flavour from the FIRST (and, in practice, only) context it's used in.
+    # Without this, analyze/literalaudit.py would have to guess a flavour
+    # from node KIND alone and misclassify a KEY-LIKE f-string composition
+    # (e.g. `f"_{name.upper()}"` used as a dict key) as PATH-LIKE.
+    node.attrs.setdefault("flavour", expected_flavour)
+    _emit_edge(store, src_id, pid, direction, sf.rel_path, site_line, site_col, role)
+
+
+# -- role tables -------------------------------------------------------------
+
+# method-on-receiver shapes: the literal/PATHEXPR sits in `call.func.value`
+# (e.g. `(MEMORY_DIR / "notes.jsonl").write_text(...)`), keyed by attr name.
+_RECEIVER_VERBS: dict[str, tuple[str, str]] = {
+    "write_text": ("write_text", "produce"),
+    "write_bytes": ("write_bytes", "produce"),
+    "mkdir": ("mkdir", "produce"),
+    "touch": ("touch", "produce"),
+    "read_text": ("read_text", "consume"),
+    "read_bytes": ("read_bytes", "consume"),
+    "exists": ("exists", "consume"),
+    "is_file": ("exists", "consume"),
+    "is_dir": ("exists", "consume"),
+    "unlink": ("unlink", "consume"),
+}
+
+# function-call-with-argument shapes: the literal/PATHEXPR sits in `args[0]`,
+# keyed by the call's dotted name (or its final component as a fallback).
+_ARG0_DOTTED_VERBS: dict[str, tuple[str, str]] = {
+    "glob.glob": ("glob", "consume"),
+    "os.path.exists": ("exists", "consume"),
+    "os.path.isfile": ("exists", "consume"),
+    "os.path.isdir": ("exists", "consume"),
+    "os.remove": ("unlink", "consume"),
+    "os.makedirs": ("mkdir", "produce"),
+}
+
+_STORE_CTOR_TAIL_RE = re.compile(r"Store$")
+
+
+def _open_mode(call: ast.Call) -> str:
+    if len(call.args) >= 2 and isinstance(call.args[1], ast.Constant) and isinstance(call.args[1].value, str):
+        return call.args[1].value
+    for kw in call.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return "r"
+
+
+def _handle_call(store: GraphStore, sf: SourceFile, scope: ModuleScope, call: ast.Call, src_id: str) -> None:
+    func = call.func
+    dotted = _dotted_call_name(func) or ""
+    tail = dotted.rsplit(".", 1)[-1] if dotted else None
+
+    # -- receiver-based verbs: `<path-expr>.write_text(...)` etc.
+    if isinstance(func, ast.Attribute) and func.attr in _RECEIVER_VERBS:
+        role, direction = _RECEIVER_VERBS[func.attr]
+        _handle_composed_or_literal(store, sf, scope, func.value, "path", role, direction,
+                                     src_id, call.lineno, call.col_offset)
+        return
+
+    # -- open(path, mode): mode-dependent produce/consume, arg[0] is the path
+    if tail == "open" and call.args:
+        mode = _open_mode(call)
+        if any(c in mode for c in "wax+"):
+            role, direction = "open-w", "produce"
+        else:
+            role, direction = "open-r", "consume"
+        _handle_composed_or_literal(store, sf, scope, call.args[0], "path", role, direction,
+                                     src_id, call.lineno, call.col_offset)
+        return
+
+    # -- Store-ctor: `SomeStore(str(path_expr))` -> produce
+    if isinstance(func, (ast.Name, ast.Attribute)) and dotted and _STORE_CTOR_TAIL_RE.search(dotted.rsplit(".", 1)[-1]):
+        if call.args:
+            _handle_composed_or_literal(store, sf, scope, call.args[0], "path", "store-ctor", "produce",
+                                         src_id, call.lineno, call.col_offset)
+        return
+
+    # -- `.get("KEY")` — os.environ.get is a path-flavour-free key lookup;
+    # any other receiver's `.get("KEY")` is treated as a dict-get lookup.
+    if isinstance(func, ast.Attribute) and func.attr == "get" and call.args:
+        base_dotted = _dotted_call_name(func.value) or ""
+        if base_dotted.endswith("environ") or base_dotted.endswith("os.environ"):
+            role = "environ-get"
+        else:
+            role = "dict-get"
+        _handle_composed_or_literal(store, sf, scope, call.args[0], "key", role, "consume",
+                                     src_id, call.lineno, call.col_offset)
+        return
+
+    # -- module-function arg0 verbs: glob.glob(...), os.path.exists(...), ...
+    lookup_key = dotted if dotted in _ARG0_DOTTED_VERBS else (tail or "")
+    if lookup_key in _ARG0_DOTTED_VERBS and call.args:
+        role, direction = _ARG0_DOTTED_VERBS[lookup_key]
+        _handle_composed_or_literal(store, sf, scope, call.args[0], "path", role, direction,
+                                     src_id, call.lineno, call.col_offset)
+
+
+def _handle_subscript(store: GraphStore, sf: SourceFile, scope: ModuleScope, node: ast.Subscript, src_id: str) -> None:
+    sl = node.slice
+    if not (isinstance(sl, ast.Constant) and isinstance(sl.value, str)):
+        return
+    if not looks_key_like(sl.value):
+        return
+    base_dotted = _dotted_call_name(node.value) or (node.value.id if isinstance(node.value, ast.Name) else "")
+    is_environ = base_dotted.endswith("environ") or base_dotted.endswith("os.environ")
+    if isinstance(node.ctx, ast.Load):
+        role, direction = ("environ-get", "consume") if is_environ else ("dict-subscript", "consume")
+    elif isinstance(node.ctx, ast.Store):
+        role, direction = ("environ-set", "produce") if is_environ else ("dict-set", "produce")
+    else:
+        return
+    lid = _ensure_literal(store, sl.value, "key")
+    _emit_edge(store, src_id, lid, direction, sf.rel_path, node.lineno, node.col_offset, role)
+
+
+def make_literals_visitor(store: GraphStore, sf: SourceFile, scope: ModuleScope):
+    """Builds the walk_module(node, fi) callback without walking anything
+    itself, so pipeline.py can fold it into the same shared whole-module
+    traversal as calls.py/names.py instead of a fourth pass over the AST."""
+    mod_id = module_node_id(sf.rel_path)
+
+    def on_node(node: ast.AST, fi: Optional[FunctionInfo]) -> None:
+        src_id = function_node_id(sf.rel_path, fi.qualname) if fi is not None else mod_id
+        if isinstance(node, ast.Call):
+            _handle_call(store, sf, scope, node, src_id)
+        elif isinstance(node, ast.Subscript):
+            _handle_subscript(store, sf, scope, node, src_id)
+
+    return on_node
+
+
+def extract_literals(store: GraphStore, sf: SourceFile, scope: ModuleScope) -> None:
+    """Standalone entry point (unit tests, `cg` debug use) — pipeline.py
+    folds make_literals_visitor into the shared whole-module walk instead."""
+    if sf.tree is None:
+        return
+    walk_module(scope, make_literals_visitor(store, sf, scope))

--- a/scripts/callgraph/extract/names.py
+++ b/scripts/callgraph/extract/names.py
@@ -1,0 +1,197 @@
+"""READS_NAME / WRITES_NAME edges, and `global`-statement handling.
+
+WRITES_NAME is emitted with a precise `via` per occurrence (module-level-
+assign | global-stmt | import-binding | def-binding | augmented) — richer
+than scopes.py's coarse per-ident `binding_kind` SET, because BUG C's
+diagnosis and `cg name`'s narrative both need the LINE a given write
+happened at, not just "this ident was assigned somewhere".
+
+READS_NAME is emitted for every Load-context Name that resolves to a
+module-global NAME slot — this module's own (a plain global read) or, for
+`mod.X` where `mod` is a module-level-imported corpus module, that module's
+NAME slot (a cross-module read).
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore
+from ..scopes import FunctionInfo, ModuleScope
+from .defs import function_node_id, module_node_id, name_node_id
+from .walk import walk_module
+
+
+def _write(store: GraphStore, src_id: str, rel_path: str, ident: str, via: str, line: int) -> None:
+    nid = name_node_id(rel_path, ident)
+    if nid not in store:
+        return  # defensive: every module-level/global-declared ident should already have a NAME node from defs.py
+    store.add_edge(Edge(src=src_id, dst=nid, kind="WRITES_NAME", confidence=Confidence.PROVEN,
+                         attrs={"via": via, "line": line}))
+
+
+def _add_write_target(store: GraphStore, src_id: str, rel_path: str, target: ast.expr, via: str, line: int) -> None:
+    if isinstance(target, ast.Name):
+        _write(store, src_id, rel_path, target.id, via, line)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            _add_write_target(store, src_id, rel_path, elt, via, line)
+    elif isinstance(target, ast.Starred):
+        _add_write_target(store, src_id, rel_path, target.value, via, line)
+
+
+def _emit_module_level_writes(store: GraphStore, sf: SourceFile, mod_id: str) -> None:
+    rel = sf.rel_path
+
+    def scan(body: list[ast.stmt]) -> None:
+        for stmt in body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                _write(store, mod_id, rel, stmt.name, "def-binding", stmt.lineno)
+                continue
+            if isinstance(stmt, ast.Assign):
+                for t in stmt.targets:
+                    _add_write_target(store, mod_id, rel, t, "module-level-assign", stmt.lineno)
+            elif isinstance(stmt, ast.AnnAssign) and stmt.target is not None:
+                _add_write_target(store, mod_id, rel, stmt.target, "module-level-assign", stmt.lineno)
+            elif isinstance(stmt, ast.AugAssign):
+                _add_write_target(store, mod_id, rel, stmt.target, "augmented", stmt.lineno)
+            elif isinstance(stmt, ast.Import):
+                for alias in stmt.names:
+                    bound = alias.asname or alias.name.split(".")[0]
+                    _write(store, mod_id, rel, bound, "import-binding", stmt.lineno)
+            elif isinstance(stmt, ast.ImportFrom):
+                for alias in stmt.names:
+                    if alias.name == "*":
+                        continue
+                    bound = alias.asname or alias.name
+                    _write(store, mod_id, rel, bound, "import-binding", stmt.lineno)
+            elif isinstance(stmt, (ast.If, ast.Try, ast.With, ast.For, ast.While)):
+                for _field, value in ast.iter_fields(stmt):
+                    if isinstance(value, list):
+                        nested = [v for v in value if isinstance(v, ast.stmt)]
+                        if nested:
+                            scan(nested)
+
+    if sf.tree is not None:
+        scan(sf.tree.body)
+
+
+def _emit_global_stmt_writes(store: GraphStore, sf: SourceFile, fi: FunctionInfo) -> None:
+    global_names: set[str] = set()
+    for node in ast.walk(fi.node):
+        if isinstance(node, ast.Global):
+            global_names.update(node.names)
+    if not global_names:
+        return
+    rel = sf.rel_path
+    fn_id = function_node_id(rel, fi.qualname)
+
+    def add_target(t: ast.expr, line: int) -> None:
+        if isinstance(t, ast.Name):
+            if t.id in global_names:
+                _write(store, fn_id, rel, t.id, "global-stmt", line)
+        elif isinstance(t, (ast.Tuple, ast.List)):
+            for elt in t.elts:
+                add_target(elt, line)
+        elif isinstance(t, ast.Starred):
+            add_target(t.value, line)
+
+    def scan(node: ast.AST) -> None:
+        if node is not fi.node and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            return
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                add_target(t, node.lineno)
+        elif isinstance(node, ast.AnnAssign) and node.target is not None:
+            add_target(node.target, node.lineno)
+        elif isinstance(node, ast.AugAssign):
+            add_target(node.target, node.lineno)
+        for child in ast.iter_child_nodes(node):
+            scan(child)
+
+    for stmt in fi.node.body:
+        scan(stmt)
+
+
+def _handle_name_load(store: GraphStore, sf: SourceFile, scope: ModuleScope, mod_id: str,
+                       node: ast.Name, fi: Optional[FunctionInfo], call_func_ids: set[int]) -> None:
+    ident = node.id
+    if fi is not None:
+        locs = scope.locals_of(fi)
+        if ident in locs.nonlocal_declared:
+            return
+        if ident in locs.effective_locals:
+            return
+    nid = name_node_id(sf.rel_path, ident)
+    if nid not in store:
+        return
+    src_id = function_node_id(sf.rel_path, fi.qualname) if fi is not None else mod_id
+    store.add_edge(Edge(src=src_id, dst=nid, kind="READS_NAME", confidence=Confidence.PROVEN, attrs={
+        "line": node.lineno, "col": node.col_offset,
+        "in_call_position": id(node) in call_func_ids,
+    }))
+
+
+def _handle_attribute_load(store: GraphStore, sf: SourceFile, mod_id: str,
+                            node: ast.Attribute, fi: Optional[FunctionInfo]) -> None:
+    base = node.value
+    if not isinstance(base, ast.Name):
+        return
+    alias_edges = store.out_edges(name_node_id(sf.rel_path, base.id), "ALIASES")
+    if not alias_edges:
+        return
+    target = store.get(alias_edges[0].dst)
+    if target is None or target.kind != "MODULE" or target.path is None:
+        return
+    target_nid = name_node_id(target.path, node.attr)
+    if target_nid not in store:
+        return
+    src_id = function_node_id(sf.rel_path, fi.qualname) if fi is not None else mod_id
+    store.add_edge(Edge(src=src_id, dst=target_nid, kind="READS_NAME", confidence=Confidence.PROVEN, attrs={
+        "line": node.lineno, "col": node.col_offset, "in_call_position": False, "cross_module": True,
+    }))
+
+
+def emit_non_walk_writes(store: GraphStore, sf: SourceFile, scope: ModuleScope) -> None:
+    """The WRITES_NAME edges that don't need the shared whole-module walk
+    (module-level bindings, and each function's own `global`-declared
+    assignments) — cheap, file-local scans, run separately from
+    make_names_visitor's walk_module pass."""
+    if sf.tree is None:
+        return
+    mod_id = module_node_id(sf.rel_path)
+    _emit_module_level_writes(store, sf, mod_id)
+    for fi in scope.functions:
+        if fi.is_lambda:
+            continue
+        _emit_global_stmt_writes(store, sf, fi)
+
+
+def make_names_visitor(store: GraphStore, sf: SourceFile, scope: ModuleScope):
+    """Builds the walk_module(node, fi) callback for READS_NAME (both
+    same-module and cross-module) without walking anything itself — see
+    calls.py's make_call_visitor for why pipeline.py shares one traversal
+    between the two."""
+    mod_id = module_node_id(sf.rel_path)
+    call_func_ids = {id(c.func) for c in ast.walk(sf.tree) if isinstance(c, ast.Call)} if sf.tree is not None else set()
+
+    def on_node(node: ast.AST, fi: Optional[FunctionInfo]) -> None:
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            _handle_name_load(store, sf, scope, mod_id, node, fi, call_func_ids)
+        elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+            _handle_attribute_load(store, sf, mod_id, node, fi)
+
+    return on_node
+
+
+def extract_names(store: GraphStore, sf: SourceFile, scope: ModuleScope) -> None:
+    """Standalone entry point (unit tests, `cg` debug use) — pipeline.py
+    calls emit_non_walk_writes + make_names_visitor directly instead, to
+    share one walk_module pass with extract/calls.py."""
+    if sf.tree is None:
+        return
+    emit_non_walk_writes(store, sf, scope)
+    walk_module(scope, make_names_visitor(store, sf, scope))

--- a/scripts/callgraph/extract/registry.py
+++ b/scripts/callgraph/extract/registry.py
@@ -1,0 +1,518 @@
+"""Registration roots: REGISTRY / REGISTERS / ENTERS / ENTRYPOINT / INJECTS.
+
+Five rules, matching the design's naming exactly:
+
+  DEC       a decorator defs.py already classified "registering" (rules.toml)
+            -> one REGISTRY per (module, decorator dotted head); the
+            function's DECORATED_BY edge is RETARGETED from the placeholder
+            EXTERNAL sink defs.py created onto this REGISTRY node.
+  MAN-LOOP  `for fn in (a, b, c): <registering-call>(fn)` — a manifest tuple
+            whose loop body registers each element (e.g. `mcp.tool()(fn)`);
+            distinguished from an unrelated `for fn in (...): fn.method()`
+            utility loop by requiring the body call itself be decorator-
+            classified "registering".
+  MAN-DICT  a module-level `NAME = {"key": bare_name, ...}` (Assign or
+            AnnAssign) whose values are ALL bare Names resolving to
+            in-corpus functions — the `_SKILL_MAP` shape. A dict whose
+            values are literals (config, not dispatch) never matches.
+  ROOT-CLI  `if __name__ == "__main__":` — enters whatever bare-name call
+            appears first inside the guard, if any.
+  ROOT-EXT  rules.toml's `[[roots]]` table — hand-maintained roots living
+            outside the corpus (systemd/cron/shell), trust=declared-in-
+            roots.toml, reusing ROOT-CLI's own guard-scan to find the
+            entered function.
+
+REG-FN (register()'s parameter/deps-dict -> `global` binding, emitting
+INJECTS) is a whole-corpus pass (extract_injections) because it has to
+correlate a function's OWN definition (which globals does it inject into)
+with every CALL SITE of that function anywhere in the corpus.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ..ingest import SourceFile
+from ..model import Confidence, Edge, GraphStore, Node
+from ..rules import Rules, load_rules
+from ..scopes import FunctionInfo, ModuleScope
+from .calls import _follow_alias_to_callable, callsite_node_id
+from .defs import function_node_id, module_node_id, name_node_id
+from .walk import walk_module
+
+
+def registry_node_id(mod_path: str, label: str) -> str:
+    return f"reg:{mod_path}::{label}"
+
+
+def _ensure_registry(store: GraphStore, mod_path: str, label: str, mechanism: str, line: Optional[int]) -> str:
+    rid = registry_node_id(mod_path, label)
+    node = store.get(rid)
+    if node is None:
+        store.add_node(Node(id=rid, kind="REGISTRY", attrs={
+            "mechanism": mechanism, "keys": [], "member_count": 0, "declaration_line": line,
+        }, path=mod_path, line=line))
+    return rid
+
+
+_ENTRY_KIND_BY_RULE = {
+    "DEC-tool": "mcp-tool", "DEC-route": "fastapi", "DEC-mcp-route": "mcp-route",
+    "MAN-LOOP": "mcp-tool", "MAN-DICT": "skill",
+}
+
+
+def _add_entrypoint(store: GraphStore, key: str, fn_id: str, rule: str, evidence: str, trust: str = "declared-in-source") -> None:
+    kind = _ENTRY_KIND_BY_RULE.get(rule, "mcp-tool")
+    entry_id = f"entry:{kind}:{key}"
+    node = store.get(entry_id)
+    if node is None:
+        store.add_node(Node(id=entry_id, kind="ENTRYPOINT", attrs={
+            "kind": kind, "key": key, "evidence": evidence, "trust": trust,
+        }))
+    store.add_edge(Edge(src=entry_id, dst=fn_id, kind="ENTERS", confidence=Confidence.PROVEN,
+                         attrs={"trust": trust, "evidence": evidence}))
+
+
+def _register_member(store: GraphStore, registry_id: str, fn_id: str, key: str, line: int, rule: str, evidence: str) -> None:
+    reg_node = store.get(registry_id)
+    if reg_node is not None:
+        keys = reg_node.attrs.setdefault("keys", [])
+        if key not in keys:
+            keys.append(key)
+        reg_node.attrs["member_count"] = reg_node.attrs.get("member_count", 0) + 1
+        if reg_node.attrs.get("declaration_line") is None:
+            reg_node.attrs["declaration_line"] = line
+    store.add_edge(Edge(src=registry_id, dst=fn_id, kind="REGISTERS", confidence=Confidence.PROVEN,
+                         attrs={"key": key, "rule": rule, "line": line}))
+    _add_entrypoint(store, key, fn_id, rule, evidence)
+
+
+# -- DEC ---------------------------------------------------------------
+
+
+def _parse_decorator_call(raw: str) -> Optional[ast.Call]:
+    try:
+        expr = ast.parse(raw, mode="eval").body
+    except SyntaxError:
+        return None
+    return expr if isinstance(expr, ast.Call) else None
+
+
+def _first_string_arg(call: Optional[ast.Call]) -> Optional[str]:
+    if call is None or not call.args:
+        return None
+    a0 = call.args[0]
+    return a0.value if isinstance(a0, ast.Constant) and isinstance(a0.value, str) else None
+
+
+def _methods_kwarg(call: Optional[ast.Call]) -> Optional[str]:
+    if call is None:
+        return None
+    for kw in call.keywords:
+        if kw.arg == "methods" and isinstance(kw.value, (ast.List, ast.Tuple)):
+            names = [e.value for e in kw.value.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+            if names:
+                return "/".join(names)
+    return None
+
+
+def _dec_key_and_rule(fi: FunctionInfo, dec_head: str, raw: str) -> tuple[str, str]:
+    last = dec_head.rsplit(".", 1)[-1]
+    call = _parse_decorator_call(raw)
+    if last in ("get", "post", "put", "delete", "patch"):
+        path = _first_string_arg(call) or "?"
+        return f"{last.upper()} {path}", "DEC-route"
+    if last == "route":
+        path = _first_string_arg(call) or "?"
+        methods = _methods_kwarg(call) or "ROUTE"
+        return f"{methods} {path}", "DEC-route"
+    if last == "custom_route":
+        path = _first_string_arg(call) or "?"
+        methods = _methods_kwarg(call) or "ROUTE"
+        return f"{methods} {path}", "DEC-mcp-route"
+    return fi.qualname, "DEC-tool"
+
+
+def _extract_dec(store: GraphStore, sf: SourceFile, scope: ModuleScope) -> None:
+    mod_path = sf.rel_path
+    for fi in scope.functions:
+        if fi.is_lambda or fi.is_nested:
+            continue
+        fid = function_node_id(mod_path, fi.qualname)
+        for edge in list(store.out_edges(fid, "DECORATED_BY")):
+            if edge.attrs.get("classification") != "registering":
+                continue
+            ext_node = store.get(edge.dst)
+            dec_head = ext_node.attrs.get("dotted") if ext_node is not None else edge.attrs.get("raw", "").split("(")[0]
+            key, rule = _dec_key_and_rule(fi, dec_head, edge.attrs.get("raw", ""))
+            line = edge.attrs.get("line") or fi.lineno
+            registry_id = _ensure_registry(store, mod_path, dec_head, "decorator", line)
+            store.retarget_edge(edge, registry_id)
+            _register_member(store, registry_id, fid, key, line, rule, f"{mod_path}:{line}")
+
+
+# -- MAN-LOOP ------------------------------------------------------------
+
+
+def _dotted_head(target: ast.expr) -> Optional[str]:
+    parts: list[str] = []
+    cur = target
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _loop_body_registers_var(body: list[ast.stmt], varname: str, rules: Rules) -> bool:
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Call):
+                continue
+            if len(node.args) != 1 or not isinstance(node.args[0], ast.Name) or node.args[0].id != varname:
+                continue
+            head = _dotted_head(node.func.func)
+            if head is not None and rules.classify_decorator(head) == "registering":
+                return True
+    return False
+
+
+def _extract_manloop(store: GraphStore, sf: SourceFile, scope: ModuleScope, top_level_index) -> None:
+    if sf.tree is None:
+        return
+    rules = load_rules()
+    mod_path = sf.rel_path
+    for fi in scope.functions:
+        if fi.is_lambda:
+            continue
+        for node in ast.walk(fi.node):
+            if not isinstance(node, ast.For) or not isinstance(node.target, ast.Name):
+                continue
+            if not isinstance(node.iter, (ast.Tuple, ast.List)):
+                continue
+            elts = node.iter.elts
+            if not elts or not all(isinstance(e, ast.Name) for e in elts):
+                continue
+            if not _loop_body_registers_var(node.body, node.target.id, rules):
+                continue
+            registry_id = _ensure_registry(store, mod_path, fi.qualname, "manifest-tuple", node.lineno)
+            enclosing_id = function_node_id(mod_path, fi.qualname)
+            for e in elts:
+                target_id = top_level_index.get(mod_path, {}).get(e.id)
+                dst = target_id if target_id is not None else f"ext:{mod_path}::{e.id}"
+                store.add_edge(Edge(src=enclosing_id, dst=dst, kind="REFERENCES", confidence=Confidence.PROVEN,
+                                     attrs={"form": "manifest-tuple-element", "line": e.lineno}))
+                if target_id is not None and store.get(target_id) is not None and store.get(target_id).kind == "FUNCTION":
+                    _register_member(store, registry_id, target_id, e.id, e.lineno, "MAN-LOOP", f"{mod_path}:{e.lineno}")
+
+
+# -- MAN-DICT --------------------------------------------------------------
+
+
+def _extract_mandict(store: GraphStore, sf: SourceFile, top_level_index) -> None:
+    if sf.tree is None:
+        return
+    mod_path = sf.rel_path
+    for stmt in sf.tree.body:
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+            target, value = stmt.targets[0], stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+            target, value = stmt.target, stmt.value
+        else:
+            continue
+        if not isinstance(target, ast.Name) or not isinstance(value, ast.Dict):
+            continue
+        if not value.keys or any(k is None for k in value.keys):
+            continue
+        if not all(isinstance(k, ast.Constant) and isinstance(k.value, str) for k in value.keys):
+            continue
+        if not all(isinstance(v, ast.Name) for v in value.values):
+            continue
+        resolved = []
+        ok = True
+        for k, v in zip(value.keys, value.values):
+            fid = top_level_index.get(mod_path, {}).get(v.id)
+            if fid is None or store.get(fid) is None or store.get(fid).kind != "FUNCTION":
+                ok = False
+                break
+            resolved.append((k.value, fid, v.lineno))
+        if not ok or not resolved:
+            continue
+        registry_id = _ensure_registry(store, mod_path, target.id, "manifest-dict", stmt.lineno)
+        mod_id = module_node_id(mod_path)
+        for key, fid, line in resolved:
+            store.add_edge(Edge(src=mod_id, dst=fid, kind="REFERENCES", confidence=Confidence.PROVEN,
+                                 attrs={"form": "manifest-dict-value", "line": line}))
+            _register_member(store, registry_id, fid, key, line, "MAN-DICT", f"{mod_path}:{line}")
+
+
+# -- ROOT-CLI / ROOT-EXT ------------------------------------------------
+
+
+def _find_main_guard(tree: ast.Module) -> Optional[ast.If]:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.If):
+            test = stmt.test
+            if isinstance(test, ast.Compare) and len(test.comparators) == 1:
+                left, right = test.left, test.comparators[0]
+                names = {n for n in (left, right) if isinstance(n, ast.Name)}
+                lits = {n.value for n in (left, right) if isinstance(n, ast.Constant)}
+                if any(n.id == "__name__" for n in names) and "__main__" in lits:
+                    return stmt
+    return None
+
+
+def _main_guard_entry_function(sf: SourceFile, top_level_index) -> tuple[Optional[str], Optional[int]]:
+    if sf.tree is None:
+        return None, None
+    guard = _find_main_guard(sf.tree)
+    if guard is None:
+        return None, None
+    for stmt in guard.body:
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                target_id = top_level_index.get(sf.rel_path, {}).get(node.func.id)
+                if target_id is not None and store_kind_is_function(target_id, top_level_index):
+                    return target_id, node.lineno
+    return None, guard.lineno
+
+
+def store_kind_is_function(node_id: str, top_level_index) -> bool:
+    # top_level_index only ever holds FUNCTION/CLASS ids; a CLASS id here
+    # would mean `if __name__ == "__main__": SomeClass()` — not a function
+    # entry, deliberately not modelled (rare, and not worth guessing an
+    # __init__ target for what's usually direct script driver code).
+    return not node_id.startswith("cls:")
+
+
+def _extract_rootcli(store: GraphStore, sf: SourceFile, top_level_index) -> None:
+    if sf.tree is None or _find_main_guard(sf.tree) is None:
+        return
+    mod_path = sf.rel_path
+    guard = _find_main_guard(sf.tree)
+    entry_fn_id, line = _main_guard_entry_function(sf, top_level_index)
+    entry_id = f"entry:cli:{mod_path}"
+    evidence = f"{mod_path}:{guard.lineno}"
+    store.add_node(Node(id=entry_id, kind="ENTRYPOINT", attrs={
+        "kind": "cli", "key": mod_path, "evidence": evidence, "trust": "declared-in-source",
+    }))
+    if entry_fn_id is not None:
+        store.add_edge(Edge(src=entry_id, dst=entry_fn_id, kind="ENTERS", confidence=Confidence.PROVEN,
+                             attrs={"trust": "declared-in-source", "line": line}))
+
+
+def extract_registry_module(store: GraphStore, sf: SourceFile, scope: ModuleScope, top_level_index) -> None:
+    """The four per-file rules (DEC, MAN-LOOP, MAN-DICT, ROOT-CLI). Call once
+    per source file, after defs.py/imports.py have both run for every file
+    in the corpus (top_level_index needs every module's FUNCTION/CLASS
+    nodes already created)."""
+    _extract_dec(store, sf, scope)
+    _extract_manloop(store, sf, scope, top_level_index)
+    _extract_mandict(store, sf, top_level_index)
+    _extract_rootcli(store, sf, top_level_index)
+
+
+def extract_external_roots(store: GraphStore, sources: list[SourceFile], top_level_index) -> None:
+    """ROOT-EXT: rules.toml's `[[roots]]` table. Call once for the whole
+    corpus, after extract_registry_module has run for every file (so the
+    ROOT-CLI ENTERS edge it may reuse already exists)."""
+    rules = load_rules()
+    by_path = {sf.rel_path: sf for sf in sources}
+    for root in rules.roots:
+        mod_path = root.get("module")
+        evidence = root.get("evidence", mod_path or "roots.toml")
+        sf = by_path.get(mod_path) if mod_path else None
+        entry_id = f"entry:external:{evidence}"
+        store.add_node(Node(id=entry_id, kind="ENTRYPOINT", attrs={
+            "kind": "external", "key": mod_path, "evidence": evidence, "trust": "declared-in-roots.toml",
+        }))
+        if sf is None:
+            continue
+        entry_fn_id, line = _main_guard_entry_function(sf, top_level_index)
+        if entry_fn_id is not None:
+            store.add_edge(Edge(src=entry_id, dst=entry_fn_id, kind="ENTERS", confidence=Confidence.PROVEN,
+                                 attrs={"trust": "declared-in-roots.toml", "line": line}))
+
+
+# -- REG-FN / INJECTS ----------------------------------------------------
+
+
+@dataclass
+class InjectorSpec:
+    fn_id: str
+    owning_module: str
+    direct: dict[str, str] = field(default_factory=dict)          # param_name -> global ident
+    dict_keys: dict[tuple[str, str], str] = field(default_factory=dict)  # (dict_param, key) -> global ident
+
+
+def _build_injector_specs(scopes: dict[str, ModuleScope], rules: Rules) -> dict[str, InjectorSpec]:
+    specs: dict[str, InjectorSpec] = {}
+    for mod_path, scope in scopes.items():
+        for fi in scope.functions:
+            if fi.is_nested or fi.is_method or fi.is_lambda:
+                continue
+            simple_name = fi.qualname.rsplit(".", 1)[-1]
+            if not rules.is_register_fn_name(simple_name):
+                continue
+            global_names: set[str] = set()
+            for node in ast.walk(fi.node):
+                if isinstance(node, ast.Global):
+                    global_names.update(node.names)
+            if not global_names:
+                continue
+            param_names = {p.name for p in fi.params}
+            direct: dict[str, str] = {}
+            dict_keys: dict[tuple[str, str], str] = {}
+            for node in ast.walk(fi.node):
+                if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                    continue
+                tgt = node.targets[0]
+                if not isinstance(tgt, ast.Name) or tgt.id not in global_names:
+                    continue
+                val = node.value
+                if isinstance(val, ast.Name) and val.id in param_names:
+                    direct[val.id] = tgt.id
+                elif (isinstance(val, ast.Subscript) and isinstance(val.value, ast.Name)
+                      and val.value.id in param_names):
+                    key_node = val.slice
+                    if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str):
+                        dict_keys[(val.value.id, key_node.value)] = tgt.id
+            if direct or dict_keys:
+                fid = function_node_id(mod_path, fi.qualname)
+                specs[fid] = InjectorSpec(fid, mod_path, direct, dict_keys)
+    return specs
+
+
+def _resolve_register_call_target(store: GraphStore, sf: SourceFile, top_level_index, node: ast.Call) -> Optional[str]:
+    func = node.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        alias_edges = store.out_edges(name_node_id(sf.rel_path, func.value.id), "ALIASES")
+        if alias_edges:
+            target = store.get(alias_edges[0].dst)
+            if target is not None and target.kind == "MODULE" and target.path is not None:
+                return top_level_index.get(target.path, {}).get(func.attr)
+        return None
+    if isinstance(func, ast.Name):
+        return top_level_index.get(sf.rel_path, {}).get(func.id)
+    return None
+
+
+def _resolve_injected_value(store: GraphStore, sf: SourceFile, scope: ModuleScope, top_level_index, expr: ast.expr):
+    if isinstance(expr, ast.Lambda):
+        qual = scope.qualname_for_node(expr)
+        if qual:
+            fid = function_node_id(sf.rel_path, qual)
+            if fid in store:
+                return fid, "FUNCTION"
+        return None, "unknown"
+    if isinstance(expr, ast.Name):
+        fid = top_level_index.get(sf.rel_path, {}).get(expr.id)
+        if fid is not None:
+            node = store.get(fid)
+            return fid, (node.kind if node is not None else "unknown")
+        # Not defined in THIS module — maybe it's imported here (e.g.
+        # `from qdrant_ops import _qdrant_upsert` re-exported and then
+        # passed straight through to register()); chase the NAME slot's
+        # own ALIASES edge(s) to the real definition before giving up.
+        nid = name_node_id(sf.rel_path, expr.id)
+        resolved = _follow_alias_to_callable(store, nid)
+        if resolved is not None:
+            target_id, _conf, _extra = resolved
+            tnode = store.get(target_id)
+            return target_id, (tnode.kind if tnode is not None else "unknown")
+        if nid in store:
+            return nid, "NAME"
+        return None, "unknown"
+    if isinstance(expr, ast.Constant):
+        return None, "LITERAL"
+    return None, "unknown"
+
+
+def _bind_call_args(store: GraphStore, spec: InjectorSpec, call_node: ast.Call) -> dict[str, ast.expr]:
+    fn_node = store.get(spec.fn_id)
+    param_order = [p["name"] for p in fn_node.attrs.get("params", [])] if fn_node is not None else []
+    bound: dict[str, ast.expr] = {}
+    for i, arg in enumerate(call_node.args):
+        if i < len(param_order):
+            bound[param_order[i]] = arg
+    for kw in call_node.keywords:
+        if kw.arg is not None:
+            bound[kw.arg] = kw.value
+    return bound
+
+
+def _emit_inject(store: GraphStore, callsite_id: str, enclosing_id: str, owning_module: str,
+                  global_ident: str, value_id, value_kind: str, param_name: str, dict_key: Optional[str],
+                  line: int) -> None:
+    dst = name_node_id(owning_module, global_ident)
+    attrs = {"value": value_id, "value_kind": value_kind, "param": param_name, "line": line}
+    if dict_key is not None:
+        attrs["key"] = dict_key
+    store.add_edge(Edge(src=callsite_id, dst=dst, kind="INJECTS", confidence=Confidence.PROBABLE, attrs=attrs))
+    if value_id is not None and value_kind == "FUNCTION":
+        store.add_edge(Edge(src=enclosing_id, dst=value_id, kind="REFERENCES", confidence=Confidence.PROVEN,
+                             attrs={"form": "injected-argument", "param": param_name, "key": dict_key, "line": line}))
+
+
+def extract_injections(store: GraphStore, sources: list[SourceFile], scopes: dict[str, ModuleScope],
+                        top_level_index) -> None:
+    """REG-FN: whole-corpus pass. Finds every `<module>.register(...)`-shaped
+    call site targeting a function with an InjectorSpec, matches call
+    arguments to injected params/deps-dict keys, and emits INJECTS
+    (CALLSITE -> NAME, value=resolved arg) plus a REFERENCES edge for any
+    argument that is itself a function/lambda reference."""
+    rules = load_rules()
+    specs = _build_injector_specs(scopes, rules)
+    if not specs:
+        return
+    for sf in sources:
+        scope = scopes.get(sf.rel_path)
+        if scope is None or sf.tree is None:
+            continue
+
+        def on_node(node: ast.AST, fi: Optional[FunctionInfo], _sf=sf, _scope=scope) -> None:
+            if not isinstance(node, ast.Call):
+                return
+            target_fid = _resolve_register_call_target(store, _sf, top_level_index, node)
+            if target_fid is None or target_fid not in specs:
+                return
+            spec = specs[target_fid]
+            bound = _bind_call_args(store, spec, node)
+            callsite_id = callsite_node_id(_sf.rel_path, node.lineno, node.col_offset,
+                                            getattr(node, "end_lineno", node.lineno),
+                                            getattr(node, "end_col_offset", node.col_offset))
+            enclosing_id = function_node_id(_sf.rel_path, fi.qualname) if fi is not None else module_node_id(_sf.rel_path)
+
+            for param_name, global_ident in spec.direct.items():
+                expr = bound.get(param_name)
+                if expr is None:
+                    continue
+                value_id, value_kind = _resolve_injected_value(store, _sf, _scope, top_level_index, expr)
+                _emit_inject(store, callsite_id, enclosing_id, spec.owning_module, global_ident,
+                             value_id, value_kind, param_name, None, node.lineno)
+
+            dict_params = {p for (p, _k) in spec.dict_keys}
+            for dict_param in dict_params:
+                dict_expr = bound.get(dict_param)
+                if not isinstance(dict_expr, ast.Dict):
+                    continue
+                literal_map = {
+                    k.value: v for k, v in zip(dict_expr.keys, dict_expr.values)
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                }
+                for (p, key), global_ident in spec.dict_keys.items():
+                    if p != dict_param:
+                        continue
+                    vexpr = literal_map.get(key)
+                    if vexpr is None:
+                        continue
+                    value_id, value_kind = _resolve_injected_value(store, _sf, _scope, top_level_index, vexpr)
+                    _emit_inject(store, callsite_id, enclosing_id, spec.owning_module, global_ident,
+                                 value_id, value_kind, dict_param, key, node.lineno)
+
+        walk_module(scope, on_node)

--- a/scripts/callgraph/extract/walk.py
+++ b/scripts/callgraph/extract/walk.py
@@ -1,0 +1,41 @@
+"""One shared whole-module AST walk that tracks "am I at module level or
+inside which FUNCTION" as it goes, used by extract/calls.py, extract/names.py
+and extract/registry.py's REG-FN pass so all three attribute nodes to the
+same enclosing scope consistently instead of each re-deriving it (which risks
+disagreeing on ambiguous-duplicate qualnames).
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Callable, Optional
+
+from ..scopes import FunctionInfo, ModuleScope
+
+OnNode = Callable[[ast.AST, Optional[FunctionInfo]], None]
+
+
+def walk_module(scope: ModuleScope, on_node: OnNode) -> None:
+    """Visit every node reachable from the module body exactly once,
+    calling on_node(node, enclosing_fi) — enclosing_fi is None at module
+    level, else the FunctionInfo (function, method, or lambda) the node
+    lexically sits inside, per ModuleScope's own qualname assignment."""
+    tree = scope.sf.tree
+    if tree is None:
+        return
+
+    def visit(node: ast.AST, current: Optional[FunctionInfo]) -> None:
+        on_node(node, current)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            qual = scope.qualname_for_node(node)
+            fi = scope.function_by_qualname.get(qual) if qual else None
+            nxt = fi if fi is not None else current
+            for child in ast.iter_child_nodes(node):
+                visit(child, nxt)
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child, current)
+
+    for stmt in tree.body:
+        visit(stmt, None)

--- a/scripts/callgraph/fixtures/calls_shapes.py
+++ b/scripts/callgraph/fixtures/calls_shapes.py
@@ -1,0 +1,62 @@
+"""Fixture: one of every CALLS resolution rung this slice implements
+(name-def-local, nested-def-local, name-constructor, self-attribute,
+module-attribute in-corpus, module-attribute-external via a bare stdlib
+import, builtin, function-local import), plus the two "not yet resolvable"
+shapes (param-call, attribute-unknown-receiver) that must land on `?`."""
+import json
+
+import calls_target
+
+
+def helper(x):
+    return x + 1
+
+
+def caller_name_def_local():
+    return helper(1)
+
+
+def outer_with_nested():
+    def helper_nested():
+        return 1
+    return helper_nested()
+
+
+class Widget:
+    def __init__(self, n):
+        self.n = n
+
+    def bump(self):
+        return self.other()
+
+    def other(self):
+        return self.n
+
+
+def make_widget():
+    return Widget(3)
+
+
+def caller_module_attribute_external():
+    return json.dumps({"a": 1})
+
+
+def caller_module_attribute_corpus():
+    return calls_target.target_fn(2)
+
+
+def caller_builtin():
+    return len([1, 2, 3])
+
+
+def caller_local_import():
+    import textwrap
+    return textwrap.dedent("  x")
+
+
+def caller_param_call(callback):
+    return callback()
+
+
+def caller_unknown_attribute(obj):
+    return obj.mystery_method()

--- a/scripts/callgraph/fixtures/calls_target.py
+++ b/scripts/callgraph/fixtures/calls_target.py
@@ -1,0 +1,6 @@
+"""Fixture: the sibling module calls_shapes.py imports, for the
+module-attribute (in-corpus) CALLS rung."""
+
+
+def target_fn(x: int) -> int:
+    return x * 2

--- a/scripts/callgraph/fixtures/dangling_global.py
+++ b/scripts/callgraph/fixtures/dangling_global.py
@@ -1,0 +1,19 @@
+"""Fixture: mirrors BUG C (mcp/graph_tools.py's `_symbol_index_cache`) — a
+function declares a name `global`, assigns it, but the module never binds
+that name at module level anywhere. The real slot lives in a different
+module (see reexport_source.py's `_INTERNAL_STATE` for a contrast: a name
+that IS bound at module level, so it must NOT be flagged global-only)."""
+
+
+def invalidate_cache():
+    global _symbol_index_cache, _symbol_index_count
+    _symbol_index_cache = {}
+    _symbol_index_count = 0
+
+
+def bump(n):
+    global _real_counter
+    _real_counter += n
+
+
+_real_counter = 0  # module-level binding: this one must NOT be global-only

--- a/scripts/callgraph/fixtures/dangling_global_real_slot.py
+++ b/scripts/callgraph/fixtures/dangling_global_real_slot.py
@@ -1,0 +1,14 @@
+"""Fixture: the module dangling_global.py's `_symbol_index_cache` /
+`_symbol_index_count` OUGHT to have been reading/writing — mirrors
+mcp/ladybug_ops.py:106-107 relative to mcp/graph_tools.py's dangling
+`global` in real BUG C. Module-level-bound (not global-only), so
+`cg writes-dead`'s dangling-global check must name THIS module as the real
+slot when diagnosing dangling_global.py's finding."""
+_symbol_index_cache = None
+_symbol_index_count = -1
+
+
+def rebuild(count):
+    global _symbol_index_cache, _symbol_index_count
+    _symbol_index_cache = {}
+    _symbol_index_count = count

--- a/scripts/callgraph/fixtures/decorator_registry.py
+++ b/scripts/callgraph/fixtures/decorator_registry.py
@@ -1,0 +1,31 @@
+"""Fixture: the @mcp.tool()-style registration decorator shape, plus a
+FastAPI-style route decorator, a wrapping decorator, and one decorator no
+rule should recognize (used to assert `classify_decorator` returns
+"unknown" rather than silently mis-tagging it as registering)."""
+import functools
+
+
+class _FakeMCP:
+    def tool(self):
+        def deco(fn):
+            return fn
+        return deco
+
+
+mcp = _FakeMCP()
+
+
+@mcp.tool()
+def registered_tool(x: int, y: str = "default") -> dict:
+    """First line of the docstring."""
+    return {"x": x, "y": y}
+
+
+@functools.lru_cache
+def cached_helper(n: int) -> int:
+    return n * 2
+
+
+@some_unrecognized_decorator
+def mystery(z):
+    return z

--- a/scripts/callgraph/fixtures/dispatch_shapes.py
+++ b/scripts/callgraph/fixtures/dispatch_shapes.py
@@ -1,0 +1,38 @@
+"""Fixture: rung 6 (unique-method-name) and the getattr-literal rung for
+extract/dispatch.py — a call whose receiver's type this tool cannot know
+(so rungs 1-3 park it on `?` with reason "attribute-unknown-receiver"), one
+case where exactly one corpus-wide method answers to the call's attribute
+name and one where two do, plus getattr(<module>, "<literal>") vs
+getattr(<module>, <variable>)."""
+import dispatch_target
+
+
+class OnlyOwner:
+    def unique_op(self):
+        return 1
+
+
+class OwnerA:
+    def shared_op(self):
+        return "a"
+
+
+class OwnerB:
+    def shared_op(self):
+        return "b"
+
+
+def call_unique_method(obj):
+    return obj.unique_op()
+
+
+def call_ambiguous_method(obj):
+    return obj.shared_op()
+
+
+def call_getattr_literal():
+    return getattr(dispatch_target, "target_fn")(1)
+
+
+def call_getattr_variable(name):
+    return getattr(dispatch_target, name)(1)

--- a/scripts/callgraph/fixtures/dispatch_target.py
+++ b/scripts/callgraph/fixtures/dispatch_target.py
@@ -1,0 +1,5 @@
+"""Fixture: sibling module for dispatch_shapes.py's getattr-literal case."""
+
+
+def target_fn(x: int) -> int:
+    return x * 3

--- a/scripts/callgraph/fixtures/flags_shapes.py
+++ b/scripts/callgraph/fixtures/flags_shapes.py
@@ -1,0 +1,57 @@
+"""Fixture: mirrors BUG B's shape (mcp/grounding.py's `ground()`) in
+miniature — a constant-initialized local, reassigned only inside guarded
+branches, escaping as a dict value, with several guarded early exits that
+skip it entirely. Also exercises the other escape forms (direct-return,
+tuple-element, closure) and the non-escaping-local negative case."""
+
+
+def assemble(items, use_extra):
+    ok = False              # init: top-level-of-body, constant
+    parts = []
+    for item in items:
+        if not item:
+            break            # guard exit: skips `ok`
+        try:
+            parts.append(str(item))
+        except Exception:
+            continue          # guard exit: skips `ok`
+
+    if use_extra and parts:
+        ok = True             # guarded assignment #1
+    elif use_extra:
+        ok = True             # guarded assignment #2 (same branch family, elif)
+    else:
+        for p in parts:
+            if not p:
+                continue       # guard exit: skips `ok`
+
+    return {"parts": parts, "ok": ok}
+
+
+def direct_return_case(x):
+    result = x * 2
+    return result
+
+
+def tuple_return_case(a, b):
+    total = a + b
+    return (a, total, b)
+
+
+def make_adder(n):
+    base = n
+    step = 1
+
+    def add(x):
+        return x + base + step
+
+    return add
+
+
+def no_escape_case():
+    unused_local = compute_something()
+    return "constant, never returned"
+
+
+def compute_something():
+    return 42

--- a/scripts/callgraph/fixtures/lazy_import.py
+++ b/scripts/callgraph/fixtures/lazy_import.py
@@ -1,0 +1,15 @@
+"""Fixture: a function-local ("lazy") import, plus a module-level one, so
+IMPORTS edges can be asserted to carry the right `scope` and
+`enclosing_fn`."""
+import json  # module-level
+
+
+def resolve_vllm():
+    import numpy  # function-local: only live inside this function's scope
+    return numpy.array([1, 2, 3])
+
+
+class Widget:
+    def render(self):
+        import textwrap  # function-local, inside a method
+        return textwrap.dedent(json.dumps({"ok": True}))

--- a/scripts/callgraph/fixtures/literals_consume.py
+++ b/scripts/callgraph/fixtures/literals_consume.py
@@ -1,0 +1,22 @@
+"""Fixture: mirrors BUG D's consumer half — scripts/graph_facts.py:33's
+`glob.glob(os.path.expanduser("~/.hermes/**/graph.kuzu"), recursive=True)`.
+`graph.kuzu` (tail literal after `**` -> `*` normalization: `graph.kuzu`)
+shares NOTHING textually with `graph.ladybug` in literals_produce.py except
+the `graph` stem — a --near-miss lead, not a match. `open(path)` (default
+mode) is the other consume shape this fixture exercises, deliberately using
+a DIFFERENT literal (`notes.jsonl`, matching literals_produce.py's
+`write_text` producer exactly) so the base literal_table view has one
+genuinely matched pair to assert on."""
+import glob
+import os
+
+from literals_produce import MEMORY_DIR
+
+
+def find_databases():
+    return glob.glob(os.path.expanduser("~/.hermes/**/graph.kuzu"), recursive=True)
+
+
+def read_note():
+    with open(MEMORY_DIR / "notes.jsonl") as f:
+        return f.read()

--- a/scripts/callgraph/fixtures/literals_keys.py
+++ b/scripts/callgraph/fixtures/literals_keys.py
@@ -1,0 +1,19 @@
+"""Fixture: KEY-LIKE literal shapes — os.environ.get/subscript and
+dict.get/subscript, both read and write positions."""
+import os
+
+
+def read_port():
+    return os.environ.get("HERMES_PORT")
+
+
+def set_port(v):
+    os.environ["HERMES_PORT"] = v
+
+
+def read_config_key(cfg: dict):
+    return cfg.get("cfg_lookup_only")   # consumer-only key: nothing ever sets it
+
+
+def write_config_key(cfg: dict, v):
+    cfg["cfg_write_only"] = v           # producer-only key: nothing ever reads it

--- a/scripts/callgraph/fixtures/literals_produce.py
+++ b/scripts/callgraph/fixtures/literals_produce.py
@@ -1,0 +1,21 @@
+"""Fixture: mirrors BUG D's producer half — mcp/server.py:261's
+`LadybugStore(str(MEMORY_DIR / "graph.ladybug"))`. `SomeStore(...)` is
+matched by the Store-ctor suffix rule; the PATHEXPR's tail literal is
+`graph.ladybug`. `write_text` on a composed path is the other produce
+shape this fixture exercises."""
+from pathlib import Path
+
+MEMORY_DIR = Path.home() / ".hermes"
+
+
+class SomeStore:
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+
+def open_store():
+    return SomeStore(str(MEMORY_DIR / "graph.ladybug"))
+
+
+def write_note(text: str) -> None:
+    (MEMORY_DIR / "notes.jsonl").write_text(text)

--- a/scripts/callgraph/fixtures/names_cross_module.py
+++ b/scripts/callgraph/fixtures/names_cross_module.py
@@ -1,0 +1,9 @@
+"""Fixture: a cross-module READS_NAME — `names_cross_module_target.CONFIG_VALUE`
+read through a module-level import, mirroring "ladybug_ops reading
+server.MEMORY_DIR" (a read via an imported module, not a coincidence of
+matching names)."""
+import names_cross_module_target
+
+
+def read_it():
+    return names_cross_module_target.CONFIG_VALUE

--- a/scripts/callgraph/fixtures/names_cross_module_target.py
+++ b/scripts/callgraph/fixtures/names_cross_module_target.py
@@ -1,0 +1,3 @@
+"""Fixture: the module names_cross_module.py reads a NAME slot from, via
+`mod.X` on a module-level import."""
+CONFIG_VALUE = 42

--- a/scripts/callgraph/fixtures/nesting.py
+++ b/scripts/callgraph/fixtures/nesting.py
@@ -1,0 +1,21 @@
+"""Fixture: nesting shapes for qualname construction — a plain function, a
+method, a function nested inside a function, and a lambda nested inside a
+function (the `register.<locals>.<lambda>@N`-shaped case)."""
+
+
+def outer():
+    def inner():
+        return 1
+    return inner
+
+
+def register(mcp, callback):
+    mcp.tool()(callback)
+
+
+register(None, lambda: 42)
+
+
+class Widget:
+    def method(self):
+        return self

--- a/scripts/callgraph/fixtures/pkg/mcp/sibling.py
+++ b/scripts/callgraph/fixtures/pkg/mcp/sibling.py
@@ -1,0 +1,6 @@
+"""Fixture: the module reached only via pkg/scripts/entry.py's sys.path
+insert — a flat sibling import with no __init__.py anywhere in sight."""
+
+
+def helper() -> str:
+    return "ok"

--- a/scripts/callgraph/fixtures/pkg/scripts/entry.py
+++ b/scripts/callgraph/fixtures/pkg/scripts/entry.py
@@ -1,0 +1,10 @@
+"""Fixture: the "10 scripts prepend ../mcp" pattern, so resolve.py's
+constant-folding of sys.path.insert(0, os.path.join(dirname(abspath(
+__file__)), "..", "mcp")) can be tested against something other than the
+live, editable repo."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+
+import sibling  # noqa: E402  (import after the sys.path.insert, on purpose)

--- a/scripts/callgraph/fixtures/reexport.py
+++ b/scripts/callgraph/fixtures/reexport.py
@@ -1,0 +1,8 @@
+"""Fixture: re-exports names from reexport_source.py, mirroring
+mcp/server.py:7401's `from graph_tools import (symbol_impact, ...)`, plus a
+bare module-level `A = B` alias."""
+from reexport_source import symbol_impact, impact_report
+
+# Bare module-level aliasing: `runner` should ALIAS to symbol_impact's
+# FUNCTION node, not create a second, disconnected identity for it.
+runner = symbol_impact

--- a/scripts/callgraph/fixtures/reexport_source.py
+++ b/scripts/callgraph/fixtures/reexport_source.py
@@ -1,0 +1,13 @@
+"""Fixture: the module a re-export pulls from (mirrors mcp/graph_tools.py's
+role relative to mcp/server.py)."""
+
+
+def symbol_impact(name: str) -> dict:
+    return {"name": name}
+
+
+def impact_report(name: str) -> list:
+    return []
+
+
+_INTERNAL_STATE = None

--- a/scripts/callgraph/fixtures/registry_injection.py
+++ b/scripts/callgraph/fixtures/registry_injection.py
@@ -1,0 +1,27 @@
+"""Fixture: REG-FN's injector side — a `register()` that assigns one
+parameter straight to a `global`-declared slot, and pulls a second slot out
+of a `deps["key"]` dict parameter. Mirrors graph_tools.py/
+investigation_tools.py's real shape exactly."""
+_get_thing = None
+_helper_a = None
+
+
+def register(get_thing, deps):
+    global _get_thing, _helper_a
+    _get_thing = get_thing
+    _helper_a = deps["helper_a"]
+
+
+def use_thing():
+    """Mirrors graph_tools.py's tool functions: a bare call to the
+    module-global slot `register()` fills in, resolvable only once
+    extract/dispatch.py's rung 4 (name-via-injected-global) has run."""
+    return _get_thing()
+
+
+def call_use_thing():
+    """A PROVEN (name-def-local) hop onto use_thing's own PROBABLE
+    (name-via-injected-global) hop — fixture for the path-confidence
+    combinator: the two-hop path from here to real_thing must report
+    PROBABLE overall, the weaker of the two links, not PROVEN."""
+    return use_thing()

--- a/scripts/callgraph/fixtures/registry_injection_caller.py
+++ b/scripts/callgraph/fixtures/registry_injection_caller.py
@@ -1,0 +1,16 @@
+"""Fixture: REG-FN's call-site side — mirrors
+`graph_tools.register(mcp, _get_ladybug)` at mcp/server.py: a module-level
+call passing a bare function reference for the direct param and a dict
+literal (bare-name values) for the deps param."""
+import registry_injection
+
+
+def real_thing():
+    return 1
+
+
+def real_helper_a():
+    return 2
+
+
+registry_injection.register(real_thing, {"helper_a": real_helper_a})

--- a/scripts/callgraph/fixtures/registry_injection_caller2.py
+++ b/scripts/callgraph/fixtures/registry_injection_caller2.py
@@ -1,0 +1,15 @@
+"""Fixture: REG-FN's RE-ENTRANT registration side — a second call to
+register() with a different function reference for `get_thing`, widening
+the injected value into a set (`register()` called twice — tests do this in
+the real corpus too). Kept in its own file, separate from
+registry_injection_caller.py, so the single-value INJECTS tests
+(test_extract_registry.py) stay exactly single-value; only the multi-value
+DISPATCHES test loads this file."""
+import registry_injection
+
+
+def other_thing():
+    return 99
+
+
+registry_injection.register(other_thing, {"helper_a": other_thing})

--- a/scripts/callgraph/fixtures/registry_mandict.py
+++ b/scripts/callgraph/fixtures/registry_mandict.py
@@ -1,0 +1,41 @@
+"""Fixture: MAN-DICT — the `_SKILL_MAP` shape (a module-level, annotated
+dict-of-bare-callables), and a config dict with literal values that must
+NOT be classified as a dispatch table."""
+from typing import Any
+
+
+def skill_one(task):
+    return task
+
+
+def skill_two(task):
+    return task
+
+
+_SKILL_MAP: dict[str, Any] = {
+    "one": skill_one,
+    "two": skill_two,
+}
+
+_CONFIG_MAP = {
+    "high": 0.9,
+    "low": 0.1,
+}
+
+
+def dispatch(skill_id, task):
+    """Mirrors a2a_server/server.py's `_dispatch`: a bare-name callsite
+    (`handler(task)`) whose callee was assigned two lines earlier from
+    `_SKILL_MAP.get(skill_id)` — resolvable only via extract/dispatch.py's
+    rung 5 (dict-dispatch), which fans out via DISPATCHES to every
+    registered member instead of guessing one."""
+    handler = _SKILL_MAP.get(skill_id)
+    if not handler:
+        return None
+    return handler(task)
+
+
+def dispatch_subscript(skill_id, task):
+    """Same shape, subscript form instead of `.get(...)`."""
+    handler = _SKILL_MAP[skill_id]
+    return handler(task)

--- a/scripts/callgraph/fixtures/registry_manloop.py
+++ b/scripts/callgraph/fixtures/registry_manloop.py
@@ -1,0 +1,34 @@
+"""Fixture: MAN-LOOP — a manifest tuple whose loop body registers each
+element via `<obj>.tool()(fn)` — and, right next to it, a loop over an
+equally bare-name tuple whose body just calls a method ON each element
+(backends.py's real `_reset_cache` shape). The second loop must NOT be
+classified MAN-LOOP: only the registering-call shape qualifies."""
+
+
+class _FakeMCP:
+    def tool(self):
+        def deco(fn):
+            return fn
+        return deco
+
+
+def tool_a():
+    return "a"
+
+
+def tool_b():
+    return "b"
+
+
+def register(mcp):
+    for fn in (tool_a, tool_b):
+        mcp.tool()(fn)
+
+
+def _config():
+    return {}
+
+
+def _reset_cache():
+    for fn in (_config,):
+        fn.cache_clear()

--- a/scripts/callgraph/fixtures/registry_rootcli.py
+++ b/scripts/callgraph/fixtures/registry_rootcli.py
@@ -1,0 +1,10 @@
+"""Fixture: ROOT-CLI — an `if __name__ == "__main__":` guard that calls a
+bare-name function directly."""
+
+
+def main():
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/callgraph/fixtures/regress/accumulator_fp.py
+++ b/scripts/callgraph/fixtures/regress/accumulator_fp.py
@@ -1,0 +1,51 @@
+"""REGRESSION FIXTURE -- the false-positive class that outranked BUG B.
+
+Not copied from history; distilled from the three real shapes measured over
+the corpus at rev d359e9a, where 16 of 23 `cg flags` rows were counters and
+the one real bug sat 7th.
+
+  n_drifted     -- mlops/embedding/drift.py::measure_drift  (pure `+=`)
+  created       -- mcp/graph/linker.py::link_findings       (pure `+=`)
+  lines_scanned -- mcp/server.py::_process_reflection_item  (reset THEN `+=`)
+
+All three are correct code: a counter is SUPPOSED to be updated on only some
+paths, so the guard-exit ratio scores it exactly like a conditionally-set
+flag. `degraded` below is the genuine flag shape, kept in the same file so
+the two are separated by classification and not by which file they live in.
+"""
+
+
+def measure_drift(rows, threshold):
+    n_drifted = 0
+    degraded = False
+    out = []
+    for r in rows:
+        if not r:
+            continue                 # guard exit, skips both
+        try:
+            score = float(r["score"])
+        except Exception:
+            degraded = True          # genuine guarded flag flip
+            continue                 # guard exit
+        if score > threshold:
+            n_drifted += 1           # accumulate on SOME paths -- correct
+        out.append(score)
+    return {"n_drifted": n_drifted, "degraded": degraded, "scores": out}
+
+
+def scan_log(path, max_lines):
+    lines_scanned = 0
+    kept = []
+    with open(path) as fh:
+        first = fh.readline()
+        if not first:
+            return {"lines_scanned": lines_scanned, "kept": kept}
+        lines_scanned = 1            # a RESET to a constant, not a flag flip
+        for line in fh:
+            if not line.strip():
+                continue             # guard exit
+            if lines_scanned >= max_lines:
+                break                # guard exit
+            lines_scanned += 1
+            kept.append(line)
+    return {"lines_scanned": lines_scanned, "kept": kept}

--- a/scripts/callgraph/fixtures/regress/bug_b/grounding.py
+++ b/scripts/callgraph/fixtures/regress/bug_b/grounding.py
@@ -1,0 +1,327 @@
+# REGRESSION FIXTURE -- DO NOT IMPORT, DO NOT RUN, DO NOT COPY BACK INTO THE TREE.
+#
+# BUG B: ground() sets `degraded = True` only inside lanes 4 and 5. When `import server` raises, S is None and lanes 1/2/3/6 short-circuit without touching the flag, so total failure returns degraded=False.
+#
+# Source : mcp/grounding.py @ d359e9ac93ce5ffb6544b611662b90fca11ec990  (whole file)
+#          `git show d359e9ac93ce:mcp/grounding.py`
+# Status : THIS BUG IS FIXED IN THE REAL TREE. This file preserves the
+#          pre-fix code purely so the callgraph tool can be re-pointed at it
+#          and proven to still surface the defect. It is parsed by ast only
+#          and is excluded from the analyzed corpus (config.SELF_PACKAGE_REL).
+# ---- VERBATIM BODY BELOW (do not edit; see test_regression_real_bugs.py) ----
+"""Grounding-injection for Loci-native workflows.
+
+`ground(task)` runs ONCE in the main loop before a fan-out and returns a compact,
+provenance-tagged, char-budgeted context block to inject into every agent prompt —
+so agents start with relevant prior knowledge instead of rediscovering it, and never
+each hit Loci themselves (cost).
+
+Design (from the Loci self-review plan):
+- STRUCTURED-FIRST, embedding-independent retrieval is the quality path: curated
+  memory files -> investigation_load(named case) -> investigation_entity_lookup(exact
+  IDs) -> code graph (when available). Semantic RAG and filtered keyword recall are
+  optional enhancements that no-op when down (degraded=True) rather than blocking.
+- filter_noise() drops pre_compress/session_end conversation-dump blobs that otherwise
+  pollute keyword/FTS recall.
+- Budget cascade: unused budget from an empty/skipped source rolls to the next.
+- Fail-open everywhere: a dead source never aborts grounding.
+
+All Loci calls are lazy-imported from `server` so importing this module is cheap and
+does not create an import cycle.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("loci-mcp.grounding")
+
+
+def _default_memory_dir() -> str:
+    """Curated MEMORY.md dir via backends (env -> gitignored config -> HERMES_MEMORY_DIR).
+    No machine/user-specific default — if nothing is configured the memory lane just no-ops."""
+    try:
+        import backends
+        return backends.memory_dir()
+    except Exception:
+        return os.environ.get("LOCI_MEMORY_MD_DIR") or os.environ.get("HERMES_MEMORY_DIR", "")
+
+
+_MEMORY_DIR_DEFAULT = _default_memory_dir()
+
+# Finding resolution states that count as "handled" — the exclusion lane surfaces these
+# as a "do NOT re-report" block so re-audits skip already-fixed/accepted items.
+_RESOLVED_STATES = frozenset({"fixed", "intentional", "wontfix"})
+
+# Sources/types whose text is a raw conversation dump — never inject these.
+_DUMP_MARKERS = ("pre_compress", "session_end", "session_dump", "conversation", "transcript", "turn")
+_ROLE_RE = re.compile(r'\b(user|assistant|system)\b\s*[:"]', re.IGNORECASE)
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+
+
+def _looks_like_dump(text: str) -> bool:
+    """Heuristic: long, low-diversity text with role markers = a conversation dump."""
+    if not text:
+        return False
+    if len(text) > 1500:
+        toks = _TOKEN_RE.findall(text)
+        if toks:
+            uniq_ratio = len(set(t.lower() for t in toks)) / len(toks)
+            if _ROLE_RE.search(text) or uniq_ratio < 0.35:
+                return True
+    return bool(_ROLE_RE.search(text)) and len(text) > 800
+
+
+def filter_noise(items: list[dict]) -> list[dict]:
+    """Drop conversation-dump blobs + duplicates from fuzzy (keyword/FTS) results.
+
+    Each item: {text, source?, type?, tags?, score?}. Curated/structured sources
+    should NOT be passed through this — it is only for the noisy recall lanes.
+    """
+    out: list[dict] = []
+    seen: set = set()
+    for it in items or []:
+        text = str(it.get("text") or it.get("content") or "")
+        if not text.strip():
+            continue
+        meta = " ".join(str(it.get(k) or "") for k in ("source", "type", "tags", "origin")).lower()
+        if any(m in meta for m in _DUMP_MARKERS):
+            continue
+        if _looks_like_dump(text):
+            continue
+        h = hash(re.sub(r"\s+", " ", text.strip().lower())[:200])
+        if h in seen:
+            continue
+        seen.add(h)
+        out.append(it)
+    return out
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    # back off to a sentence/line boundary
+    for sep in ("\n", ". ", "; ", ", ", " "):
+        i = cut.rfind(sep)
+        if i > limit * 0.5:
+            cut = cut[: i + 1]
+            break
+    return cut.rstrip() + " …[truncated]"
+
+
+# Common tokens that inflate overlap without indicating relevance.
+_MEM_STOP = {"the", "and", "for", "with", "not", "via", "per", "any", "all", "new",
+             "code", "node", "map", "data", "file", "list", "task", "type", "into",
+             "loci", "dama", "mcp", "fix", "add"}
+
+
+_MEM_DISTINCTIVE = 7  # a shared token this long is topical, not incidental English
+
+
+def _select_memory_files(task: dict, memory_dir: str, limit: int = 2,
+                         min_score: int = 2) -> list[tuple[str, str, str]]:
+    """Top-`limit` MEMORY.md entries that share enough DISTINCTIVE tokens with the task.
+    Returns [(slug, index_line, body)] with bodies read. Fail-open.
+
+    A candidate must share >= `min_score` tokens AND >= 1 *distinctive* token (len >=
+    _MEM_DISTINCTIVE) — otherwise two incidental English words ("event", "single") from
+    an unrelated memory pass the bar and inject off-topic noise. Ranked by a weight that
+    counts distinctive tokens double. Capped so a fuzzy match never crowds out the precise
+    (case/RAG) lanes."""
+    out: list[tuple[str, str, str]] = []
+    try:
+        d = Path(memory_dir)
+        idx = d / "MEMORY.md"
+        if not idx.exists():
+            return out
+        want = {t.lower() for t in _TOKEN_RE.findall(
+            f"{task.get('title','')} {task.get('focus','')} {' '.join(task.get('codeRefs', []) or [])}")
+            if len(t) >= 4 and t.lower() not in _MEM_STOP}
+        if not want:
+            return out
+        scored = []
+        for line in idx.read_text(errors="ignore").splitlines():
+            m = re.search(r"\((?P<file>[\w.-]+\.md)\)", line)
+            if not m:
+                continue
+            toks = {t.lower() for t in _TOKEN_RE.findall(line) if len(t) >= 4}
+            shared = want & toks
+            if len(shared) < min_score or not any(len(t) >= _MEM_DISTINCTIVE for t in shared):
+                continue
+            weight = sum(2 if len(t) >= _MEM_DISTINCTIVE else 1 for t in shared)
+            scored.append((weight, m.group("file"), line.strip()))
+        scored.sort(reverse=True)
+        for score, fname, line in scored[:limit]:
+            body = ""
+            fp = d / fname
+            if fp.exists():
+                body = fp.read_text(errors="ignore")
+            out.append((fname, line, body))
+    except Exception:
+        return out
+    return out
+
+
+def _jload(s: Any) -> dict | list | None:
+    try:
+        return json.loads(s) if isinstance(s, str) else s
+    except Exception:
+        return None
+
+
+def ground(task: dict, opts: Optional[dict] = None) -> dict:
+    """Assemble a grounding block for a task. Returns
+    {block: str, sources: [str], chars: int, degraded: bool}. Fail-open.
+
+    task: {title, focus?, caseIds?:[str], entities?:[str], codeRefs?:[str]}
+    opts: {budgetChars=4000, memoryDir=..., allowKeyword=False, graphAvailable=False}
+    """
+    opts = opts or {}
+    budget = int(opts.get("budgetChars", 4000))
+    memory_dir = opts.get("memoryDir", _MEMORY_DIR_DEFAULT)
+    parts: list[str] = []
+    sources: list[str] = []
+    degraded = False
+    remaining = [budget]
+
+    def add(tag: str, text: str, slice_frac: float) -> None:
+        if remaining[0] <= 0 or not text:
+            return
+        cap = min(remaining[0], max(200, int(budget * slice_frac)))
+        chunk = _truncate(text, cap)
+        block = f"[{tag}] {chunk}"
+        parts.append(block)
+        sources.append(tag)
+        remaining[0] -= len(block)
+
+    import importlib
+    try:
+        S = importlib.import_module("server")
+    except Exception as exc:
+        logger.warning("grounding: server module unavailable, all lanes disabled: %s", exc)
+        S = None
+
+    # 1. Named cases -> investigation_load (structured, retracted excluded). Fail-open per
+    # case: a raising server tool (or malformed finding) skips that case, never aborts ground().
+    for cid in (task.get("caseIds") or [])[:3]:
+        if not S:
+            break
+        try:
+            data = _jload(S.investigation_load(cid, last_n_findings=6))
+            if isinstance(data, dict) and not data.get("error"):
+                man = data.get("manifest", {})
+                summary = f"{cid} :: hypothesis={man.get('hypothesis')} | next={man.get('next_step')}"
+                add(f"case:{cid}", summary, 0.12)
+                for f in (data.get("recent_findings") or [])[:3]:
+                    if isinstance(f, dict):
+                        add(f"case:{cid}:finding", str(f.get("text", "")), 0.08)
+        except Exception as exc:
+            logger.debug("grounding: case lane failed for %r: %r", cid, exc)
+            continue
+
+    # 2. Exclusion lane: findings already resolved (fixed/intentional/wontfix) for the
+    # grounded cases -> a compact "do NOT re-report" block so a re-audit auto-skips items
+    # already handled (the manual known-state step, automated). Budget-bounded, noise-
+    # filtered, fail-open: a missing/empty resolution set simply omits the block. Uses a
+    # separate load (large last_n) so the case lane above stays byte-for-byte unchanged.
+    resolved_known: list[str] = []
+    _seen_known: set = set()
+    for cid in (task.get("caseIds") or [])[:3]:
+        if not S:
+            break
+        try:
+            data = _jload(S.investigation_load(cid, last_n_findings=200))
+            if not isinstance(data, dict) or data.get("error"):
+                continue
+            for f in (data.get("recent_findings") or []):
+                if not isinstance(f, dict):
+                    continue
+                res = str(f.get("resolution", "open") or "open").lower()
+                if res not in _RESOLVED_STATES:
+                    continue
+                txt = str(f.get("text", "")).strip()
+                if not txt:
+                    continue
+                h = re.sub(r"\s+", " ", txt.lower())[:120]
+                if h in _seen_known:
+                    continue
+                _seen_known.add(h)
+                resolved_known.append(f"[{res}] {txt[:180]}")
+        except Exception as exc:
+            logger.debug("grounding: resolved-findings lane failed for %r: %r", cid, exc)
+            continue
+    if resolved_known:
+        add("known — do NOT re-report", " • ".join(resolved_known[:12]), 0.15)
+
+    # 3. Exact entities -> entity_lookup (O(1), no embedding). Fail-open per entity.
+    for ent in (task.get("entities") or [])[:5]:
+        if not S:
+            break
+        try:
+            data = _jload(S.investigation_entity_lookup(ent, limit=3))
+            if isinstance(data, dict) and data.get("total_findings"):
+                add(f"entity:{ent}", f"seen in {data.get('investigations_count')} case(s), "
+                                     f"{data.get('total_findings')} finding(s)", 0.06)
+        except Exception as exc:
+            logger.debug("grounding: entity lane failed for %r: %r", ent, exc)
+            continue
+
+    # 4. Code graph (only if reconnected / available).
+    if opts.get("graphAvailable") and task.get("codeRefs") and S:
+        for ref in (task.get("codeRefs") or [])[:2]:
+            try:
+                rep = _jload(S.impact_report(ref))
+                if isinstance(rep, dict) and rep.get("resolved"):
+                    add(f"code:{ref}", f"callers={rep.get('transitive_caller_count')} "
+                                       f"findings={rep.get('referencing_finding_count')} "
+                                       f"co={[c.get('name') for c in rep.get('co_referenced', [])[:4]]}", 0.10)
+            except Exception as exc:
+                logger.debug("grounding: code-graph lane failed for %r: %r", ref, exc)
+                pass
+    elif task.get("codeRefs"):
+        degraded = True  # code-graph grounding wanted but unavailable
+
+    # 5. Semantic RAG (enhancement; live now that embeddings are up, degraded when down).
+    if S and remaining[0] > 400:
+        try:
+            q = f"{task.get('title','')} {task.get('focus','')}".strip()
+            res = _jload(S.rag_context_search(q, budget_chars=min(remaining[0], 2000), limit=6))
+            ctx = (res or {}).get("context", "") if isinstance(res, dict) else ""
+            if ctx and (res.get("result_count") or 0) > 0:
+                add("rag", ctx, 0.35)
+            elif isinstance(res, dict) and not res.get("qdrant_available", True):
+                degraded = True
+        except Exception as exc:
+            logger.debug("grounding: rag lane failed for %r: %r", task.get("title", ""), exc)
+            degraded = True
+
+    # Curated memory files — a SUPPLEMENT after the precise (case/RAG) lanes, so a
+    # fuzzy-matched memory can never crowd them out. Capped + thresholded selection.
+    for fname, line, body in _select_memory_files(task, memory_dir):
+        add(f"memory:{fname[:-3]}", (body or line), 0.15)
+
+    # 6. Keyword/FTS fallback (off by default; filtered) — only if structured yield was thin.
+    if opts.get("allowKeyword") and S and sum(len(p) for p in parts) < 500:
+        try:
+            res = _jload(S.investigation_search(f"{task.get('title','')} {task.get('focus','')}", limit=8))
+            items = (res or {}).get("results", []) if isinstance(res, dict) else []
+            for it in filter_noise([{"text": r.get("text"), "source": r.get("source")} for r in items])[:3]:
+                add("recall", str(it.get("text", "")), 0.10)
+        except Exception as exc:
+            logger.debug("grounding: keyword fallback lane failed for %r: %r", task.get("title", ""), exc)
+            pass
+
+    header = ("## GROUNDING — prior context (read-only reference, NOT ground truth; verify "
+              "against live code/data before asserting; cite the [tag] if you rely on it)")
+    if degraded:
+        header += "\n(NOTE: some grounding lanes were unavailable this run — coverage is partial.)"
+    footer = ("Do not present facts absent above as remembered; if grounding is silent on a "
+              "point, say so.")
+    block = header + "\n" + "\n".join(parts) + "\n" + footer if parts else ""
+    return {"block": block, "sources": sources, "chars": len(block), "degraded": degraded}

--- a/scripts/callgraph/fixtures/regress/bug_c/graph_tools.py
+++ b/scripts/callgraph/fixtures/regress/bug_c/graph_tools.py
@@ -1,0 +1,419 @@
+# REGRESSION FIXTURE -- DO NOT IMPORT, DO NOT RUN, DO NOT COPY BACK INTO THE TREE.
+#
+# BUG C (write side): code_memory_relink() declares `global _symbol_index_cache, _symbol_index_count` and assigns them, but graph_tools.py never binds those names at module level.
+#
+# Source : mcp/graph_tools.py @ 30a2dc22656898d58fbdd4da4e3e7a3bdac39953  (whole file)
+#          `git show 30a2dc226568:mcp/graph_tools.py`
+# Status : THIS BUG IS FIXED IN THE REAL TREE. This file preserves the
+#          pre-fix code purely so the callgraph tool can be re-pointed at it
+#          and proven to still surface the defect. It is parsed by ast only
+#          and is excluded from the analyzed corpus (config.SELF_PACKAGE_REL).
+# ---- VERBATIM BODY BELOW (do not edit; see test_regression_real_bugs.py) ----
+"""Code<->memory graph MCP tools — split out of server.py (P1 of the Loci self-review).
+
+Thin wrappers over the graph.* layer; they need only a _get_ladybug accessor, injected by
+register(). server.py calls register(mcp, _get_ladybug) after the FastMCP instance exists,
+so the tools register identically (FastMCP reads each function signature + docstring).
+"""
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("loci-mcp")
+
+_get_ladybug = None  # injected by register()
+
+
+def code_graph_ingest(path: str, max_files: Optional[int] = None, replace: bool = False) -> str:
+    """
+    Parse a source file or directory with tree-sitter and ingest its symbol graph
+    into the Kuzu code graph (CodeFile / CodeSymbol nodes; DEFINES / CALLS / IMPORTS
+    edges). Enables ``code_graph_query`` and the AST-backed code<->memory linkage.
+
+    Supports python, java, kotlin, rust, javascript, typescript/tsx, go (c/c++
+    parse but currently yield file-level nodes only). Binary/oversized files and
+    common vendor dirs (.git, node_modules, .venv, build, dist, target) are skipped.
+
+    Ingest is additive (MERGE) by default. When ``replace=True`` the existing
+    CodeFile/CodeSymbol nodes under this ``path`` (and their DEFINES/CALLS/IMPORTS
+    edges + inbound REFERENCES) are deleted BEFORE parsing, so re-ingesting a
+    moved or updated checkout stays idempotent and drops stale-path nodes. Only
+    code nodes are pruned — Findings / Investigations / Entities are untouched.
+
+    Args:
+        path: A source file or a directory root to walk.
+        max_files: Optional cap on files parsed (directory mode).
+        replace: If True, prune existing code nodes under ``path`` before ingest
+            (idempotent re-ingest). Default False preserves additive behaviour.
+
+    Returns:
+        JSON with per-run counts {files, symbols, defines, calls, imports} (and a
+        ``pruned`` block when ``replace`` is set) or an error.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable — cannot ingest code graph."})
+    try:
+        from graph.code_parse import parse_path, parse_source, detect_lang
+        p = Path(path).expanduser()
+        if not p.exists():
+            return json.dumps({"error": f"Path not found: {path}"})
+        if p.is_file():
+            lang = detect_lang(str(p))
+            if not lang:
+                return json.dumps({"error": f"Unsupported/undetected language for file: {path}"})
+            try:
+                src = p.read_bytes()
+            except Exception as exc:
+                return json.dumps({"error": f"Could not read {path}: {exc!r}"})
+            parsed = [parse_source(str(p), src, lang)]
+        else:
+            parsed = parse_path(str(p), max_files=max_files)
+        # Prune stale/duplicate code nodes under this path so re-ingest is clean.
+        pruned = ks.delete_code_under(str(p)) if replace else None
+        counts = ks.ingest_code(parsed)
+        out = {"path": str(p), "parsed_files": len(parsed), "ingested": counts}
+        if pruned is not None:
+            out["pruned"] = pruned
+        return json.dumps(out, indent=2)
+    except Exception as exc:
+        logger.debug("code_graph_ingest failed: %r", exc)
+        return json.dumps({"error": f"code_graph_ingest failed: {exc!r}"})
+
+
+def code_graph_query(cypher: str, params: Optional[dict] = None) -> str:
+    """
+    Run a READ-ONLY Cypher query against the LadybugDB graph (code symbols + findings +
+    entities + investigations) and return the rows.
+
+    Write-shaped queries (CREATE/DELETE/SET/MERGE/DROP/COPY/ALTER) are rejected —
+    this tool never mutates the graph. Use it for impact analysis and traversal, e.g.
+    finding callers of a symbol, symbols a file defines, or findings that reference a
+    given CodeSymbol.
+
+    Node tables: CodeFile(path,lang), CodeSymbol(id,name,kind,file,line,lang),
+      Finding(id,investigation,ftype,text,confidence,source,ts), Entity(name,etype,distinctive),
+      Investigation(id,title).
+    Rel tables: DEFINES(CodeFile->CodeSymbol), CALLS(CodeSymbol->CodeSymbol),
+      IMPORTS(CodeFile->CodeFile), REFERENCES(Finding->CodeSymbol), MENTIONS(Finding->Entity),
+      DERIVED_FROM(Finding->Finding), IN_INVESTIGATION(Finding->Investigation),
+      RELATED(Investigation->Investigation).
+
+    Example: MATCH (c:CodeSymbol)-[:CALLS]->(t:CodeSymbol {name:'helper'}) RETURN c.id, c.file
+
+    Args:
+        cypher: A read-only Cypher query.
+        params: Optional parameter dict for ``$name`` placeholders.
+
+    Returns:
+        JSON with {rows: [...], row_count} or an error (including a write-guard rejection).
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        rows = ks.code_query(cypher, params or None)
+        return json.dumps({"row_count": len(rows), "rows": rows}, indent=2, default=str)
+    except ValueError as exc:  # write-guard rejection
+        return json.dumps({"error": f"rejected (read-only tool): {exc}"})
+    except Exception as exc:
+        logger.debug("code_graph_query failed: %r", exc)
+        return json.dumps({"error": f"code_graph_query failed: {exc!r}"})
+
+
+def code_memory_relink() -> str:
+    """
+    (Re)build all Finding -> CodeSymbol REFERENCES edges across the whole graph.
+
+    Scans every Finding's text and links it to the CodeSymbols it distinctively
+    names (precision-focused: distinctive types / explicit ``symbol:`` markers /
+    ``File.ext`` mentions / unique long identifiers — never bare common words).
+    Idempotent (MERGE). Run this after ingesting code with ``code_graph_ingest``
+    so already-stored findings get connected; new findings auto-link on write.
+
+    Returns:
+        JSON ``{"findings_scanned": int, "links_created": int}`` (zeros if the
+        graph store is unavailable).
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph import linker
+        result = linker.relink_all(ks)
+        # A relink can change the symbol set relationship; drop the cached index
+        # so subsequent auto-links rebuild against the current graph.
+        global _symbol_index_cache, _symbol_index_count
+        _symbol_index_cache, _symbol_index_count = None, -1
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.debug("code_memory_relink failed: %r", exc)
+        return json.dumps({"error": f"code_memory_relink failed: {exc!r}"})
+
+
+def code_memory_map(anchor: str, anchor_type: str = "auto", hops: int = 1) -> str:
+    """
+    Map the code<->memory neighbourhood around an anchor node as a subgraph.
+
+    Walks up to ``hops`` steps from the anchor over all edge types (CALLS,
+    DEFINES, REFERENCES, IN_INVESTIGATION, MENTIONS, ...) and returns the nodes
+    and edges around it — the concrete bridge between a code symbol and the
+    findings/investigations that touch it (and vice-versa).
+
+    Args:
+        anchor: The anchor's key — a CodeSymbol name, Finding id, Investigation
+            id, or CodeFile path, depending on ``anchor_type``.
+        anchor_type: One of ``CodeSymbol`` / ``Finding`` / ``Investigation`` /
+            ``CodeFile``, or ``auto`` (default) to try each in that order and use
+            the first that exists in the graph.
+        hops: BFS radius (default 1).
+
+    Returns:
+        JSON ``{"matched": {"label", "key"} | None, "nodes": [...],
+        "edges": [...]}``. ``matched`` reports which anchor label resolved.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph import queries
+        candidates = (
+            [anchor_type] if anchor_type and anchor_type != "auto"
+            else ["CodeSymbol", "Finding", "Investigation", "CodeFile"]
+        )
+        for label in candidates:
+            key = anchor
+            if label == "CodeSymbol":
+                # CodeSymbol's primary key is its id ("file::Qual"); callers usually
+                # pass a bare NAME. If the anchor isn't a direct id, resolve name->id.
+                if not ks.code_query("MATCH (s:CodeSymbol {id:$k}) RETURN s.id LIMIT 1", {"k": anchor}):
+                    rows = ks.code_query("MATCH (s:CodeSymbol {name:$n}) RETURN s.id LIMIT 1", {"n": anchor})
+                    if rows:
+                        key = rows[0][0]
+            sub = queries.subgraph(ks, label, key, hops=hops)
+            # A resolved anchor yields at least the anchor node itself.
+            if sub.get("nodes"):
+                return json.dumps(
+                    {"matched": {"label": label, "key": key}, **sub},
+                    indent=2, default=str,
+                )
+        return json.dumps({"matched": None, "nodes": [], "edges": []}, indent=2)
+    except Exception as exc:
+        logger.debug("code_memory_map failed: %r", exc)
+        return json.dumps({"error": f"code_memory_map failed: {exc!r}"})
+
+
+def symbol_impact(symbol: str, hops: int = 3) -> str:
+    """
+    Blast radius of a code symbol across code and memory.
+
+    Combines the transitive CALLS callers that reach ``symbol`` (up to ``hops``)
+    with the Findings — and their Investigations — that REFERENCE the symbol or
+    any of those callers. Answers "if this symbol is broken, which prior
+    findings/investigations are implicated, and what calls into it?"
+
+    Args:
+        symbol: A CodeSymbol id (``file::Qualname``) or a bare symbol name.
+        hops: Max transitive CALLS depth (default 3).
+
+    Returns:
+        JSON ``{"callers": [...symbols...], "findings": [...],
+        "investigations": [...]}``.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph import queries
+        return json.dumps(queries.symbol_impact(ks, symbol, hops=hops), indent=2, default=str)
+    except Exception as exc:
+        logger.debug("symbol_impact failed: %r", exc)
+        return json.dumps({"error": f"symbol_impact failed: {exc!r}"})
+
+
+def impact_report(symbol: str, hops: int = 3) -> str:
+    """
+    Change blast radius for a code symbol or class: who calls it (transitively) and
+    which findings / investigations reference it or its callers.
+
+    Answers "if I change this, what code and what prior analysis is affected?".
+    For a class name it also folds in the class's own methods. Composes the
+    graph.analytics.impact_report primitive over the code<->memory graph.
+
+    Args:
+        symbol: A CodeSymbol name (method or class), e.g. "EskfFusion" or "updateGps".
+        hops: Transitive CALLS depth for callers (default 3, max 6).
+
+    Returns:
+        JSON with resolved symbols, direct + transitive caller counts, the count of
+        referencing findings, affected investigations (by finding count, with samples),
+        and the symbols most co-referenced with it. Empty structure if unavailable.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph.analytics import impact_report as _impact
+        return json.dumps(_impact(ks, symbol, hops=hops), indent=2, default=str)
+    except Exception as exc:
+        logger.debug("impact_report failed: %r", exc)
+        return json.dumps({"error": f"impact_report failed: {exc!r}"})
+
+
+def finding_code_context(finding_id: str) -> str:
+    """
+    The code a finding references, each symbol wrapped with its callers/callees.
+
+    Attach concrete code context when reviewing a finding — the CodeSymbols it
+    mentions plus each one's immediate call neighbourhood — so you can judge the
+    claim against the actual code. Composes graph.analytics.finding_code_context.
+
+    Args:
+        finding_id: The Finding id to contextualize.
+
+    Returns:
+        JSON {finding_id, text, symbols:[{id,name,kind,file,line,callers,callees}]}.
+        Empty symbols if the finding references no code (or is unavailable).
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph.analytics import finding_code_context as _ctx
+        return json.dumps(_ctx(ks, finding_id), indent=2, default=str)
+    except Exception as exc:
+        logger.debug("finding_code_context failed: %r", exc)
+        return json.dumps({"error": f"finding_code_context failed: {exc!r}"})
+
+
+def investigation_code_briefing(investigation_id: str, top: int = 3) -> str:
+    """
+    The code story of an investigation: what code it touches, the blast radius of its
+    most-analysed symbols, and which other investigations share that code.
+
+    A one-call briefing composed from investigation_footprint + impact_report (over the
+    investigation's hotspot symbols) + related_investigations_via_code. Use it to onboard
+    onto a case or see how it connects to the codebase and to other cases.
+
+    Args:
+        investigation_id: The investigation to brief.
+        top: How many hotspot symbols to expand impact for (default 3).
+
+    Returns:
+        JSON {investigation, finding_count, symbols_touched, files_touched,
+        top_symbols:[{symbol, in_investigation_findings, transitive_callers,
+        total_referencing_findings, other_investigations}], related_investigations}.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph.analytics import investigation_code_briefing as _brief
+        return json.dumps(_brief(ks, investigation_id, top=top), indent=2, default=str)
+    except Exception as exc:
+        logger.debug("investigation_code_briefing failed: %r", exc)
+        return json.dumps({"error": f"investigation_code_briefing failed: {exc!r}"})
+
+
+def subsystem_report(anchor: str, limit: int = 15) -> str:
+    """
+    Full picture of a subsystem: the code under a file path or path/package prefix,
+    its call boundary (who calls in / what it calls out), the symbols most analysed
+    in memory, and which investigations touch it.
+
+    Give a file (".../EskfFusion.java"), a directory, or a package prefix. Composes
+    graph.analytics.subsystem_report over the code<->memory graph.
+
+    Args:
+        anchor: A CodeFile path, or a path/package prefix matching several files.
+        limit: Max rows per section (default 15).
+
+    Returns:
+        JSON {anchor, files, symbol_count, kinds, inbound_callers, outbound_callees,
+        hotspot_symbols, investigations}.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph.analytics import subsystem_report as _sub
+        return json.dumps(_sub(ks, anchor, limit=limit), indent=2, default=str)
+    except Exception as exc:
+        logger.debug("subsystem_report failed: %r", exc)
+        return json.dumps({"error": f"subsystem_report failed: {exc!r}"})
+
+
+def related_investigations_via_code(investigation_id: str, limit: int = 15) -> str:
+    """
+    Other investigations that reference the SAME code symbols as this one.
+
+    Code-mediated case linkage: surfaces prior investigations that touched the same
+    subsystem (shared CodeSymbols), ranked by overlap — even when they share no
+    entities or text. Composes graph.analytics.related_investigations_via_code.
+
+    Args:
+        investigation_id: The investigation to find code-neighbours for.
+        limit: Max related investigations (default 15).
+
+    Returns:
+        JSON list of {investigation, shared_symbols, sample_symbols}, ranked desc.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph.analytics import related_investigations_via_code as _rel
+        return json.dumps({"investigation_id": investigation_id,
+                           "related": _rel(ks, investigation_id, limit=limit)}, indent=2, default=str)
+    except Exception as exc:
+        logger.debug("related_investigations_via_code failed: %r", exc)
+        return json.dumps({"error": f"related_investigations_via_code failed: {exc!r}"})
+
+
+def dead_code_candidates(lang: Optional[str] = None, limit: int = 50) -> str:
+    """
+    Functions/methods with no code caller and no finding reference — a reliable
+    dead-code list with framework entry points (@mcp.tool, @app.route, @property…),
+    private (_), test, and dunder symbols excluded.
+
+    Requires an ingested code graph (code_graph_ingest). Call-graph recall varies by
+    language (Python is sparser than Java/Kotlin), so treat results as candidates to
+    verify. Composes graph.analytics.dead_code_candidates.
+
+    Args:
+        lang: Optional filter — "python" / "java" / "kotlin" / etc.
+        limit: Max candidates (default 50).
+
+    Returns:
+        JSON {candidates:[{name,kind,file,line,decorators}], count, note}.
+    """
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph.analytics import dead_code_candidates as _dead
+        return json.dumps(_dead(ks, lang=lang, limit=limit), indent=2, default=str)
+    except Exception as exc:
+        logger.debug("dead_code_candidates failed: %r", exc)
+        return json.dumps({"error": f"dead_code_candidates failed: {exc!r}"})
+
+
+def register(mcp, get_ladybug):
+    """Inject deps and register every graph tool on the shared FastMCP instance."""
+    global _get_ladybug
+    _get_ladybug = get_ladybug
+    for fn in (
+        code_graph_ingest,
+        code_graph_query,
+        code_memory_relink,
+        code_memory_map,
+        symbol_impact,
+        impact_report,
+        finding_code_context,
+        investigation_code_briefing,
+        subsystem_report,
+        related_investigations_via_code,
+        dead_code_candidates,
+    ):
+        mcp.tool()(fn)

--- a/scripts/callgraph/fixtures/regress/bug_c/ladybug_ops.py
+++ b/scripts/callgraph/fixtures/regress/bug_c/ladybug_ops.py
@@ -1,0 +1,266 @@
+# REGRESSION FIXTURE -- DO NOT IMPORT, DO NOT RUN, DO NOT COPY BACK INTO THE TREE.
+#
+# BUG C (real slot): the module that ACTUALLY owns _symbol_index_cache / _symbol_index_count at module level. Present so the audit has a real cross-module slot to name in its diagnosis.
+#
+# Source : mcp/ladybug_ops.py @ 30a2dc22656898d58fbdd4da4e3e7a3bdac39953  (whole file)
+#          `git show 30a2dc226568:mcp/ladybug_ops.py`
+# Status : THIS BUG IS FIXED IN THE REAL TREE. This file preserves the
+#          pre-fix code purely so the callgraph tool can be re-pointed at it
+#          and proven to still surface the defect. It is parsed by ast only
+#          and is excluded from the analyzed corpus (config.SELF_PACKAGE_REL).
+# ---- VERBATIM BODY BELOW (do not edit; see test_regression_real_bugs.py) ----
+"""Leaf LadybugDB helpers — split out of server.py (P2c of the Loci self-review split).
+
+Only the *stateless leaves* live here: the finding/investigation mirror, the
+entity-lookup projection, the symbol-index cache, and the one-time backfill. The
+LadybugStore singleton itself — ``_ladybug_store`` / ``_ladybug_failed`` /
+``_ladybug_last_attempt`` / ``_LADYBUG_RETRY_SECONDS`` / ``_ladybug_lock`` and the
+``_get_ladybug`` accessor built on them, plus ``_ladybug_health_state`` /
+``_ladybug_writer_pid`` which feed the frozen ``kuzu`` / ``kuzu_writer_pid`` wire
+keys — DELIBERATELY stay in server.py: several tests monkeypatch those latches on
+the server module and assert on ``server._get_ladybug()``, so moving them here
+would make every one of those patches a silent no-op.
+
+Dependencies follow the same injection contract as inv_store / graph_tools: the
+store accessor and the memory root are pushed in through ``register()`` rather than
+imported, so this module never imports server and no cycle exists. The memory root
+arrives as a LAMBDA (not a Path) because ``_ladybug_backfill_if_empty`` iterates it
+and ~10 tests rebind ``server.MEMORY_DIR`` to a tmpdir.
+"""
+from __future__ import annotations
+
+import logging
+
+from inv_store import _distinctive_entity_set, _read_jsonl
+
+logger = logging.getLogger("loci-mcp")
+
+# --- injected by register() -------------------------------------------------
+_get_ladybug = None
+_get_memory_dir = None
+
+
+def _root():
+    """The investigation memory root, resolved through the injected accessor."""
+    return _get_memory_dir()
+
+
+def _ladybug_upsert_investigation(investigation_id: str, title: str = "") -> None:
+    ks = _get_ladybug()
+    if not ks:
+        return
+    try:
+        ks.upsert_investigation(str(investigation_id), str(title or ""))
+    except Exception as exc:
+        logger.debug("LadybugDB investigation upsert failed (fail-open): %r", exc)
+
+
+def _coerce_ts(v) -> int:
+    """Coerce a finding timestamp (int, epoch-string, or ISO-8601) to an int epoch. 0 on failure."""
+    if isinstance(v, bool):
+        return 0
+    if isinstance(v, (int, float)):
+        return int(v)
+    if isinstance(v, str) and v.strip():
+        s = v.strip()
+        if s.isdigit():
+            return int(s)
+        try:
+            from datetime import datetime
+            return int(datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp())
+        except Exception:
+            return 0
+    return 0
+
+
+def _mirror_finding_to_ladybug(finding: dict, investigation_id: str, ks=None) -> None:
+    """Mirror one finding (node + MENTIONS + DERIVED_FROM) into the graph. Fail-open."""
+    ks = ks or _get_ladybug()
+    if not ks or not isinstance(finding, dict):
+        return
+    fid = finding.get("id")
+    if not fid:
+        return
+    try:
+        ks.upsert_finding({
+            "id": fid,
+            "investigation": investigation_id or finding.get("investigation_id") or "",
+            "type": (finding.get("finding_type") or finding.get("type")
+                     or finding.get("ftype") or ""),
+            "text": finding.get("text", "") or "",
+            "confidence": finding.get("confidence", "") or "",
+            "source": finding.get("source", "") or "",
+            "ts": _coerce_ts(finding.get("ts") or finding.get("created_at") or finding.get("timestamp")),
+        })
+        ents = finding.get("entities")
+        if isinstance(ents, dict):
+            distinctive = _distinctive_entity_set(ents)
+            triples = []
+            for etype, vals in ents.items():
+                for v in vals or []:
+                    name = str(v).strip()
+                    if name:
+                        triples.append((name, str(etype), name.lower() in distinctive))
+            if triples:
+                ks.link_mentions(fid, triples)
+        df = finding.get("derived_from")
+        if df:
+            ks.link_derived_from(fid, list(df) if isinstance(df, (list, tuple, set)) else [df])
+    except Exception as exc:
+        logger.debug("LadybugDB finding mirror failed (fail-open): %r", exc)
+
+
+# --- Finding -> CodeSymbol auto-linker (REFERENCES) --------------------------
+# A tiny cache so the per-write auto-link doesn't rebuild the symbol index on
+# every finding. Invalidated when the CodeSymbol count changes (e.g. after a new
+# code_graph_ingest / code_memory_relink). Fail-open throughout.
+_symbol_index_cache = None             # built graph.linker index
+_symbol_index_count = -1               # CodeSymbol count the cache was built at
+
+
+def _get_symbol_index(ks):
+    """Return a cached graph.linker symbol index, rebuilding it when the graph's
+    CodeSymbol count changes. Returns None (fail-open) if unavailable/empty."""
+    global _symbol_index_cache, _symbol_index_count
+    if not ks:
+        return None
+    try:
+        rows = ks.code_query("MATCH (s:CodeSymbol) RETURN count(s)")
+        count = int(rows[0][0]) if rows and rows[0] else 0
+        if count == 0:
+            _symbol_index_cache, _symbol_index_count = None, 0
+            return None
+        if _symbol_index_cache is None or count != _symbol_index_count:
+            from graph import linker
+            srows = ks._rows("MATCH (s:CodeSymbol) RETURN s.id, s.name, s.kind, s.file")
+            symbols = [{"id": r[0], "name": r[1], "kind": r[2], "file": r[3]} for r in srows]
+            _symbol_index_cache = linker.build_symbol_index(symbols)
+            _symbol_index_count = count
+        return _symbol_index_cache
+    except Exception as exc:
+        logger.debug("symbol index build failed (fail-open): %r", exc)
+        return None
+
+
+def _autolink_finding_to_ladybug(finding: dict, ks=None) -> None:
+    """Auto-create REFERENCES edges from one just-mirrored finding to CodeSymbols.
+    Cheap single-finding link over a cached index. Fail-open — never raises."""
+    ks = ks or _get_ladybug()
+    if not ks or not isinstance(finding, dict):
+        return
+    fid = finding.get("id")
+    text = finding.get("text")
+    if not fid or not text:
+        return
+    try:
+        index = _get_symbol_index(ks)
+        if not index:
+            return  # no code graph ingested yet — nothing to link against
+        from graph import linker
+        linker.link_findings(ks, [{"id": fid, "text": text}], index)
+    except Exception as exc:
+        logger.debug("LadybugDB finding auto-link failed (fail-open): %r", exc)
+
+
+def _ladybug_backfill_if_empty(ks) -> None:
+    """Backfill existing on-disk findings into a freshly-created graph (once)."""
+    try:
+        rows = ks.code_query("MATCH (f:Finding) RETURN count(f)")
+        existing = int(rows[0][0]) if rows and rows[0] else 0
+    except Exception:
+        existing = 0
+    if existing > 0:
+        return
+    finding_rows: list[dict] = []
+    mention_rows: list[dict] = []
+    derived_rows: list[dict] = []
+    invs: list[str] = []
+    try:
+        for inv_dir in sorted(_root().iterdir()):
+            if not inv_dir.is_dir() or inv_dir.name.startswith("_"):
+                continue
+            fjsonl = inv_dir / "findings.jsonl"
+            if not fjsonl.exists():
+                continue
+            invs.append(inv_dir.name)
+            for f in _read_jsonl(fjsonl):
+                fid = f.get("id")
+                if not fid:
+                    continue
+                inv = str(f.get("investigation_id") or inv_dir.name)
+                finding_rows.append({
+                    "id": fid, "investigation": inv,
+                    "type": f.get("finding_type") or f.get("type") or f.get("ftype") or "",
+                    "text": f.get("text", "") or "", "confidence": f.get("confidence", "") or "",
+                    "source": f.get("source", "") or "",
+                    "ts": _coerce_ts(f.get("ts") or f.get("created_at") or f.get("timestamp")),
+                })
+                ents = f.get("entities")
+                if isinstance(ents, dict):
+                    distinctive = _distinctive_entity_set(ents)
+                    for etype, vals in ents.items():
+                        for v in vals or []:
+                            name = str(v).strip()
+                            if name:
+                                mention_rows.append({"f": fid, "name": name, "etype": str(etype),
+                                                     "distinctive": name.lower() in distinctive})
+                df = f.get("derived_from")
+                if df:
+                    for p in (df if isinstance(df, (list, tuple, set)) else [df]):
+                        if p:
+                            derived_rows.append({"f": fid, "p": str(p)})
+    except Exception as exc:
+        logger.debug("LadybugDB backfill scan failed (fail-open): %r", exc)
+    if not finding_rows:
+        return
+    try:
+        for iv in invs:
+            ks.upsert_investigation(iv, "")
+        n = ks.upsert_findings_batch(finding_rows)
+        ks.link_mentions_batch(mention_rows)
+        ks.link_derived_from_batch(derived_rows)
+        logger.info("LadybugDB backfill: mirrored %d findings, %d mentions, %d derivations (batched).",
+                    n, len(mention_rows), len(derived_rows))
+    except Exception as exc:
+        logger.debug("LadybugDB backfill batch failed (fail-open): %r", exc)
+
+
+def _entity_lookup_ladybug(entity: str, investigation_id, limit: int) -> list[dict]:
+    """Graph-primary entity lookup. Normalizes to the finding shape the tools use."""
+    ks = _get_ladybug()
+    if not ks:
+        return []
+    try:
+        rows = ks.entity_findings(entity, limit=max(limit * 2, limit))
+    except Exception as exc:
+        logger.debug("Kuzu entity_findings failed (fail-open): %r", exc)
+        return []
+    out: list[dict] = []
+    for r in rows or []:
+        inv = r.get("investigation") or ""
+        if investigation_id and inv != investigation_id:
+            continue
+        out.append({
+            "id": r.get("id"),
+            "investigation_id": inv,
+            "finding_type": r.get("ftype", "") or "",
+            "text": r.get("text", "") or "",
+            "confidence": r.get("confidence", "") or "",
+            "source": r.get("source", "") or "",
+        })
+        if len(out) >= limit:
+            break
+    return out
+
+
+def register(get_ladybug, get_memory_dir):
+    """Inject the store accessor and the memory-root accessor.
+
+    Both are callables, never values: ``get_ladybug`` is server's ``_get_ladybug``
+    (so these helpers reach the singleton through the same patched server globals
+    the resilience tests drive), and ``get_memory_dir`` is a lambda over
+    ``server.MEMORY_DIR`` so tmpdir rebinds keep steering the backfill scan.
+    """
+    global _get_ladybug, _get_memory_dir
+    _get_ladybug = get_ladybug
+    _get_memory_dir = get_memory_dir

--- a/scripts/callgraph/fixtures/regress/bug_c_fixed.py
+++ b/scripts/callgraph/fixtures/regress/bug_c_fixed.py
@@ -1,0 +1,45 @@
+"""REGRESSION FIXTURE -- BUG C's shape AFTER the real fix (mutation check).
+
+Mirrors the accepted fix in c1c40a9: the invalidation is delegated to the
+module that OWNS the cache instead of being written through a `global` in a
+module that never binds those names. The point of this file is negative --
+`dangling_globals()` must find nothing here. A detector that fires on the
+fix as loudly as on the bug teaches people to ignore it.
+
+The `global _relink_count` below is deliberate: it is a REAL module-level
+slot, declared global and bound at module level, so it exercises the
+"legitimate global write" path that must NOT be reported.
+"""
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+_relink_count = 0
+
+
+def _get_ladybug():
+    return None
+
+
+def code_memory_relink() -> str:
+    ks = _get_ladybug()
+    if not ks:
+        return json.dumps({"error": "LadybugDB graph store unavailable."})
+    try:
+        from graph import linker
+        result = linker.relink_all(ks)
+        # Must go through ladybug_ops -- assigning the names here would bind
+        # this module's own globals and leave the real cache stale.
+        import ladybug_ops
+        ladybug_ops.invalidate_symbol_index()
+        global _relink_count
+        _relink_count += 1
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.debug("code_memory_relink failed: %r", exc)
+        return json.dumps({"error": f"code_memory_relink failed: {exc!r}"})
+
+
+def relink_count() -> int:
+    return _relink_count

--- a/scripts/callgraph/fixtures/regress/bug_d/graph_facts.py
+++ b/scripts/callgraph/fixtures/regress/bug_d/graph_facts.py
@@ -1,0 +1,142 @@
+# REGRESSION FIXTURE -- DO NOT IMPORT, DO NOT RUN, DO NOT COPY BACK INTO THE TREE.
+#
+# BUG D (consumer): _find_graph() globs ~/.hermes/**/graph.kuzu -- a near-miss for the graph.ladybug the server actually writes. Nothing ever matched, so every request reported "code graph not found".
+#
+# Source : scripts/graph_facts.py @ c1c40a9165a3282df6581d981c9401812da1cddc  (whole file)
+#          `git show c1c40a9165a3:scripts/graph_facts.py`
+# Status : THIS BUG IS FIXED IN THE REAL TREE. This file preserves the
+#          pre-fix code purely so the callgraph tool can be re-pointed at it
+#          and proven to still surface the defect. It is parsed by ast only
+#          and is excluded from the analyzed corpus (config.SELF_PACKAGE_REL).
+# ---- VERBATIM BODY BELOW (do not edit; see test_regression_real_bugs.py) ----
+#!/usr/bin/env python3
+"""Produce DETERMINISTIC code-graph facts for a workflow — zero tokens, no LLM.
+
+The main loop runs this before a fan-out and passes the JSON as the workflow's
+`args.graphFacts`. A task tagged `tier: 'graph'` in loci-native.js is then resolved
+straight from these facts with NO agent spawned — replacing the "grep agent" for
+mechanical inventory work with an exact query over the Kuzu code<->memory graph.
+
+Spec (argv[1] or stdin) is a list of requests, each with a `key` and ONE of:
+  {"key":"callsites","impact":"investigation_store"}   -> impact_report (callers/co-ref/findings)
+  {"key":"module","subsystem":"mcp/server.py"}         -> subsystem_report (symbols/hotspots/boundaries)
+  {"key":"dead","deadCode":true}                        -> dead_code_candidates
+
+Emits: {"<key>": {"kind":..., "text":<human summary>, "raw":<full dict>}, ...}
+Fail-open: a bad/empty request yields a text note, never aborts the batch.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+
+
+def _find_graph() -> str | None:
+    import glob
+    # "graph.kuzu" is the ON-DISK database directory name. It predates the
+    # Kuzu -> LadybugDB rename and is deliberately NOT renamed: every existing
+    # deployment has its database at this path, and changing it would orphan them.
+    for p in glob.glob(os.path.expanduser("~/.hermes/**/graph.kuzu"), recursive=True):
+        return p
+    return None
+
+
+def _summarize_impact(sym: str, r: dict) -> str:
+    resolved = [x.get("id") or x.get("name") for x in (r.get("resolved") or [])]
+    if not resolved:
+        return f"'{sym}': not found in the code graph."
+    callers = r.get("direct_callers") or []
+    # de-dup while preserving order, cap for readability
+    seen, uniq = set(), []
+    for c in callers:
+        if c not in seen:
+            seen.add(c); uniq.append(c)
+    lines = [f"'{sym}' resolved to {len(resolved)} symbol(s): {', '.join(resolved[:4])}"]
+    lines.append(f"direct callers ({len(uniq)}): {', '.join(uniq[:25])}"
+                 + (" …" if len(uniq) > 25 else ""))
+    if r.get("transitive_caller_count") is not None:
+        lines.append(f"transitive callers: {r['transitive_caller_count']}")
+    co = [c.get("name") for c in (r.get("co_referenced") or [])][:8]
+    if co:
+        lines.append(f"co-referenced symbols: {', '.join(x for x in co if x)}")
+    if r.get("referencing_finding_count"):
+        invs = [i.get("id") for i in (r.get("investigations") or [])]
+        lines.append(f"referenced by {r['referencing_finding_count']} finding(s) "
+                     f"in investigations: {', '.join(x for x in invs if x)[:200]}")
+    return "\n".join(lines)
+
+
+def _summarize_subsystem(path: str, r: dict) -> str:
+    files = r.get("files") or []
+    if not files:
+        return f"'{path}': no files matched in the code graph."
+    lines = [f"subsystem '{path}': {len(files)} file(s), {r.get('symbol_count')} symbols, "
+             f"kinds={r.get('kinds')}"]
+    hot = [(h.get("name"), h.get("findings")) for h in (r.get("hotspot_symbols") or [])][:8]
+    if hot:
+        lines.append("hotspots (symbol:findings): " + ", ".join(f"{n}:{c}" for n, c in hot))
+    if r.get("inbound_callers"):
+        lines.append(f"inbound callers (cross-boundary): {len(r['inbound_callers'])}")
+    if r.get("outbound_callees"):
+        lines.append(f"outbound callees (cross-boundary): {len(r['outbound_callees'])}")
+    invs = [i.get("id") for i in (r.get("investigations") or [])]
+    if invs:
+        lines.append(f"investigations touching it: {', '.join(x for x in invs if x)[:200]}")
+    return "\n".join(lines)
+
+
+def _summarize_dead(r: dict) -> str:
+    cands = r.get("candidates") or []
+    names = [c.get("name") for c in cands][:40]
+    return (f"dead-code candidates ({len(cands)}): " + ", ".join(x for x in names if x)
+            + (" …" if len(cands) > 40 else "")) if cands else "no dead-code candidates."
+
+
+def main() -> int:
+    raw = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] not in ("-", "") else sys.stdin.read()
+    try:
+        spec = json.loads(raw)
+    except Exception as exc:
+        print(f"error: spec must be JSON ({exc})", file=sys.stderr)
+        return 2
+    if isinstance(spec, dict):
+        spec = [spec]
+
+    out: dict = {}
+    db = _find_graph()
+    if not db:
+        for req in spec:
+            out[req.get("key", "?")] = {"kind": "unavailable", "text": "code graph not found", "raw": {}}
+        print(json.dumps(out, indent=2))
+        print("[graph_facts: no graph.kuzu found]", file=sys.stderr)
+        return 0
+
+    from graph.ladybug_store import LadybugStore
+    from graph import analytics as A
+    ks = LadybugStore(db)
+
+    for req in spec:
+        key = req.get("key", "?")
+        try:
+            if "impact" in req:
+                r = A.impact_report(ks, req["impact"])
+                out[key] = {"kind": "impact", "text": _summarize_impact(req["impact"], r), "raw": r}
+            elif "subsystem" in req:
+                r = A.subsystem_report(ks, req["subsystem"])
+                out[key] = {"kind": "subsystem", "text": _summarize_subsystem(req["subsystem"], r), "raw": r}
+            elif req.get("deadCode"):
+                r = A.dead_code_candidates(ks)
+                out[key] = {"kind": "dead_code", "text": _summarize_dead(r), "raw": r}
+            else:
+                out[key] = {"kind": "noop", "text": "no recognized request field", "raw": {}}
+        except Exception as exc:  # fail-open per request
+            out[key] = {"kind": "error", "text": f"graph query failed: {exc}", "raw": {}}
+
+    print(json.dumps(out, indent=2))
+    print(f"[graph_facts: {len(out)} fact(s) from {db}]", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/callgraph/fixtures/regress/bug_d/server.py
+++ b/scripts/callgraph/fixtures/regress/bug_d/server.py
@@ -1,0 +1,93 @@
+# REGRESSION FIXTURE -- DO NOT IMPORT, DO NOT RUN, DO NOT COPY BACK INTO THE TREE.
+#
+# BUG D (producer): MEMORY_DIR + _get_ladybug, which opens MEMORY_DIR / "graph.ladybug".
+#
+# Source : mcp/server.py @ c1c40a9165a3282df6581d981c9401812da1cddc  (slice L159-166, L218-287)
+#          `git show c1c40a9165a3:mcp/server.py`
+# Status : THIS BUG IS FIXED IN THE REAL TREE. This file preserves the
+#          pre-fix code purely so the callgraph tool can be re-pointed at it
+#          and proven to still surface the defect. It is parsed by ast only
+#          and is excluded from the analyzed corpus (config.SELF_PACKAGE_REL).
+# ---- VERBATIM BODY BELOW (do not edit; see test_regression_real_bugs.py) ----
+# --- mcp/server.py lines 159-166 @ c1c40a9165a3 ---
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+MEMORY_DIR = Path(os.environ.get(
+    "HERMES_MEMORY_DIR",
+    Path.home() / ".hermes" / "memory-sessions",
+))
+
+# --- mcp/server.py lines 218-287 @ c1c40a9165a3 ---
+# ---------------------------------------------------------------------------
+# LadybugDB graph store (primary relationship/graph backend) — fail-open like Qdrant.
+# Mirrors findings/entities/derivation into an embedded graph and backs the
+# entity-lookup / related-cases / contamination / code-symbol paths. If ladybug or
+# the module is unavailable, every consumer degrades to the pre-existing path.
+# ---------------------------------------------------------------------------
+_ladybug_store = None                     # LadybugStore singleton once initialized
+_ladybug_failed = False                   # PERMANENT-failure latch (ladybug unimportable) — don't retry
+_ladybug_last_attempt = 0.0               # monotonic ts of last TRANSIENT init failure
+_LADYBUG_RETRY_SECONDS = 30               # backoff before retrying after a transient failure
+_ladybug_lock = threading.Lock()
+
+
+def _get_ladybug():
+    """Lazy, fail-open LadybugStore singleton. Returns None if unavailable.
+
+    Distinguishes a genuinely UNRECOVERABLE failure (ladybug is not importable) — which
+    latches permanently so we stop retrying — from a TRANSIENT one (another process
+    holds Kuzu's single-writer lock, or a transient IO error at open time), which does
+    NOT latch: a later call retries after a short backoff so the code graph self-heals
+    once the other writer releases the lock. Never raises.
+    """
+    global _ladybug_store, _ladybug_failed, _ladybug_last_attempt
+    if _ladybug_store is not None:
+        return _ladybug_store
+    if _ladybug_failed:
+        return None
+    with _ladybug_lock:
+        if _ladybug_store is not None:
+            return _ladybug_store
+        if _ladybug_failed:
+            return None
+        # Back off between transient-failure retries so we don't hammer a held lock.
+        if _ladybug_last_attempt and (time.monotonic() - _ladybug_last_attempt) < _LADYBUG_RETRY_SECONDS:
+            return None
+        try:
+            from graph import ladybug_store as _kz
+            if not getattr(_kz, "_HAS_LADYBUG", True):
+                # ladybug itself isn't importable — unrecoverable, latch permanently.
+                _ladybug_failed = True
+                logger.warning("LadybugDB not importable — graph features disabled (permanent).")
+                return None
+            MEMORY_DIR.mkdir(parents=True, exist_ok=True)  # ladybug won't create parents
+            ks = _kz.LadybugStore(str(MEMORY_DIR / "graph.ladybug"))
+            if not ks.available():
+                # Import worked but open failed — almost always another process holds
+                # the single-writer lock. Treat as TRANSIENT: retry after the backoff.
+                _ladybug_last_attempt = time.monotonic()
+                logger.warning("LadybugDB store unavailable (lock contention or transient IO?) "
+                               "— will retry after %ss.", _LADYBUG_RETRY_SECONDS)
+                return None
+            _ladybug_store = ks
+            _ladybug_last_attempt = 0.0
+        except ImportError as exc:
+            # graph module / ladybug genuinely missing — unrecoverable, latch permanently.
+            _ladybug_failed = True
+            logger.warning("LadybugDB graph module missing (%r) — graph features disabled (permanent).", exc)
+            return None
+        except Exception as exc:  # fail-open — never break the server on graph init
+            # Unknown/transient error (e.g. IO on mkdir/open) — do NOT latch; retry later.
+            _ladybug_last_attempt = time.monotonic()
+            logger.warning("LadybugDB graph init failed (%r) — will retry after %ss.", exc, _LADYBUG_RETRY_SECONDS)
+            return None
+    # One-time backfill of pre-existing findings, guarded by an empty-graph check.
+    try:
+        _ladybug_backfill_if_empty(_ladybug_store)
+    except Exception as exc:
+        logger.debug("LadybugDB backfill skipped (fail-open): %r", exc)
+    return _ladybug_store
+
+

--- a/scripts/callgraph/fixtures/regress/fp_shapes/callback_arg.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/callback_arg.py
@@ -1,0 +1,27 @@
+"""FP shape: a function passed by BARE NAME as a call argument.
+
+Real source: mcp/server.py's health block --
+    checks.append(_health_check("embeddings_sparse", _health_probe_embeddings_sparse))
+Nine `_health_probe_*` functions were reported dead this way.
+"""
+
+
+def probe_sparse():
+    return {"ok": True}
+
+
+def run_check(label, fn):
+    return label, fn()
+
+
+def loci_health():
+    checks = []
+    checks.append(run_check("embeddings_sparse", probe_sparse))
+    return checks
+
+
+# Stands in for the @mcp.tool() registration that makes this entry point live
+# in the real code: without a root, EVERY function in the fixture is trivially
+# unreachable and the test would pass for the wrong reason.
+if __name__ == "__main__":
+    loci_health()

--- a/scripts/callgraph/fixtures/regress/fp_shapes/lambda_call.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/lambda_call.py
@@ -1,0 +1,27 @@
+"""FP shape: a function called ONLY from inside a lambda body.
+
+Real source: mcp/server.py --
+    ("qdrant_reachable", lambda: backends.qdrant()[0]),
+A lambda is consumed at the point it is written, so its body is reachable
+exactly when the scope constructing it is.
+"""
+
+
+def probe_via_lambda(timeout):
+    return timeout > 0
+
+
+def loci_health():
+    out = {}
+    for key, resolver in (
+        ("qdrant_reachable", lambda: probe_via_lambda(0.5)),
+    ):
+        out[key] = resolver()
+    return out
+
+
+# Stands in for the @mcp.tool() registration that makes this entry point live
+# in the real code: without a root, EVERY function in the fixture is trivially
+# unreachable and the test would pass for the wrong reason.
+if __name__ == "__main__":
+    loci_health()

--- a/scripts/callgraph/fixtures/regress/fp_shapes/lazy_import_nested.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/lazy_import_nested.py
@@ -1,0 +1,22 @@
+"""FP shape: a FUNCTION-LOCAL import used from inside a NESTED scope.
+
+Real source: mcp/server.py::loci_health does a function-local
+`import backends`, then calls it from inside a lambda:
+    ("qdrant_reachable", lambda: backends.qdrant()[0])
+Python closures make the binding visible to the lambda; keyed on the
+lambda's own qualname it is invisible, and mcp/backends.py::qdrant was
+reported dead despite a live call site.
+"""
+
+
+def loci_health():
+    import lazy_import_target
+    probes = [lambda: lazy_import_target.helper(0.5)]
+    return [p() for p in probes]
+
+
+# Stands in for the @mcp.tool() registration that makes this entry point live
+# in the real code: without a root, EVERY function in the fixture is trivially
+# unreachable and the test would pass for the wrong reason.
+if __name__ == "__main__":
+    loci_health()

--- a/scripts/callgraph/fixtures/regress/fp_shapes/lazy_import_target.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/lazy_import_target.py
@@ -1,0 +1,5 @@
+"""Target module for the function-local-import-in-a-nested-scope shape."""
+
+
+def helper(timeout=1.0):
+    return ("http://localhost", timeout)

--- a/scripts/callgraph/fixtures/regress/fp_shapes/nested_siblings.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/nested_siblings.py
@@ -1,0 +1,22 @@
+"""FP shape: a nested def called by bare name from a SIBLING nested def.
+
+Real source: mcp/graph/code_parse.py::parse_source defines
+`enclosing_def_node` and `_in_method` side by side, and `_in_method` calls
+`enclosing_def_node(node)`. Python resolves a bare name
+local -> ENCLOSING -> global, so resolution must walk outward.
+"""
+
+
+def outer(nodes):
+
+    def sibling_a(node):
+        return getattr(node, "parent", None)
+
+    def sibling_b(node):
+        return sibling_a(node) is not None
+
+    return [n for n in nodes if sibling_b(n)]
+
+
+if __name__ == "__main__":
+    outer([])

--- a/scripts/callgraph/fixtures/regress/fp_shapes/pkg/analytics.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/pkg/analytics.py
@@ -1,0 +1,20 @@
+"""FP shape: relative from-import of a SIBLING SUBMODULE.
+
+Real source: mcp/graph/analytics.py --
+    from . import queries as Q
+    ...
+    for s in Q.finding_symbols(ks, finding_id):
+For a relative import the display module is just ".", so the dotted-name
+fallback probed "..queries" and "queries" and never the package-qualified
+name; Q aliased an external sink instead of the MODULE and four live
+queries.py functions were reported dead.
+"""
+from . import queries as Q
+
+
+def finding_report(ks, finding_id):
+    return [s for s in Q.finding_symbols(ks, finding_id)]
+
+
+if __name__ == "__main__":
+    finding_report(None, None)

--- a/scripts/callgraph/fixtures/regress/fp_shapes/pkg/queries.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/pkg/queries.py
@@ -1,0 +1,5 @@
+"""Submodule reached through `from . import queries as Q`."""
+
+
+def finding_symbols(ks, finding_id):
+    return [ks, finding_id]

--- a/scripts/callgraph/fixtures/regress/fp_shapes/truly_dead.py
+++ b/scripts/callgraph/fixtures/regress/fp_shapes/truly_dead.py
@@ -1,0 +1,31 @@
+"""COUNTER-TEST: the false-positive fixes must not make everything reachable.
+
+`never_mentioned_anywhere` appears nowhere but its own def, and must still be
+reported. If this stops failing, `cg dead` has become a query that never says
+anything.
+"""
+
+
+def used():
+    return 1
+
+
+def passed_around():
+    return 3
+
+
+def never_mentioned_anywhere():
+    return 2
+
+
+def take(fn):
+    return fn
+
+
+def main():
+    take(passed_around)
+    return used()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/callgraph/ingest.py
+++ b/scripts/callgraph/ingest.py
@@ -1,0 +1,220 @@
+"""Corpus walk + ast.parse, and a `--rev` path that streams file content
+from git instead of the working tree.
+
+While another workflow is mid-editing a file in the corpus, the working
+tree copy of that file may be inconsistent at any single moment. Reading a
+specific git revision (default: the working tree; pass rev="HEAD" or any
+commit-ish) is the correct way to get stable line numbers, and is required
+whenever a concurrent edit is possible. Every report built on top of this
+module names which source it read.
+
+A SyntaxError on one file degrades that file to a stub (tree=None,
+error=<message>) and never aborts the rest of the build.
+
+No parse cache: measured cold-parsing all 114 corpus files takes ~0.2s
+(ast.parse itself; pickling a tree back out costs about as much as
+re-parsing it), so a cache would add staleness risk for no real speedup at
+this corpus size. `--no-cache` is accepted and is a no-op today; if the
+corpus grows enough for this to matter, revisit here first.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import subprocess
+from dataclasses import dataclass, field
+from typing import Optional
+
+from . import config
+
+
+@dataclass
+class SourceFile:
+    rel_path: str            # repo-relative POSIX path, e.g. "mcp/server.py"
+    source: str
+    tree: Optional[ast.AST]
+    error: Optional[str]     # SyntaxError message, else None
+    origin: str               # "working tree" or "rev <sha>"
+    sha1: str = field(default="", repr=False)
+
+
+def _run_git(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=config.REPO_ROOT,
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def list_git_files(rev: str) -> list[str]:
+    """Repo-relative POSIX paths of corpus .py files as they existed at
+    `rev`, per config.in_corpus (test dirs / __pycache__ / this package
+    excluded)."""
+    out = _run_git(["ls-tree", "-r", "--name-only", rev])
+    return sorted(p for p in out.splitlines() if config.in_corpus(p))
+
+
+def read_git_blob(rel_path: str, rev: str) -> str:
+    """Single-file read via `git show`. Kept for callers that only need one
+    blob; load_corpus below uses the batched path (one subprocess for the
+    whole corpus, not one per file) because it runs on every `--rev` build,
+    including while another workflow is mid-editing files this tool must
+    still read a stable copy of."""
+    result = subprocess.run(
+        ["git", "show", f"{rev}:{rel_path}"], cwd=config.REPO_ROOT,
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def list_git_files_with_sha(rev: str) -> list[tuple[str, str]]:
+    """(rel_path, blob_sha) for every corpus .py file at `rev`, sorted by
+    path -- one `git ls-tree` call, no per-file subprocess. `git ls-tree -r`
+    (without --name-only) lines look like `<mode> blob <sha>\\t<path>`."""
+    out = _run_git(["ls-tree", "-r", rev])
+    result: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if "\t" not in line:
+            continue
+        meta, path = line.split("\t", 1)
+        parts = meta.split()
+        if len(parts) != 3 or parts[1] != "blob":
+            continue
+        if config.in_corpus(path):
+            result.append((path, parts[2]))
+    result.sort(key=lambda pair: pair[0])
+    return result
+
+
+def _read_git_blobs_batch(shas: list[str]) -> dict[str, bytes]:
+    """Every blob in `shas`, read via ONE `git cat-file --batch` subprocess
+    instead of one `git show`/`git cat-file` per file -- the difference
+    between ~114 process spawns and 1 for a full-corpus `--rev` build.
+    `--batch` writes, per requested object in request order: a header line
+    `<sha> <type> <size>\\n`, exactly `<size>` bytes of content, then a
+    trailing `\\n`."""
+    if not shas:
+        return {}
+    proc = subprocess.run(
+        ["git", "cat-file", "--batch"], cwd=config.REPO_ROOT,
+        input=("\n".join(shas) + "\n").encode("ascii"),
+        capture_output=True, check=True,
+    )
+    out = proc.stdout
+    result: dict[str, bytes] = {}
+    pos = 0
+    for sha in shas:
+        nl = out.index(b"\n", pos)
+        header = out[pos:nl].decode("ascii")
+        parts = header.split()
+        if len(parts) != 3:
+            raise RuntimeError(f"git cat-file --batch: unexpected header {header!r} for {sha}")
+        obj_sha, obj_type, size_s = parts
+        size = int(size_s)
+        start = nl + 1
+        result[obj_sha] = out[start:start + size]
+        pos = start + size + 1  # skip the trailing newline after the object body
+    return result
+
+
+def resolve_rev_sha(rev: str) -> str:
+    out = _run_git(["rev-parse", rev])
+    return out.strip()
+
+
+def _parse_one(rel_path: str, source: str, origin: str) -> SourceFile:
+    sha1 = hashlib.sha1(source.encode("utf-8", errors="surrogateescape")).hexdigest()
+    try:
+        tree = ast.parse(source, filename=rel_path)
+        return SourceFile(rel_path, source, tree, None, origin, sha1)
+    except SyntaxError as exc:
+        msg = f"{exc.__class__.__name__}: {exc.msg} (line {exc.lineno})"
+        return SourceFile(rel_path, source, None, msg, origin, sha1)
+    except (ValueError, RecursionError) as exc:  # e.g. null bytes, too-deep nesting
+        return SourceFile(rel_path, source, None, f"{exc.__class__.__name__}: {exc}", origin, sha1)
+
+
+def load_corpus(rev: Optional[str] = None, no_cache: bool = False) -> tuple[list[SourceFile], str]:
+    """Returns (source files, origin label). origin is "working tree" or
+    "rev <sha>" — every report prints this so a result read mid-edit is
+    never mistaken for a stable one."""
+    if rev is None:
+        rel_paths = config.iter_corpus_files_worktree()
+        origin = "working tree"
+        out: list[SourceFile] = []
+        for rel_path in rel_paths:
+            abs_path = config.REPO_ROOT / rel_path
+            try:
+                source = abs_path.read_text(encoding="utf-8", errors="surrogateescape")
+            except OSError as exc:
+                out.append(SourceFile(rel_path, "", None, f"OSError: {exc}", origin, ""))
+                continue
+            out.append(_parse_one(rel_path, source, origin))
+        return out, origin
+
+    sha = resolve_rev_sha(rev)
+    origin = f"rev {sha[:12]}"
+    files_with_sha = list_git_files_with_sha(rev)
+    blobs = _read_git_blobs_batch([s for _p, s in files_with_sha])
+    out = []
+    for rel_path, blob_sha in files_with_sha:
+        raw = blobs.get(blob_sha)
+        if raw is None:
+            out.append(SourceFile(rel_path, "", None, f"git cat-file: blob {blob_sha} missing", origin, ""))
+            continue
+        source = raw.decode("utf-8", errors="surrogateescape")
+        out.append(_parse_one(rel_path, source, origin))
+    return out, origin
+
+
+def list_git_test_files(rev: str) -> list[str]:
+    """Repo-relative POSIX paths of .py files under a `tests/` directory
+    nested inside a corpus root, as they existed at `rev` — the test-side
+    counterpart of list_git_files, used only by `cg writes-dead
+    --include-tests`."""
+    out = _run_git(["ls-tree", "-r", "--name-only", rev])
+    result: list[str] = []
+    for p in out.splitlines():
+        if not p.endswith(".py"):
+            continue
+        top = p.split("/", 1)[0]
+        if top not in config.CORPUS_ROOTS:
+            continue
+        if "tests" not in p.split("/")[:-1]:
+            continue
+        result.append(p)
+    return sorted(result)
+
+
+def load_test_sources(rev: Optional[str] = None) -> list[SourceFile]:
+    """Test-tree counterpart of load_corpus — NOT part of the modelled
+    corpus (config.in_corpus excludes tests/ on purpose); this is read-only
+    source text for `cg writes-dead --include-tests`'s textual mitigation
+    scan, never parsed into the GraphStore."""
+    if rev is None:
+        rel_paths = config.iter_test_files_worktree()
+        origin = "working tree"
+    else:
+        sha = resolve_rev_sha(rev)
+        rel_paths = list_git_test_files(rev)
+        origin = f"rev {sha[:12]}"
+
+    out: list[SourceFile] = []
+    for rel_path in rel_paths:
+        if rev is None:
+            abs_path = config.REPO_ROOT / rel_path
+            try:
+                source = abs_path.read_text(encoding="utf-8", errors="surrogateescape")
+            except OSError as exc:
+                out.append(SourceFile(rel_path, "", None, f"OSError: {exc}", origin, ""))
+                continue
+        else:
+            source = read_git_blob(rel_path, rev)
+        out.append(_parse_one(rel_path, source, origin))
+    return out
+
+
+def corpus_wall_time_note() -> str:  # pragma: no cover - human-facing only
+    return "cold build should finish in well under 2s for the full corpus"

--- a/scripts/callgraph/model.py
+++ b/scripts/callgraph/model.py
@@ -1,0 +1,233 @@
+"""Node/Edge dataclasses, the Confidence enum, and GraphStore.
+
+GraphStore keeps id->Node plus forward/reverse adjacency indexed by edge
+kind, so a tiered closure (proven / probable / unproven) is a handful of
+cheap dict lookups rather than a full scan-and-filter over every edge. This
+is the shared representation every extract/* and analyze/* module reads and
+writes; nothing downstream should invent its own dict-of-dicts.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any, Iterable, Iterator, Optional
+
+
+class Confidence(IntEnum):
+    """Ordered UNPROVEN < PROBABLE < PROVEN so `Confidence.combine(...)` over
+    a chain's hops yields the weakest (most honest) link, never the average."""
+    UNPROVEN = 0
+    PROBABLE = 1
+    PROVEN = 2
+
+    @classmethod
+    def combine(cls, confidences: Iterable["Confidence"]) -> "Confidence":
+        values = list(confidences)
+        if not values:
+            return cls.PROVEN
+        return min(values)
+
+    @classmethod
+    def parse(cls, text: str) -> "Confidence":
+        return cls[text.strip().upper()]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.name.lower()
+
+
+@dataclass
+class Node:
+    id: str
+    kind: str
+    attrs: dict[str, Any] = field(default_factory=dict)
+    path: Optional[str] = None
+    line: Optional[int] = None
+    col: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "attrs": self.attrs,
+            "path": self.path,
+            "line": self.line,
+            "col": self.col,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Node":
+        return cls(
+            id=d["id"], kind=d["kind"], attrs=dict(d.get("attrs") or {}),
+            path=d.get("path"), line=d.get("line"), col=d.get("col"),
+        )
+
+
+@dataclass
+class Edge:
+    src: str
+    dst: str
+    kind: str
+    confidence: Confidence = Confidence.PROVEN
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "src": self.src, "dst": self.dst, "kind": self.kind,
+            "confidence": self.confidence.name, "attrs": self.attrs,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Edge":
+        return cls(
+            src=d["src"], dst=d["dst"], kind=d["kind"],
+            confidence=Confidence.parse(d.get("confidence", "PROVEN")),
+            attrs=dict(d.get("attrs") or {}),
+        )
+
+
+class GraphStore:
+    """id -> Node, plus forward/reverse adjacency indexed by edge kind."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, Node] = {}
+        self.edges: list[Edge] = []
+        self._out: dict[str, dict[str, list[Edge]]] = {}
+        self._in: dict[str, dict[str, list[Edge]]] = {}
+
+    # -- mutation ---------------------------------------------------------
+
+    def add_node(self, node: Node) -> Node:
+        """Idempotent: re-adding the same id merges attrs into the existing
+        node rather than creating a duplicate (multiple extract passes may
+        legitimately touch the same MODULE/NAME node)."""
+        existing = self.nodes.get(node.id)
+        if existing is not None:
+            existing.attrs.update(node.attrs)
+            if existing.path is None:
+                existing.path = node.path
+            if existing.line is None:
+                existing.line = node.line
+            if existing.col is None:
+                existing.col = node.col
+            return existing
+        self.nodes[node.id] = node
+        return node
+
+    def add_edge(self, edge: Edge) -> Edge:
+        self.edges.append(edge)
+        self._out.setdefault(edge.src, {}).setdefault(edge.kind, []).append(edge)
+        self._in.setdefault(edge.dst, {}).setdefault(edge.kind, []).append(edge)
+        return edge
+
+    def retarget_edge(self, edge: Edge, new_dst: str) -> None:
+        """Repoint an already-added edge's dst in place, fixing up the
+        reverse index too. Used by extract/registry.py to rewire a
+        DECORATED_BY edge from the placeholder EXTERNAL sink defs.py created
+        (before a REGISTRY node for that decorator site existed) onto the
+        real REGISTRY node, without creating a second, double-counted edge."""
+        old_bucket = self._in.get(edge.dst, {}).get(edge.kind)
+        if old_bucket is not None:
+            old_bucket[:] = [e for e in old_bucket if e is not edge]
+        edge.dst = new_dst
+        self._in.setdefault(new_dst, {}).setdefault(edge.kind, []).append(edge)
+
+    # -- reads --------------------------------------------------------------
+
+    def get(self, node_id: str) -> Optional[Node]:
+        return self.nodes.get(node_id)
+
+    def __contains__(self, node_id: str) -> bool:
+        return node_id in self.nodes
+
+    def out_edges(self, node_id: str, kind: Optional[str] = None) -> list[Edge]:
+        by_kind = self._out.get(node_id, {})
+        if kind is None:
+            return [e for edges in by_kind.values() for e in edges]
+        return list(by_kind.get(kind, []))
+
+    def in_edges(self, node_id: str, kind: Optional[str] = None) -> list[Edge]:
+        by_kind = self._in.get(node_id, {})
+        if kind is None:
+            return [e for edges in by_kind.values() for e in edges]
+        return list(by_kind.get(kind, []))
+
+    def nodes_of_kind(self, kind: str) -> Iterator[Node]:
+        return (n for n in self.nodes.values() if n.kind == kind)
+
+    def edges_of_kind(self, kind: str) -> Iterator[Edge]:
+        return (e for e in self.edges if e.kind == kind)
+
+    def stats(self) -> dict[str, int]:
+        node_counts: dict[str, int] = {}
+        for n in self.nodes.values():
+            node_counts[n.kind] = node_counts.get(n.kind, 0) + 1
+        edge_counts: dict[str, int] = {}
+        for e in self.edges:
+            edge_counts[e.kind] = edge_counts.get(e.kind, 0) + 1
+        return {"nodes": len(self.nodes), "edges": len(self.edges), **{
+            f"node:{k}": v for k, v in node_counts.items()
+        }, **{f"edge:{k}": v for k, v in edge_counts.items()}}
+
+    # -- (de)serialization --------------------------------------------------
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "nodes": [n.to_dict() for n in self.nodes.values()],
+            "edges": [e.to_dict() for e in self.edges],
+        }, indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> "GraphStore":
+        data = json.loads(text)
+        store = cls()
+        for nd in data["nodes"]:
+            store.add_node(Node.from_dict(nd))
+        for ed in data["edges"]:
+            store.add_edge(Edge.from_dict(ed))
+        return store
+
+    _DOT_SHAPE_BY_KIND = {
+        "FUNCTION": "box", "MODULE": "folder", "CLASS": "component",
+        "REGISTRY": "hexagon", "ENTRYPOINT": "doublecircle", "NAME": "ellipse",
+        "LITERAL": "note", "PATHEXPR": "note",
+    }
+    _DOT_STYLE_BY_CONFIDENCE = {
+        Confidence.PROVEN: "solid", Confidence.PROBABLE: "dashed", Confidence.UNPROVEN: "dotted",
+    }
+
+    def to_dot(self, node_ids: Optional[Iterable[str]] = None,
+               edges: Optional[Iterable[Edge]] = None) -> str:
+        """Graphviz DOT export. With no filter this emits the WHOLE graph
+        (every node/edge this build produced — large: tens of thousands of
+        nodes for the real corpus, fine for `dot -Tsvg` but not for
+        eyeballing directly). Pass `node_ids`/`edges` — e.g. the node ids
+        and Edge objects a `cg reach`/`cg callers`/`cg paths` traversal
+        already collected — to emit just that subgraph instead, which is
+        the normal way to actually look at one of these. Edge style encodes
+        confidence (solid=proven, dashed=probable, dotted=unproven) so the
+        honesty tiering survives the trip through Graphviz."""
+        if node_ids is None:
+            sel_nodes = list(self.nodes.values())
+        else:
+            ids = set(node_ids)
+            sel_nodes = [self.nodes[i] for i in ids if i in self.nodes]
+        sel_edges = list(self.edges) if edges is None else list(edges)
+
+        def esc(s: object) -> str:
+            return str(s).replace("\\", "\\\\").replace('"', '\\"')
+
+        lines = ["digraph callgraph {", "  rankdir=LR;", "  node [shape=box, fontsize=10];"]
+        for n in sel_nodes:
+            label = esc(n.attrs.get("qualname") or n.attrs.get("match_text") or n.id)
+            shape = self._DOT_SHAPE_BY_KIND.get(n.kind, "box")
+            lines.append(f'  "{esc(n.id)}" [label="{label}\\n[{n.kind}]", shape={shape}];')
+        if "?" not in {n.id for n in sel_nodes} and any(e.dst == "?" or e.src == "?" for e in sel_edges):
+            lines.append('  "?" [label="? UNRESOLVED", shape=doublecircle, style=filled, fillcolor=lightgrey];')
+        for e in sel_edges:
+            style = self._DOT_STYLE_BY_CONFIDENCE.get(e.confidence, "solid")
+            lines.append(f'  "{esc(e.src)}" -> "{esc(e.dst)}" [label="{esc(e.kind)}", style={style}];')
+        lines.append("}")
+        return "\n".join(lines)

--- a/scripts/callgraph/pipeline.py
+++ b/scripts/callgraph/pipeline.py
@@ -1,0 +1,118 @@
+"""Orchestrates ingest -> resolve -> extract into one GraphStore. cli.py
+calls this; nothing else should hand-roll the build sequence.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .extract.calls import build_top_level_index, make_call_visitor
+from .extract.defs import extract_module
+from .extract.dispatch import extract_probable_calls
+from .extract.flow import extract_flow
+from .extract.funcrefs import make_funcrefs_visitor
+from .extract.imports import extract_imports
+from .extract.literals import make_literals_visitor
+from .extract.names import emit_non_walk_writes, make_names_visitor
+from .extract.registry import extract_external_roots, extract_injections, extract_registry_module
+from .extract.walk import walk_module
+from .ingest import SourceFile, load_corpus
+from .model import GraphStore
+from .resolve import ResolutionTable
+from .scopes import ModuleScope
+
+
+@dataclass
+class BuildMeta:
+    source: str                 # "working tree" or "rev <sha>"
+    file_count: int
+    error_count: int
+    errors: list[tuple[str, str]] = field(default_factory=list)
+    elapsed_s: float = 0.0
+    scope_prefixes: Optional[list[str]] = None
+
+
+@dataclass
+class BuildResult:
+    store: GraphStore
+    table: ResolutionTable
+    scopes: dict[str, ModuleScope]
+    sources: list[SourceFile]
+    meta: BuildMeta
+
+
+def _filter_scope(sources: list[SourceFile], scope_prefixes: Optional[list[str]]) -> list[SourceFile]:
+    if not scope_prefixes:
+        return sources
+    return [sf for sf in sources if any(sf.rel_path.startswith(p) for p in scope_prefixes)]
+
+
+def build_graph(rev: Optional[str] = None, scope_prefixes: Optional[list[str]] = None,
+                 no_cache: bool = False) -> BuildResult:
+    t0 = time.time()
+    sources, origin = load_corpus(rev=rev, no_cache=no_cache)
+    sources = _filter_scope(sources, scope_prefixes)
+
+    table = ResolutionTable(sources)
+    store = GraphStore()
+
+    scopes: dict[str, ModuleScope] = {}
+    errors: list[tuple[str, str]] = []
+    for sf in sources:
+        scopes[sf.rel_path] = extract_module(store, sf, table)
+        if sf.error is not None:
+            errors.append((sf.rel_path, sf.error))
+
+    for sf in sources:
+        extract_imports(store, sf, scopes[sf.rel_path], table, scopes)
+
+    # Everything from here on needs every module's FUNCTION/CLASS/ALIASES
+    # already in the store, so it runs as its own whole-corpus pass rather
+    # than being folded into the per-file loops above.
+    top_level_index = build_top_level_index(store)
+
+    # extract/calls.py and extract/names.py each only need a callback
+    # (they don't own the traversal) so both run in ONE whole-module walk
+    # per file here, instead of two — see calls.py's make_call_visitor.
+    funcref_flushes = []
+    for sf in sources:
+        scope = scopes[sf.rel_path]
+        emit_non_walk_writes(store, sf, scope)
+        call_visit = make_call_visitor(store, sf, scope, table, top_level_index)
+        names_visit = make_names_visitor(store, sf, scope)
+        literals_visit = make_literals_visitor(store, sf, scope)
+        refs_visit, refs_flush = make_funcrefs_visitor(store, sf, scope, top_level_index)
+        funcref_flushes.append(refs_flush)
+
+        def combined(node, fi, _c=call_visit, _n=names_visit, _l=literals_visit, _r=refs_visit) -> None:
+            _c(node, fi)
+            _n(node, fi)
+            _l(node, fi)
+            _r(node, fi)
+
+        walk_module(scope, combined)
+        extract_flow(store, sf, scope)
+
+    for sf in sources:
+        extract_registry_module(store, sf, scopes[sf.rel_path], top_level_index)
+    extract_injections(store, sources, scopes, top_level_index)
+    extract_external_roots(store, sources, top_level_index)
+
+    # AFTER registry: the generic name-escape pass defers to the specific
+    # registration forms above for any reference they already modelled.
+    for flush in funcref_flushes:
+        flush()
+
+    # The probable tier (CALLS rungs 4-6 + DISPATCHES) needs REGISTRY/
+    # REGISTERS/INJECTS already built, so it runs last, only ever touching
+    # CALLS edges rungs 1-3 left on the `?` sink.
+    extract_probable_calls(store, scopes, top_level_index)
+
+    meta = BuildMeta(
+        source=origin, file_count=len(sources), error_count=len(errors),
+        errors=errors, elapsed_s=time.time() - t0, scope_prefixes=scope_prefixes,
+    )
+    return BuildResult(store=store, table=table, scopes=scopes, sources=sources, meta=meta)

--- a/scripts/callgraph/resolve.py
+++ b/scripts/callgraph/resolve.py
@@ -1,0 +1,475 @@
+"""The module resolution table.
+
+Maps repo-relative path <-> every dotted name a module answers to, modelling
+this codebase's actual import reality:
+
+  * The implicit repo-root namespace: `mcp.graph_tools`, `a2a_server.server`
+    (works because Python 3 namespace packages don't require __init__.py).
+  * Flat sibling imports inside a directory that has been put on sys.path,
+    either by a *literal* `sys.path.insert(0, <expr>)` this tool can
+    constant-fold, or trivially by virtue of being the importing file's own
+    directory (`import qdrant_ops` from mcp/server.py).
+  * The 10 `sys.path.insert(0, os.path.join(..., "..", "mcp"))`-shaped
+    inserts in scripts/ that make `import graph_tools` &c. work from a
+    script that isn't inside mcp/.
+
+Every resolution records WHICH insert made it work (or "implicit repo
+root" / "same directory") — that provenance is itself a debugging answer,
+and a flat import that only resolves because of an insert written in a
+*different* file is exactly the kind of fact this tool exists to surface.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+import posixpath
+from dataclasses import dataclass, field
+from typing import Optional
+
+from . import config
+from .ingest import SourceFile
+
+# --------------------------------------------------------------------------
+# sys.path.insert / .append literal folding
+# --------------------------------------------------------------------------
+
+
+class _Unresolvable:
+    """Sentinel: the expression could not be constant-folded."""
+
+
+UNRESOLVABLE = _Unresolvable()
+
+
+@dataclass(frozen=True)
+class _Dir:
+    """A folded value representing a directory, given as a repo-relative
+    POSIX path ("" means the repo root itself)."""
+    rel: str
+
+
+@dataclass(frozen=True)
+class _FileSelf:
+    """The analyzed file's own path (before any dirname/.parent is applied)."""
+    rel_path: str
+
+
+@dataclass(frozen=True)
+class _Lit:
+    """A plain string constant with no path semantics attached yet."""
+    value: str
+
+
+_FoldedValue = object  # _Dir | _FileSelf | _Lit | _Unresolvable
+
+
+def _dirname_of(value: _FoldedValue) -> _FoldedValue:
+    if isinstance(value, _FileSelf):
+        return _Dir(posixpath.dirname(value.rel_path))
+    if isinstance(value, _Dir):
+        return _Dir(posixpath.dirname(value.rel))
+    return UNRESOLVABLE
+
+
+def _up_n(value: _FoldedValue, n: int) -> _FoldedValue:
+    for _ in range(n):
+        value = _dirname_of(value)
+        if value is UNRESOLVABLE:
+            return UNRESOLVABLE
+    return value
+
+
+def _join(base: _FoldedValue, parts: list[_FoldedValue]) -> _FoldedValue:
+    if isinstance(base, _FileSelf):
+        base = _Dir(posixpath.dirname(base.rel_path))
+    if not isinstance(base, _Dir):
+        return UNRESOLVABLE
+    segs = [base.rel] if base.rel else []
+    for p in parts:
+        if not isinstance(p, _Lit):
+            return UNRESOLVABLE
+        segs.append(p.value)
+    joined = posixpath.normpath("/".join(segs)) if segs else "."
+    if joined == ".":
+        joined = ""
+    return _Dir(joined)
+
+
+class _FoldEnv:
+    """Symbol table of simple `NAME = <path-expr>` bindings, built with a
+    single linear pass over a statement list (module body, or one
+    function's body) — no real control-flow tracking, which matches the
+    rest of this tool's "linear walk, not a CFG" philosophy."""
+
+    def __init__(self, rel_path: str, parent: Optional["_FoldEnv"] = None) -> None:
+        self.rel_path = rel_path
+        self.parent = parent
+        self.vars: dict[str, _FoldedValue] = {}
+        self.sys_aliases: set[str] = set(parent.sys_aliases) if parent else {"sys"}
+
+    def lookup(self, name: str) -> _FoldedValue:
+        if name in self.vars:
+            return self.vars[name]
+        if self.parent is not None:
+            return self.parent.lookup(name)
+        return UNRESOLVABLE
+
+    def learn_simple_assigns(self, body: list[ast.stmt]) -> None:
+        for stmt in body:
+            if isinstance(stmt, ast.Import):
+                for alias in stmt.names:
+                    if alias.name == "sys":
+                        self.sys_aliases.add(alias.asname or "sys")
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+                folded = self.fold(stmt.value)
+                if folded is not UNRESOLVABLE:
+                    self.vars[stmt.targets[0].id] = folded
+
+    def fold(self, node: ast.AST) -> _FoldedValue:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return _Lit(node.value)
+        if isinstance(node, ast.Name):
+            if node.id == "__file__":
+                return _FileSelf(self.rel_path)
+            return self.lookup(node.id)
+        if isinstance(node, ast.Call):
+            func = node.func
+            fname = _dotted_call_name(func)
+            if fname in ("os.path.dirname",) and len(node.args) == 1:
+                return _dirname_of(self.fold(node.args[0]))
+            if fname in ("os.path.abspath", "os.path.normpath", "os.path.realpath", "str") and len(node.args) == 1:
+                return self.fold(node.args[0])
+            if fname in ("os.path.join",) and node.args:
+                base = self.fold(node.args[0])
+                rest = [self.fold(a) for a in node.args[1:]]
+                return _join(base, rest)
+            if fname in ("Path", "pathlib.Path") and len(node.args) == 1:
+                return self.fold(node.args[0])
+            # `<expr>.resolve()` / `<expr>.absolute()` as a *call* (the
+            # common `Path(__file__).resolve()` shape) — fname is None here
+            # because _dotted_call_name gives up on a non-Name base, so this
+            # has to be checked explicitly rather than falling through.
+            if isinstance(func, ast.Attribute) and func.attr in ("resolve", "absolute") and not node.args:
+                return self.fold(func.value)
+            return UNRESOLVABLE
+        if isinstance(node, ast.Attribute):
+            if node.attr == "parent":
+                return _up_n(self.fold(node.value), 1)
+            return UNRESOLVABLE
+        if isinstance(node, ast.Subscript):
+            base = node.value
+            if isinstance(base, ast.Attribute) and base.attr == "parents":
+                idx = node.slice
+                if isinstance(idx, ast.Constant) and isinstance(idx.value, int):
+                    return _up_n(self.fold(base.value), idx.value + 1)
+            return UNRESOLVABLE
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            left = self.fold(node.left)
+            right = self.fold(node.right)
+            return _join(left, [right])
+        return UNRESOLVABLE
+
+
+def _dotted_call_name(func: ast.AST) -> Optional[str]:
+    """Best-effort dotted name of a Call target, e.g. os.path.dirname."""
+    parts: list[str] = []
+    node = func
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    else:
+        return None
+    return ".".join(reversed(parts))
+
+
+@dataclass
+class SysPathInsert:
+    inserting_file: str
+    lineno: int
+    target_dir: str          # repo-relative POSIX dir, "" for repo root
+    scope: str                 # "module-level" | "function-local"
+
+
+def find_sys_path_inserts(sf: SourceFile) -> list[SysPathInsert]:
+    if sf.tree is None:
+        return []
+    out: list[SysPathInsert] = []
+    module_env = _FoldEnv(sf.rel_path)
+    module_env.learn_simple_assigns(sf.tree.body)
+
+    def scan(stmts: list[ast.stmt], env: _FoldEnv) -> None:
+        for stmt in _iter_all(stmts):
+            if isinstance(stmt, ast.Call):
+                out_ins = _match_path_insert(stmt, env)
+                if out_ins is not None:
+                    scope = "module-level" if env is module_env else "function-local"
+                    out.append(SysPathInsert(sf.rel_path, stmt.lineno, out_ins, scope))
+
+    def _match_path_insert(call: ast.Call, env: _FoldEnv) -> Optional[str]:
+        func = call.func
+        if not isinstance(func, ast.Attribute):
+            return None
+        if func.attr not in ("insert", "append"):
+            return None
+        path_attr = func.value
+        if not isinstance(path_attr, ast.Attribute) or path_attr.attr != "path":
+            return None
+        base = path_attr.value
+        if not isinstance(base, ast.Name) or base.id not in env.sys_aliases:
+            return None
+        if func.attr == "insert":
+            if len(call.args) < 2:
+                return None
+            expr = call.args[1]
+        else:
+            if not call.args:
+                return None
+            expr = call.args[0]
+        folded = env.fold(expr)
+        if isinstance(folded, _FileSelf):
+            folded = _Dir(posixpath.dirname(folded.rel_path))
+        if not isinstance(folded, _Dir):
+            return None
+        if folded.rel.startswith(".."):
+            return None  # above repo root: cannot be modelled, not a corpus dir
+        return folded.rel
+
+    # Module level (direct statements + inside simple if/try wrappers, which
+    # is how every real insert in this corpus is written).
+    scan(sf.tree.body, module_env)
+
+    # Function-local (any nesting depth): each function gets its own env
+    # seeded from the module env plus its own top-of-body simple assigns.
+    for node in ast.walk(sf.tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            fn_env = _FoldEnv(sf.rel_path, parent=module_env)
+            fn_env.learn_simple_assigns(node.body)
+            scan(node.body, fn_env)
+
+    return out
+
+
+def _iter_all(stmts: list[ast.stmt]):
+    """Yield every statement/expression node reachable from a statement
+    list, without descending into nested function/class defs (those are
+    handled as their own scan() call so scope stays correct)."""
+    stack = list(stmts)
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            continue  # nested scope; handled separately (or irrelevant)
+        for child in ast.iter_child_nodes(node):
+            stack.append(child)
+
+
+# --------------------------------------------------------------------------
+# Module table
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class RootProvenance:
+    root_dir: str            # "" for repo root
+    evidence: str              # "implicit: repo root" | "<file>:<line>" | "implicit: <file> is a __main__ entry point"
+    scope: str                  # "module-level" | "function-local" | "implicit"
+    source_file: Optional[str] = None   # the file whose insert/guard established this root, if any
+
+
+@dataclass
+class ModuleInfo:
+    rel_path: str
+    kind: str                                    # flat-dir | package-member | script
+    importable_as: dict[str, list[RootProvenance]] = field(default_factory=dict)
+    has_main: bool = False
+
+
+def _module_kind(rel_path: str, all_rel_paths: set[str]) -> str:
+    """flat-dir: sibling files reached via a bare filename import (no
+    __init__.py in this directory). package-member: this directory (or the
+    file itself) is a real package, reached via dotted submodule import."""
+    base = posixpath.basename(rel_path)
+    if base == "__init__.py":
+        return "package-member"
+    parent = posixpath.dirname(rel_path)
+    init_candidate = f"{parent}/__init__.py" if parent else "__init__.py"
+    return "package-member" if init_candidate in all_rel_paths else "flat-dir"
+
+
+def _has_main_guard(tree: ast.Module) -> bool:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.If):
+            test = stmt.test
+            if isinstance(test, ast.Compare) and len(test.comparators) == 1:
+                left, right = test.left, test.comparators[0]
+                names = {n for n in (left, right) if isinstance(n, ast.Name)}
+                lits = {n.value for n in (left, right) if isinstance(n, ast.Constant)}
+                if any(n.id == "__name__" for n in names) and "__main__" in lits:
+                    return True
+    return False
+
+
+def _dotted_for(rel_path: str, root_dir: str) -> Optional[str]:
+    """Dotted module name of rel_path as seen from sys.path root root_dir
+    ("" = repo root), or None if rel_path is not under root_dir."""
+    if root_dir:
+        prefix = root_dir + "/"
+        if not rel_path.startswith(prefix):
+            return None
+        sub = rel_path[len(prefix):]
+    else:
+        sub = rel_path
+    if sub.endswith("/__init__.py"):
+        sub = sub[: -len("/__init__.py")]
+    elif sub.endswith(".py"):
+        sub = sub[: -len(".py")]
+    if not sub:
+        return None
+    return sub.replace("/", ".")
+
+
+class ResolutionTable:
+    """Built once per corpus load. Owns per-module importable_as sets and
+    resolves `import`/`from ... import` dotted names to a target module,
+    an EXTERNAL classification, or UNRESOLVED."""
+
+    def __init__(self, sources: list[SourceFile]) -> None:
+        self.sources_by_path: dict[str, SourceFile] = {sf.rel_path: sf for sf in sources}
+        all_rel_paths = set(self.sources_by_path)
+
+        self.inserts: list[SysPathInsert] = []
+        for sf in sources:
+            self.inserts.extend(find_sys_path_inserts(sf))
+
+        # roots: root_dir -> list of RootProvenance (one per distinct insert
+        # site producing that dir; repo root is always present, implicit).
+        self.roots: dict[str, list[RootProvenance]] = {"": [RootProvenance("", "implicit: repo root", "implicit")]}
+        for ins in self.inserts:
+            self.roots.setdefault(ins.target_dir, []).append(
+                RootProvenance(ins.target_dir, f"{ins.inserting_file}:{ins.lineno}", ins.scope, ins.inserting_file)
+            )
+        # A directory that contains at least one `if __name__ == "__main__":`
+        # entry point is *also* a usable root for every sibling in that same
+        # directory: when Python runs a script directly (`python
+        # eval/harness.py`), it auto-adds that script's own directory to
+        # sys.path[0] — no explicit insert required. This is exactly how
+        # `import harness` / `from tasks import TASKS` resolve from
+        # eval/grounding_gate_eval.py: eval/harness.py's own __main__ guard
+        # is what puts eval/ on sys.path for every file that runs alongside
+        # it, not anything grounding_gate_eval.py itself does.
+        main_dirs: dict[str, str] = {}
+        for sf in sources:
+            if sf.tree is not None and _has_main_guard(sf.tree):
+                main_dirs.setdefault(posixpath.dirname(sf.rel_path), sf.rel_path)
+        for root_dir, entry_file in main_dirs.items():
+            self.roots.setdefault(root_dir, []).append(
+                RootProvenance(root_dir, f"implicit: {entry_file} is a __main__ entry point", "implicit", entry_file)
+            )
+
+        self.modules: dict[str, ModuleInfo] = {}
+        self.by_dotted: dict[str, list[tuple[str, RootProvenance]]] = {}
+        for sf in sources:
+            info = ModuleInfo(rel_path=sf.rel_path, kind=_module_kind(sf.rel_path, all_rel_paths))
+            if sf.tree is not None:
+                info.has_main = _has_main_guard(sf.tree)
+            for root_dir, provs in self.roots.items():
+                dotted = _dotted_for(sf.rel_path, root_dir)
+                if dotted is None:
+                    continue
+                info.importable_as.setdefault(dotted, []).extend(provs)
+                for prov in provs:
+                    self.by_dotted.setdefault(dotted, []).append((sf.rel_path, prov))
+            self.modules[sf.rel_path] = info
+
+    # -- queries -----------------------------------------------------------
+
+    def module_for_path(self, rel_path: str) -> Optional[ModuleInfo]:
+        return self.modules.get(rel_path)
+
+    def resolve_dotted(self, dotted: str, importer_rel_path: str) -> "ResolveResult":
+        importer_dir = posixpath.dirname(importer_rel_path)
+
+        matches = self.by_dotted.get(dotted, [])
+        if matches:
+            # Preference order for which provenance to cite when several
+            # roots answer to the same dotted name:
+            #   1. a root THIS FILE ITSELF established (its own literal
+            #      sys.path.insert, or its own __main__ guard) — guaranteed
+            #      to have executed immediately before this import runs;
+            #   2. same-dir (root_dir == importer's own directory) — always
+            #      trivially available;
+            #   3. first found — a flat import that only resolves because
+            #      of an insert written in a DIFFERENT file, surfaced via
+            #      cross_file_root below.
+            own_file = [m for m in matches if m[1].source_file == importer_rel_path]
+            same_dir = [m for m in matches if m[1].root_dir == importer_dir]
+            chosen_path, chosen_prov = (own_file or same_dir or matches)[0]
+            resolved_via = self._classify(chosen_prov, importer_dir)
+            cross_file = (
+                chosen_prov.source_file is not None
+                and chosen_prov.source_file != importer_rel_path
+                and resolved_via.startswith("sys.path.insert")
+            )
+            unique = len({m[0] for m in matches}) == 1
+            return ResolveResult(
+                status="corpus", target_path=chosen_path, resolved_via=resolved_via,
+                evidence=chosen_prov.evidence, ambiguous=not unique,
+                candidates=sorted({m[0] for m in matches}), cross_file_root=cross_file,
+            )
+
+        top = dotted.split(".")[0]
+        if top in config.stdlib_module_names():
+            return ResolveResult(status="stdlib", target_path=None, resolved_via="stdlib",
+                                  evidence="", ambiguous=False, candidates=[], cross_file_root=False)
+        if top in config.third_party_top_level_names():
+            return ResolveResult(status="third-party", target_path=None, resolved_via="third-party",
+                                  evidence="", ambiguous=False, candidates=[], cross_file_root=False)
+        return ResolveResult(status="unresolved", target_path=None, resolved_via="unresolved",
+                              evidence="", ambiguous=False, candidates=[], cross_file_root=False)
+
+    @staticmethod
+    def _classify(prov: RootProvenance, importer_dir: str) -> str:
+        if prov.root_dir == importer_dir and prov.root_dir != "":
+            return "same-dir"
+        if prov.evidence == "implicit: repo root":
+            return "package"
+        if prov.evidence.startswith("implicit:"):
+            return "same-dir (via __main__ entry point)"
+        return f"sys.path.insert@{prov.evidence}"
+
+    def resolve_relative(self, level: int, module: Optional[str], importer_rel_path: str) -> "ResolveResult":
+        base_dir = posixpath.dirname(importer_rel_path)
+        target_dir = base_dir
+        for _ in range(max(level - 1, 0)):
+            target_dir = posixpath.dirname(target_dir)
+        dotted = target_dir.replace("/", ".") if target_dir else ""
+        if module:
+            dotted = f"{dotted}.{module}" if dotted else module
+        if not dotted:
+            return ResolveResult(status="unresolved", target_path=None, resolved_via="unresolved",
+                                  evidence="", ambiguous=False, candidates=[], cross_file_root=False)
+        # Relative imports resolve directly against the filesystem, not
+        # through the sys.path root table.
+        candidate_pkg = f"{dotted.replace('.', '/')}/__init__.py"
+        candidate_mod = f"{dotted.replace('.', '/')}.py"
+        for candidate in (candidate_mod, candidate_pkg):
+            if candidate in self.sources_by_path:
+                return ResolveResult(status="corpus", target_path=candidate, resolved_via="relative",
+                                      evidence=f"{importer_rel_path} (relative import, level={level})",
+                                      ambiguous=False, candidates=[candidate], cross_file_root=False)
+        return ResolveResult(status="unresolved", target_path=None, resolved_via="unresolved",
+                              evidence="", ambiguous=False, candidates=[], cross_file_root=False)
+
+
+@dataclass
+class ResolveResult:
+    status: str                # "corpus" | "stdlib" | "third-party" | "unresolved"
+    target_path: Optional[str]
+    resolved_via: str
+    evidence: str
+    ambiguous: bool
+    candidates: list[str]
+    cross_file_root: bool

--- a/scripts/callgraph/ruff.toml
+++ b/scripts/callgraph/ruff.toml
@@ -1,0 +1,9 @@
+# Fixtures under this package are INTENTIONALLY malformed: several are verbatim
+# line-range excerpts of real modules at the pre-fix revision, so their imports are
+# legitimately absent (F821), and one carries a deliberately unrecognised decorator.
+# Linting them would report the very defects they exist to reproduce.
+#
+# They are excluded by config rather than by a `# ruff: noqa` header because the
+# regression tests assert on exact fixture LINE NUMBERS -- prepending anything
+# shifts every assertion and breaks 10 tests.
+extend-exclude = ["fixtures"]

--- a/scripts/callgraph/rules.py
+++ b/scripts/callgraph/rules.py
@@ -1,0 +1,60 @@
+"""Loads rules.toml — the pattern set for decorator/registrar classification,
+kept as data so a new registrar or wrapper is a one-line edit for any
+engineer, not a code change.
+
+stdlib only (tomllib, stdlib since Python 3.11).
+"""
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+from . import config
+
+RULES_PATH = config.PACKAGE_ROOT / "rules.toml"
+
+
+@dataclass
+class Rules:
+    decorator_registering: tuple[str, ...] = ()
+    decorator_wrapping: tuple[str, ...] = ()
+    register_fn_names: tuple[str, ...] = ()
+    roots: tuple[dict, ...] = ()
+    raw: dict = field(default_factory=dict)
+
+    def classify_decorator(self, head: str) -> str:
+        """head: the dotted tail of the decorator with any call parens
+        stripped, e.g. "mcp.tool" from "@mcp.tool()", "app.get" from
+        "@app.get(\"/a2a\")". Matched against the LAST dotted component so
+        both "tool" and "mcp.tool" style entries in rules.toml work."""
+        last = head.rsplit(".", 1)[-1]
+        if head in self.decorator_registering or last in self.decorator_registering:
+            return "registering"
+        if head in self.decorator_wrapping or last in self.decorator_wrapping:
+            return "wrapping"
+        return "unknown"
+
+    def is_register_fn_name(self, name: str) -> bool:
+        for pattern in self.register_fn_names:
+            if pattern.endswith("*"):
+                if name.startswith(pattern[:-1]):
+                    return True
+            elif name == pattern:
+                return True
+        return False
+
+
+@lru_cache(maxsize=1)
+def load_rules() -> Rules:
+    with RULES_PATH.open("rb") as f:
+        data = tomllib.load(f)
+    dec = data.get("decorators", {})
+    registrars = data.get("registrars", {})
+    return Rules(
+        decorator_registering=tuple(dec.get("registering", [])),
+        decorator_wrapping=tuple(dec.get("wrapping", [])),
+        register_fn_names=tuple(registrars.get("register_fn_names", [])),
+        roots=tuple(data.get("roots", [])),
+        raw=data,
+    )

--- a/scripts/callgraph/rules.toml
+++ b/scripts/callgraph/rules.toml
@@ -1,0 +1,82 @@
+# Pattern set for callgraph, in DATA not code, so a new registrar or wrapper
+# is a one-line edit here rather than a code change. Patterns match against
+# the decorator's verbatim source text (as captured by ast.get_source_segment),
+# using suffix match on the "head" (the dotted-attribute part before any
+# call parens) unless noted otherwise.
+#
+# This file currently backs extract/defs.py's DECORATED_BY classification
+# (registering | wrapping | unknown). Later steps (extract/registry.py) are
+# expected to extend this file with manifest/route/registrar rules rather
+# than inventing a second rules file.
+
+[decorators]
+# A registering decorator makes the function callable from OUTSIDE the
+# Python corpus (an MCP client tool call, an HTTP route). Matched against
+# the decorator's dotted "head" (e.g. "mcp.tool", "app.get").
+registering = [
+    "tool",             # *.tool / *.tool()  (FastMCP)
+    "resource",         # *.resource(...)    (FastMCP)
+    "custom_route",     # *.custom_route(...)
+    "get",              # *.get(...)         (FastAPI route)
+    "post",             # *.post(...)
+    "put",
+    "delete",
+    "patch",
+    "route",
+]
+
+# A wrapping decorator changes call behaviour (caching, locking, a context
+# manager, an abstract stub) but calls still flow through to the body — it
+# does not register the function anywhere external.
+wrapping = [
+    "lru_cache",
+    "functools.lru_cache",
+    "cache",
+    "functools.cache",
+    "contextmanager",
+    "contextlib.contextmanager",
+    "wraps",
+    "functools.wraps",
+    "staticmethod",
+    "classmethod",
+    "abstractmethod",
+    "abc.abstractmethod",
+    "dataclass",
+    "dataclasses.dataclass",
+    "property",
+    "_writes",
+]
+
+# extract/registry.py's REG-FN rule: a module-level function whose NAME
+# matches one of these (exact match, or a "prefix*" glob) is a candidate
+# dependency-injector — it's only actually treated as one if its body ALSO
+# assigns a `global`-declared name directly from one of its own parameters,
+# or from `<dict-param>["<literal key>"]`. Matching the name alone is not
+# enough (plenty of functions are named "register" without this shape); the
+# body-shape check is what makes REG-FN precise.
+[registrars]
+register_fn_names = [
+    "register",
+    "setup",
+    "init_*",
+]
+
+# extract/registry.py's ROOT-EXT rule: entry points that live OUTSIDE the
+# Python corpus (systemd ExecStart lines, cron entries, shell wrappers) and
+# therefore can never be discovered by parsing .py files. Hand-maintained,
+# and — per the design's own honesty rule — WILL go stale; every `cg dead`
+# footer prints this table's size and this file's mtime for exactly that
+# reason. `module` is the repo-relative .py file the external trigger runs;
+# the entered function is whatever that module's own `if __name__ ==
+# "__main__":` guard calls (ROOT-CLI's own logic, reused here) — ROOT-EXT
+# only adds a second, independently-trusted ENTRYPOINT for the same
+# function, tagged trust=declared-in-roots.toml instead of
+# declared-in-source, so a report can tell "the source says this runs
+# standalone" apart from "an operator told this tool it runs standalone."
+[[roots]]
+module = "a2a_server/server.py"
+evidence = "a2a_server/loci-a2a.service:21 (systemd ExecStart)"
+
+[[roots]]
+module = "scripts/a2a_context_bridge.py"
+evidence = "scripts/systemd/loci-context-bridge.service:27 (systemd ExecStart)"

--- a/scripts/callgraph/scopes.py
+++ b/scripts/callgraph/scopes.py
@@ -1,0 +1,472 @@
+"""Per-module symbol tables, built in one AST pass: module globals,
+function/class nesting with qualnames, decorator source text, `global`
+declarations, and import statements. Everything downstream (extract/defs.py,
+extract/imports.py, and later slices' extract/calls.py etc.) reads a
+ModuleScope; nothing re-walks the tree for names.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .ingest import SourceFile
+
+PARAM_KIND_NAMES = {
+    "posonly": "POSITIONAL_ONLY",
+    "pos_or_kw": "POSITIONAL_OR_KEYWORD",
+    "vararg": "VAR_POSITIONAL",
+    "kwonly": "KEYWORD_ONLY",
+    "kwarg": "VAR_KEYWORD",
+}
+
+
+@dataclass
+class ParamInfo:
+    name: str
+    kind: str
+    has_default: bool = False
+    default_is_literal: bool = False
+
+
+@dataclass
+class FunctionInfo:
+    qualname: str
+    node: ast.AST                      # FunctionDef | AsyncFunctionDef | Lambda
+    lineno: int
+    end_lineno: int
+    col: int
+    is_async: bool
+    is_lambda: bool
+    is_method: bool
+    is_nested: bool
+    params: list[ParamInfo]
+    decorators: list[str]              # verbatim source text, outermost first
+    docstring_first_line: Optional[str]
+    parent_class: Optional[str] = None  # simple class name if is_method
+    ambiguous_duplicate: bool = False
+
+
+@dataclass
+class ClassInfo:
+    qualname: str
+    node: ast.ClassDef
+    lineno: int
+    end_lineno: int
+    bases: list[str]                   # verbatim source text per base
+    method_qualnames: list[str] = field(default_factory=list)
+    ambiguous_duplicate: bool = False
+
+
+@dataclass
+class NameInfo:
+    ident: str
+    binding_kinds: set[str] = field(default_factory=set)   # assign|def|import|global-only
+    binding_lines: dict[str, list[int]] = field(default_factory=dict)
+
+    @property
+    def is_dunder(self) -> bool:
+        return self.ident.startswith("__") and self.ident.endswith("__")
+
+    @property
+    def is_private(self) -> bool:
+        return self.ident.startswith("_") and not self.is_dunder
+
+    def record(self, kind: str, line: int) -> None:
+        self.binding_kinds.add(kind)
+        self.binding_lines.setdefault(kind, []).append(line)
+
+
+@dataclass
+class ImportRecord:
+    lineno: int
+    is_from: bool
+    module: Optional[str]              # dotted module (None for bare relative "from . import x")
+    level: int                         # 0 for absolute
+    names: list[tuple[str, Optional[str]]]  # (imported name, asname)
+    scope: str                          # "module-level" | "function-local"
+    enclosing_fn: Optional[str]         # qualname of enclosing function, if function-local
+
+
+@dataclass
+class FunctionLocals:
+    """A function's own binding surface, computed with the same "linear walk,
+    not a CFG" philosophy as the rest of this tool: every assignment target
+    reachable in the function's body (without descending into nested
+    def/class/lambda scopes) is treated as local for the WHOLE function, and
+    `global`/`nonlocal` declarations override that. Used by extract/calls.py
+    (to spot `param-call` callsites) and extract/names.py (to tell a real
+    module-global read from a same-named local)."""
+    params: set[str] = field(default_factory=set)
+    assigned: set[str] = field(default_factory=set)
+    global_declared: set[str] = field(default_factory=set)
+    nonlocal_declared: set[str] = field(default_factory=set)
+
+    @property
+    def effective_locals(self) -> set[str]:
+        return (self.params | self.assigned) - self.global_declared - self.nonlocal_declared
+
+
+@dataclass
+class ModuleAssign:
+    """A module-level `A = B` (or `A = mod.B`) simple aliasing candidate."""
+    lineno: int
+    target: str
+    value_kind: str    # "name" | "attribute" | "other"
+    value_name: Optional[str]       # for "name": the RHS identifier
+    value_base: Optional[str] = None   # for "attribute": the base name (mod.X -> "mod")
+    value_attr: Optional[str] = None   # for "attribute": the attr (mod.X -> "X")
+
+
+class ModuleScope:
+    def __init__(self, sf: SourceFile) -> None:
+        self.sf = sf
+        self._lines = sf.source.splitlines(keepends=True)
+        self.functions: list[FunctionInfo] = []
+        self.classes: list[ClassInfo] = []
+        self.names: dict[str, NameInfo] = {}
+        self.imports: list[ImportRecord] = []
+        self.module_assigns: list[ModuleAssign] = []
+        self._seen_qualnames: dict[str, int] = {}
+        # id(ast-node) -> qualname, so a later whole-module walk (calls.py,
+        # names.py, registry.py) can recover "which function am I inside"
+        # from the same qualnames this pass already computed (incl. the
+        # "#2"-style disambiguation suffix), instead of recomputing a
+        # possibly-inconsistent qualname independently.
+        self._node_to_qualname: dict[int, str] = {}
+        self.function_by_qualname: dict[str, FunctionInfo] = {}
+        self._locals_cache: dict[int, FunctionLocals] = {}
+        if sf.tree is not None:
+            self._build()
+
+    # -- helpers -------------------------------------------------------
+
+    def _name(self, ident: str) -> NameInfo:
+        info = self.names.get(ident)
+        if info is None:
+            info = NameInfo(ident=ident)
+            self.names[ident] = info
+        return info
+
+    def qualname_for_node(self, node: ast.AST) -> Optional[str]:
+        """The qualname this pass assigned to a def/lambda node, or None if
+        `node` isn't one of this module's own FunctionDef/AsyncFunctionDef/
+        Lambda nodes."""
+        return self._node_to_qualname.get(id(node))
+
+    def source_of(self, node: ast.AST) -> str:
+        """Public wrapper over the cached-split source-segment extractor,
+        for extract/calls.py and extract/registry.py to capture verbatim
+        callee/receiver text without each re-splitting the file."""
+        return self._src(node)
+
+    def locals_of(self, fi: FunctionInfo) -> FunctionLocals:
+        cached = self._locals_cache.get(id(fi.node))
+        if cached is not None:
+            return cached
+        params = {p.name for p in fi.params}
+        assigned: set[str] = set()
+        global_declared: set[str] = set()
+        nonlocal_declared: set[str] = set()
+
+        def add_target(t: ast.expr) -> None:
+            if isinstance(t, ast.Name):
+                assigned.add(t.id)
+            elif isinstance(t, (ast.Tuple, ast.List)):
+                for elt in t.elts:
+                    add_target(elt)
+            elif isinstance(t, ast.Starred):
+                add_target(t.value)
+
+        def walk(node: ast.AST) -> None:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)) and node is not fi.node:
+                return  # nested scope: its own locals, not this function's
+            if isinstance(node, ast.Global):
+                global_declared.update(node.names)
+            elif isinstance(node, ast.Nonlocal):
+                nonlocal_declared.update(node.names)
+            elif isinstance(node, ast.Assign):
+                for t in node.targets:
+                    add_target(t)
+            elif isinstance(node, ast.AnnAssign) and node.target is not None:
+                add_target(node.target)
+            elif isinstance(node, ast.AugAssign):
+                add_target(node.target)
+            elif isinstance(node, (ast.For, ast.AsyncFor)):
+                add_target(node.target)
+            elif isinstance(node, ast.withitem):
+                if node.optional_vars is not None:
+                    add_target(node.optional_vars)
+            elif isinstance(node, ast.ExceptHandler):
+                if node.name:
+                    assigned.add(node.name)
+            elif isinstance(node, ast.NamedExpr):
+                add_target(node.target)
+            for child in ast.iter_child_nodes(node):
+                walk(child)
+
+        if isinstance(fi.node, ast.Lambda):
+            walk(fi.node.body)
+        else:
+            for stmt in fi.node.body:
+                walk(stmt)
+        fl = FunctionLocals(params=params, assigned=assigned,
+                             global_declared=global_declared, nonlocal_declared=nonlocal_declared)
+        self._locals_cache[id(fi.node)] = fl
+        return fl
+
+    def _src(self, node: ast.AST) -> str:
+        # ast.get_source_segment() re-splits the WHOLE file into lines on
+        # every call; called once per decorator/base that's cheap, but
+        # called across a 7,000-line file dozens of times it dominates the
+        # build. Cache the split once per module instead.
+        end_lineno = getattr(node, "end_lineno", None)
+        end_col = getattr(node, "end_col_offset", None)
+        if end_lineno is None or end_col is None:
+            return "<unavailable>"
+        lines = self._lines
+        lineno = node.lineno - 1
+        end_lineno0 = end_lineno - 1
+        col = node.col_offset
+        if lineno == end_lineno0:
+            return lines[lineno].encode()[col:end_col].decode()
+        first = lines[lineno].encode()[col:].decode()
+        last = lines[end_lineno0].encode()[:end_col].decode()
+        mid = lines[lineno + 1:end_lineno0]
+        return "".join([first, *mid, last])
+
+    def _unique_qualname(self, qualname: str) -> tuple[str, bool]:
+        count = self._seen_qualnames.get(qualname, 0)
+        self._seen_qualnames[qualname] = count + 1
+        if count == 0:
+            return qualname, False
+        return f"{qualname}#{count + 1}", True
+
+    # -- main walk -------------------------------------------------------
+
+    def _build(self) -> None:
+        tree = self.sf.tree
+        assert tree is not None
+        self._walk_body(tree.body, stack=[])
+        for lam in _find_lambdas_in(tree.body):
+            self._visit_lambda(lam, [])
+        self._collect_module_names(tree.body)
+        self._collect_global_only()
+
+    def _walk_body(self, body: list[ast.stmt], stack: list[tuple[str, str]]) -> None:
+        for stmt in body:
+            self._walk_stmt(stmt, stack)
+
+    def _walk_stmt(self, stmt: ast.stmt, stack: list[tuple[str, str]]) -> None:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            self._visit_function(stmt, stack)
+            return
+        if isinstance(stmt, ast.ClassDef):
+            self._visit_class(stmt, stack)
+            return
+        if isinstance(stmt, ast.Import):
+            self._visit_import(stmt, stack)
+        elif isinstance(stmt, ast.ImportFrom):
+            self._visit_import_from(stmt, stack)
+        # Recurse into simple nested-statement containers (if/try/with/for/
+        # while) so nested `def`/`class`/import/global are still found —
+        # this is a linear walk, not a CFG, matching the rest of the tool.
+        for field_name, value in ast.iter_fields(stmt):
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.stmt):
+                        self._walk_stmt(item, stack)
+            elif isinstance(value, ast.stmt):
+                self._walk_stmt(value, stack)
+
+    def _qualname_for(self, name: str, stack: list[tuple[str, str]]) -> str:
+        if not stack:
+            return name
+        parent_kind, parent_qual = stack[-1]
+        if parent_kind == "class":
+            return f"{parent_qual}.{name}"
+        return f"{parent_qual}.<locals>.{name}"
+
+    def _extract_params(self, args: ast.arguments) -> list[ParamInfo]:
+        out: list[ParamInfo] = []
+
+        def add(a: ast.arg, kind: str, default: Optional[ast.expr]) -> None:
+            has_default = default is not None
+            is_lit = has_default and isinstance(default, ast.Constant)
+            out.append(ParamInfo(a.arg, PARAM_KIND_NAMES[kind], has_default, is_lit))
+
+        posonly = list(getattr(args, "posonlyargs", []))
+        pos = list(args.args)
+        n_pos_defaults = len(args.defaults)
+        all_pos = posonly + pos
+        pos_defaults: list[Optional[ast.expr]] = [None] * (len(all_pos) - n_pos_defaults) + list(args.defaults)
+        for a, d in zip(posonly, pos_defaults[: len(posonly)]):
+            add(a, "posonly", d)
+        for a, d in zip(pos, pos_defaults[len(posonly):]):
+            add(a, "pos_or_kw", d)
+        if args.vararg:
+            add(args.vararg, "vararg", None)
+        for a, d in zip(args.kwonlyargs, args.kw_defaults):
+            add(a, "kwonly", d)
+        if args.kwarg:
+            add(args.kwarg, "kwarg", None)
+        return out
+
+    def _visit_function(self, node, stack: list[tuple[str, str]]) -> None:
+        is_nested = bool(stack) and stack[-1][0] == "function"
+        is_method = bool(stack) and stack[-1][0] == "class"
+        qualname_raw = self._qualname_for(node.name, stack)
+        qualname, ambiguous = self._unique_qualname(qualname_raw)
+        decorators = [self._src(d) for d in node.decorator_list]
+        doc = ast.get_docstring(node, clean=True)
+        doc_first = doc.splitlines()[0] if doc else None
+        fi = FunctionInfo(
+            qualname=qualname, node=node, lineno=node.lineno,
+            end_lineno=getattr(node, "end_lineno", node.lineno), col=node.col_offset,
+            is_async=isinstance(node, ast.AsyncFunctionDef), is_lambda=False,
+            is_method=is_method, is_nested=is_nested,
+            params=self._extract_params(node.args), decorators=decorators,
+            docstring_first_line=doc_first,
+            parent_class=stack[-1][1].rsplit(".", 1)[-1] if is_method else None,
+            ambiguous_duplicate=ambiguous,
+        )
+        self.functions.append(fi)
+        self._node_to_qualname[id(node)] = qualname
+        self.function_by_qualname[qualname] = fi
+        if stack and stack[-1][0] == "class":
+            # class method table wants simple names, not the module-relative id
+            pass
+        new_stack = stack + [("function", qualname)]
+        self._walk_body(node.body, new_stack)
+        for lam in _find_lambdas_in(node.body):
+            self._visit_lambda(lam, new_stack)
+
+    def _visit_lambda(self, node: ast.Lambda, stack: list[tuple[str, str]]) -> None:
+        raw_name = f"<lambda>@{node.lineno}"
+        qualname_raw = self._qualname_for(raw_name, stack)
+        qualname, ambiguous = self._unique_qualname(qualname_raw)
+        is_method = bool(stack) and stack[-1][0] == "class"
+        fi = FunctionInfo(
+            qualname=qualname, node=node, lineno=node.lineno,
+            end_lineno=getattr(node, "end_lineno", node.lineno), col=node.col_offset,
+            is_async=False, is_lambda=True, is_method=is_method, is_nested=True,
+            params=self._extract_params(node.args), decorators=[],
+            docstring_first_line=None,
+            parent_class=stack[-1][1].rsplit(".", 1)[-1] if is_method else None,
+            ambiguous_duplicate=ambiguous,
+        )
+        self.functions.append(fi)
+        self._node_to_qualname[id(node)] = qualname
+        self.function_by_qualname[qualname] = fi
+
+    def _visit_class(self, node: ast.ClassDef, stack: list[tuple[str, str]]) -> None:
+        qualname_raw = self._qualname_for(node.name, stack)
+        qualname, ambiguous = self._unique_qualname(qualname_raw)
+        bases = [self._src(b) for b in node.bases]
+        ci = ClassInfo(qualname=qualname, node=node, lineno=node.lineno,
+                        end_lineno=getattr(node, "end_lineno", node.lineno),
+                        bases=bases, ambiguous_duplicate=ambiguous)
+        self.classes.append(ci)
+        new_stack = stack + [("class", qualname)]
+        before = len(self.functions)
+        self._walk_body(node.body, new_stack)
+        ci.method_qualnames = [f.qualname for f in self.functions[before:] if not f.is_nested or f.is_method]
+        for lam in _find_lambdas_in(node.body):
+            self._visit_lambda(lam, new_stack)
+
+    def _visit_import(self, stmt: ast.Import, stack: list[tuple[str, str]]) -> None:
+        scope = "module-level" if not stack else "function-local"
+        enclosing = stack[-1][1] if stack and stack[-1][0] == "function" else None
+        names: list[tuple[str, Optional[str]]] = []
+        for alias in stmt.names:
+            bound = alias.asname or alias.name.split(".")[0]
+            names.append((alias.name, alias.asname))
+            if scope == "module-level":
+                self._name(bound).record("import", stmt.lineno)
+        self.imports.append(ImportRecord(stmt.lineno, False, None, 0, names, scope, enclosing))
+
+    def _visit_import_from(self, stmt: ast.ImportFrom, stack: list[tuple[str, str]]) -> None:
+        scope = "module-level" if not stack else "function-local"
+        enclosing = stack[-1][1] if stack and stack[-1][0] == "function" else None
+        names = [(a.name, a.asname) for a in stmt.names]
+        if scope == "module-level":
+            for imported, asname in names:
+                if imported == "*":
+                    continue
+                bound = asname or imported
+                self._name(bound).record("import", stmt.lineno)
+        self.imports.append(ImportRecord(stmt.lineno, True, stmt.module, stmt.level, names, scope, enclosing))
+
+    # -- module-level NAME slots -----------------------------------------
+
+    def _collect_module_names(self, body: list[ast.stmt]) -> None:
+        for stmt in body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._name(stmt.name).record("def", stmt.lineno)
+            elif isinstance(stmt, ast.ClassDef):
+                self._name(stmt.name).record("def", stmt.lineno)
+            elif isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    self._record_assign_target(target, stmt.lineno)
+                if len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+                    self._record_module_alias(stmt.targets[0].id, stmt.value, stmt.lineno)
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                self._name(stmt.target.id).record("assign", stmt.lineno)
+                if stmt.value is not None:
+                    self._record_module_alias(stmt.target.id, stmt.value, stmt.lineno)
+            elif isinstance(stmt, ast.AugAssign) and isinstance(stmt.target, ast.Name):
+                self._name(stmt.target.id).record("assign", stmt.lineno)
+            elif isinstance(stmt, (ast.If, ast.Try, ast.With, ast.For, ast.While)):
+                for field_name, value in ast.iter_fields(stmt):
+                    if isinstance(value, list):
+                        nested = [v for v in value if isinstance(v, ast.stmt)]
+                        if nested:
+                            self._collect_module_names(nested)
+
+    def _record_assign_target(self, target: ast.expr, lineno: int) -> None:
+        if isinstance(target, ast.Name):
+            self._name(target.id).record("assign", lineno)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                self._record_assign_target(elt, lineno)
+
+    def _record_module_alias(self, target_name: str, value: ast.expr, lineno: int) -> None:
+        if isinstance(value, ast.Name):
+            self.module_assigns.append(ModuleAssign(lineno, target_name, "name", value.id))
+        elif isinstance(value, ast.Attribute) and isinstance(value.value, ast.Name):
+            self.module_assigns.append(
+                ModuleAssign(lineno, target_name, "attribute", None, value.value.id, value.attr)
+            )
+
+    # -- global-only detection -------------------------------------------
+
+    def _collect_global_only(self) -> None:
+        if self.sf.tree is None:
+            return
+        for node in ast.walk(self.sf.tree):
+            if isinstance(node, ast.Global):
+                for ident in node.names:
+                    info = self._name(ident)
+                    if "assign" not in info.binding_kinds and "def" not in info.binding_kinds:
+                        info.record("global-only", node.lineno)
+
+
+def _find_lambdas_in(body: list[ast.stmt]):
+    """Lambdas that are direct expressions within this body (not inside a
+    nested def/class, which get their own scan when that scope is
+    visited)."""
+    out: list[ast.Lambda] = []
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return
+        if isinstance(node, ast.Lambda):
+            out.append(node)
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    for stmt in body:
+        visit(stmt)
+    return out

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -1,0 +1,351 @@
+"""Standalone health check for this checkout: builds the graph over
+fixtures/ (no git, no network) and once over the real corpus at HEAD (git
+read, still no network/venv/LadybugDB dependency), then asserts the
+SPECIFIC findings this tool exists to produce -- not merely "did not
+raise". Runnable directly (`cg selftest`) and imported by
+tests/test_selftest.py so pytest exercises the identical checks.
+
+Deliberately does NOT re-run the three historical-revision bug regressions
+(BUG B/C/D at their specific pre-fix commits) -- those already have
+dedicated, thorough coverage in tests/test_cli_step10_12.py and
+tests/test_pipeline_real_corpus.py, and re-doing three more full-corpus
+git-blob builds here would blow the 5s budget for no new signal. This file
+checks the same dispatch shapes those bugs came from, over the fast
+fixtures/ build, plus the one real-corpus invariant that would catch a
+regression in any of them structurally: the hard gate (no registered
+function ever reported dead) and the registration-surface counts.
+
+ACCEPTANCE (build_steps step 13): green from a clean checkout, no venv, no
+network, no LadybugDB; the full run (fixture build + the one HEAD corpus
+build + every assertion) finishes in well under 5s.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from .analyze.deadcode import registered_but_dead
+from .analyze.flags import rank_flags
+from .analyze.literalaudit import near_miss_pairs, orphans
+from .analyze.nameaudit import dangling_globals
+from .model import Confidence
+from .pipeline import build_graph
+from .tests.helpers import build_fixture_store
+
+
+@dataclass
+class Check:
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class SelftestReport:
+    checks: list = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        return all(c.ok for c in self.checks)
+
+    @property
+    def failed(self):
+        return [c for c in self.checks if not c.ok]
+
+
+def _run(checks: list, name: str, fn) -> None:
+    """Runs one check function; a raised exception (including a failed
+    `assert`) is recorded as a failing Check instead of aborting the rest
+    of the run -- one broken dispatch shape should never hide the other
+    thirteen results."""
+    try:
+        fn()
+        checks.append(Check(name, True))
+    except AssertionError as exc:
+        checks.append(Check(name, False, f"assertion failed: {exc}"))
+    except Exception as exc:  # tool error inside a check itself
+        checks.append(Check(name, False, f"{exc.__class__.__name__}: {exc}"))
+
+
+# -- fixture-based checks, one per dispatch shape in the design ------------
+
+
+def _check_dec():
+    store, _, _ = build_fixture_store(["decorator_registry.py"])
+    reg_id = "reg:decorator_registry.py::mcp.tool"
+    reg = store.get(reg_id)
+    assert reg is not None and reg.attrs["mechanism"] == "decorator"
+    members = {e.dst for e in store.out_edges(reg_id, "REGISTERS")}
+    assert members == {"fn:decorator_registry.py::registered_tool"}
+    entry = store.get("entry:mcp-tool:registered_tool")
+    assert entry is not None
+    enters = store.out_edges(entry.id, "ENTERS")
+    assert len(enters) == 1 and enters[0].dst == "fn:decorator_registry.py::registered_tool"
+    # the decorator no rule recognizes must NOT spawn a registry
+    assert store.get("reg:decorator_registry.py::some_unrecognized_decorator") is None
+    mystery_dbs = store.out_edges("fn:decorator_registry.py::mystery", "DECORATED_BY")
+    assert mystery_dbs and mystery_dbs[0].attrs["classification"] == "unknown"
+
+
+def _check_manloop():
+    store, _, _ = build_fixture_store(["registry_manloop.py"])
+    reg_id = "reg:registry_manloop.py::register"
+    reg = store.get(reg_id)
+    assert reg is not None and reg.attrs["mechanism"] == "manifest-tuple"
+    members = {e.dst for e in store.out_edges(reg_id, "REGISTERS")}
+    assert members == {"fn:registry_manloop.py::tool_a", "fn:registry_manloop.py::tool_b"}
+    # the unrelated "call a method ON each tuple element" loop is NOT MAN-LOOP
+    assert store.get("reg:registry_manloop.py::_reset_cache") is None
+
+
+def _check_mandict():
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    reg_id = "reg:registry_mandict.py::_SKILL_MAP"
+    reg = store.get(reg_id)
+    assert reg is not None and reg.attrs["mechanism"] == "manifest-dict"
+    keys = {e.attrs["key"] for e in store.out_edges(reg_id, "REGISTERS")}
+    assert keys == {"one", "two"}
+    # a config dict of literal values must never be mistaken for a dispatch table
+    assert store.get("reg:registry_mandict.py::_CONFIG_MAP") is None
+    # the `.get(...)` dispatch callsite fans out to both registered skills
+    sites = [
+        n for n in store.nodes_of_kind("CALLSITE")
+        if n.attrs.get("enclosing_fn") == "fn:registry_mandict.py::dispatch" and n.attrs.get("callee") == "handler"
+    ]
+    assert len(sites) == 1
+    call_edge = store.out_edges(sites[0].id, "CALLS")[0]
+    assert call_edge.dst == "?" and call_edge.attrs["reason"] == "dict-dispatch-fanout"
+    disp_targets = {e.dst for e in store.out_edges(sites[0].id, "DISPATCHES")}
+    assert disp_targets == {"fn:registry_mandict.py::skill_one", "fn:registry_mandict.py::skill_two"}
+
+
+def _check_reg_fn_injects():
+    # Load BOTH callers, mirroring register() being called twice in the
+    # real corpus (tests do this) -- the re-entrant, widened-to-fanout shape.
+    store, _, _ = build_fixture_store([
+        "registry_injection.py", "registry_injection_caller.py", "registry_injection_caller2.py",
+    ])
+    nid = "name:registry_injection.py::_get_thing"
+    injects = store.in_edges(nid, "INJECTS")
+    assert len(injects) == 2
+    values = {e.attrs["value"] for e in injects}
+    assert values == {
+        "fn:registry_injection_caller.py::real_thing",
+        "fn:registry_injection_caller2.py::other_thing",
+    }
+    use_thing_id = "fn:registry_injection.py::use_thing"
+    sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == use_thing_id]
+    assert len(sites) == 1
+    edge = store.out_edges(sites[0].id, "CALLS")[0]
+    assert edge.dst == "?" and edge.attrs["reason"] == "injected-global-multi-value"
+    assert edge.attrs["alternatives"] == 2
+    disp_targets = {e.dst for e in store.out_edges(sites[0].id, "DISPATCHES")}
+    assert disp_targets == values
+    assert all(e.confidence == Confidence.PROBABLE for e in store.out_edges(sites[0].id, "DISPATCHES"))
+    # the deps["helper_a"] key-injection side is ALSO called from both
+    # callers (caller2.py's dict passes a different bare name for it) --
+    # two INJECTS edges too, same shape as the direct-param side above.
+    helper_injects = store.in_edges("name:registry_injection.py::_helper_a", "INJECTS")
+    assert len(helper_injects) == 2
+    assert all(e.attrs["param"] == "deps" and e.attrs["key"] == "helper_a" for e in helper_injects)
+
+
+def _check_rootcli():
+    store, _, _ = build_fixture_store(["registry_rootcli.py"])
+    entry = store.get("entry:cli:registry_rootcli.py")
+    assert entry is not None and entry.attrs["trust"] == "declared-in-source"
+    enters = store.out_edges(entry.id, "ENTERS")
+    assert len(enters) == 1 and enters[0].dst == "fn:registry_rootcli.py::main"
+
+
+def _check_dangling_global():
+    # THIS IS BUG C, in miniature: a `global`-declared write with no
+    # module-level binding, correctly NOT flagged for an ident that IS
+    # bound at module level in the SAME module, with the real slot named
+    # in a DIFFERENT module.
+    store, _, _ = build_fixture_store(["dangling_global.py", "dangling_global_real_slot.py"])
+    findings = {f.slot.id: f for f in dangling_globals(store)}
+    assert "name:dangling_global.py::_symbol_index_cache" in findings
+    assert "name:dangling_global.py::_symbol_index_count" in findings
+    assert "name:dangling_global.py::_real_counter" not in findings
+    real = findings["name:dangling_global.py::_symbol_index_cache"].real_slots
+    assert len(real) == 1 and real[0].path == "dangling_global_real_slot.py" and real[0].line == 7
+
+
+def _check_literal_orphans():
+    # THIS IS BUG D, in miniature: a produced path with zero consumers and
+    # a consumed path with zero producers, paired by --near-miss on their
+    # shared stem, while a genuinely matched pair (notes.jsonl) is excluded
+    # from the orphan lists entirely.
+    store, _, _ = build_fixture_store(["literals_produce.py", "literals_consume.py", "literals_keys.py"])
+    producer_only, consumer_only = orphans(store, flavour="path")
+    p_texts = {g.match_text for g in producer_only}
+    c_texts = {g.match_text for g in consumer_only}
+    assert "graph.ladybug" in p_texts and "notes.jsonl" not in p_texts
+    assert "graph.kuzu" in c_texts and "notes.jsonl" not in c_texts
+    pairs = near_miss_pairs(producer_only, consumer_only)
+    matches = [p for p in pairs if p.shared_stem == "graph"]
+    assert len(matches) == 1
+    assert {matches[0].producer.match_text, matches[0].consumer.match_text} == {"graph.ladybug", "graph.kuzu"}
+    kp, kc = orphans(store, flavour="key")
+    assert "cfg_write_only" in {g.match_text for g in kp}
+    assert "cfg_lookup_only" in {g.match_text for g in kc}
+
+
+def _check_flags():
+    # THIS IS BUG B, in miniature: a constant-initialized local reassigned
+    # only inside guarded branches ranks ABOVE one that is never reassigned
+    # at all, by the guard-exits-that-skip-it / assignments-made ratio.
+    store, _, _ = build_fixture_store(["flags_shapes.py"])
+    rows = rank_flags(store)
+    by_ident = {r.ident: r for r in rows}
+    assert "ok" in by_ident and "step" in by_ident
+    assert "parts" not in by_ident and "result" not in by_ident  # non-constant inits excluded
+    assert by_ident["ok"].score > by_ident["step"].score
+    assert rows[0].ident == "ok"
+    assert by_ident["ok"].escape_form == "dict-value"
+
+
+def _check_calls_ladder():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+
+    def _edge_for(fn_qualname):
+        fid = f"fn:calls_shapes.py::{fn_qualname}"
+        sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fid]
+        assert len(sites) == 1, fn_qualname
+        return store.out_edges(sites[0].id, "CALLS")[0]
+
+    e = _edge_for("caller_name_def_local")
+    assert e.dst == "fn:calls_shapes.py::helper" and e.confidence == Confidence.PROVEN
+    e = _edge_for("caller_module_attribute_corpus")
+    assert e.dst == "fn:calls_target.py::target_fn" and e.confidence == Confidence.PROVEN
+    e = _edge_for("caller_module_attribute_external")
+    assert e.dst.startswith("ext:") and e.confidence == Confidence.PROVEN
+    e = _edge_for("caller_local_import")
+    assert e.dst.startswith("ext:") and e.confidence == Confidence.PROVEN
+    e = _edge_for("caller_param_call")
+    assert e.dst == "?"
+    e = _edge_for("caller_unknown_attribute")
+    assert e.dst == "?"
+
+
+def _check_dispatch():
+    store, _, _ = build_fixture_store(["dispatch_shapes.py", "dispatch_target.py"])
+
+    def _edge_for(fn_qualname, callee=None):
+        fid = f"fn:dispatch_shapes.py::{fn_qualname}"
+        sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fid]
+        if callee is not None:
+            sites = [n for n in sites if n.attrs.get("callee") == callee]
+        assert len(sites) == 1, (fn_qualname, callee)
+        return store.out_edges(sites[0].id, "CALLS")[0]
+
+    e = _edge_for("call_unique_method")
+    assert e.dst == "fn:dispatch_shapes.py::OnlyOwner.unique_op" and e.confidence == Confidence.PROBABLE
+    e = _edge_for("call_ambiguous_method")
+    assert e.dst == "?" and e.attrs["reason"] == "ambiguous-method-name" and e.attrs["alternatives"] == 2
+    fid = "fn:dispatch_shapes.py::call_getattr_literal"
+    site = next(n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fid)
+    e = store.out_edges(site.id, "CALLS")[0]
+    assert e.dst == "fn:dispatch_target.py::target_fn" and e.confidence == Confidence.PROVEN
+    fid = "fn:dispatch_shapes.py::call_getattr_variable"
+    site = next(n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fid)
+    e = store.out_edges(site.id, "CALLS")[0]
+    assert e.dst == "?" and e.attrs["reason"] == "computed-getattr"
+
+
+def _check_cross_module_names():
+    store, _, _ = build_fixture_store(["names_cross_module.py", "names_cross_module_target.py"])
+    nid = "name:names_cross_module_target.py::CONFIG_VALUE"
+    reads = store.in_edges(nid, "READS_NAME")
+    assert len(reads) == 1
+    assert reads[0].src == "fn:names_cross_module.py::read_it"
+    assert reads[0].attrs.get("cross_module") is True
+
+
+def _check_nesting():
+    store, _, _ = build_fixture_store(["nesting.py"])
+    assert store.get("fn:nesting.py::outer.<locals>.inner") is not None
+    lambdas = [n for n in store.nodes_of_kind("FUNCTION") if n.attrs.get("is_lambda") and n.path == "nesting.py"]
+    assert len(lambdas) == 1
+    # a lambda passed straight into a registering call is a real,
+    # addressable FUNCTION node -- not silently dropped.
+    assert lambdas[0].id.startswith("fn:nesting.py::")
+
+
+def _check_reexport():
+    store, _, _ = build_fixture_store(["reexport.py", "reexport_source.py"])
+    target = "fn:reexport_source.py::symbol_impact"
+    aliases_import = store.out_edges("name:reexport.py::symbol_impact", "ALIASES")
+    assert len(aliases_import) == 1 and aliases_import[0].dst == target
+    # `runner = symbol_impact` is a bare module-level alias to the IMPORTED
+    # name slot, not straight to the function -- a one-more-hop ALIASES
+    # chain (NAME -> NAME -> FUNCTION), exactly the "one-or-more ALIASES
+    # hops" rung 2 of the CALLS resolution ladder is built to walk.
+    aliases_bare = store.out_edges("name:reexport.py::runner", "ALIASES")
+    assert len(aliases_bare) == 1 and aliases_bare[0].dst == "name:reexport.py::symbol_impact"
+    chained = store.out_edges(aliases_bare[0].dst, "ALIASES")
+    assert len(chained) == 1 and chained[0].dst == target
+    definers = store.in_edges(target, "DEFINES")
+    assert len(definers) == 1  # the re-exports don't create a second definition
+
+
+def _check_lazy_import():
+    store, _, _ = build_fixture_store(["lazy_import.py"])
+    edges = list(store.edges_of_kind("IMPORTS"))
+    lazy = [e for e in edges if e.attrs.get("scope") == "function-local" and e.src == "mod:lazy_import.py"]
+    assert any(e.attrs.get("module") == "numpy" and e.attrs.get("enclosing_fn") == "resolve_vllm" for e in lazy)
+    assert any(e.attrs.get("module") == "textwrap" and e.attrs.get("enclosing_fn") == "Widget.render" for e in lazy)
+    module_level = [e for e in edges if e.attrs.get("scope") != "function-local" and e.attrs.get("module") == "json"]
+    assert module_level
+
+
+# -- one real-corpus check: the hard gate + registration-surface counts ---
+
+
+def _check_real_corpus():
+    result = build_graph(rev="HEAD")
+    store = result.store
+    assert result.meta.file_count == 114, result.meta.file_count
+    assert result.meta.error_count == 0, result.meta.errors
+    bad = registered_but_dead(store)
+    assert bad == [], [n.id for n in bad]
+    from collections import Counter
+    by_rule = Counter(e.attrs["rule"] for e in store.edges_of_kind("REGISTERS"))
+    assert by_rule["DEC-tool"] == 41, dict(by_rule)
+    assert by_rule["DEC-route"] == 6, dict(by_rule)
+    assert by_rule["DEC-mcp-route"] == 1, dict(by_rule)
+    assert by_rule["MAN-LOOP"] == 31, dict(by_rule)
+    assert by_rule["MAN-DICT"] == 13, dict(by_rule)
+    unmatched = [e for e in store.edges_of_kind("DECORATED_BY") if e.attrs["classification"] == "unknown"]
+    assert unmatched == [], [(e.src, e.attrs["raw"]) for e in unmatched]
+
+
+_ALL_CHECKS = [
+    ("DEC: @mcp.tool()-style decorator registers fn + entrypoint; unknown decorator classified unknown", _check_dec),
+    ("MAN-LOOP: manifest tuple registers both members; unrelated bare-name loop is not MAN-LOOP", _check_manloop),
+    ("MAN-DICT: _SKILL_MAP registers + dispatch fans out; literal-valued config dict is not a registry", _check_mandict),
+    ("REG-FN/INJECTS: register()-param + deps[key] injection; re-entrant registration widens to DISPATCHES", _check_reg_fn_injects),
+    ("ROOT-CLI: __main__ guard ENTERS the called function", _check_rootcli),
+    ("BUG C shape: DANGLING-GLOBAL flags global-only slot and names the real slot in another module", _check_dangling_global),
+    ("BUG D shape: path-literal orphans found + paired by --near-miss on shared stem", _check_literal_orphans),
+    ("BUG B shape: guarded-reassignment flag ranks above a never-reassigned one", _check_flags),
+    ("CALLS ladder rungs 1-3: proven in-corpus/external resolution; param-call and unknown-attr land on ?", _check_calls_ladder),
+    ("Dispatch rungs 5-6 + getattr-literal: unique-method probable, ambiguous unresolved, getattr(lit) proven", _check_dispatch),
+    ("Cross-module READS_NAME via an imported module's attribute", _check_cross_module_names),
+    ("Qualname nesting: closure-nested def and a lambda passed to a registering call", _check_nesting),
+    ("ALIASES: re-export and bare module-level alias both resolve to the one definition", _check_reexport),
+    ("Lazy imports: function-local scope + enclosing_fn recorded, distinct from module-level", _check_lazy_import),
+    ("Real corpus @ HEAD: hard gate (zero registered-but-dead) + registration-surface counts", _check_real_corpus),
+]
+
+
+def run_selftest() -> SelftestReport:
+    t0 = time.time()
+    checks: list = []
+    for name, fn in _ALL_CHECKS:
+        _run(checks, name, fn)
+    return SelftestReport(checks=checks, elapsed_s=time.time() - t0)

--- a/scripts/callgraph/tests/conftest.py
+++ b/scripts/callgraph/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Session-scoped fixtures so the ~1.3s full-corpus build against `--rev
+HEAD` runs once per test session, not once per test function."""
+import pytest
+
+from ..ingest import load_corpus
+from ..pipeline import build_graph
+from ..resolve import ResolutionTable
+
+
+@pytest.fixture(scope="session")
+def head_build():
+    return build_graph(rev="HEAD")
+
+
+@pytest.fixture(scope="session")
+def head_sources():
+    sources, _ = load_corpus(rev="HEAD")
+    return sources
+
+
+@pytest.fixture(scope="session")
+def head_table(head_sources):
+    return ResolutionTable(head_sources)

--- a/scripts/callgraph/tests/helpers.py
+++ b/scripts/callgraph/tests/helpers.py
@@ -1,0 +1,80 @@
+"""Shared test helpers: load a fixture .py file as a SourceFile without
+going through ingest.load_corpus's repo-root file discovery (fixtures/ is
+outside the analyzed corpus by design — config.SELF_PACKAGE_REL excludes
+this whole package)."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from ..extract.calls import build_top_level_index, make_call_visitor
+from ..extract.defs import extract_module
+from ..extract.dispatch import extract_probable_calls
+from ..extract.flow import extract_flow
+from ..extract.funcrefs import make_funcrefs_visitor
+from ..extract.imports import extract_imports
+from ..extract.literals import make_literals_visitor
+from ..extract.names import emit_non_walk_writes, make_names_visitor
+from ..extract.registry import extract_external_roots, extract_injections, extract_registry_module
+from ..extract.walk import walk_module
+from ..ingest import SourceFile
+from ..model import GraphStore
+from ..resolve import ResolutionTable
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def load_fixture(rel_path: str) -> SourceFile:
+    text = (FIXTURES_DIR / rel_path).read_text()
+    return source_file(rel_path, text)
+
+
+def source_file(rel_path: str, text: str) -> SourceFile:
+    import hashlib
+    sha1 = hashlib.sha1(text.encode()).hexdigest()
+    try:
+        tree = ast.parse(text, filename=rel_path)
+        return SourceFile(rel_path, text, tree, None, "fixture", sha1)
+    except SyntaxError as exc:
+        return SourceFile(rel_path, text, None, f"SyntaxError: {exc.msg}", "fixture", sha1)
+
+
+def build_fixture_store(rel_paths: list[str]):
+    """Runs the FULL pipeline (defs -> imports -> calls/names -> registry ->
+    injections/roots) over a small, curated set of fixture files — mirrors
+    pipeline.build_graph's stage order exactly, without going through
+    ingest.load_corpus's repo-root file discovery. Returns (store, table,
+    scopes)."""
+    sources = [load_fixture(p) for p in rel_paths]
+    table = ResolutionTable(sources)
+    store = GraphStore()
+    scopes = {sf.rel_path: extract_module(store, sf, table) for sf in sources}
+    for sf in sources:
+        extract_imports(store, sf, scopes[sf.rel_path], table, scopes)
+    top_level_index = build_top_level_index(store)
+    funcref_flushes = []
+    for sf in sources:
+        scope = scopes[sf.rel_path]
+        emit_non_walk_writes(store, sf, scope)
+        call_visit = make_call_visitor(store, sf, scope, table, top_level_index)
+        names_visit = make_names_visitor(store, sf, scope)
+        literals_visit = make_literals_visitor(store, sf, scope)
+        refs_visit, refs_flush = make_funcrefs_visitor(store, sf, scope, top_level_index)
+        funcref_flushes.append(refs_flush)
+
+        def combined(node, fi, _c=call_visit, _n=names_visit, _l=literals_visit, _r=refs_visit) -> None:
+            _c(node, fi)
+            _n(node, fi)
+            _l(node, fi)
+            _r(node, fi)
+
+        walk_module(scope, combined)
+        extract_flow(store, sf, scope)
+    for sf in sources:
+        extract_registry_module(store, sf, scopes[sf.rel_path], top_level_index)
+    extract_injections(store, sources, scopes, top_level_index)
+    extract_external_roots(store, sources, top_level_index)
+    for flush in funcref_flushes:
+        flush()
+    extract_probable_calls(store, scopes, top_level_index)
+    return store, table, scopes

--- a/scripts/callgraph/tests/test_analyze_flags.py
+++ b/scripts/callgraph/tests/test_analyze_flags.py
@@ -1,0 +1,46 @@
+"""analyze/flags.py: the partial-assignment ranker — BUG B's shape, in
+miniature, against real GraphStore output over fixtures/flags_shapes.py."""
+from ..analyze.flags import rank_flags
+from ..tests.helpers import build_fixture_store
+
+
+def _store():
+    store, _, _ = build_fixture_store(["flags_shapes.py"])
+    return store
+
+
+def test_rank_flags_only_includes_constant_initialized_escaping_locals():
+    store = _store()
+    rows = rank_flags(store)
+    idents = {r.ident for r in rows}
+    # `ok` (constant False init) and `step` (constant 1 init, closure
+    # escape) both qualify; `parts`/`base`/`result`/`total` do not (their
+    # inits are not ast.Constant).
+    assert "ok" in idents
+    assert "step" in idents
+    assert "parts" not in idents
+    assert "base" not in idents
+    assert "result" not in idents
+    assert "total" not in idents
+
+
+def test_ok_ranks_above_step_by_guard_exit_ratio():
+    store = _store()
+    rows = rank_flags(store)
+    by_ident = {r.ident: r for r in rows}
+    assert by_ident["ok"].score > by_ident["step"].score
+    assert rows[0].ident == "ok"          # sorted descending by score
+    assert by_ident["ok"].score == 3 / 2  # 3 guard exits / 2 guarded assigns
+    assert by_ident["step"].score == 0.0  # never reassigned, no guard exits either
+
+
+def test_fn_filter_scopes_to_single_function():
+    store = _store()
+    rows = rank_flags(store, fn_filter="fn:flags_shapes.py::assemble")
+    assert {r.ident for r in rows} == {"ok"}
+
+
+def test_scope_prefix_filter():
+    store = _store()
+    rows = rank_flags(store, scope_prefixes=["nonexistent/"])
+    assert rows == []

--- a/scripts/callgraph/tests/test_analyze_literalaudit.py
+++ b/scripts/callgraph/tests/test_analyze_literalaudit.py
@@ -1,0 +1,85 @@
+"""analyze/literalaudit.py: producer/consumer table, orphan detection, and
+the fenced near-miss pairing — BUG D's regression, against real GraphStore
+output over fixtures.py."""
+from ..analyze.literalaudit import literal_table, materialize_near_miss_edges, near_miss_pairs, orphans
+from ..tests.helpers import build_fixture_store
+
+
+def _build():
+    return build_fixture_store(["literals_produce.py", "literals_consume.py", "literals_keys.py"])
+
+
+def test_literal_table_matches_notes_jsonl_both_directions():
+    store, _, _ = _build()
+    groups = {g.match_text: g for g in literal_table(store, flavour="path")}
+    g = groups["notes.jsonl"]
+    assert len(g.produce_sites) == 1
+    assert len(g.consume_sites) == 1
+    assert g.produce_sites[0].path == "literals_produce.py"
+    assert g.consume_sites[0].path == "literals_consume.py"
+
+
+def test_orphans_path_finds_bug_d_shape():
+    store, _, _ = _build()
+    producer_only, consumer_only = orphans(store, flavour="path")
+    p_texts = {g.match_text for g in producer_only}
+    c_texts = {g.match_text for g in consumer_only}
+    assert "graph.ladybug" in p_texts
+    assert "graph.kuzu" in c_texts
+    # the matched pair must NOT show up as an orphan in either direction
+    assert "notes.jsonl" not in p_texts
+    assert "notes.jsonl" not in c_texts
+
+
+def test_orphans_key_finds_dict_get_set_shape():
+    store, _, _ = _build()
+    producer_only, consumer_only = orphans(store, flavour="key")
+    p_texts = {g.match_text for g in producer_only}
+    c_texts = {g.match_text for g in consumer_only}
+    assert "cfg_write_only" in p_texts
+    assert "cfg_lookup_only" in c_texts
+    assert "HERMES_PORT" not in p_texts
+    assert "HERMES_PORT" not in c_texts
+
+
+def test_near_miss_pairs_graph_ladybug_and_graph_kuzu():
+    store, _, _ = _build()
+    producer_only, consumer_only = orphans(store, flavour="path")
+    pairs = near_miss_pairs(producer_only, consumer_only)
+    matches = [p for p in pairs if p.shared_stem == "graph"]
+    assert len(matches) == 1
+    nm = matches[0]
+    assert {nm.producer.match_text, nm.consumer.match_text} == {"graph.ladybug", "graph.kuzu"}
+    assert 0.0 < nm.distance < 1.0
+
+
+def test_near_miss_requires_cross_module():
+    # Two producer-only / consumer-only literals sharing a stem but BOTH
+    # sited only in the SAME module must not pair — the design's own
+    # "module boundary" requirement.
+    from ..model import Confidence, Edge, GraphStore, Node
+
+    store = GraphStore()
+    store.add_node(Node(id="fn:same.py::a", kind="FUNCTION", attrs={}, path="same.py", line=1))
+    store.add_node(Node(id="lit:p", kind="LITERAL", attrs={"raw": "x.foo", "normalized": "x.foo", "flavour": "path", "tail": "x.foo"}))
+    store.add_node(Node(id="lit:c", kind="LITERAL", attrs={"raw": "x.bar", "normalized": "x.bar", "flavour": "path", "tail": "x.bar"}))
+    store.add_edge(Edge(src="fn:same.py::a", dst="lit:p", kind="PRODUCES_LITERAL", confidence=Confidence.PROVEN,
+                         attrs={"role": "test", "line": 1, "col": 0}))
+    store.add_edge(Edge(src="fn:same.py::a", dst="lit:c", kind="CONSUMES_LITERAL", confidence=Confidence.PROVEN,
+                         attrs={"role": "test", "line": 2, "col": 0}))
+    producer_only, consumer_only = orphans(store, flavour="path")
+    pairs = near_miss_pairs(producer_only, consumer_only)
+    assert pairs == []
+
+
+def test_materialize_near_miss_edges_adds_edges_to_store():
+    store, _, _ = _build()
+    producer_only, consumer_only = orphans(store, flavour="path")
+    pairs = near_miss_pairs(producer_only, consumer_only)
+    before = len(list(store.edges_of_kind("NEAR_MISS")))
+    edges = materialize_near_miss_edges(store, pairs)
+    after = len(list(store.edges_of_kind("NEAR_MISS")))
+    assert after - before == len(edges)
+    assert len(edges) >= 1
+    for e in edges:
+        assert e.confidence.name == "PROBABLE"

--- a/scripts/callgraph/tests/test_analyze_nameaudit.py
+++ b/scripts/callgraph/tests/test_analyze_nameaudit.py
@@ -1,0 +1,93 @@
+"""analyze/nameaudit.py: DANGLING-GLOBAL (BUG C) and WRITE-WITH-NO-READ,
+against real GraphStore output over fixtures."""
+from ..analyze.nameaudit import dangling_globals, read_by_tests, write_no_read
+from ..tests.helpers import build_fixture_store
+
+
+def test_dangling_global_flags_global_only_slot():
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    findings = dangling_globals(store)
+    slots = {f.slot.id for f in findings}
+    assert "name:dangling_global.py::_symbol_index_cache" in slots
+    assert "name:dangling_global.py::_symbol_index_count" in slots
+
+
+def test_dangling_global_excludes_module_level_bound_ident():
+    # `_real_counter` IS bound at module level in dangling_global.py itself
+    # -> must never be reported dangling, even though bump() also declares
+    # it `global` and reassigns it.
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    findings = dangling_globals(store)
+    slots = {f.slot.id for f in findings}
+    assert "name:dangling_global.py::_real_counter" not in slots
+
+
+def test_dangling_global_names_the_real_slot_in_another_module():
+    store, _, _ = build_fixture_store(["dangling_global.py", "dangling_global_real_slot.py"])
+    findings = {f.slot.id: f for f in dangling_globals(store)}
+    f = findings["name:dangling_global.py::_symbol_index_cache"]
+    assert len(f.real_slots) == 1
+    real = f.real_slots[0]
+    assert real.path == "dangling_global_real_slot.py"
+    assert real.line == 7
+    assert real.id == "name:dangling_global_real_slot.py::_symbol_index_cache"
+
+
+def test_dangling_global_write_sites_recorded():
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    findings = {f.slot.id: f for f in dangling_globals(store)}
+    f = findings["name:dangling_global.py::_symbol_index_count"]
+    assert len(f.global_writes) == 1
+    assert f.global_writes[0].src == "fn:dangling_global.py::invalidate_cache"
+
+
+def test_dangling_global_no_real_slot_found_leaves_list_empty():
+    # Without dangling_global_real_slot.py in the build, there is no
+    # module-level-bound `_symbol_index_cache` anywhere in the corpus.
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    findings = {f.slot.id: f for f in dangling_globals(store)}
+    assert findings["name:dangling_global.py::_symbol_index_cache"].real_slots == []
+
+
+def test_dangling_global_scope_filter():
+    store, _, _ = build_fixture_store(["dangling_global.py", "dangling_global_real_slot.py"])
+    findings = dangling_globals(store, scope_prefixes=["dangling_global_real_slot.py"])
+    assert findings == []
+
+
+def test_write_no_read_flags_write_only_slot():
+    # reexport_source.py's `_INTERNAL_STATE` is module-level-bound (a
+    # WRITES_NAME via module-level-assign) but nothing in the fixture set
+    # ever reads it.
+    store, _, _ = build_fixture_store(["reexport.py", "reexport_source.py"])
+    findings = {f.slot.id for f in write_no_read(store)}
+    assert "name:reexport_source.py::_INTERNAL_STATE" in findings
+
+
+def test_write_no_read_excludes_slot_with_a_read():
+    # dangling_global.py's `invalidate_cache` def-binding IS read nowhere
+    # in THIS fixture set either — but calls_shapes.py::helper (used
+    # elsewhere) has both a write (def-binding) and a read; confirm a
+    # write+read pair never appears in write_no_read.
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    findings = {f.slot.id for f in write_no_read(store)}
+    assert "name:calls_shapes.py::helper" not in findings
+
+
+def test_write_no_read_scope_filter():
+    store, _, _ = build_fixture_store(["reexport.py", "reexport_source.py"])
+    findings = write_no_read(store, scope_prefixes=["reexport.py"])
+    assert all(f.slot.path == "reexport.py" for f in findings)
+    assert not any(f.slot.id == "name:reexport_source.py::_INTERNAL_STATE" for f in findings)
+
+
+def test_read_by_tests_matches_whole_word_token():
+    from ..ingest import SourceFile
+
+    test_src = SourceFile(
+        rel_path="mcp/tests/test_thing.py",
+        source="from reexport_source import _INTERNAL_STATE\n\ndef test_x():\n    assert _INTERNAL_STATE is None\n",
+        tree=None, error=None, origin="fixture", sha1="",
+    )
+    hits = read_by_tests({"_INTERNAL_STATE", "totally_unused_ident"}, [test_src])
+    assert hits == {"_INTERNAL_STATE": ["mcp/tests/test_thing.py"]}

--- a/scripts/callgraph/tests/test_analyze_reach.py
+++ b/scripts/callgraph/tests/test_analyze_reach.py
@@ -1,0 +1,102 @@
+"""analyze/reach.py: shortest_path/path_confidence/entrypoints_reaching/
+function_at_line, against real GraphStore output built from fixtures."""
+from ..analyze.reach import (
+    entrypoints_reaching, function_at_line, path_confidence, shortest_path,
+)
+from ..model import Confidence
+from ..tests.helpers import build_fixture_store
+
+
+# -- shortest_path / path_confidence -----------------------------------------
+
+
+def test_shortest_path_single_hop():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    hops = shortest_path(store, "fn:calls_shapes.py::caller_name_def_local", "fn:calls_shapes.py::helper")
+    assert hops is not None and len(hops) == 1
+    assert hops[0].edge.dst == "fn:calls_shapes.py::helper"
+    assert hops[0].edge.confidence == Confidence.PROVEN
+    assert path_confidence(hops) == Confidence.PROVEN
+
+
+def test_shortest_path_src_equals_dst_is_empty_path():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    hops = shortest_path(store, "fn:calls_shapes.py::helper", "fn:calls_shapes.py::helper")
+    assert hops == []
+
+
+def test_shortest_path_unreachable_returns_none():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    hops = shortest_path(store, "fn:calls_shapes.py::helper", "fn:calls_target.py::target_fn")
+    assert hops is None
+
+
+def test_path_confidence_is_the_minimum_hop_not_the_average():
+    # call_use_thing --[PROVEN name-def-local]--> use_thing
+    #                --[PROBABLE name-via-injected-global]--> real_thing
+    # THE hand-built fixture chain for step 9's acceptance line: a mixed
+    # proven+probable chain must report PROBABLE overall, not PROVEN and
+    # not some blended value — Confidence has no such thing, only min().
+    store, _, _ = build_fixture_store(["registry_injection.py", "registry_injection_caller.py"])
+    hops = shortest_path(
+        store, "fn:registry_injection.py::call_use_thing", "fn:registry_injection_caller.py::real_thing",
+    )
+    assert hops is not None and len(hops) == 2
+    confidences = [h.edge.confidence for h in hops]
+    assert confidences == [Confidence.PROVEN, Confidence.PROBABLE]
+    assert path_confidence(hops) == Confidence.PROBABLE
+    # One PROVEN hop alone would report PROVEN — confirms this isn't
+    # trivially always PROBABLE for any chain touching this fixture.
+    assert path_confidence(hops[:1]) == Confidence.PROVEN
+
+
+# -- function_at_line ----------------------------------------------------
+
+
+def test_function_at_line_finds_enclosing_function():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    fn = store.get("fn:calls_shapes.py::caller_name_def_local")
+    mid_line = (fn.line + fn.attrs["end_lineno"]) // 2
+    assert function_at_line(store, "calls_shapes.py", mid_line) == fn.id
+
+
+def test_function_at_line_picks_innermost_nested_function():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    nested = store.get("fn:calls_shapes.py::outer_with_nested.<locals>.helper_nested")
+    assert function_at_line(store, "calls_shapes.py", nested.line) == nested.id
+
+
+def test_function_at_line_falls_back_to_module_for_top_level_code():
+    store, _, _ = build_fixture_store(["registry_injection_caller.py"])
+    # line 1 is the module docstring, outside every function's span.
+    assert function_at_line(store, "registry_injection_caller.py", 1) == "mod:registry_injection_caller.py"
+
+
+# -- entrypoints_reaching -----------------------------------------------------
+
+
+def test_entrypoints_reaching_direct_registration():
+    store, _, _ = build_fixture_store(["decorator_registry.py"])
+    fn_id = "fn:decorator_registry.py::registered_tool"
+    entries = entrypoints_reaching(store, fn_id)
+    assert entries == {"entry:mcp-tool:registered_tool": Confidence.PROVEN}
+
+
+def test_entrypoints_reaching_through_injected_global_is_probable():
+    # register()'s own function is not itself registered anywhere in this
+    # fixture set — the interesting case is a function that calls THROUGH
+    # an injected global reaching whatever entrypoint enters the CALLER.
+    store, _, _ = build_fixture_store([
+        "registry_injection.py", "registry_injection_caller.py", "registry_manloop.py",
+    ])
+    # registry_manloop.py's `register` isn't itself an entrypoint target,
+    # so instead verify the *absence* case: a function reachable from
+    # nothing has an empty entrypoint set — the honest "0 known" answer.
+    entries = entrypoints_reaching(store, "fn:registry_injection.py::use_thing")
+    assert entries == {}
+
+
+def test_entrypoints_reaching_unregistered_function_is_empty():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    entries = entrypoints_reaching(store, "fn:calls_target.py::target_fn")
+    assert entries == {}

--- a/scripts/callgraph/tests/test_cli.py
+++ b/scripts/callgraph/tests/test_cli.py
@@ -1,0 +1,264 @@
+"""cli.py: argument parsing and that each subcommand actually prints the
+data it claims to, not just that it exits 0."""
+import json
+
+import pytest
+
+from ..cli import main
+
+
+def _run(capsys, argv):
+    code = main(argv)
+    out = capsys.readouterr().out
+    return code, out
+
+
+def test_build_text(capsys):
+    code, out = _run(capsys, ["build", "--rev", "HEAD", "--scope", "mcp/graph_tools.py"])
+    assert code == 0
+    assert "source: rev" in out
+    assert "node:FUNCTION" in out
+
+
+def test_build_json(capsys):
+    code, out = _run(capsys, ["build", "--rev", "HEAD", "--scope", "mcp/graph_tools.py", "--format", "json"])
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["file_count"] == 1
+    assert payload["stats"]["node:MODULE"] == 1
+
+
+def test_modules_lists_importable_as(capsys):
+    code, out = _run(capsys, ["modules", "--rev", "HEAD", "--scope", "mcp/graph_tools.py"])
+    assert code == 0
+    assert "mcp/graph_tools.py" in out
+    assert "graph_tools" in out
+
+
+def test_defs_summary_counts(capsys):
+    code, out = _run(capsys, ["defs", "--rev", "HEAD", "--scope", "mcp/graph_tools.py"])
+    assert code == 0
+    assert "functions:" in out
+    assert "NAME slots:" in out
+
+
+def test_defs_all_lists_qualnames(capsys):
+    code, out = _run(capsys, ["defs", "--rev", "HEAD", "--scope", "mcp/graph_tools.py", "--all"])
+    assert code == 0
+    assert "symbol_impact" in out
+
+
+def test_imports_unresolved_small(capsys):
+    code, out = _run(capsys, ["imports", "--rev", "HEAD", "--unresolved"])
+    assert code == 0
+    lines = [l for l in out.splitlines() if "->" in l]
+    assert len(lines) < 20
+
+
+def test_imports_lazy_only_function_local(capsys):
+    code, out = _run(capsys, ["imports", "--rev", "HEAD", "--scope", "mcp/server.py", "--lazy"])
+    assert code == 0
+    lines = [l for l in out.splitlines() if "->" in l]
+    assert lines  # mcp/server.py has function-local imports
+    assert all("[local]" in l for l in lines)
+
+
+def test_aliases_symbol_impact(capsys):
+    code, out = _run(capsys, ["aliases", "--rev", "HEAD", "mcp/server.py::symbol_impact"])
+    assert code == 0
+    assert "fn:mcp/graph_tools.py::symbol_impact" in out
+
+
+def test_bad_subcommand_exits_nonzero():
+    with pytest.raises(SystemExit):
+        main(["not-a-real-command"])
+
+
+# -- callers / reach ---------------------------------------------------------
+
+
+def test_callers_proven_finds_in_server_callsites(capsys):
+    code, out = _run(capsys, ["callers", "_get_ladybug", "--rev", "HEAD", "--conf", "proven"])
+    assert code == 0
+    assert "-- PROVEN" in out
+    assert out.count("call[name-def-local]") == 2
+    assert out.count("passed-by-ref") == 2
+
+
+def test_callers_ambiguous_bare_name_lists_candidates(capsys):
+    code, out = _run(capsys, ["callers", "register", "--rev", "HEAD", "--scope", "mcp/"])
+    assert code == 0
+    assert "ambiguous symbol" in out
+
+
+def test_callers_json_format(capsys):
+    # Default --conf is "probable", so this now also picks up the 15 rung-4
+    # (name-via-injected-global) PROBABLE calls inside graph_tools.py that
+    # only resolve once extract/dispatch.py's probable tier has run — on
+    # top of the 2 PROVEN in-server calls + 2 passed-by-ref REFERENCES rows
+    # step 4/step 5 slices already covered.
+    code, out = _run(capsys, ["callers", "_get_ladybug", "--rev", "HEAD", "--format", "json"])
+    assert code == 0
+    rows = json.loads(out)
+    assert isinstance(rows, list) and len(rows) == 19
+    from collections import Counter
+    counts = Counter((r["kind"], r["confidence"]) for r in rows)
+    assert counts[("CALLS", "PROVEN")] == 2
+    assert counts[("CALLS", "PROBABLE")] == 15
+    assert counts[("REFERENCES", "PROVEN")] == 2
+    assert all(r.get("rung") == "name-via-injected-global" for r in rows if r["kind"] == "CALLS" and r["confidence"] == "PROBABLE")
+
+
+def test_reach_from_get_ladybug(capsys):
+    code, out = _run(capsys, ["reach", "_get_ladybug", "--rev", "HEAD", "--depth", "1"])
+    assert code == 0
+    assert "forward reach from fn:mcp/server.py::_get_ladybug" in out
+
+
+# -- registry -----------------------------------------------------------------
+
+
+def test_registry_lists_known_surfaces(capsys):
+    code, out = _run(capsys, ["registry", "--rev", "HEAD"])
+    assert code == 0
+    assert "reg:mcp/server.py::mcp.tool" in out
+    assert "members= 40" in out or "members=40" in out
+    assert "reg:a2a_server/server.py::_SKILL_MAP" in out
+
+
+def test_registry_unmatched_is_empty(capsys):
+    code, out = _run(capsys, ["registry", "--rev", "HEAD", "--unmatched"])
+    assert code == 0
+    assert "0 unclassified" in out
+
+
+# -- name ---------------------------------------------------------------------
+
+
+def test_name_get_ladybug_shows_write_and_injection(capsys):
+    code, out = _run(capsys, ["name", "_get_ladybug", "--rev", "HEAD"])
+    assert code == 0
+    assert "WRITE" in out and "via=global-stmt" in out
+    assert "INJECT" in out
+    assert "WARNING" in out  # cross-module coupling
+
+
+def test_name_unknown_ident_errors(capsys):
+    code, out = _run(capsys, ["name", "totally_not_a_real_identifier_xyz", "--rev", "HEAD", "--scope", "mcp/graph_tools.py"])
+    assert code == 2
+
+
+# -- dead / holes ---------------------------------------------------------------
+
+
+def test_dead_scope_mcp_never_lists_a_registered_tool(capsys):
+    code, out = _run(capsys, ["dead", "--rev", "HEAD", "--scope", "mcp/"])
+    assert code == 0
+    assert "does NOT mean safe to delete" in out
+    # None of the 40 real @mcp.tool() names should ever appear as UNREACHABLE.
+    assert "investigation_store" not in out
+    assert "symbol_impact" not in out
+
+
+def test_holes_groups_by_reason(capsys):
+    code, out = _run(capsys, ["holes", "--rev", "HEAD", "--scope", "mcp/graph_tools.py"])
+    assert code == 0
+    assert "callsite(s) total" in out
+
+
+# -- probable tier: dispatch / injected globals -------------------------------
+
+
+def test_callers_get_ladybug_shows_probable_injected_rows_with_why(capsys):
+    code, out = _run(capsys, ["callers", "_get_ladybug", "--rev", "HEAD", "--scope", "mcp/", "--why"])
+    assert code == 0
+    assert "-- PROBABLE" in out
+    # 11 from mcp/graph_tools.py's own injected NAME slot + 4 from
+    # mcp/ladybug_ops.py's separately-injected slot pointing at the same
+    # target function (see test_pipeline_real_corpus.py for the split).
+    assert out.count("call[name-via-injected-global]") == 15
+    assert "-- why: rule=name-via-injected-global  because=injected at mcp/server.py:" in out
+
+
+def test_callers_skill_shows_dispatch_row_as_one_of_thirteen(capsys):
+    code, out = _run(capsys, ["callers", "a2a_server/server.py::skill_memory_recall", "--rev", "HEAD"])
+    assert code == 0
+    assert "dispatch  1 of 13" in out
+
+
+def test_explain_dispatch_callsite_lists_all_thirteen_candidates(capsys):
+    code, out = _run(capsys, ["explain", "a2a_server/server.py:1444", "--rev", "HEAD", "--scope", "a2a_server/"])
+    if "no CALLSITE found" in out:
+        # The dispatch callsite's line can drift; fall back to locating it
+        # via the JSON callers output for skill_memory_recall instead of a
+        # hardcoded line number.
+        _, callers_out = _run(capsys, ["callers", "a2a_server/server.py::skill_memory_recall", "--rev", "HEAD", "--format", "json"])
+        rows = json.loads(callers_out)
+        disp = [r for r in rows if r["kind"] == "DISPATCHES"][0]
+        code, out = _run(capsys, ["explain", disp["src"], "--rev", "HEAD"])
+    assert code == 0
+    assert out.count("DISPATCHES ->") == 13
+    assert "1 of 13" in out
+
+
+def test_paths_reports_minimum_confidence(capsys):
+    code, out = _run(capsys, [
+        "paths", "mcp/graph_tools.py::code_memory_relink", "_get_ladybug", "--rev", "HEAD", "--scope", "mcp/",
+    ])
+    assert code == 0
+    assert "path confidence: PROBABLE" in out
+
+
+def test_reach_to_degenerates_to_paths(capsys):
+    code, out = _run(capsys, [
+        "reach", "mcp/graph_tools.py::code_memory_relink", "--to", "_get_ladybug", "--rev", "HEAD", "--scope", "mcp/",
+    ])
+    assert code == 0
+    assert "path confidence: PROBABLE" in out
+
+
+def test_build_dot_emits_a_valid_looking_digraph(capsys):
+    code, out = _run(capsys, ["build", "--rev", "HEAD", "--scope", "mcp/graph_tools.py", "--format", "dot"])
+    assert code == 0
+    assert out.startswith("digraph callgraph {")
+    assert out.rstrip().endswith("}")
+    assert '[FUNCTION]' in out
+    assert "-> " in out
+
+
+def test_callers_dot_scopes_to_the_traversed_subgraph(capsys):
+    code, out = _run(capsys, ["callers", "_get_ladybug", "--rev", "HEAD", "--conf", "proven", "--format", "dot"])
+    assert code == 0
+    assert out.startswith("digraph callgraph {")
+    assert '"fn:mcp/server.py::_get_ladybug"' in out
+    # a node that has nothing to do with this traversal must not appear
+    assert "code_memory_relink" not in out
+
+
+def test_reach_dot_includes_traversed_hops(capsys):
+    code, out = _run(capsys, ["reach", "_get_ladybug", "--rev", "HEAD", "--scope", "mcp/", "--depth", "1", "--format", "dot"])
+    assert code == 0
+    assert out.startswith("digraph callgraph {")
+    assert 'label="CALLS"' in out or 'label="REFERENCES"' in out
+
+
+def test_paths_dot_renders_the_hop_chain(capsys):
+    code, out = _run(capsys, [
+        "paths", "mcp/graph_tools.py::code_memory_relink", "_get_ladybug", "--rev", "HEAD", "--scope", "mcp/", "--format", "dot",
+    ])
+    assert code == 0
+    assert out.startswith("digraph callgraph {")
+    assert '"fn:mcp/graph_tools.py::code_memory_relink"' in out
+    assert '"fn:mcp/server.py::_get_ladybug"' in out
+    assert "style=dashed" in out  # the PROBABLE hop (see test_paths_reports_minimum_confidence)
+
+
+def test_entrypoints_names_code_memory_relink_tool(capsys):
+    code, out = _run(capsys, ["entrypoints", "mcp/graph_tools.py:1", "--rev", "HEAD", "--scope", "mcp/"])
+    # line 1 of graph_tools.py is the module docstring: falls back to the
+    # MODULE id, which has no direct ENTRYPOINT of its own (modules are
+    # only trivial roots for reachable_functions' forward closure, not a
+    # registered entrypoint themselves) — just confirms the command runs
+    # cleanly end to end and prints the honest "0 known" verdict.
+    assert code == 0
+    assert "mcp/graph_tools.py:1" in out

--- a/scripts/callgraph/tests/test_cli_step10_12.py
+++ b/scripts/callgraph/tests/test_cli_step10_12.py
@@ -1,0 +1,112 @@
+"""CLI end-to-end tests for `cg writes-dead` / `cg literals` / `cg flags`
+against the REAL corpus at the specific revisions BUG B/C/D were introduced
+and fixed at — the regression tests the design's acceptance criteria ask
+for, exercised through the actual command line, not just the underlying
+analyze/* functions."""
+import json
+
+from ..cli import main
+
+
+def _run(capsys, argv):
+    code = main(argv)
+    out = capsys.readouterr().out
+    return code, out
+
+
+# -- BUG C: writes-dead / dangling-global -------------------------------------
+
+
+def test_writes_dead_finds_bug_c_at_broken_revision(capsys):
+    code, out = _run(capsys, ["writes-dead", "--rev", "c1c40a9^", "--scope", "mcp/"])
+    assert code == 0
+    assert "DANGLING-GLOBAL" in out
+    assert "_symbol_index_cache" in out
+    assert "_symbol_index_count" in out
+    assert "mcp/graph_tools.py" in out
+    assert "mcp/ladybug_ops.py:106" in out
+
+
+def test_writes_dead_clean_at_head(capsys):
+    code, out = _run(capsys, ["writes-dead", "--rev", "HEAD", "--scope", "mcp/", "--format", "json"])
+    assert code == 0
+    payload = json.loads(out)
+    slots = [f["slot"] for f in payload["dangling_global"]]
+    assert not any("_symbol_index_cache" in s or "_symbol_index_count" in s for s in slots)
+
+
+def test_writes_dead_include_tests_shrinks_weak_list(capsys):
+    code, out_default = _run(capsys, ["writes-dead", "--rev", "HEAD", "--format", "json"])
+    assert code == 0
+    default_count = len(json.loads(out_default)["write_no_read"])
+
+    code, out_tests = _run(capsys, ["writes-dead", "--rev", "HEAD", "--include-tests", "--format", "json"])
+    assert code == 0
+    payload = json.loads(out_tests)
+    assert len(payload["write_no_read"]) <= default_count
+    assert payload["include_tests"] is True
+
+
+# -- BUG D: literals -----------------------------------------------------------
+
+
+def test_literals_orphans_finds_bug_d_at_broken_revision(capsys):
+    code, out = _run(capsys, ["literals", "--paths", "--orphans", "--rev", "08c9198^"])
+    assert code == 0
+    assert "graph.ladybug" in out
+    assert "mcp/server.py:261" in out
+    assert "CONSUMED BY NOBODY" in out
+    assert "graph.kuzu" in out
+    assert "scripts/graph_facts.py:29" in out
+    assert "PRODUCED BY NOBODY" in out
+
+
+def test_literals_near_miss_pairs_the_bug_d_orphans(capsys):
+    code, out = _run(capsys, ["literals", "graph", "--paths", "--near-miss", "--rev", "08c9198^"])
+    assert code == 0
+    assert "'graph.ladybug'" in out
+    assert "'graph.kuzu'" in out
+    assert "stem=graph" in out
+    assert "lead, not finding" in out
+
+
+def test_literals_matched_at_head(capsys):
+    code, out = _run(capsys, ["literals", "graph", "--paths", "--rev", "HEAD", "--format", "json"])
+    assert code == 0
+    rows = json.loads(out)
+    matches = [r for r in rows if r["text"] == "graph.ladybug"]
+    assert len(matches) == 1
+    assert matches[0]["produced_by"]
+    assert matches[0]["consumed_by"]
+
+
+def test_literals_orphans_empty_at_head_for_graph_ladybug(capsys):
+    code, out = _run(capsys, ["literals", "graph", "--paths", "--orphans", "--rev", "HEAD", "--format", "json"])
+    assert code == 0
+    payload = json.loads(out)
+    texts = {g["text"] for g in payload["producer_only"]} | {g["text"] for g in payload["consumer_only"]}
+    assert "graph.ladybug" not in texts
+    assert "graph.kuzu" not in texts
+
+
+# -- BUG B: flags ---------------------------------------------------------------
+
+
+def test_flags_ranks_degraded_first_at_broken_revision(capsys):
+    code, out = _run(capsys, ["flags", "mcp/grounding.py::ground", "--rev", "69adfa4^"])
+    assert code == 0
+    assert "ground::degraded" in out
+    assert "init=" in out and "(constant)" in out
+    assert "escapes as dict-value" in out
+    assert out.count("guard exit") >= 4
+    assert "does NOT assign degraded" in out
+
+
+def test_flags_json_row_shape(capsys):
+    code, out = _run(capsys, ["flags", "mcp/grounding.py::ground", "--rev", "69adfa4^", "--format", "json"])
+    assert code == 0
+    rows = json.loads(out)
+    assert len(rows) == 1
+    assert rows[0]["ident"] == "degraded"
+    assert rows[0]["escape_form"] == "dict-value"
+    assert rows[0]["score"] > 1.0

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,0 +1,52 @@
+"""config.py against the REAL repo: acceptance criterion is an exact file
+count (114), not a vibe. If this drifts, either the repo changed shape or
+the exclusion rules regressed — both worth failing loudly on."""
+from .. import config
+
+
+def test_corpus_is_exactly_114_files():
+    files = config.iter_corpus_files_worktree()
+    assert len(files) == 114, sorted(files)
+
+
+def test_corpus_excludes_test_directories():
+    files = config.iter_corpus_files_worktree()
+    assert not any("/tests/" in f for f in files)
+
+
+def test_corpus_excludes_venv_and_pycache():
+    files = config.iter_corpus_files_worktree()
+    assert not any(".venv" in f or "__pycache__" in f for f in files)
+
+
+def test_corpus_excludes_its_own_package():
+    files = config.iter_corpus_files_worktree()
+    assert not any(f.startswith("scripts/callgraph/") for f in files)
+
+
+def test_corpus_covers_all_five_roots():
+    files = config.iter_corpus_files_worktree()
+    roots_seen = {f.split("/", 1)[0] for f in files}
+    assert roots_seen == set(config.CORPUS_ROOTS)
+
+
+def test_in_corpus_matches_iter_corpus_files():
+    files = set(config.iter_corpus_files_worktree())
+    for f in files:
+        assert config.in_corpus(f)
+    assert not config.in_corpus("mcp/tests/test_foo.py")
+    assert not config.in_corpus("scripts/callgraph/census.py")
+    assert not config.in_corpus("README.md")
+
+
+def test_stdlib_module_names_contains_known_stdlib():
+    names = config.stdlib_module_names()
+    assert "os" in names and "json" in names and "ast" in names
+    assert "graph_tools" not in names
+
+
+def test_third_party_names_finds_installed_packages():
+    # The venv is fully provisioned per the task brief; fastmcp's dependency
+    # stack (dotenv, starlette, ...) should be discoverable.
+    names = config.third_party_top_level_names()
+    assert "dotenv" in names or "starlette" in names

--- a/scripts/callgraph/tests/test_dead_false_positives.py
+++ b/scripts/callgraph/tests/test_dead_false_positives.py
@@ -1,0 +1,153 @@
+"""FALSE-POSITIVE GATE for `cg dead`.
+
+A dead-code query is killed by its false positives, not by its misses. If it
+names functions that are obviously live, people stop reading it, and a tool
+people suppress is a tool that is not working.
+
+Two layers here:
+
+1. THE HARD GATE, over the real corpus at HEAD: zero registered function may
+   ever be reported dead. This is an absolute, not a ratio.
+
+2. One test per DISPATCH SHAPE that produced a false positive during
+   validation, each against a minimal fixture. These are the shapes that took
+   `cg dead` from 165 rows to 66 on this corpus. They are separated from the
+   corpus test on purpose: the corpus number will drift as the code changes,
+   but "a function passed by bare name is not dead" must hold forever.
+
+The remaining 66 rows are NOT all false positives and are NOT asserted to
+zero — see docs/LIMITS.md for the hand-verified breakdown. 53 of them are
+methods reached only through an attribute call on an untyped receiver, which
+is a genuine limit of a tool with no type inference, not a bug to be fixed by
+loosening this file.
+"""
+from __future__ import annotations
+
+
+from ..analyze.deadcode import dead_functions, registered_but_dead
+from .helpers import build_fixture_store
+
+
+# ---------------------------------------------------------------------------
+# 1. the hard gate, on the real corpus
+# ---------------------------------------------------------------------------
+
+
+def test_no_registered_function_is_ever_reported_dead(head_build):
+    """40 @mcp.tool(), 31 register()d, 13 _SKILL_MAP, 6 FastAPI routes,
+    1 resource, 1 custom_route = 92 registered functions. None may be dead."""
+    store = head_build.store
+    registered = {e.dst for e in store.edges_of_kind("REGISTERS")}
+    assert len(registered) == 92, f"registration surface changed: {len(registered)}"
+
+    offenders = registered_but_dead(store)
+    assert offenders == [], (
+        f"{len(offenders)} registered function(s) reported dead: "
+        f"{[n.id for n in offenders]}"
+    )
+
+
+def test_mcp_tool_and_manifest_surfaces_specifically(head_build):
+    """The two shapes named in the brief, asserted by name rather than folded
+    into the aggregate above, so a failure says WHICH surface broke."""
+    store = head_build.store
+    dead_ids = {n.id for n in dead_functions(store)}
+
+    tools = {e.dst for e in store.edges_of_kind("REGISTERS")
+             if e.src == "reg:mcp/server.py::mcp.tool"}
+    manifest = {e.dst for e in store.edges_of_kind("REGISTERS")
+                if (src := store.get(e.src)) is not None
+                and src.attrs.get("mechanism") == "manifest-tuple"}
+
+    assert len(tools) == 40, f"@mcp.tool() count changed: {len(tools)}"
+    assert len(manifest) == 31, f"register() manifest count changed: {len(manifest)}"
+    assert tools & dead_ids == set()
+    assert manifest & dead_ids == set()
+
+
+def test_dead_row_count_does_not_regress(head_build):
+    """A ceiling, not a target. 66 rows at the HEAD this was validated against
+    (down from 165 before the five resolution fixes + the dunder filter). If this climbs sharply,
+    a resolution path has broken and the query is filling up with noise again.
+    """
+    n = len(dead_functions(head_build.store))
+    assert n <= 85, (
+        f"`cg dead` reports {n} unreachable functions (was 66 when validated). "
+        "A jump means a dispatch shape stopped resolving — find it before "
+        "raising this number."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. one test per false-positive shape found during validation
+# ---------------------------------------------------------------------------
+
+
+def _dead_names(*sources) -> set[str]:
+    store, _, _ = build_fixture_store(list(sources))
+    return {n.attrs["qualname"] for n in dead_functions(store)}
+
+
+def test_bare_name_passed_as_call_argument_is_not_dead():
+    """mcp/server.py:
+        checks.append(_health_check("embeddings_sparse", _health_probe_embeddings_sparse))
+    Nine `_health_probe_*` functions were reported dead this way."""
+    assert "probe_sparse" not in _dead_names("regress/fp_shapes/callback_arg.py")
+
+
+def test_function_called_only_inside_a_lambda_body_is_not_dead():
+    """mcp/server.py:
+        ("qdrant_reachable", lambda: backends.qdrant()[0]),
+    A lambda is consumed where it is written, so its body is reachable exactly
+    when the scope constructing it is."""
+    assert "probe_via_lambda" not in _dead_names("regress/fp_shapes/lambda_call.py")
+
+
+def test_function_local_import_is_visible_inside_a_nested_scope():
+    """`import backends` in loci_health, used as `backends.qdrant()` from
+    inside a lambda nested in it. Python closures make the binding visible;
+    resolution has to walk outward through the <locals> chain."""
+    names = _dead_names("regress/fp_shapes/lazy_import_nested.py",
+                        "regress/fp_shapes/lazy_import_target.py")
+    assert "helper" not in names
+
+
+def test_sibling_nested_def_called_by_bare_name_is_not_dead():
+    """mcp/graph/code_parse.py's parse_source defines enclosing_def_node and
+    _in_method side by side; _in_method calls enclosing_def_node(node)."""
+    names = _dead_names("regress/fp_shapes/nested_siblings.py")
+    assert "outer.<locals>.sibling_a" not in names
+
+
+def test_protocol_dunders_are_not_reported(head_build):
+    """`with _Mutex(...)` invokes __enter__/__exit__ without ever naming them.
+    Asserted on the real corpus because that is where the shape occurred."""
+    names = {n.attrs["qualname"] for n in dead_functions(head_build.store)}
+    assert "_Mutex.__enter__" not in names
+    assert "_Mutex.__exit__" not in names
+    assert not any(q.rsplit(".", 1)[-1].startswith("__") for q in names)
+
+
+def test_relative_from_import_of_a_submodule_resolves():
+    """mcp/graph/analytics.py: `from . import queries as Q` then
+    `Q.finding_symbols(...)`. Four live queries.py functions were reported
+    dead because Q aliased an external sink instead of the MODULE."""
+    names = _dead_names("regress/fp_shapes/pkg/__init__.py",
+                        "regress/fp_shapes/pkg/queries.py",
+                        "regress/fp_shapes/pkg/analytics.py")
+    assert "finding_symbols" not in names
+
+
+# ---------------------------------------------------------------------------
+# 3. the counter-test: the fixes must not make EVERYTHING reachable
+# ---------------------------------------------------------------------------
+
+
+def test_genuinely_unreferenced_function_is_still_reported():
+    """The above fixes are deliberately broad. If they were broad enough to
+    swallow a function that nothing mentions at all, `cg dead` would be
+    worthless — it would simply never report anything."""
+    names = _dead_names("regress/fp_shapes/truly_dead.py")
+    assert "never_mentioned_anywhere" in names
+    assert "used" not in names          # called by main()
+    assert "passed_around" not in names  # bare-name escape only

--- a/scripts/callgraph/tests/test_extract_calls.py
+++ b/scripts/callgraph/tests/test_extract_calls.py
@@ -1,0 +1,151 @@
+"""extract/calls.py: CALLSITE nodes and the rungs-1-3 CALLS resolution
+ladder, against real GraphStore output (not just "doesn't raise")."""
+from ..model import Confidence
+from ..tests.helpers import build_fixture_store
+
+
+def _build():
+    return build_fixture_store(["calls_shapes.py", "calls_target.py"])
+
+
+def _calls_from(store, fn_qualname):
+    fn_id = f"fn:calls_shapes.py::{fn_qualname}"
+    sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fn_id]
+    assert len(sites) == 1, f"expected exactly one callsite in {fn_qualname}, found {len(sites)}"
+    site = sites[0]
+    edges = store.out_edges(site.id, "CALLS")
+    assert len(edges) == 1
+    return site, edges[0]
+
+
+def test_every_call_gets_a_callsite_node():
+    store, _, _ = _build()
+    sites = list(store.nodes_of_kind("CALLSITE"))
+    assert len(sites) >= 10
+
+
+def test_name_def_local_rung():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_name_def_local")
+    assert edge.dst == "fn:calls_shapes.py::helper"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "name-def-local"
+    assert site.attrs["form"] == "name"
+
+
+def test_nested_def_local_rung():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "outer_with_nested")
+    assert edge.dst == "fn:calls_shapes.py::outer_with_nested.<locals>.helper_nested"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "nested-def-local"
+
+
+def test_constructor_rung_targets_init():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "make_widget")
+    assert edge.dst == "fn:calls_shapes.py::Widget.__init__"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "name-constructor"
+
+
+def test_self_attribute_rung():
+    store, _, _ = _build()
+    fn_id = "fn:calls_shapes.py::Widget.bump"
+    sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fn_id]
+    assert len(sites) == 1
+    edge = store.out_edges(sites[0].id, "CALLS")[0]
+    assert edge.dst == "fn:calls_shapes.py::Widget.other"
+    assert edge.attrs["rung"] == "self-attribute"
+    assert edge.confidence == Confidence.PROVEN
+
+
+def test_module_attribute_external_rung():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_module_attribute_external")
+    assert edge.dst == "ext:json.dumps"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "module-attribute-external"
+    ext = store.get("ext:json.dumps")
+    assert ext is not None and ext.attrs["distribution"] == "stdlib"
+
+
+def test_module_attribute_in_corpus_rung():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_module_attribute_corpus")
+    assert edge.dst == "fn:calls_target.py::target_fn"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "module-attribute"
+
+
+def test_builtin_rung():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_builtin")
+    assert edge.dst == "ext:builtins.len"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "builtin"
+
+
+def test_function_local_import_rung_tagged_scope():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_local_import")
+    assert edge.dst == "ext:textwrap.dedent"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["scope"] == "function-local"
+    assert "local import at calls_shapes.py" in edge.attrs["because"]
+
+
+def test_param_call_is_unresolved_with_reason():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_param_call")
+    assert site.attrs["form"] == "param-call"
+    assert edge.dst == "?"
+    assert edge.confidence == Confidence.UNPROVEN
+    assert edge.attrs["reason"] == "param-call"
+
+
+def test_unknown_attribute_receiver_is_unresolved():
+    store, _, _ = _build()
+    site, edge = _calls_from(store, "caller_unknown_attribute")
+    assert site.attrs["form"] == "attribute"
+    assert edge.dst == "?"
+    assert edge.attrs["reason"] == "attribute-unknown-receiver"
+
+
+def test_unresolved_sink_node_exists_and_is_kind_unresolved():
+    store, _, _ = _build()
+    node = store.get("?")
+    assert node is not None
+    assert node.kind == "UNRESOLVED"
+
+
+def test_chained_call_gets_two_distinct_callsite_ids():
+    # `pyotp.TOTP(x).now()` shape: outer and inner Call share (line, col)
+    # but must be two distinct CALLSITE nodes, not one merged/overwritten
+    # node with two CALLS edges hanging off it.
+    from ..tests.helpers import source_file
+    from ..model import GraphStore
+    from ..resolve import ResolutionTable
+    from ..extract.defs import extract_module
+    from ..extract.imports import extract_imports
+    from ..extract.calls import build_top_level_index, extract_calls
+
+    text = (
+        "import pyotp\n\n"
+        "def f(seed):\n"
+        "    return pyotp.TOTP(seed).now()\n"
+    )
+    sf = source_file("chained.py", text)
+    table = ResolutionTable([sf])
+    store = GraphStore()
+    scope = extract_module(store, sf, table)
+    extract_imports(store, sf, scope, table, {"chained.py": scope})
+    idx = build_top_level_index(store)
+    extract_calls(store, sf, scope, table, idx)
+
+    sites = [n for n in store.nodes_of_kind("CALLSITE") if n.path == "chained.py"]
+    assert len(sites) == 2
+    forms = {n.attrs["form"] for n in sites}
+    assert forms == {"attribute"}
+    ids = {n.id for n in sites}
+    assert len(ids) == 2  # distinct node identities, not one node with 2 edges

--- a/scripts/callgraph/tests/test_extract_defs.py
+++ b/scripts/callgraph/tests/test_extract_defs.py
@@ -1,0 +1,91 @@
+"""extract/defs.py: MODULE/CLASS/FUNCTION/NAME nodes, DEFINES edges, and
+DECORATED_BY classification, via a real GraphStore (not just "doesn't
+raise")."""
+from ..extract.defs import extract_module
+from ..model import GraphStore
+from ..tests.helpers import load_fixture
+
+
+def test_module_node_created():
+    store = GraphStore()
+    sf = load_fixture("decorator_registry.py")
+    extract_module(store, sf)
+    mod = store.get("mod:decorator_registry.py")
+    assert mod is not None and mod.kind == "MODULE"
+    assert mod.attrs["origin"] == "fixture"
+
+
+def test_function_nodes_and_defines_edges():
+    store = GraphStore()
+    sf = load_fixture("decorator_registry.py")
+    extract_module(store, sf)
+    fn = store.get("fn:decorator_registry.py::registered_tool")
+    assert fn is not None
+    assert fn.kind == "FUNCTION"
+    assert fn.line == 19  # the `def registered_tool(...)` line
+
+    defines = store.out_edges("mod:decorator_registry.py", "DEFINES")
+    dst_ids = {e.dst for e in defines}
+    assert "fn:decorator_registry.py::registered_tool" in dst_ids
+    assert "fn:decorator_registry.py::cached_helper" in dst_ids
+
+
+def test_decorated_by_classification():
+    store = GraphStore()
+    sf = load_fixture("decorator_registry.py")
+    extract_module(store, sf)
+    dbs = store.out_edges("fn:decorator_registry.py::registered_tool", "DECORATED_BY")
+    assert len(dbs) == 1
+    assert dbs[0].attrs["classification"] == "registering"
+    assert dbs[0].attrs["raw"] == "mcp.tool()"
+
+    dbs2 = store.out_edges("fn:decorator_registry.py::cached_helper", "DECORATED_BY")
+    assert dbs2[0].attrs["classification"] == "wrapping"
+
+    dbs3 = store.out_edges("fn:decorator_registry.py::mystery", "DECORATED_BY")
+    assert dbs3[0].attrs["classification"] == "unknown"
+
+
+def test_class_node_and_method_defines_edge():
+    store = GraphStore()
+    sf = load_fixture("nesting.py")
+    extract_module(store, sf)
+    cls = store.get("cls:nesting.py::Widget")
+    assert cls is not None
+    method_id = "fn:nesting.py::Widget.method"
+    assert method_id in cls.attrs["method_ids"]
+    defines = {e.dst for e in store.out_edges("cls:nesting.py::Widget", "DEFINES")}
+    assert method_id in defines
+    # the class itself is DEFINES'd by the module, not floating unattached
+    mod_defines = {e.dst for e in store.out_edges("mod:nesting.py", "DEFINES")}
+    assert "cls:nesting.py::Widget" in mod_defines
+
+
+def test_lambda_gets_its_own_addressable_function_node():
+    store = GraphStore()
+    sf = load_fixture("nesting.py")
+    extract_module(store, sf)
+    lambdas = [n for n in store.nodes_of_kind("FUNCTION") if n.attrs.get("is_lambda")]
+    assert len(lambdas) == 1
+    assert lambdas[0].id.startswith("fn:nesting.py::<lambda>@")
+
+
+def test_name_slots_created_for_module_globals():
+    store = GraphStore()
+    sf = load_fixture("dangling_global.py")
+    extract_module(store, sf)
+    dangling = store.get("name:dangling_global.py::_symbol_index_cache")
+    assert dangling is not None
+    assert dangling.attrs["binding_kind"] == ["global-only"]
+    real = store.get("name:dangling_global.py::_real_counter")
+    assert "assign" in real.attrs["binding_kind"]
+    assert "global-only" not in real.attrs["binding_kind"]
+
+
+def test_params_recorded_on_function_node():
+    store = GraphStore()
+    sf = load_fixture("decorator_registry.py")
+    extract_module(store, sf)
+    fn = store.get("fn:decorator_registry.py::registered_tool")
+    names = [p["name"] for p in fn.attrs["params"]]
+    assert names == ["x", "y"]

--- a/scripts/callgraph/tests/test_extract_dispatch.py
+++ b/scripts/callgraph/tests/test_extract_dispatch.py
@@ -1,0 +1,142 @@
+"""extract/dispatch.py: the probable tier (CALLS rungs 4-6) and DISPATCHES,
+against real GraphStore output — not just "doesn't raise"."""
+from ..model import Confidence
+from ..tests.helpers import build_fixture_store
+
+
+def _calls_from(store, mod, fn_qualname, callee_ident=None):
+    fn_id = f"fn:{mod}::{fn_qualname}"
+    sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fn_id]
+    if callee_ident is not None:
+        sites = [n for n in sites if n.attrs.get("callee") == callee_ident]
+    assert len(sites) == 1, (fn_qualname, callee_ident, len(sites))
+    site = sites[0]
+    edges = store.out_edges(site.id, "CALLS")
+    assert len(edges) == 1
+    return site, edges[0]
+
+
+# -- rung 4: name-via-injected-global ---------------------------------------
+
+
+def test_single_value_injection_resolves_probable_with_because():
+    store, _, _ = build_fixture_store(["registry_injection.py", "registry_injection_caller.py"])
+    site, edge = _calls_from(store, "registry_injection.py", "use_thing")
+    assert edge.dst == "fn:registry_injection_caller.py::real_thing"
+    assert edge.confidence == Confidence.PROBABLE
+    assert edge.attrs["rung"] == "name-via-injected-global"
+    assert edge.attrs["because"] == "injected at registry_injection_caller.py:16"
+
+
+def test_multi_value_injection_leaves_calls_unresolved_and_dispatches_fan_out():
+    store, _, _ = build_fixture_store([
+        "registry_injection.py", "registry_injection_caller.py", "registry_injection_caller2.py",
+    ])
+    site, edge = _calls_from(store, "registry_injection.py", "use_thing")
+    assert edge.dst == "?"
+    assert edge.attrs["reason"] == "injected-global-multi-value"
+    assert edge.attrs["alternatives"] == 2
+    disp = {e.dst for e in store.out_edges(site.id, "DISPATCHES")}
+    assert disp == {
+        "fn:registry_injection_caller.py::real_thing",
+        "fn:registry_injection_caller2.py::other_thing",
+    }
+    for e in store.out_edges(site.id, "DISPATCHES"):
+        assert e.confidence == Confidence.PROBABLE
+        assert e.attrs["fanout"] == 2
+
+
+def test_proven_rungs_1_3_are_never_revisited_by_the_probable_tier():
+    # register()'s own body calls _get_thing/_helper_a nowhere by bare name,
+    # but the module DOES have proven-rung calls (real_thing() inside
+    # registry_injection_caller.py's own module body is a def, not a call);
+    # use the calls_shapes fixture instead, which is dense with proven rungs,
+    # and assert none of them got touched by a second pass.
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    fn_id = "fn:calls_shapes.py::caller_name_def_local"
+    sites = [n for n in store.nodes_of_kind("CALLSITE") if n.attrs.get("enclosing_fn") == fn_id]
+    edge = store.out_edges(sites[0].id, "CALLS")[0]
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "name-def-local"
+
+
+# -- rung 5: dict-dispatch ----------------------------------------------------
+
+
+def test_dict_get_dispatch_fans_out_to_every_registry_member():
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    site, edge = _calls_from(store, "registry_mandict.py", "dispatch", "handler")
+    assert edge.dst == "?"
+    assert edge.attrs["reason"] == "dict-dispatch-fanout"
+    assert edge.attrs["registry"] == "reg:registry_mandict.py::_SKILL_MAP"
+    assert edge.attrs["fanout"] == 2
+    assert edge.attrs["selector"] == "skill_id"
+    disp = {e.dst: e for e in store.out_edges(site.id, "DISPATCHES")}
+    assert set(disp) == {"fn:registry_mandict.py::skill_one", "fn:registry_mandict.py::skill_two"}
+    for e in disp.values():
+        assert e.confidence == Confidence.PROBABLE
+        assert e.attrs["fanout"] == 2
+        assert e.attrs["selector"] == "skill_id"
+        assert e.attrs["registry"] == "reg:registry_mandict.py::_SKILL_MAP"
+
+
+def test_dict_subscript_dispatch_same_as_dict_get():
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    site, edge = _calls_from(store, "registry_mandict.py", "dispatch_subscript", "handler")
+    assert edge.attrs["reason"] == "dict-dispatch-fanout"
+    disp = {e.dst for e in store.out_edges(site.id, "DISPATCHES")}
+    assert disp == {"fn:registry_mandict.py::skill_one", "fn:registry_mandict.py::skill_two"}
+
+
+def test_config_dict_is_not_a_dispatch_source():
+    # _CONFIG_MAP's values are literals, not bare-callable Names, so
+    # extract/registry.py never creates a REGISTRY for it — a local var
+    # assigned from it must not spuriously get a DISPATCHES fan-out either.
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    assert store.get("reg:registry_mandict.py::_CONFIG_MAP") is None
+
+
+# -- rung 6: unique-method-name -----------------------------------------------
+
+
+def test_unique_method_name_resolves_probable():
+    store, _, _ = build_fixture_store(["dispatch_shapes.py", "dispatch_target.py"])
+    site, edge = _calls_from(store, "dispatch_shapes.py", "call_unique_method")
+    assert edge.dst == "fn:dispatch_shapes.py::OnlyOwner.unique_op"
+    assert edge.confidence == Confidence.PROBABLE
+    assert edge.attrs["rung"] == "unique-method-name"
+    assert edge.attrs["alternatives"] == 1
+
+
+def test_ambiguous_method_name_stays_unresolved_with_alternatives_count():
+    store, _, _ = build_fixture_store(["dispatch_shapes.py", "dispatch_target.py"])
+    site, edge = _calls_from(store, "dispatch_shapes.py", "call_ambiguous_method")
+    assert edge.dst == "?"
+    assert edge.attrs["reason"] == "ambiguous-method-name"
+    assert edge.attrs["alternatives"] == 2
+
+
+# -- getattr-literal -----------------------------------------------------
+
+
+def test_getattr_with_literal_attribute_resolves_proven():
+    store, _, _ = build_fixture_store(["dispatch_shapes.py", "dispatch_target.py"])
+    fn_id = "fn:dispatch_shapes.py::call_getattr_literal"
+    sites = [n for n in store.nodes_of_kind("CALLSITE")
+             if n.attrs.get("enclosing_fn") == fn_id and n.attrs.get("form") == "getattr-result"]
+    assert len(sites) == 1
+    edge = store.out_edges(sites[0].id, "CALLS")[0]
+    assert edge.dst == "fn:dispatch_target.py::target_fn"
+    assert edge.confidence == Confidence.PROVEN
+    assert edge.attrs["rung"] == "getattr-literal"
+
+
+def test_getattr_with_variable_attribute_stays_a_hole():
+    store, _, _ = build_fixture_store(["dispatch_shapes.py", "dispatch_target.py"])
+    fn_id = "fn:dispatch_shapes.py::call_getattr_variable"
+    sites = [n for n in store.nodes_of_kind("CALLSITE")
+             if n.attrs.get("enclosing_fn") == fn_id and n.attrs.get("form") == "getattr-result"]
+    assert len(sites) == 1
+    edge = store.out_edges(sites[0].id, "CALLS")[0]
+    assert edge.dst == "?"
+    assert edge.attrs["reason"] == "computed-getattr"

--- a/scripts/callgraph/tests/test_extract_flow.py
+++ b/scripts/callgraph/tests/test_extract_flow.py
@@ -1,0 +1,101 @@
+"""extract/flow.py: escaping-local detection (LOCALBINDING/ESCAPES) and the
+per-function control-flow summary the flag audit reads — BUG B's shape, in
+miniature, against real GraphStore output over fixtures/flags_shapes.py."""
+from ..extract.flow import local_binding_id
+from ..tests.helpers import build_fixture_store
+
+FN = "fn:flags_shapes.py::assemble"
+OK = local_binding_id(FN, "ok")
+
+
+def _store():
+    store, _, _ = build_fixture_store(["flags_shapes.py"])
+    return store
+
+
+def test_ok_is_constant_initialized_and_dict_value_escape():
+    store = _store()
+    node = store.get(OK)
+    assert node is not None
+    assert node.attrs["init_is_constant"] is True
+    edges = [e for e in store.out_edges(FN, "ESCAPES") if e.dst == OK]
+    assert len(edges) == 1
+    assert edges[0].attrs["escape_form"] == "dict-value"
+
+
+def test_ok_has_two_guarded_reassignments_tagged_if_branch():
+    store = _store()
+    node = store.get(OK)
+    contexts = [c["context"] for c in node.attrs["assign_contexts"]]
+    assert contexts == ["if-branch", "if-branch"]
+    assert len(node.attrs["assign_lines"]) == 2
+
+
+def test_ok_has_three_guard_exits_none_of_which_assign_it():
+    store = _store()
+    node = store.get(OK)
+    guard_exits = node.attrs["guard_exits"]
+    assert len(guard_exits) == 3
+    kinds = sorted(g["kind"] for g in guard_exits)
+    assert kinds == ["break", "continue", "continue"]
+
+
+def test_parts_escapes_but_is_not_constant_initialized():
+    store = _store()
+    parts_id = local_binding_id(FN, "parts")
+    node = store.get(parts_id)
+    assert node is not None
+    assert node.attrs["init_is_constant"] is False
+    edges = [e for e in store.out_edges(FN, "ESCAPES") if e.dst == parts_id]
+    assert edges[0].attrs["escape_form"] == "dict-value"
+
+
+def test_direct_return_escape_form():
+    fn = "fn:flags_shapes.py::direct_return_case"
+    store = _store()
+    lid = local_binding_id(fn, "result")
+    node = store.get(lid)
+    assert node is not None
+    edges = [e for e in store.out_edges(fn, "ESCAPES") if e.dst == lid]
+    assert edges[0].attrs["escape_form"] == "direct-return"
+
+
+def test_tuple_element_escape_form_and_params_excluded():
+    fn = "fn:flags_shapes.py::tuple_return_case"
+    store = _store()
+    total_id = local_binding_id(fn, "total")
+    node = store.get(total_id)
+    assert node is not None
+    edges = [e for e in store.out_edges(fn, "ESCAPES") if e.dst == total_id]
+    assert edges[0].attrs["escape_form"] == "tuple-element"
+    # `a` and `b` are parameters returned as-is, not locally (re)bound —
+    # must NOT get their own LOCALBINDING (see module docstring).
+    assert store.get(local_binding_id(fn, "a")) is None
+    assert store.get(local_binding_id(fn, "b")) is None
+
+
+def test_closure_escape_marks_free_variables_of_returned_nested_function():
+    fn = "fn:flags_shapes.py::make_adder"
+    store = _store()
+    base_id = local_binding_id(fn, "base")
+    step_id = local_binding_id(fn, "step")
+    base_node = store.get(base_id)
+    step_node = store.get(step_id)
+    assert base_node is not None and step_node is not None
+    base_edges = [e for e in store.out_edges(fn, "ESCAPES") if e.dst == base_id]
+    step_edges = [e for e in store.out_edges(fn, "ESCAPES") if e.dst == step_id]
+    assert base_edges[0].attrs["escape_form"] == "closure"
+    assert step_edges[0].attrs["escape_form"] == "closure"
+    assert step_node.attrs["init_is_constant"] is True   # `step = 1`
+    assert base_node.attrs["init_is_constant"] is False  # `base = n`
+    # the nested function's OWN name, returned by itself, is not a "local"
+    # of make_adder in the sense this module models.
+    assert store.get(local_binding_id(fn, "add")) is None
+
+
+def test_no_escape_case_creates_no_localbinding():
+    fn = "fn:flags_shapes.py::no_escape_case"
+    store = _store()
+    lid = local_binding_id(fn, "unused_local")
+    assert store.get(lid) is None
+    assert store.out_edges(fn, "ESCAPES") == []

--- a/scripts/callgraph/tests/test_extract_imports.py
+++ b/scripts/callgraph/tests/test_extract_imports.py
@@ -1,0 +1,83 @@
+"""extract/imports.py: IMPORTS edges (scope, resolved_via) and ALIASES
+edges (from-import re-exports, bare module-level A = B), across the
+synthetic fixtures — this is the step-3 acceptance surface."""
+from ..extract.defs import extract_module
+from ..extract.imports import extract_imports
+from ..model import GraphStore
+from ..resolve import ResolutionTable
+from ..tests.helpers import load_fixture
+
+
+def _build(rel_paths: list[str]):
+    sources = [load_fixture(p) for p in rel_paths]
+    table = ResolutionTable(sources)
+    store = GraphStore()
+    scopes = {sf.rel_path: extract_module(store, sf, table) for sf in sources}
+    for sf in sources:
+        extract_imports(store, sf, scopes[sf.rel_path], table, scopes)
+    return store, table
+
+
+def test_lazy_import_edge_carries_scope_and_enclosing_fn():
+    store, _ = _build(["lazy_import.py"])
+    edges = store.out_edges("mod:lazy_import.py", "IMPORTS")
+    by_module = {e.attrs["module"]: e for e in edges}
+    assert by_module["json"].attrs["scope"] == "module-level"
+    assert by_module["json"].attrs["enclosing_fn"] is None
+    assert by_module["numpy"].attrs["scope"] == "function-local"
+    assert by_module["numpy"].attrs["enclosing_fn"] == "resolve_vllm"
+    assert by_module["numpy"].confidence.name == "PROVEN"  # third-party numpy
+
+
+def test_flat_sibling_import_resolves_to_module_node():
+    store, _ = _build(["pkg/scripts/entry.py", "pkg/mcp/sibling.py"])
+    edges = store.out_edges("mod:pkg/scripts/entry.py", "IMPORTS")
+    sibling_edge = next(e for e in edges if e.attrs["module"] == "sibling")
+    assert sibling_edge.dst == "mod:pkg/mcp/sibling.py"
+    assert sibling_edge.confidence.name == "PROVEN"
+    assert "sys.path.insert@pkg/scripts/entry.py" in sibling_edge.attrs["resolved_via"]
+
+
+def test_reexport_aliases_to_function_node_not_a_disconnected_copy():
+    store, _ = _build(["reexport.py", "reexport_source.py"])
+    aliases = store.out_edges("name:reexport.py::symbol_impact", "ALIASES")
+    assert len(aliases) == 1
+    assert aliases[0].dst == "fn:reexport_source.py::symbol_impact"
+    assert aliases[0].confidence.name == "PROVEN"
+    assert aliases[0].attrs["form"] == "from-import"
+
+    aliases2 = store.out_edges("name:reexport.py::impact_report", "ALIASES")
+    assert aliases2[0].dst == "fn:reexport_source.py::impact_report"
+
+
+def test_bare_module_level_assign_aliases_to_the_same_function():
+    store, _ = _build(["reexport.py", "reexport_source.py"])
+    # `runner = symbol_impact` inside reexport.py: `runner` aliases the
+    # `symbol_impact` NAME slot in the SAME module (a one-hop, same-module
+    # alias) — and that slot's own ALIASES edge (built from the from-import)
+    # is what actually reaches the function. A two-hop chain, not a
+    # collapsed shortcut: a reverse closure over ALIASES follows both hops,
+    # and `runner` must never become a second, disconnected identity for
+    # symbol_impact.
+    runner_aliases = store.out_edges("name:reexport.py::runner", "ALIASES")
+    assert len(runner_aliases) == 1
+    assert runner_aliases[0].dst == "name:reexport.py::symbol_impact"
+    assert runner_aliases[0].attrs["form"] == "assign"
+
+    imported_slot_aliases = store.out_edges("name:reexport.py::symbol_impact", "ALIASES")
+    assert imported_slot_aliases[0].dst == "fn:reexport_source.py::symbol_impact"
+
+
+def test_import_module_binding_aliases_to_module_node():
+    store, _ = _build(["pkg/scripts/entry.py", "pkg/mcp/sibling.py"])
+    alias = store.out_edges("name:pkg/scripts/entry.py::sibling", "ALIASES")
+    assert len(alias) == 1
+    assert alias[0].dst == "mod:pkg/mcp/sibling.py"
+    assert alias[0].attrs["form"] == "import"
+
+
+def test_stdlib_import_creates_external_node():
+    store, _ = _build(["lazy_import.py"])
+    ext = store.get("ext:json")
+    assert ext is not None
+    assert ext.attrs["distribution"] == "stdlib"

--- a/scripts/callgraph/tests/test_extract_literals.py
+++ b/scripts/callgraph/tests/test_extract_literals.py
@@ -1,0 +1,112 @@
+"""extract/literals.py: LITERAL/PATHEXPR nodes and PRODUCES_LITERAL /
+CONSUMES_LITERAL edges, against real GraphStore output over fixtures."""
+from ..extract.literals import (
+    classify_flavour, literal_node_id, looks_key_like, looks_path_like, normalize_literal, tail_segment,
+)
+from ..tests.helpers import build_fixture_store
+
+
+def test_looks_path_like():
+    assert looks_path_like("~/.hermes/**/graph.kuzu")
+    assert looks_path_like("mcp/server.py")
+    assert looks_path_like("graph.ladybug")
+    assert not looks_path_like("HERMES_PORT")
+    assert not looks_path_like("")
+
+
+def test_looks_key_like():
+    assert looks_key_like("HERMES_PORT")
+    assert looks_key_like("cfg_lookup_only")
+    assert not looks_key_like("~/.hermes/**/graph.kuzu")
+    assert not looks_key_like("has a space")
+
+
+def test_normalize_collapses_double_star():
+    assert normalize_literal("~/.hermes/**/graph.kuzu") == "~/.hermes/*/graph.kuzu"
+
+
+def test_tail_segment_last_path_component():
+    assert tail_segment("~/.hermes/*/graph.kuzu") == "graph.kuzu"
+    assert tail_segment("graph.ladybug") == "graph.ladybug"
+
+
+def test_classify_flavour():
+    assert classify_flavour("mcp/server.py") == "path"
+    assert classify_flavour("HERMES_PORT") == "key"
+    assert classify_flavour("has a space and/slash") is None or classify_flavour("has a space and/slash") == "path"
+
+
+def test_literal_node_id_stable_for_same_normalized_text():
+    a = literal_node_id(normalize_literal("~/.hermes/**/graph.kuzu"))
+    b = literal_node_id(normalize_literal("~/.hermes/*/graph.kuzu"))
+    assert a == b
+
+
+# -- store-ctor PATHEXPR producer (BUG D producer shape) ---------------------
+
+
+def test_store_ctor_pathexpr_produces_tail_literal():
+    store, _, _ = build_fixture_store(["literals_produce.py"])
+    pathexprs = [n for n in store.nodes_of_kind("PATHEXPR") if n.attrs.get("tail_literal") == "graph.ladybug"]
+    assert len(pathexprs) == 1
+    pid = pathexprs[0].id
+    edges = store.in_edges(pid, "PRODUCES_LITERAL")
+    assert len(edges) == 1
+    assert edges[0].attrs["role"] == "store-ctor"
+    assert edges[0].src == "fn:literals_produce.py::open_store"
+
+
+def test_write_text_on_composed_path_produces():
+    store, _, _ = build_fixture_store(["literals_produce.py"])
+    pathexprs = [n for n in store.nodes_of_kind("PATHEXPR") if n.attrs.get("tail_literal") == "notes.jsonl"]
+    assert len(pathexprs) == 1
+    edges = store.in_edges(pathexprs[0].id, "PRODUCES_LITERAL")
+    assert any(e.attrs["role"] == "write_text" for e in edges)
+
+
+# -- glob/open consumer shapes (BUG D consumer shape) -------------------------
+
+
+def test_glob_with_expanduser_wrapper_consumes_bare_literal():
+    store, _, _ = build_fixture_store(["literals_consume.py", "literals_produce.py"])
+    normalized = normalize_literal("~/.hermes/**/graph.kuzu")
+    lid = literal_node_id(normalized)
+    node = store.get(lid)
+    assert node is not None
+    assert node.kind == "LITERAL"
+    assert node.attrs["flavour"] == "path"
+    edges = store.in_edges(lid, "CONSUMES_LITERAL")
+    assert len(edges) == 1
+    assert edges[0].attrs["role"] == "glob"
+    assert edges[0].src == "fn:literals_consume.py::find_databases"
+
+
+def test_open_default_mode_consumes_composed_path():
+    store, _, _ = build_fixture_store(["literals_consume.py", "literals_produce.py"])
+    pathexprs = [n for n in store.nodes_of_kind("PATHEXPR") if n.attrs.get("tail_literal") == "notes.jsonl"]
+    consume_edges = [e for pe in pathexprs for e in store.in_edges(pe.id, "CONSUMES_LITERAL")]
+    assert any(e.attrs["role"] == "open-r" and e.src == "fn:literals_consume.py::read_note" for e in consume_edges)
+
+
+# -- key-like: environ + dict get/subscript -----------------------------------
+
+
+def test_environ_get_and_subscript_share_one_literal_both_directions():
+    store, _, _ = build_fixture_store(["literals_keys.py"])
+    lid = literal_node_id(normalize_literal("HERMES_PORT"))
+    node = store.get(lid)
+    assert node is not None and node.attrs["flavour"] == "key"
+    consumes = store.in_edges(lid, "CONSUMES_LITERAL")
+    produces = store.in_edges(lid, "PRODUCES_LITERAL")
+    assert any(e.attrs["role"] == "environ-get" for e in consumes)
+    assert any(e.attrs["role"] == "environ-set" for e in produces)
+
+
+def test_dict_get_and_subscript_orphan_keys_are_distinct():
+    store, _, _ = build_fixture_store(["literals_keys.py"])
+    lookup_id = literal_node_id(normalize_literal("cfg_lookup_only"))
+    write_id = literal_node_id(normalize_literal("cfg_write_only"))
+    assert store.in_edges(lookup_id, "CONSUMES_LITERAL")
+    assert not store.in_edges(lookup_id, "PRODUCES_LITERAL")
+    assert store.in_edges(write_id, "PRODUCES_LITERAL")
+    assert not store.in_edges(write_id, "CONSUMES_LITERAL")

--- a/scripts/callgraph/tests/test_extract_names.py
+++ b/scripts/callgraph/tests/test_extract_names.py
@@ -1,0 +1,73 @@
+"""extract/names.py: WRITES_NAME (module-level-assign | global-stmt |
+import-binding | def-binding) and READS_NAME (same-module and cross-module),
+against real GraphStore output."""
+from ..model import Confidence
+from ..tests.helpers import build_fixture_store
+
+
+def test_module_level_assign_write():
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    nid = "name:dangling_global.py::_real_counter"
+    writes = store.in_edges(nid, "WRITES_NAME")
+    kinds = {(w.src, w.attrs["via"]) for w in writes}
+    assert ("mod:dangling_global.py", "module-level-assign") in kinds
+
+
+def test_global_stmt_write_line_and_src():
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    nid = "name:dangling_global.py::_symbol_index_count"
+    writes = store.in_edges(nid, "WRITES_NAME")
+    assert len(writes) == 1
+    w = writes[0]
+    assert w.src == "fn:dangling_global.py::invalidate_cache"
+    assert w.attrs["via"] == "global-stmt"
+    assert w.attrs["line"] == 11  # `_symbol_index_count = 0` inside invalidate_cache
+
+
+def test_def_binding_write():
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    nid = "name:dangling_global.py::invalidate_cache"
+    writes = store.in_edges(nid, "WRITES_NAME")
+    assert any(w.attrs["via"] == "def-binding" and w.src == "mod:dangling_global.py" for w in writes)
+
+
+def test_augmented_write_tagged_separately_from_plain_assign():
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    # `_real_counter += n` inside bump() is a global-stmt AugAssign — via
+    # must say "global-stmt" (it's the global declaration that matters,
+    # scopes.py's own binding_kind already lumps assign+augassign, but
+    # names.py's WRITES_NAME still distinguishes it as an augmented op via
+    # a separate edge instance from the module-level plain assign).
+    nid = "name:dangling_global.py::_real_counter"
+    writes = store.in_edges(nid, "WRITES_NAME")
+    via_by_src = {w.src: w.attrs["via"] for w in writes}
+    assert via_by_src["fn:dangling_global.py::bump"] == "global-stmt"
+    assert via_by_src["mod:dangling_global.py"] == "module-level-assign"
+
+
+def test_reads_name_in_call_position():
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    nid = "name:calls_shapes.py::helper"
+    reads = store.in_edges(nid, "READS_NAME")
+    assert len(reads) == 1
+    assert reads[0].src == "fn:calls_shapes.py::caller_name_def_local"
+    assert reads[0].attrs["in_call_position"] is True
+
+
+def test_local_variable_is_not_misreported_as_a_global_read():
+    # `caller_param_call`'s `callback` parameter is a genuine local, not a
+    # module NAME — no NAME node exists for "callback" at all, so this is
+    # really just confirming no spurious READS_NAME edge is created.
+    store, _, _ = build_fixture_store(["calls_shapes.py", "calls_target.py"])
+    assert store.get("name:calls_shapes.py::callback") is None
+
+
+def test_cross_module_reads_name_via_imported_module_attribute():
+    store, _, _ = build_fixture_store(["names_cross_module.py", "names_cross_module_target.py"])
+    nid = "name:names_cross_module_target.py::CONFIG_VALUE"
+    reads = store.in_edges(nid, "READS_NAME")
+    assert len(reads) == 1
+    r = reads[0]
+    assert r.src == "fn:names_cross_module.py::read_it"
+    assert r.attrs["cross_module"] is True
+    assert r.confidence == Confidence.PROVEN

--- a/scripts/callgraph/tests/test_extract_registry.py
+++ b/scripts/callgraph/tests/test_extract_registry.py
@@ -1,0 +1,179 @@
+"""extract/registry.py: DEC, MAN-LOOP, MAN-DICT, ROOT-CLI, and REG-FN/INJECTS,
+against real GraphStore output."""
+from ..model import Confidence
+from ..tests.helpers import build_fixture_store
+
+
+# -- DEC (reuses slice-1's decorator_registry.py fixture) ------------------
+
+
+def test_dec_creates_registry_and_retargets_decorated_by():
+    store, _, _ = build_fixture_store(["decorator_registry.py"])
+    reg_id = "reg:decorator_registry.py::mcp.tool"
+    reg = store.get(reg_id)
+    assert reg is not None and reg.kind == "REGISTRY"
+    assert reg.attrs["mechanism"] == "decorator"
+
+    # the DECORATED_BY edge on registered_tool must now target the REGISTRY
+    # node, not the placeholder EXTERNAL sink defs.py created.
+    fid = "fn:decorator_registry.py::registered_tool"
+    dbs = store.out_edges(fid, "DECORATED_BY")
+    assert len(dbs) == 1
+    assert dbs[0].dst == reg_id
+    # the classification/raw attrs survive the retarget untouched
+    assert dbs[0].attrs["classification"] == "registering"
+    assert dbs[0].attrs["raw"] == "mcp.tool()"
+
+    # a non-registering decorator's DECORATED_BY edge is untouched (still EXTERNAL)
+    cached_id = "fn:decorator_registry.py::cached_helper"
+    cached_dbs = store.out_edges(cached_id, "DECORATED_BY")
+    assert cached_dbs[0].dst.startswith("ext:")
+
+
+def test_dec_registers_member_and_entrypoint():
+    store, _, _ = build_fixture_store(["decorator_registry.py"])
+    reg_id = "reg:decorator_registry.py::mcp.tool"
+    fid = "fn:decorator_registry.py::registered_tool"
+    members = store.out_edges(reg_id, "REGISTERS")
+    assert len(members) == 1
+    assert members[0].dst == fid
+    assert members[0].attrs["key"] == "registered_tool"
+
+    entry = store.get("entry:mcp-tool:registered_tool")
+    assert entry is not None and entry.kind == "ENTRYPOINT"
+    enters = store.out_edges(entry.id, "ENTERS")
+    assert len(enters) == 1 and enters[0].dst == fid
+
+
+def test_unrecognized_decorator_creates_no_registry():
+    store, _, _ = build_fixture_store(["decorator_registry.py"])
+    assert store.get("reg:decorator_registry.py::some_unrecognized_decorator") is None
+
+
+# -- MAN-LOOP ----------------------------------------------------------
+
+
+def test_manloop_registers_both_tuple_elements():
+    store, _, _ = build_fixture_store(["registry_manloop.py"])
+    reg_id = "reg:registry_manloop.py::register"
+    reg = store.get(reg_id)
+    assert reg is not None and reg.attrs["mechanism"] == "manifest-tuple"
+    members = {e.dst for e in store.out_edges(reg_id, "REGISTERS")}
+    assert members == {"fn:registry_manloop.py::tool_a", "fn:registry_manloop.py::tool_b"}
+    for name in ("tool_a", "tool_b"):
+        assert store.get(f"entry:mcp-tool:{name}") is not None
+
+
+def test_manloop_emits_references_for_each_element():
+    store, _, _ = build_fixture_store(["registry_manloop.py"])
+    register_fn_id = "fn:registry_manloop.py::register"
+    refs = {e.dst for e in store.out_edges(register_fn_id, "REFERENCES")}
+    assert refs == {"fn:registry_manloop.py::tool_a", "fn:registry_manloop.py::tool_b"}
+
+
+def test_unrelated_loop_over_bare_names_is_not_manloop():
+    # backends.py's real shape: `for fn in (_config,): fn.cache_clear()` —
+    # calling a method ON the loop var is not registering it anywhere.
+    store, _, _ = build_fixture_store(["registry_manloop.py"])
+    assert store.get("reg:registry_manloop.py::_reset_cache") is None
+    reset_fn_id = "fn:registry_manloop.py::_reset_cache"
+    # `_config` IS referenced by name here (it escapes into the tuple), so
+    # extract/funcrefs.py emits a plain name-escape edge — that is correct and
+    # is what keeps `_config` off `cg dead`. What must NOT appear is a
+    # REGISTRATION form: this loop registers nothing.
+    forms = {e.attrs.get("form") for e in store.out_edges(reset_fn_id, "REFERENCES")}
+    assert forms == {"name-escape"}, forms
+    assert not store.edges_of_kind("REGISTERS") or all(
+        e.src != "reg:registry_manloop.py::_reset_cache" for e in store.edges_of_kind("REGISTERS")
+    )
+
+
+# -- MAN-DICT ----------------------------------------------------------
+
+
+def test_mandict_registers_skill_map_only():
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    reg_id = "reg:registry_mandict.py::_SKILL_MAP"
+    reg = store.get(reg_id)
+    assert reg is not None and reg.attrs["mechanism"] == "manifest-dict"
+    keys = {e.attrs["key"] for e in store.out_edges(reg_id, "REGISTERS")}
+    assert keys == {"one", "two"}
+    assert store.get("entry:skill:one") is not None
+    assert store.get("entry:skill:two") is not None
+
+
+def test_config_dict_with_literal_values_is_not_mandict():
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    assert store.get("reg:registry_mandict.py::_CONFIG_MAP") is None
+
+
+def test_mandict_emits_references_from_module():
+    store, _, _ = build_fixture_store(["registry_mandict.py"])
+    mod_refs = {e.dst for e in store.out_edges("mod:registry_mandict.py", "REFERENCES")}
+    assert mod_refs == {"fn:registry_mandict.py::skill_one", "fn:registry_mandict.py::skill_two"}
+
+
+# -- ROOT-CLI ------------------------------------------------------------
+
+
+def test_rootcli_entrypoint_enters_main():
+    store, _, _ = build_fixture_store(["registry_rootcli.py"])
+    entry = store.get("entry:cli:registry_rootcli.py")
+    assert entry is not None and entry.attrs["trust"] == "declared-in-source"
+    enters = store.out_edges(entry.id, "ENTERS")
+    assert len(enters) == 1
+    assert enters[0].dst == "fn:registry_rootcli.py::main"
+
+
+# -- REG-FN / INJECTS ------------------------------------------------------
+
+
+def _injection_store():
+    return build_fixture_store(["registry_injection.py", "registry_injection_caller.py"])
+
+
+def test_direct_param_injection():
+    store, _, _ = _injection_store()
+    nid = "name:registry_injection.py::_get_thing"
+    injects = store.in_edges(nid, "INJECTS")
+    assert len(injects) == 1
+    e = injects[0]
+    assert e.confidence == Confidence.PROBABLE
+    assert e.attrs["value"] == "fn:registry_injection_caller.py::real_thing"
+    assert e.attrs["value_kind"] == "FUNCTION"
+    assert e.attrs["param"] == "get_thing"
+
+
+def test_deps_dict_key_injection():
+    store, _, _ = _injection_store()
+    nid = "name:registry_injection.py::_helper_a"
+    injects = store.in_edges(nid, "INJECTS")
+    assert len(injects) == 1
+    e = injects[0]
+    assert e.attrs["value"] == "fn:registry_injection_caller.py::real_helper_a"
+    assert e.attrs["value_kind"] == "FUNCTION"
+    assert e.attrs["param"] == "deps"
+    assert e.attrs["key"] == "helper_a"
+
+
+def test_injection_emits_references_for_function_valued_args():
+    store, _, _ = _injection_store()
+    mod_id = "mod:registry_injection_caller.py"
+    refs = {e.dst for e in store.out_edges(mod_id, "REFERENCES") if e.attrs.get("form") == "injected-argument"}
+    assert refs == {
+        "fn:registry_injection_caller.py::real_thing",
+        "fn:registry_injection_caller.py::real_helper_a",
+    }
+
+
+def test_writes_dead_style_fixture_still_bug_c_shaped():
+    # Sanity: the dangling_global.py fixture (used by scopes.py's own tests)
+    # produces WRITES_NAME(via=global-stmt) edges through THIS module too —
+    # confirms extract/names.py and scopes.py agree on what counts as
+    # global-only.
+    store, _, _ = build_fixture_store(["dangling_global.py"])
+    nid = "name:dangling_global.py::_symbol_index_cache"
+    writes = store.in_edges(nid, "WRITES_NAME")
+    assert len(writes) == 1
+    assert writes[0].attrs["via"] == "global-stmt"
+    assert writes[0].src == "fn:dangling_global.py::invalidate_cache"

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -1,0 +1,51 @@
+"""ingest.py: worktree parsing, git-rev parsing, and the SyntaxError
+degrade-not-abort contract."""
+from .. import ingest
+from ..tests.helpers import source_file
+
+
+def test_load_corpus_worktree_parses_114_files_with_no_errors():
+    sources, origin = ingest.load_corpus(rev=None)
+    assert origin == "working tree"
+    assert len(sources) == 114
+    errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
+    assert errors == []
+    assert all(sf.tree is not None for sf in sources)
+
+
+def test_load_corpus_rev_head_reads_git_blobs():
+    sources, origin = ingest.load_corpus(rev="HEAD")
+    assert origin.startswith("rev ")
+    assert len(sources) == 114
+    assert all(sf.error is None for sf in sources)
+    server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
+    assert "loci-mcp" in server.source[:200]
+
+
+def test_load_corpus_rev_head_differs_from_worktree_when_mcp_server_dirty():
+    # mcp/server.py is the file another workflow is mid-editing per the task
+    # brief; --rev HEAD must read the committed blob, not whatever is
+    # sitting in the working tree at the moment this test runs. We only
+    # assert both are *readable* and non-empty, since the working tree copy
+    # is explicitly allowed to be mid-edit / different right now.
+    worktree_sources, _ = ingest.load_corpus(rev=None)
+    rev_sources, _ = ingest.load_corpus(rev="HEAD")
+    wt = {sf.rel_path for sf in worktree_sources}
+    rv = {sf.rel_path for sf in rev_sources}
+    assert wt == rv
+
+
+def test_syntax_error_degrades_one_file_without_aborting_build():
+    good = source_file("ok.py", "def f():\n    return 1\n")
+    bad = source_file("broken.py", "def f(:\n    pass\n")
+    assert good.tree is not None and good.error is None
+    assert bad.tree is None
+    assert bad.error is not None and "SyntaxError" in bad.error
+
+
+def test_parse_one_reparses_identical_content_consistently():
+    a = source_file("a.py", "x = 1\n")
+    b = source_file("b.py", "x = 1\n")
+    # Same content, different path -> same sha1, independent trees.
+    assert a.sha1 == b.sha1
+    assert ingest.ast.dump(a.tree) == ingest.ast.dump(b.tree)

--- a/scripts/callgraph/tests/test_model.py
+++ b/scripts/callgraph/tests/test_model.py
@@ -1,0 +1,76 @@
+"""model.py: GraphStore's (de)serialization and DOT export, against a
+small hand-built store -- not the real corpus, so these stay fast and the
+expected output is something a human can read in the assertion itself."""
+from ..model import Confidence, Edge, GraphStore, Node
+
+
+def _store():
+    store = GraphStore()
+    store.add_node(Node("fn:a.py::foo", "FUNCTION", {"qualname": "foo"}, path="a.py", line=1))
+    store.add_node(Node("fn:b.py::bar", "FUNCTION", {"qualname": "bar"}, path="b.py", line=1))
+    store.add_node(Node("mod:a.py", "MODULE", {}, path="a.py", line=1))
+    store.add_edge(Edge("mod:a.py", "fn:a.py::foo", "DEFINES", Confidence.PROVEN))
+    store.add_edge(Edge("call:a.py:3:0", "fn:b.py::bar", "CALLS", Confidence.PROBABLE, {"rung": "x"}))
+    return store
+
+
+def test_json_round_trip_preserves_nodes_edges_and_confidence():
+    store = _store()
+    text = store.to_json()
+    restored = GraphStore.from_json(text)
+    assert set(restored.nodes) == set(store.nodes)
+    assert len(restored.edges) == len(store.edges)
+    call_edges = list(restored.edges_of_kind("CALLS"))
+    assert len(call_edges) == 1
+    assert call_edges[0].confidence == Confidence.PROBABLE
+    assert call_edges[0].attrs["rung"] == "x"
+
+
+def test_stats_counts_by_kind():
+    store = _store()
+    stats = store.stats()
+    assert stats["node:FUNCTION"] == 2
+    assert stats["node:MODULE"] == 1
+    assert stats["edge:DEFINES"] == 1
+    assert stats["edge:CALLS"] == 1
+    assert stats["nodes"] == 3
+    assert stats["edges"] == 2
+
+
+def test_to_dot_whole_graph_includes_every_node_and_edge():
+    store = _store()
+    dot = store.to_dot()
+    assert dot.startswith("digraph callgraph {")
+    assert dot.rstrip().endswith("}")
+    assert '"fn:a.py::foo"' in dot
+    assert '"fn:b.py::bar"' in dot
+    assert '"mod:a.py" -> "fn:a.py::foo"' in dot
+    assert 'label="foo\\n[FUNCTION]"' in dot
+
+
+def test_to_dot_confidence_maps_to_line_style():
+    store = _store()
+    dot = store.to_dot()
+    # DEFINES is PROVEN -> solid; the CALLS edge is PROBABLE -> dashed.
+    lines = {l for l in dot.splitlines() if "->" in l}
+    defines_line = next(l for l in lines if "DEFINES" in l)
+    calls_line = next(l for l in lines if "CALLS" in l)
+    assert "style=solid" in defines_line
+    assert "style=dashed" in calls_line
+
+
+def test_to_dot_filtered_subgraph_excludes_unselected_nodes():
+    store = _store()
+    dot = store.to_dot(node_ids={"fn:a.py::foo", "mod:a.py"}, edges=[])
+    assert '"fn:a.py::foo"' in dot
+    assert '"fn:b.py::bar"' not in dot
+    assert "->" not in dot  # edges=[] means no edge lines at all
+
+
+def test_to_dot_escapes_quotes_in_labels():
+    store = GraphStore()
+    store.add_node(Node('fn:a.py::weird"name', "FUNCTION", {"qualname": 'weird"name'}, path="a.py", line=1))
+    dot = store.to_dot()
+    assert '\\"' in dot
+    # the raw (unescaped) quote must never appear inside a quoted DOT string
+    assert 'weird"name"' not in dot

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -1,0 +1,403 @@
+"""Integration tests against the real repo (read via --rev so a concurrent
+edit to mcp/server.py can never make these flaky) — the actual acceptance
+bar for steps 1-3, not just the synthetic fixtures.
+
+Most of these share the `head_build` session fixture (see conftest.py) so
+the corpus is only parsed once per test run; a few need a different
+`--rev` or `--scope` and build independently."""
+from ..analyze.deadcode import registered_but_dead
+from ..analyze.reach import (
+    direct_callers, entrypoints_reaching, function_at_line, path_confidence, shortest_path,
+)
+from ..model import Confidence
+from ..pipeline import build_graph
+
+
+def test_build_is_clean_and_fast(head_build):
+    assert head_build.meta.file_count == 114
+    assert head_build.meta.error_count == 0
+    # The 2s figure in ingest.py's own docstring is about ast.parse'ing the
+    # corpus (steps 1-3's budget). Steps 4-6 (CALLSITE/CALLS resolution over
+    # ~11,600 callsites, the whole-module READS_NAME/WRITES_NAME walk, and
+    # registry/injection extraction) are real additional work layered on
+    # top of that parse; the design's own ceiling for the FULLY assembled
+    # tool (all 13 build steps) is "under 5s" for a cold build plus every
+    # fixture assertion (see build_steps step 13) — this asserts against
+    # that end-state budget with headroom, not the steps-1-3-only figure.
+    assert head_build.meta.elapsed_s < 4.5, "cold build must stay well under the design's 5s full-tool budget"
+
+
+def test_module_level_function_count_matches_census_within_tolerance(head_build):
+    module_level = [
+        n for n in head_build.store.nodes_of_kind("FUNCTION")
+        if not n.attrs["is_nested"] and not n.attrs["is_method"]
+    ]
+    # docs/census.txt estimate: ~890 module-level functions corpus-wide.
+    assert 850 <= len(module_level) <= 930, len(module_level)
+
+
+def test_mcp_top_level_module_level_function_count(head_build):
+    # "mcp/ top-level" means files directly under mcp/ (server.py,
+    # graph_tools.py, ...) as opposed to the mcp/graph/ and mcp/memcheck/
+    # subpackages.
+    module_level = [
+        n for n in head_build.store.nodes_of_kind("FUNCTION")
+        if n.path is not None and n.path.startswith("mcp/") and n.path.count("/") == 1
+        and not n.attrs["is_nested"] and not n.attrs["is_method"]
+    ]
+    # docs/census.txt estimate: 297 in mcp/ top-level.
+    assert 265 <= len(module_level) <= 330, len(module_level)
+
+
+def test_forty_mcp_tool_decorators_classified_registering(head_build):
+    registering = [
+        e for e in head_build.store.edges_of_kind("DECORATED_BY")
+        if e.attrs["classification"] == "registering" and e.attrs["raw"].startswith("mcp.tool")
+        and e.src.startswith("fn:mcp/server.py::")
+    ]
+    assert len(registering) == 40
+
+
+def test_no_unknown_decorators_in_real_corpus(head_build):
+    unknown = [
+        e for e in head_build.store.edges_of_kind("DECORATED_BY") if e.attrs["classification"] == "unknown"
+    ]
+    assert unknown == [], [(e.src, e.attrs["raw"]) for e in unknown]
+
+
+def test_symbol_impact_reexport_alias_resolves_to_graph_tools(head_build):
+    aliases = head_build.store.out_edges("name:mcp/server.py::symbol_impact", "ALIASES")
+    assert len(aliases) == 1
+    assert aliases[0].dst == "fn:mcp/graph_tools.py::symbol_impact"
+    assert aliases[0].confidence.name == "PROVEN"
+
+
+def test_callers_of_symbol_impact_do_not_double_count_the_alias(head_build):
+    # `cg callers symbol_impact` must not treat server.py's re-export as a
+    # second, independent function — it is the SAME function node reached
+    # two ways (DEFINES from graph_tools.py, ALIASES from server.py).
+    fn_id = "fn:mcp/graph_tools.py::symbol_impact"
+    definers = list(head_build.store.in_edges(fn_id, "DEFINES"))
+    assert len(definers) == 1
+    assert definers[0].src == "mod:mcp/graph_tools.py"
+    aliasers = list(head_build.store.in_edges(fn_id, "ALIASES"))
+    assert len(aliasers) == 1
+    assert aliasers[0].src == "name:mcp/server.py::symbol_impact"
+
+
+def test_bug_c_dangling_global_regression_before_the_fix():
+    # At c1c40a9^ (the commit before "make code_memory_relink actually
+    # invalidate the symbol-index cache"), graph_tools.py declares these
+    # `global` with no module-level binding in that file — the real slot
+    # lives in ladybug_ops.py:106-107 (a different module entirely). This
+    # needs its own build: a different --rev than every other test here.
+    result = build_graph(rev="c1c40a9~1", scope_prefixes=["mcp/graph_tools.py"])
+    names = result.store.nodes_of_kind("NAME")
+    dangling = {n.id.split("::")[-1] for n in names if "global-only" in n.attrs["binding_kind"]}
+    assert {"_symbol_index_cache", "_symbol_index_count"} <= dangling
+
+
+def test_bug_c_is_fixed_on_head(head_build):
+    names = [n for n in head_build.store.nodes_of_kind("NAME") if n.path == "mcp/graph_tools.py"]
+    dangling = {n.id.split("::")[-1] for n in names if "global-only" in n.attrs["binding_kind"]}
+    assert "_symbol_index_cache" not in dangling
+    assert "_symbol_index_count" not in dangling
+
+
+def test_unresolved_imports_are_all_genuinely_optional_third_party(head_build):
+    unresolved = [e for e in head_build.store.edges_of_kind("IMPORTS") if e.attrs.get("resolved_via") == "unresolved"]
+    modules = {e.attrs["module"] for e in unresolved}
+    # Every one of these is a real optional dependency guarded by
+    # try/except ImportError or a lazy import, not present in the venv —
+    # not a resolver bug. If this set grows to include a corpus-internal
+    # module name, that IS a resolver regression.
+    assert modules <= {
+        "cy_ioc_extract", "mnemosyne", "mnemosyne.core.memory", "mnemosyne.core.beam",
+        "psycopg2", "psutil",
+    }
+    assert len(unresolved) < 20, "the unresolved list must fit on one screen"
+
+
+# ---------------------------------------------------------------------------
+# Step 4: CALLSITE / CALLS (rungs 1-3, proven tier)
+# ---------------------------------------------------------------------------
+
+
+def test_callsite_count_is_in_the_expected_ballpark(head_build):
+    # docs/census.txt estimate: ~11,600 (5,106 by name + 6,538 by attribute).
+    count = sum(1 for _ in head_build.store.nodes_of_kind("CALLSITE"))
+    assert 11000 <= count <= 12500, count
+
+
+def test_every_callsite_has_exactly_one_calls_edge(head_build):
+    store = head_build.store
+    for n in store.nodes_of_kind("CALLSITE"):
+        edges = store.out_edges(n.id, "CALLS")
+        assert len(edges) == 1, (n.id, len(edges))
+
+
+def test_unresolved_callsites_go_to_the_sink_not_dropped(head_build):
+    store = head_build.store
+    total = sum(1 for _ in store.nodes_of_kind("CALLSITE"))
+    unresolved = len(store.in_edges("?", "CALLS"))
+    assert 0 < unresolved < total
+    for e in store.in_edges("?", "CALLS"):
+        assert "reason" in e.attrs
+
+
+def test_callers_get_ladybug_proven_finds_the_in_server_callsites(head_build):
+    # THE acceptance line for step 4: `cg callers _get_ladybug --conf
+    # proven` must find the direct in-server calls. The 15 calls inside
+    # graph_tools.py that only resolve through the injected global are
+    # rung-4 (probable) territory — a later slice's job — and correctly do
+    # NOT show up here.
+    store = head_build.store
+    rows = direct_callers(store, "fn:mcp/server.py::_get_ladybug")
+    calls = [r for r in rows if r.kind == "CALLS" and r.edge.confidence == Confidence.PROVEN]
+    call_locs = {(r.site_node.line, r.site_node.col) for r in calls}
+    assert len(calls) == 2, call_locs
+    assert all(loc[0] > 0 for loc in call_locs)  # both callsites resolved to real lines in server.py
+    refs = [r for r in rows if r.kind == "REFERENCES"]
+    assert len(refs) == 2  # passed by reference at server.py:365 and the graph_tools.register() call
+
+
+# ---------------------------------------------------------------------------
+# Step 5: REGISTRY / REGISTERS / ENTERS / ENTRYPOINT — the hard gate
+# ---------------------------------------------------------------------------
+
+
+def test_hard_gate_no_registered_function_is_reported_dead(head_build):
+    # "If any of the registered functions appears in the dead list, stop
+    # and fix before writing another module" — the literal gate from
+    # build_steps step 5, run against the WHOLE corpus.
+    bad = registered_but_dead(head_build.store)
+    assert bad == [], [n.id for n in bad]
+
+
+def test_registry_counts_match_the_real_corpus(head_build):
+    from collections import Counter
+    store = head_build.store
+    by_rule = Counter(e.attrs["rule"] for e in store.edges_of_kind("REGISTERS"))
+    # 40 @mcp.tool() + 1 @mcp.resource(), both DEC-tool (both make a
+    # function externally callable by its own Python name — the specific
+    # decorator classification, tool vs resource, isn't the resolution's
+    # concern here). Verified independently via `git grep '^@mcp\.tool'`.
+    assert by_rule["DEC-tool"] == 41
+    assert by_rule["DEC-route"] == 6         # a2a_server's @app.get/@app.post
+    assert by_rule["DEC-mcp-route"] == 1     # mcp/server.py's @mcp.custom_route("/health", ...)
+    assert by_rule["MAN-LOOP"] == 31         # graph_tools(11) + investigation_tools(11) + llm_tools(9)
+    assert by_rule["MAN-DICT"] == 13         # a2a_server's _SKILL_MAP
+
+
+def test_registry_unmatched_is_empty(head_build):
+    unmatched = [e for e in head_build.store.edges_of_kind("DECORATED_BY") if e.attrs["classification"] == "unknown"]
+    assert unmatched == []
+
+
+def test_decorated_by_retargeted_from_external_to_registry(head_build):
+    # The placeholder EXTERNAL sink defs.py creates for every decorator
+    # must be gone from a REGISTERING function's DECORATED_BY edge once
+    # registry.py has run — it now points at the REGISTRY node instead.
+    store = head_build.store
+    _ = "fn:mcp/graph_tools.py::code_graph_ingest"
+    # code_graph_ingest is MAN-LOOP registered (not decorated) — check an
+    # actually-decorated one instead:
+    dec_fid = None
+    for e in store.edges_of_kind("DECORATED_BY"):
+        if e.attrs["raw"].startswith("mcp.tool") and e.src.startswith("fn:mcp/server.py::"):
+            dec_fid = e.src
+            edge = e
+            break
+    assert dec_fid is not None
+    assert edge.dst == "reg:mcp/server.py::mcp.tool"
+    assert store.get(edge.dst).kind == "REGISTRY"
+
+
+def test_root_cli_entrypoints_cover_most_main_guard_modules(head_build):
+    store = head_build.store
+    modules_with_main = [n for n in store.nodes_of_kind("MODULE") if n.attrs.get("has_main")]
+    cli_entries = [n for n in store.nodes_of_kind("ENTRYPOINT") if n.attrs["kind"] == "cli"]
+    assert len(cli_entries) == len(modules_with_main)
+    with_target = [n for n in cli_entries if store.out_edges(n.id, "ENTERS")]
+    # Not every __main__ guard's first call resolves (some drive argparse
+    # sub-dispatch instead of a single main()); most should, though.
+    assert len(with_target) / len(cli_entries) > 0.5
+
+
+# ---------------------------------------------------------------------------
+# Step 6: READS_NAME / WRITES_NAME / INJECTS
+# ---------------------------------------------------------------------------
+
+
+def test_name_get_ladybug_write_and_injection_and_reads(head_build):
+    store = head_build.store
+    nid = "name:mcp/graph_tools.py::_get_ladybug"
+    writes = store.in_edges(nid, "WRITES_NAME")
+    global_stmt_writes = [w for w in writes if w.attrs["via"] == "global-stmt"]
+    assert len(global_stmt_writes) == 1
+    assert global_stmt_writes[0].src == "fn:mcp/graph_tools.py::register"
+    assert global_stmt_writes[0].attrs["line"] == 396
+
+    injects = store.in_edges(nid, "INJECTS")
+    assert len(injects) == 1
+    assert injects[0].attrs["value"] == "fn:mcp/server.py::_get_ladybug"
+    assert injects[0].confidence == Confidence.PROBABLE
+
+    reads = store.in_edges(nid, "READS_NAME")
+    assert len(reads) == 11
+    assert all(r.attrs["in_call_position"] for r in reads)
+
+
+def test_investigation_tools_deps_dict_four_keys_injected(head_build):
+    store = head_build.store
+    expected = {"_apply_lifecycle", "_compute_self_check", "_event_log_append", "_qdrant_upsert"}
+    found = set()
+    for ident in expected:
+        nid = f"name:mcp/investigation_tools.py::{ident}"
+        injects = store.in_edges(nid, "INJECTS")
+        assert len(injects) == 1, ident
+        assert injects[0].attrs["param"] == "deps"
+        assert injects[0].attrs["key"] == ident
+        found.add(ident)
+    assert found == expected
+
+
+def test_qdrant_upsert_injection_resolves_through_the_reexport_alias(head_build):
+    # _qdrant_upsert isn't DEFINED in server.py (it's re-exported from
+    # qdrant_ops.py) — the injected value must still resolve to the real
+    # function, not degrade to a bare NAME reference.
+    store = head_build.store
+    nid = "name:mcp/investigation_tools.py::_qdrant_upsert"
+    e = store.in_edges(nid, "INJECTS")[0]
+    assert e.attrs["value"] == "fn:mcp/qdrant_ops.py::_qdrant_upsert"
+    assert e.attrs["value_kind"] == "FUNCTION"
+
+
+# ---------------------------------------------------------------------------
+# Step 7: the probable tier (CALLS rungs 4-6) + DISPATCHES
+# ---------------------------------------------------------------------------
+
+
+def test_get_ladybug_inside_graph_tools_resolves_probable_via_injected_global(head_build):
+    # THE acceptance line for step 7's first half: `_get_ladybug()` inside
+    # graph_tools.py resolves to server's definition as PROBABLE with
+    # because="injected at <the graph_tools.register() call site>". The
+    # exact line number is read off the real INJECTS edge (never hardcoded
+    # here) so this test survives mcp/server.py growing or shrinking above
+    # the register() call — only the RELATIONSHIP is asserted.
+    store = head_build.store
+    inject_edge = store.in_edges("name:mcp/graph_tools.py::_get_ladybug", "INJECTS")[0]
+    inject_site = store.get(inject_edge.src)
+    expected_because = f"injected at {inject_site.path}:{inject_site.line}"
+
+    rows = direct_callers(store, "fn:mcp/server.py::_get_ladybug")
+    probable_calls = [r for r in rows if r.kind == "CALLS" and r.edge.confidence == Confidence.PROBABLE]
+    graph_tools_calls = [r for r in probable_calls if r.site_node is not None and r.site_node.path == "mcp/graph_tools.py"]
+    # Matches step 6's own test: exactly 11 in_call_position READS_NAME
+    # edges for THIS NAME slot (mcp/graph_tools.py::_get_ladybug) — every
+    # one of them is a bare `_get_ladybug()` CALLSITE, and every one must
+    # now resolve through rung 4. direct_callers(fn:...) additionally picks
+    # up mcp/ladybug_ops.py's own separately-injected NAME slot pointing at
+    # the same target function — see the next test for that one.
+    assert len(graph_tools_calls) == 11
+    assert all(r.edge.attrs["rung"] == "name-via-injected-global" for r in graph_tools_calls)
+    assert all(r.edge.attrs["because"] == expected_because for r in graph_tools_calls)
+
+
+def test_ladybug_ops_get_ladybug_calls_also_resolve_probable(head_build):
+    # ladybug_ops.py's own `_get_ladybug` slot is injected at a DIFFERENT
+    # callsite (mcp/server.py's ladybug_ops.register(...) call, not
+    # graph_tools'), proving rung 4 isn't special-cased to one module.
+    store = head_build.store
+    rows = direct_callers(store, "fn:mcp/server.py::_get_ladybug")
+    ladybug_ops_calls = [
+        r for r in rows if r.kind == "CALLS" and r.edge.confidence == Confidence.PROBABLE
+        and r.site_node is not None and r.site_node.path == "mcp/ladybug_ops.py"
+    ]
+    assert len(ladybug_ops_calls) == 4
+    assert all(r.edge.attrs["rung"] == "name-via-injected-global" for r in ladybug_ops_calls)
+
+
+def test_a2a_dispatch_fans_out_to_all_thirteen_skills(head_build):
+    # THE acceptance line for step 7's second half: `await handler(task)` at
+    # a2a_server/server.py fans out to all 13 skills, each printing as
+    # "1 of 13" (see test_cli.py's dispatch test for the rendered form).
+    store = head_build.store
+    site = next(
+        (n for n in store.nodes_of_kind("CALLSITE")
+         if n.path == "a2a_server/server.py" and n.attrs.get("form") == "name" and n.attrs.get("callee") == "handler"),
+        None,
+    )
+    assert site is not None, "expected a2a_server's `handler(task)` dispatch callsite"
+    call_edge = store.out_edges(site.id, "CALLS")[0]
+    assert call_edge.dst == "?"
+    assert call_edge.attrs["reason"] == "dict-dispatch-fanout"
+    assert call_edge.attrs["fanout"] == 13
+    assert call_edge.attrs["registry"] == "reg:a2a_server/server.py::_SKILL_MAP"
+
+    disp = store.out_edges(site.id, "DISPATCHES")
+    assert len(disp) == 13
+    assert all(e.confidence == Confidence.PROBABLE for e in disp)
+    assert all(e.attrs["fanout"] == 13 for e in disp)
+    assert all(e.attrs["registry"] == "reg:a2a_server/server.py::_SKILL_MAP" for e in disp)
+    targets = {e.dst for e in disp}
+    registry_members = {e.dst for e in store.out_edges("reg:a2a_server/server.py::_SKILL_MAP", "REGISTERS")}
+    assert targets == registry_members
+    assert len(registry_members) == 13
+
+
+def test_dispatches_edges_participate_in_backward_closure(head_build):
+    # `cg callers <one skill>` must show the dispatch row (design: "Reverse
+    # closure over CALLS u REFERENCES u DISPATCHES u ALIASES"), not just the
+    # proven in-corpus rows earlier slices already covered.
+    store = head_build.store
+    rows = direct_callers(store, "fn:a2a_server/server.py::skill_memory_recall")
+    disp_rows = [r for r in rows if r.kind == "DISPATCHES"]
+    assert len(disp_rows) == 1
+    assert disp_rows[0].edge.attrs["selector"] == "skill_id"
+    assert disp_rows[0].site_node is not None and disp_rows[0].site_node.path == "a2a_server/server.py"
+
+
+def test_hard_gate_still_holds_after_the_probable_tier(head_build):
+    # The probable tier must never turn a registered function's status from
+    # "already fine" into "now dead" — retargeting/attrs mutation on `?`
+    # edges must never touch an already-PROVEN/PROBABLE rung-1-3 edge.
+    bad = registered_but_dead(head_build.store)
+    assert bad == [], [n.id for n in bad]
+
+
+# ---------------------------------------------------------------------------
+# Step 9: traversal commands — cg paths / cg entrypoints
+# ---------------------------------------------------------------------------
+
+
+def test_entrypoints_names_the_mcp_tool_reaching_code_memory_relink(head_build):
+    # ACCEPTANCE for step 9: `cg entrypoints mcp/graph_tools.py:<a line
+    # inside code_memory_relink>` names the MCP tool that reaches it. Uses a
+    # line computed from the function's own span (never a hardcoded literal
+    # line number) so this survives the file growing/shrinking elsewhere.
+    store = head_build.store
+    fn = store.get("fn:mcp/graph_tools.py::code_memory_relink")
+    assert fn is not None
+    mid_line = (fn.line + fn.attrs["end_lineno"]) // 2
+    start_id = function_at_line(store, "mcp/graph_tools.py", mid_line)
+    assert start_id == fn.id
+
+    entries = entrypoints_reaching(store, start_id)
+    assert entries.get("entry:mcp-tool:code_memory_relink") == Confidence.PROVEN
+
+
+def test_paths_from_code_memory_relink_to_get_ladybug_is_probable(head_build):
+    # ACCEPTANCE for step 9: path confidence equals the minimum hop
+    # confidence — code_memory_relink's own `ks = _get_ladybug()` call is a
+    # single PROBABLE (rung 4) hop, so the whole path reports PROBABLE, not
+    # PROVEN. See test_analyze_reach.py for the hand-built mixed-hop fixture
+    # chain that isolates the min-combinator behaviour itself.
+    store = head_build.store
+    hops = shortest_path(
+        store, "fn:mcp/graph_tools.py::code_memory_relink", "fn:mcp/server.py::_get_ladybug",
+        conf_floor=Confidence.UNPROVEN,
+    )
+    assert hops is not None and len(hops) == 1
+    assert hops[0].edge.confidence == Confidence.PROBABLE
+    assert path_confidence(hops) == Confidence.PROBABLE

--- a/scripts/callgraph/tests/test_regression_real_bugs.py
+++ b/scripts/callgraph/tests/test_regression_real_bugs.py
@@ -1,0 +1,240 @@
+"""REGRESSION GATE: the three structurally-visible bugs this tool exists to catch.
+
+Every other test in this package runs against fixtures that were WRITTEN to
+demonstrate a shape. These run against the REAL pre-fix code, copied verbatim
+out of git history into fixtures/regress/ (see that directory's generator
+provenance headers). The distinction matters: a hand-written fixture proves the
+analyzer handles a shape its own author had in mind, and nothing more. These
+prove it handles the code that actually shipped the bug -- 316 lines of
+grounding.py with ten lanes of unrelated control flow, 408 lines of
+graph_tools.py, the real glob call in graph_facts.py.
+
+If a later change blinds the tool, these fail. That is the entire point:
+`selftest`'s "BUG x shape" checks can keep passing against the toy fixtures
+long after the analyzer has stopped working on real input.
+
+BUG A (mcp/graph/queries.py's node["_id"] vs the backend's "_ID") is
+DELIBERATELY ABSENT. It is a data-format mismatch between this code and a
+value produced at runtime by another library. Nothing in the source text
+distinguishes the correct key from the wrong one -- both are string
+subscripts of an opaque dict -- so no call graph can see it, and pretending
+otherwise by special-casing key casing would be a contrived check that
+earns false confidence. See docs/LIMITS.md.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from ..analyze.flags import rank_flags
+from ..analyze.literalaudit import near_miss_pairs, orphans
+from ..analyze.nameaudit import dangling_globals
+from ..config import REPO_ROOT
+from .helpers import FIXTURES_DIR, build_fixture_store
+
+MARKER = "# ---- VERBATIM BODY BELOW (do not edit; see test_regression_real_bugs.py) ----\n"
+
+
+# ---------------------------------------------------------------------------
+# fixture provenance -- the fixtures must stay VERBATIM copies of real history
+# ---------------------------------------------------------------------------
+
+# (fixture rel path, commit-ish, source path in that commit, line slices or None)
+PROVENANCE = [
+    ("regress/bug_b/grounding.py", "d359e9a", "mcp/grounding.py", None),
+    ("regress/bug_c/graph_tools.py", "c1c40a9^", "mcp/graph_tools.py", None),
+    ("regress/bug_c/ladybug_ops.py", "c1c40a9^", "mcp/ladybug_ops.py", None),
+    ("regress/bug_d/graph_facts.py", "08c9198^", "scripts/graph_facts.py", None),
+    ("regress/bug_d/server.py", "08c9198^", "mcp/server.py", [(159, 166), (218, 287)]),
+]
+
+
+def _git_show(rev: str, path: str) -> str | None:
+    try:
+        p = subprocess.run(["git", "show", f"{rev}:{path}"], cwd=REPO_ROOT,
+                            capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return p.stdout if p.returncode == 0 else None
+
+
+@pytest.mark.parametrize("rel,rev,src,slices", PROVENANCE, ids=[p[0] for p in PROVENANCE])
+def test_fixture_is_verbatim_pre_fix_code(rel, rev, src, slices):
+    """The fixture body must still be byte-identical to what git says shipped.
+
+    Without this, a future maintainer 'fixing' a failing regression test by
+    editing the fixture would silently turn it back into a toy -- the exact
+    failure mode this whole file exists to prevent.
+    """
+    real = _git_show(rev, src)
+    if real is None:
+        pytest.skip(f"git history for {rev}:{src} unavailable")
+    body = (FIXTURES_DIR / rel).read_text().split(MARKER, 1)[1]
+    if slices is None:
+        assert body == real, f"{rel} has drifted from {rev}:{src}"
+    else:
+        lines = real.splitlines(keepends=True)
+        for a, b in slices:
+            chunk = "".join(lines[a - 1:b])
+            assert chunk in body, f"{rel} no longer contains {src} lines {a}-{b} verbatim"
+
+
+# ---------------------------------------------------------------------------
+# BUG B -- degraded assigned on only some control-flow paths before return
+# ---------------------------------------------------------------------------
+
+
+def test_bug_b_flags_ranks_degraded_in_real_grounding():
+    """`cg flags mcp/grounding.py` must surface `degraded`.
+
+    Real numbers on the real pre-fix file: init `False` at the top of
+    ground(), 3 guarded reassignments to True, 11 guarded exits (break/
+    continue in `if not S:` guards and except handlers) that skip it
+    entirely -> score 11/3 = 3.67, and it is the ONLY candidate in the
+    whole module.
+    """
+    store, _, _ = build_fixture_store(["regress/bug_b/grounding.py"])
+    rows = rank_flags(store)
+
+    assert [r.ident for r in rows] == ["degraded"], (
+        "degraded must be the sole flag candidate in the real grounding.py; got "
+        f"{[(r.ident, r.fn_id) for r in rows]}"
+    )
+    row = rows[0]
+    assert row.fn_id.endswith("::ground")
+    assert row.escape_form == "dict-value"        # returned inside the result dict
+    assert row.binding.attrs["init_is_constant"] is True
+    # The defect IS this asymmetry: far more paths skip the flag than set it.
+    assert len(row.binding.attrs["guard_exits"]) == 11
+    assert len(row.binding.attrs["constant_rebind_lines"]) == 3
+    assert row.score == pytest.approx(11 / 3)
+    assert row.pattern == "flag"
+
+
+def test_bug_b_survives_whole_corpus_ranking():
+    """Scoped to the file the tool is decisive; over the WHOLE corpus it is a
+    ranker and `degraded` is merely near the top, not first.
+
+    Pinned deliberately: measured at rev d359e9a (where the bug was live)
+    `degraded` is 3rd of 7 rows. The two above it -- canary.py's
+    `rollback_recommended` and server.py's `sampling_mode` -- are the same
+    shape in CORRECT code, which static analysis cannot distinguish from a
+    real one. If a future change pushes `degraded` far down this list, the
+    ranker has stopped working even though the scoped test still passes.
+    """
+    pytest.importorskip("subprocess")
+    from ..pipeline import build_graph
+    if _git_show("d359e9a", "mcp/grounding.py") is None:
+        pytest.skip("git history unavailable")
+    res = build_graph(rev="d359e9a")
+    rows = rank_flags(res.store)
+    idx = [i for i, r in enumerate(rows)
+           if r.ident == "degraded" and (r.binding.path or "").endswith("grounding.py")]
+    assert idx, "degraded vanished from the whole-corpus flag ranking"
+    assert idx[0] < 5, f"degraded fell to rank {idx[0] + 1} of {len(rows)}"
+    assert len(rows) <= 12, (
+        f"flag ranker got noisier: {len(rows)} rows corpus-wide (was 7). "
+        "A row count that climbs is how this query becomes unreadable."
+    )
+
+
+def test_accumulators_are_not_ranked_as_flags():
+    """The false-positive class that made BUG B rank 7th of 23 before this
+    validation pass: counters. `created = 0 ... created += len(chunk)` matches
+    "constant init, updated on only some paths" exactly, and there were 16 of
+    them drowning the real bug."""
+    store, _, _ = build_fixture_store(["regress/accumulator_fp.py"])
+
+    default_rows = {r.ident for r in rank_flags(store)}
+    assert "n_drifted" not in default_rows      # pure `+=` counter
+    assert "lines_scanned" not in default_rows  # hybrid: reset to a constant, then `+=`
+    assert "degraded" in default_rows           # the genuine flag in the same file
+
+    with_acc = {r.ident: r for r in rank_flags(store, include_accumulators=True)}
+    assert with_acc["n_drifted"].pattern == "accumulator"
+    assert with_acc["lines_scanned"].pattern == "accumulator"
+    assert with_acc["degraded"].pattern == "flag"
+
+
+# ---------------------------------------------------------------------------
+# BUG C -- module-level name written by exactly one module and read by none
+# ---------------------------------------------------------------------------
+
+
+def test_bug_c_dangling_global_in_real_graph_tools():
+    """`cg writes-dead` must report both phantom globals AND name the real slot.
+
+    Naming the real slot is what makes this a diagnosis rather than a lint
+    warning: it is the difference between "this global is odd" and "the cache
+    you meant to invalidate lives in ladybug_ops".
+    """
+    store, _, _ = build_fixture_store([
+        "regress/bug_c/graph_tools.py",
+        "regress/bug_c/ladybug_ops.py",
+    ])
+    findings = dangling_globals(store)
+    by_ident = {f.slot.id.rsplit("::", 1)[-1]: f for f in findings}
+
+    assert set(by_ident) == {"_symbol_index_cache", "_symbol_index_count"}, (
+        f"expected exactly the two phantom globals, got {sorted(by_ident)}"
+    )
+    for ident, f in by_ident.items():
+        assert f.slot.path == "regress/bug_c/graph_tools.py"
+        assert "global-only" in set(f.slot.attrs["binding_kind"])
+        # the write is attributed to the function that actually made it
+        assert [e.src.rsplit("::", 1)[-1] for e in f.global_writes] == ["code_memory_relink"]
+        assert all(e.attrs["via"] == "global-stmt" for e in f.global_writes)
+        # and the REAL slot is found, in the other module, module-level bound
+        assert [n.path for n in f.real_slots] == ["regress/bug_c/ladybug_ops.py"], (
+            f"{ident}: real slot not located in ladybug_ops"
+        )
+
+
+def test_bug_c_would_not_fire_once_fixed():
+    """Mutation check: the SAME analyzer over the FIXED shape must stay quiet.
+
+    A detector that fires on the fix as well as the bug is not a detector.
+    """
+    store, _, _ = build_fixture_store(["regress/bug_c_fixed.py"])
+    assert dangling_globals(store) == []
+
+
+# ---------------------------------------------------------------------------
+# BUG D -- a path literal produced in one module, near-missed in another
+# ---------------------------------------------------------------------------
+
+
+def test_bug_d_literal_orphans_in_real_code():
+    """`cg literals --paths --orphans` must show graph.ladybug produced and
+    never consumed, and graph.kuzu consumed and never produced."""
+    store, _, _ = build_fixture_store([
+        "regress/bug_d/server.py",
+        "regress/bug_d/graph_facts.py",
+    ])
+    producer_only, consumer_only = orphans(store, flavour="path")
+
+    prod = {g.match_text: g for g in producer_only}
+    cons = {g.match_text: g for g in consumer_only}
+    assert "graph.ladybug" in prod, f"producer orphans were {sorted(prod)}"
+    assert "graph.kuzu" in cons, f"consumer orphans were {sorted(cons)}"
+
+    # attributed to the right side of the split
+    assert {s.path for s in prod["graph.ladybug"].produce_sites} == {"regress/bug_d/server.py"}
+    assert {s.path for s in cons["graph.kuzu"].consume_sites} == {"regress/bug_d/graph_facts.py"}
+    assert prod["graph.ladybug"].produce_sites[0].role == "store-ctor"
+    assert cons["graph.kuzu"].consume_sites[0].role == "glob"
+
+
+def test_bug_d_near_miss_pairs_the_two_halves():
+    """The orphan pair is the lead; --near-miss is what puts the two halves on
+    one line, across the module boundary, on the shared `graph` stem."""
+    store, _, _ = build_fixture_store([
+        "regress/bug_d/server.py",
+        "regress/bug_d/graph_facts.py",
+    ])
+    pairs = near_miss_pairs(*orphans(store, flavour="path"))
+    hit = [nm for nm in pairs
+           if nm.producer.match_text == "graph.ladybug" and nm.consumer.match_text == "graph.kuzu"]
+    assert hit, f"BUG D pair missing; pairs were {[(p.producer.match_text, p.consumer.match_text) for p in pairs]}"
+    assert hit[0].shared_stem == "graph"

--- a/scripts/callgraph/tests/test_resolve.py
+++ b/scripts/callgraph/tests/test_resolve.py
@@ -1,0 +1,148 @@
+"""resolve.py: sys.path.insert constant-folding + the resolution table,
+against both synthetic fixtures and the real corpus's known cases."""
+from ..resolve import ResolutionTable, find_sys_path_inserts
+from ..tests.helpers import load_fixture, source_file
+
+
+# -- constant-folding of sys.path.insert -------------------------------------
+
+def test_fold_dirname_join_pattern():
+    sf = load_fixture("pkg/scripts/entry.py")
+    inserts = find_sys_path_inserts(sf)
+    assert len(inserts) == 1
+    ins = inserts[0]
+    assert ins.target_dir == "pkg/mcp"
+    assert ins.inserting_file == "pkg/scripts/entry.py"
+    assert ins.lineno == 8
+    assert ins.scope == "module-level"
+
+
+def test_fold_this_dir_variable_and_parent_chain():
+    text = (
+        "from pathlib import Path\n"
+        "import sys\n"
+        "_THIS_DIR = str(Path(__file__).resolve().parent)\n"
+        "if _THIS_DIR not in sys.path:\n"
+        "    sys.path.insert(0, _THIS_DIR)\n"
+    )
+    sf = source_file("mcp/server.py", text)
+    inserts = find_sys_path_inserts(sf)
+    assert len(inserts) == 1
+    assert inserts[0].target_dir == "mcp"
+
+
+def test_fold_parents_subscript_and_div_operator():
+    text = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "def f():\n"
+        "    _scripts = str(Path(__file__).resolve().parent.parent / 'scripts')\n"
+        "    sys.path.insert(0, _scripts)\n"
+    )
+    sf = source_file("mcp/server.py", text)
+    inserts = find_sys_path_inserts(sf)
+    assert len(inserts) == 1
+    assert inserts[0].target_dir == "scripts"
+    assert inserts[0].scope == "function-local"
+
+
+def test_fold_sys_import_alias_is_recognized():
+    text = (
+        "import sys as _sys\n"
+        "import os\n"
+        "def f():\n"
+        "    _sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'mcp'))\n"
+    )
+    sf = source_file("scripts/x.py", text)
+    inserts = find_sys_path_inserts(sf)
+    assert len(inserts) == 1
+    assert inserts[0].target_dir == "mcp"
+
+
+def test_fold_gives_up_on_non_literal_expressions():
+    text = (
+        "import sys, os\n"
+        "sys.path.insert(0, os.environ['SOME_DIR'])\n"
+    )
+    sf = source_file("scripts/x.py", text)
+    assert find_sys_path_inserts(sf) == []
+
+
+# -- ResolutionTable on a small synthetic corpus -----------------------------
+
+def _synthetic_table() -> ResolutionTable:
+    sources = [load_fixture("pkg/scripts/entry.py"), load_fixture("pkg/mcp/sibling.py")]
+    return ResolutionTable(sources)
+
+
+def test_flat_import_resolves_via_named_insert():
+    table = _synthetic_table()
+    res = table.resolve_dotted("sibling", "pkg/scripts/entry.py")
+    assert res.status == "corpus"
+    assert res.target_path == "pkg/mcp/sibling.py"
+    assert res.resolved_via == "sys.path.insert@pkg/scripts/entry.py:8"
+    assert res.ambiguous is False
+
+
+def test_same_dir_import_needs_no_insert():
+    sources = [load_fixture("reexport.py"), load_fixture("reexport_source.py")]
+    table = ResolutionTable(sources)
+    res = table.resolve_dotted("reexport_source", "reexport.py")
+    assert res.status == "corpus"
+    assert res.target_path == "reexport_source.py"
+
+
+def test_stdlib_and_unresolved_classification():
+    table = _synthetic_table()
+    assert table.resolve_dotted("os", "pkg/scripts/entry.py").status == "stdlib"
+    assert table.resolve_dotted("totally_made_up_thing_xyz", "pkg/scripts/entry.py").status == "unresolved"
+
+
+# -- ResolutionTable against the real corpus: the step-1 acceptance case ----
+
+def test_graph_facts_insert_is_named_at_its_own_line(head_table):
+    res = head_table.resolve_dotted("graph.ladybug_store", "scripts/graph_facts.py")
+    assert res.status == "corpus"
+    assert res.target_path == "mcp/graph/ladybug_store.py"
+    assert res.resolved_via == "sys.path.insert@scripts/graph_facts.py:21"
+
+
+def test_shadow_eval_import_server_resolves_to_mcp_not_a2a(head_table):
+    res = head_table.resolve_dotted("server", "scripts/shadow_eval.py")
+    assert res.status == "corpus"
+    assert res.target_path == "mcp/server.py"
+
+
+def test_every_flat_mcp_sibling_import_in_server_resolves_same_dir(head_table):
+    for name, expected in [
+        ("qdrant_ops", "mcp/qdrant_ops.py"),
+        ("graph_tools", "mcp/graph_tools.py"),
+        ("investigation_tools", "mcp/investigation_tools.py"),
+        ("llm_tools", "mcp/llm_tools.py"),
+        ("ladybug_ops", "mcp/ladybug_ops.py"),
+    ]:
+        res = head_table.resolve_dotted(name, "mcp/server.py")
+        assert res.status == "corpus" and res.target_path == expected, name
+        assert res.resolved_via == "same-dir"
+
+
+def test_real_corpus_import_unresolved_list_is_small_and_only_missing_third_party(head_sources, head_table):
+    sources, table = head_sources, head_table
+    unresolved = []
+    from ..scopes import ModuleScope
+    for sf in sources:
+        scope = ModuleScope(sf)
+        for rec in scope.imports:
+            if rec.is_from:
+                dotted = rec.module or ""
+            else:
+                dotted = rec.names[0][0] if rec.names else ""
+            if not dotted or rec.level > 0:
+                continue
+            res = table.resolve_dotted(dotted, sf.rel_path)
+            if res.status == "unresolved":
+                unresolved.append((sf.rel_path, dotted))
+    # An engineer must be able to read this list in one screen (design's own
+    # bar); a regression that suddenly can't resolve dozens of imports would
+    # blow well past it.
+    assert len(unresolved) < 20, unresolved

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -1,0 +1,81 @@
+"""Cache-invalidation / staleness tests for ingest.py's `--rev` path.
+
+ingest.py's own docstring is explicit: there is NO parse cache (measured
+cold-parse cost for the whole corpus is small enough that a cache would add
+staleness risk for no real speedup at this corpus size — `--no-cache` is
+accepted and is a documented no-op). "Cache invalidation tested" therefore
+means proving the ABSENCE of a staleness bug, not exercising an eviction
+path that doesn't exist: back-to-back builds at different revisions must
+never leak content from one into the other, a build must be exactly
+reproducible against the same rev, and `--rev` must read the git-committed
+blob rather than a possibly-mid-edit working tree file — the concurrent-
+edit scenario build_steps step 13 was written under (another workflow is
+mid-editing mcp/server.py while these tests run)."""
+from ..ingest import load_corpus
+
+
+def _source_for(sources, rel_path):
+    return next(sf for sf in sources if sf.rel_path == rel_path)
+
+
+def test_rebuilding_the_same_rev_is_byte_identical():
+    sources_a, origin_a = load_corpus(rev="HEAD")
+    sources_b, origin_b = load_corpus(rev="HEAD")
+    assert origin_a == origin_b
+    by_path_a = {sf.rel_path: sf.source for sf in sources_a}
+    by_path_b = {sf.rel_path: sf.source for sf in sources_b}
+    assert by_path_a == by_path_b
+
+
+def test_switching_revs_does_not_leak_content_between_builds():
+    # mcp/grounding.py genuinely differs between 69adfa4^ (BUG B present)
+    # and 69adfa4 (the fix commit) — see docs/LIMITS.md's BUG B section and
+    # tests/test_cli_step10_12.py's flags regression, which depend on this
+    # same pair of revisions actually differing.
+    before, _ = load_corpus(rev="69adfa4^")
+    after, _ = load_corpus(rev="69adfa4")
+    src_before = _source_for(before, "mcp/grounding.py").source
+    src_after = _source_for(after, "mcp/grounding.py").source
+    assert src_before != src_after
+
+    # Read the OLDER rev again, interleaved after the newer one, and prove
+    # the result is exactly what it was the first time — nothing from the
+    # `69adfa4` build (nor any other in-process state) contaminated it.
+    before_again, _ = load_corpus(rev="69adfa4^")
+    assert _source_for(before_again, "mcp/grounding.py").source == src_before
+
+
+def test_no_cache_flag_is_accepted_and_does_not_change_the_result():
+    default_sources, _ = load_corpus(rev="HEAD")
+    no_cache_sources, _ = load_corpus(rev="HEAD", no_cache=True)
+    by_path_default = {sf.rel_path: sf.source for sf in default_sources}
+    by_path_no_cache = {sf.rel_path: sf.source for sf in no_cache_sources}
+    assert by_path_default == by_path_no_cache
+
+
+def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, monkeypatch):
+    # Simulate "another workflow is mid-editing mcp/server.py" by writing a
+    # syntactically broken decoy directly into a scratch copy of the repo
+    # root's mcp/server.py path resolution — without touching the real
+    # working tree file (this package must never write under mcp/). Instead
+    # we assert the CONTRACT directly: load_corpus(rev="HEAD") never reads
+    # config.REPO_ROOT / rel_path from disk at all when rev is not None —
+    # it goes through git plumbing exclusively. Verified by monkeypatching
+    # Path.read_text to explode if anything tries a direct filesystem read
+    # while a rev is requested.
+    from pathlib import Path
+
+    original_read_text = Path.read_text
+
+    def _boom(self, *a, **kw):
+        raise AssertionError(f"load_corpus(rev=...) must not read {self} off disk directly")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    try:
+        sources, origin = load_corpus(rev="HEAD")
+    finally:
+        monkeypatch.setattr(Path, "read_text", original_read_text)
+    assert origin.startswith("rev ")
+    assert len(sources) == 114
+    server = _source_for(sources, "mcp/server.py")
+    assert server.error is None and "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_scopes.py
+++ b/scripts/callgraph/tests/test_scopes.py
@@ -1,0 +1,102 @@
+"""scopes.py: qualnames (incl. nesting/lambdas), decorator source capture,
+params, and NAME-slot binding kinds (incl. global-only, the raw signal
+behind BUG C)."""
+from ..scopes import ModuleScope
+from ..tests.helpers import load_fixture
+
+
+def _scope(rel_path: str) -> ModuleScope:
+    return ModuleScope(load_fixture(rel_path))
+
+
+def test_nesting_qualnames():
+    s = _scope("nesting.py")
+    quals = {f.qualname for f in s.functions}
+    assert "outer" in quals
+    assert "outer.<locals>.inner" in quals
+    assert "register" in quals
+    assert "Widget.method" in quals
+    # the lambda passed to register(None, lambda: 42) is a real, addressable
+    # Function — defined at module scope (lexically), not inside register().
+    lambdas = [f for f in s.functions if f.is_lambda]
+    assert len(lambdas) == 1
+    assert lambdas[0].qualname.startswith("<lambda>@")
+
+
+def test_is_method_and_is_nested_flags():
+    s = _scope("nesting.py")
+    by_qual = {f.qualname: f for f in s.functions}
+    assert by_qual["Widget.method"].is_method is True
+    assert by_qual["Widget.method"].is_nested is False
+    assert by_qual["outer.<locals>.inner"].is_nested is True
+    assert by_qual["outer.<locals>.inner"].is_method is False
+    assert by_qual["outer"].is_nested is False
+
+
+def test_class_bases_and_qualname():
+    s = _scope("nesting.py")
+    assert len(s.classes) == 1
+    assert s.classes[0].qualname == "Widget"
+    assert s.classes[0].bases == []
+
+
+def test_decorator_source_captured_verbatim():
+    s = _scope("decorator_registry.py")
+    by_qual = {f.qualname: f for f in s.functions}
+    assert by_qual["registered_tool"].decorators == ["mcp.tool()"]
+    assert by_qual["cached_helper"].decorators == ["functools.lru_cache"]
+    assert by_qual["mystery"].decorators == ["some_unrecognized_decorator"]
+
+
+def test_docstring_first_line():
+    s = _scope("decorator_registry.py")
+    by_qual = {f.qualname: f for f in s.functions}
+    assert by_qual["registered_tool"].docstring_first_line == "First line of the docstring."
+    assert by_qual["cached_helper"].docstring_first_line is None
+
+
+def test_params_kinds_and_defaults():
+    s = _scope("decorator_registry.py")
+    by_qual = {f.qualname: f for f in s.functions}
+    params = by_qual["registered_tool"].params
+    assert [p.name for p in params] == ["x", "y"]
+    assert params[0].kind == "POSITIONAL_OR_KEYWORD" and not params[0].has_default
+    assert params[1].kind == "POSITIONAL_OR_KEYWORD" and params[1].has_default
+    assert params[1].default_is_literal is True
+
+
+def test_module_level_and_function_local_import_scope():
+    s = _scope("lazy_import.py")
+    module_level = [r for r in s.imports if r.scope == "module-level"]
+    local = [r for r in s.imports if r.scope == "function-local"]
+    assert len(module_level) == 1 and module_level[0].names == [("json", None)]
+    assert {r.names[0][0] for r in local} == {"numpy", "textwrap"}
+    numpy_rec = next(r for r in local if r.names[0][0] == "numpy")
+    assert numpy_rec.enclosing_fn == "resolve_vllm"
+    textwrap_rec = next(r for r in local if r.names[0][0] == "textwrap")
+    assert textwrap_rec.enclosing_fn == "Widget.render"
+
+
+def test_dangling_global_name_slot_detected():
+    s = _scope("dangling_global.py")
+    names = s.names
+    assert "global-only" in names["_symbol_index_cache"].binding_kinds
+    assert "global-only" in names["_symbol_index_count"].binding_kinds
+    # _real_counter IS bound at module level (the `_real_counter = 0` line),
+    # so even though it's also declared `global` inside bump(), it must NOT
+    # be flagged global-only — that's the whole discriminating test for
+    # BUG C's dangling-global check.
+    assert "global-only" not in names["_real_counter"].binding_kinds
+    assert "assign" in names["_real_counter"].binding_kinds
+
+
+def test_name_dunder_and_private_flags():
+    s = _scope("dangling_global.py")
+    assert s.names["_symbol_index_cache"].is_private is True
+    assert s.names["_symbol_index_cache"].is_dunder is False
+
+
+def test_module_level_bare_alias_recorded():
+    s = _scope("reexport.py")
+    assert any(ma.target == "runner" and ma.value_kind == "name" and ma.value_name == "symbol_impact"
+               for ma in s.module_assigns)

--- a/scripts/callgraph/tests/test_selftest.py
+++ b/scripts/callgraph/tests/test_selftest.py
@@ -1,0 +1,99 @@
+"""Wires selftest.py's own check set into pytest, and exercises `cg
+selftest`/`cg limits` through the CLI end-to-end -- the build_steps step 13
+acceptance bar, run the same way `cg selftest` runs it standalone."""
+import json
+import time
+
+from ..cli import main
+from ..selftest import run_selftest
+
+
+def test_selftest_all_checks_pass():
+    report = run_selftest()
+    failed = [(c.name, c.detail) for c in report.failed]
+    assert failed == [], failed
+    assert report.ok is True
+
+
+def test_selftest_covers_every_dispatch_shape_and_the_hard_gate():
+    # A regression here (someone silently deleting a check) is exactly the
+    # failure mode this test exists to catch — pin the count and a handful
+    # of the load-bearing names.
+    report = run_selftest()
+    names = {c.name for c in report.checks}
+    assert len(report.checks) == 15
+    assert any("hard gate" in n for n in names)
+    assert any("BUG C" in n for n in names)
+    assert any("BUG D" in n for n in names)
+    assert any("BUG B" in n for n in names)
+
+
+def test_selftest_finishes_well_under_the_five_second_budget():
+    # build_steps step 13's own acceptance line: "total wall time for a
+    # full cold build plus all fixture assertions under 5s." Timed here
+    # independently of run_selftest()'s own self-reported elapsed_s, and
+    # given a little headroom over the hard 5s design ceiling since this
+    # runs on shared/variable CI hardware, not a dedicated benchmark box.
+    t0 = time.time()
+    report = run_selftest()
+    wall = time.time() - t0
+    assert report.ok
+    assert wall < 8.0, f"selftest took {wall:.2f}s — investigate before this creeps past the 5s design budget"
+    assert report.elapsed_s < 8.0
+
+
+def test_cli_selftest_exits_zero_and_prints_pass_summary(capsys):
+    code = main(["selftest"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "PASS" in out
+    assert "FAIL" not in out
+    assert "selftest green" in out
+    assert "/15 checks passed" in out
+
+
+def test_cli_selftest_json_shape(capsys):
+    code = main(["selftest", "--format", "json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert len(payload["checks"]) == 15
+    assert all(c["ok"] for c in payload["checks"])
+
+
+def test_cli_selftest_reports_a_broken_check_with_nonzero_exit(monkeypatch):
+    # Prove the CLI actually surfaces a failure rather than always printing
+    # green — flip one check to fail and confirm both the exit code and the
+    # FAIL line show up.
+    from .. import cli as cli_mod
+    from ..selftest import Check, SelftestReport
+
+    def _fake_run_selftest():
+        return SelftestReport(checks=[Check("fake check", False, "boom")], elapsed_s=0.01)
+
+    monkeypatch.setattr(cli_mod, "run_selftest", _fake_run_selftest)
+    code = cli_mod.main(["selftest"])
+    assert code == 1
+
+
+# -- cg limits ----------------------------------------------------------------
+
+
+def test_cli_limits_prints_the_docs_file(capsys):
+    code = main(["limits"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "# Known limits" in out
+    assert "cg writes-dead" in out
+    assert "cg flags" in out
+    assert "BUG A" in out
+
+
+def test_cli_limits_json_shape(capsys):
+    code = main(["limits", "--format", "json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["path"].endswith("docs/LIMITS.md")
+    assert "Known limits" in payload["text"]


### PR DESCRIPTION
Two independent pieces of work, merged together at the author's request.

---

# 1. Decomposition — `mcp/server.py`

**Functions over 150 lines: 8 → 0.** Over 140: 11 → 0. Eleven functions decomposed in total.

Contract verification, checked independently rather than taken from the tooling:

```
decorated tools: main=40  now=40   lost=none
signature changes: NONE
docstring changes: NONE
```

### The honest cost

`server.py` grows **7,330 → 7,718 (+388)**. Inherent to decomposition — every helper adds a def line, a signature and a docstring. The win is cyclomatic complexity and per-unit comprehensibility, not raw line count.

### Deliberately skipped

**`reflection_loop_tick`'s main loop.** Its `continue` at 2840 is **not** the last statement of the enclosing loop (2842–2863 follow), so an early-return helper is not equivalent — AST-confirmed, not assumed. It also threads seven accumulators, and `stats` is written verbatim to the on-disk state file *and* returned in the tool payload; restructuring risks both contracts for maybe 6 cx.

**`memory_surface`'s fetch stage** contains a bare `raise` that escapes to an outer handler producing a *different* error string from its sibling path. Any `(value, error)` extraction must preserve raise-vs-return to keep both reachable.

### Reported, not fixed

`memory_confidence` conflates a Qdrant search **failure** with an empty result — the `except` sets `results = []`, so an errored search returns the `no_trace` payload claiming *"no memory found"* at confidence 0.0. Same class as the `ground()` bug fixed in #154; needs its own PR.

---

# 2. New tool — `scripts/callgraph/`

Stdlib-only static call/reference graph. No database, no network, 114 files in ~3.6s. **249 tests.**

The existing `mcp/graph/` package needs a live LadybugDB and models symbols and calls; this models **registration**, **name reads/writes**, and **cross-module literal agreement** — and runs when nothing else is up, which is when you need it.

Queries: `callers`, `reach`, `paths`, `entrypoints`, `name`, `writes-dead`, `literals`, `flags`, `dead`, `registry`, `holes`, `explain`, `selftest`, `limits`.

### Validated against defects that were real

Fixtures are pinned to the **actual pre-fix revisions**, and the tests assert it names the *cause*, not merely that it warns:

| bug | revision | caught by |
|---|---|---|
| **B** `ground()`'s `degraded` set on only some paths | `69adfa4^` | `cg flags mcp/grounding.py::ground` ranks it first |
| **C** dead `global` naming a slot the module never binds | `c1c40a9^` | `cg writes-dead` — reports DANGLING-GLOBAL **and names the real slot in `ladybug_ops`** |
| **D** `graph.ladybug` produced, `graph.kuzu` consumed | `08c9198^` | `cg literals --paths --orphans` |

**Bug A** (the `_id`/`_ID` casing mismatch) is deliberately **out of scope** and documented as such — a data-format defect, not a structural one. A tool that claims to catch everything is one nobody calibrates against.

### False positives on registered entry points: zero

All **40** `@mcp.tool()` functions and all **45** registered-by-reference candidates are correctly reachable. This was the make-or-break: a tool that flags 70 live entry points as dead trains people to suppress it, and the suppression list is then where real dead code hides.

Confidence is a first-class edge property — proven / probable / unproven, reported in separate blocks and never summed. Static analysis of dynamic Python can't be exact, and presenting a guess as fact is how these tools lose trust.

### Sanity-checked against the current tree

`writes-dead` reports **0** dangling globals and `graph.ladybug` no longer appears as an orphan — both correct, since we fixed those. It surfaces a genuine remaining one: `settings.json`, consumed by two scripts, produced by nobody.

### One implementation note

`fixtures/` is excluded from lint via `scripts/callgraph/ruff.toml`, not per-file `noqa` headers. Several fixtures are verbatim line-range excerpts of real modules and the regression tests assert exact fixture **line numbers** — prepending anything shifts every assertion (it broke 10 tests when I tried). The reason is recorded in the config.

---

**All 10 CI jobs green.** Repo-wide lint gate passes again.