### PR TITLE
bridge: send TOTP to the local A2A hop, and stop dropping failed sends

### DIFF
--- a/scripts/a2a_context_bridge.py
+++ b/scripts/a2a_context_bridge.py
@@ -62,6 +62,12 @@ MIN_IMP        = float(os.environ.get("BRIDGE_MIN_IMP", "0.5"))
 MAX_ITEMS      = int(os.environ.get("BRIDGE_MAX_ITEMS", "20"))
 AGENT_ID       = os.environ.get("HERMES_AGENT_ID", "hermes")
 
+# The bridge relays through the LOCAL A2A server, and that server may enforce TOTP on /a2a
+# (oxalis-mrpink does; hugbot5000-jetson does not). Without this the bearer alone gets a
+# flat 401 on every send and the bridge is inert. Empty seed = no header, so a node whose
+# server does not enforce TOTP is unaffected.
+LOCAL_A2A_TOTP_SEED = os.environ.get("HERMES_A2A_TOTP_SEED", "").strip()
+
 _mnem_dir   = os.path.expanduser(os.environ.get("MNEMOSYNE_DATA_DIR", "~/.hermes/mnemosyne/data"))
 MNEMOSYNE_DB= os.path.join(_mnem_dir, "mnemosyne.db")
 
@@ -159,6 +165,26 @@ def _fetch_recent_memories(since: str, min_importance: float, max_items: int) ->
 
 
 # ── A2A call ──────────────────────────────────────────────────────────────────────
+def _totp_now() -> str:
+    """
+    Current TOTP code for the local A2A server, or "" when no seed is configured.
+
+    Fails loud rather than silently sending an unauthenticated request: if a seed IS set
+    but pyotp is missing, every send would 401 and the only symptom would be a fail count
+    in the log, which is the failure mode this helper exists to remove.
+    """
+    if not LOCAL_A2A_TOTP_SEED:
+        return ""
+    try:
+        import pyotp
+    except ImportError:
+        raise SystemExit(
+            "HERMES_A2A_TOTP_SEED is set but pyotp is not installed — the local server "
+            "enforces TOTP and every send would 401. Install pyotp or unset the seed."
+        )
+    return pyotp.TOTP(LOCAL_A2A_TOTP_SEED).now()
+
+
 async def _broadcast_memory(session: aiohttp.ClientSession, mem: dict, dry_run: bool) -> dict:
     if dry_run:
         return {"status": "dry_run", "id": mem["id"], "content_len": len(mem["content"])}
@@ -193,6 +219,11 @@ async def _broadcast_memory(session: aiohttp.ClientSession, mem: dict, dry_run: 
         "Authorization": f"Bearer {LOCAL_A2A_TOKEN}",
         "Content-Type":  "application/json",
     }
+    # Generated per send, not once per run: a run that spans a 30s TOTP step would otherwise
+    # start failing halfway through with a stale code.
+    totp_code = _totp_now()
+    if totp_code:
+        headers["X-TOTP"] = totp_code
     try:
         async with session.post(
             f"{LOCAL_A2A_URL.rstrip('/')}/a2a",
@@ -242,12 +273,23 @@ async def run(dry_run: bool, verbose: bool):
             _save_state(state)
         return
 
-    ok = fail = 0
+    # Ids already delivered, so holding the watermark back to retry a failure does not
+    # re-send everything newer than it. Bounded so the state file cannot grow without end.
+    sent_ids = list(state.get("sent_ids") or [])
+    sent_set = set(sent_ids)
+
+    ok = fail = skipped = 0
     async with aiohttp.ClientSession() as session:
         for mem in mems:
+            if mem["id"] in sent_set:
+                skipped += 1
+                continue
             result = await _broadcast_memory(session, mem, dry_run)
             if result.get("status") in ("ok", "dry_run"):
                 ok += 1
+                if not dry_run:
+                    sent_set.add(mem["id"])
+                    sent_ids.append(mem["id"])
                 if verbose:
                     log.debug("  ok  id=%s peers=%s preview=%r",
                                result["id"], result.get("peers_ok", "?"),
@@ -257,12 +299,24 @@ async def run(dry_run: bool, verbose: bool):
                 log.warning("  FAIL id=%s status=%s err=%s",
                              result["id"], result.get("status"), result.get("error", ""))
 
-    log.info("Bridge complete — ok=%d fail=%d dry_run=%s", ok, fail, dry_run)
+    log.info("Bridge complete — ok=%d fail=%d skipped=%d dry_run=%s", ok, fail, skipped, dry_run)
 
     if not dry_run:
-        state["last_run"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
-        state["last_ok"]  = ok
-        state["last_fail"]= fail
+        # Only advance the watermark on a clean run. It used to advance unconditionally, so
+        # anything that failed to send was never looked at again — a peer that was briefly
+        # down or an auth error silently dropped those memories for good. Holding it back
+        # costs a re-fetch next tick; sent_ids stops that becoming a re-send.
+        if fail == 0:
+            state["last_run"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        else:
+            log.warning(
+                "Holding watermark at %s — %d send(s) failed and would otherwise be "
+                "skipped permanently. They retry next tick.", state.get("last_run", since), fail
+            )
+            state.setdefault("last_run", since)
+        state["last_ok"]   = ok
+        state["last_fail"] = fail
+        state["sent_ids"]  = sent_ids[-1000:]
         _save_state(state)
 
 

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -53,4 +53,53 @@ before and after.
 | `BRIDGE_MIN_IMP` | 0.5 | memories below this importance are not propagated |
 | `BRIDGE_MAX_ITEMS` | 20 | per run |
 | `BRIDGE_EXCLUDE_SOURCES` | `bridge:,broadcast:,context_broadcast` | echo suppression — do not narrow without reading #144 |
-| `BRIDGE_STATE_FILE` | `~/.hermes/bridge_state.json` | last successful run timestamp |
+| `BRIDGE_STATE_FILE` | `~/.hermes/bridge_state.json` | last clean-run timestamp, plus the bounded `sent_ids` delivered-set |
+| `HERMES_A2A_TOTP_SEED` | unset | required where the LOCAL server enforces TOTP; unset = no header sent |
+
+## mrpink-context-bridge (the oxalis-mrpink half)
+
+`mrpink-context-bridge.{service,timer}` are the live units from the second node, kept here
+for the same reason as the first pair: the mesh should be reproducible from the checkout
+rather than from whoever last touched the box. They differ from the loci pair in three ways
+that matter, and each of them cost debugging time:
+
+- **User scope, not system.** The A2A server there is a `systemd --user` unit, so the bridge
+  is one too. That only survives a reboot with `loginctl enable-linger rjmendez` — without
+  lingering the whole user manager exits at logout and the timer goes with it.
+- **Two `EnvironmentFile=` lines, and the order is load-bearing.** `.bridge.env` comes second
+  so it can override `HERMES_A2A_URL` from `.env`, which points at that box's WSL `eth0`
+  address — reassigned on reboot. Loopback is stable and the server binds `0.0.0.0`.
+  Do **not** move these into a drop-in: on that host a drop-in `Environment=` silently loses
+  to the main unit's `EnvironmentFile=`, which is the opposite of what the docs imply.
+- **TOTP.** See below.
+
+### Before enabling it on a second node, part 2: TOTP
+
+If the local A2A server enforces TOTP on `/a2a` (oxalis-mrpink does, hugbot5000-jetson does
+not — check `"totp_enabled"` in `/health`), the bridge needs `HERMES_A2A_TOTP_SEED` in its
+environment. Without it the bearer alone returns a flat `401` on every send, and the symptom
+is a bridge that runs cleanly on a timer forever while moving nothing:
+
+```
+Bridge complete — ok=0 fail=4 skipped=0
+```
+
+`pyotp` is then a hard requirement; the script exits with a message rather than sending
+unauthenticated requests. An empty seed emits no header, so this is a no-op on nodes whose
+server does not enforce TOTP.
+
+### Failure handling
+
+The watermark only advances on a clean run. If any send fails, it is held and those memories
+retry on the next tick — it used to advance unconditionally, so a peer that was briefly down
+silently dropped whatever was in flight. The state file therefore also carries `sent_ids`
+(bounded to the last 1000) so that holding the watermark retries the failure without
+re-sending everything newer than it.
+
+A run that is holding back says so at WARNING level:
+
+```
+Holding watermark at <ts> — N send(s) failed and would otherwise be skipped permanently.
+```
+
+A bridge that is failing is now noisy by design. Silence means it is working.

--- a/scripts/systemd/mrpink-context-bridge.service
+++ b/scripts/systemd/mrpink-context-bridge.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=MrPink A2A context bridge (push local memories to mesh peers)
+Documentation=https://github.com/rjmendez/loci
+# Mirrors loci-context-bridge.service on hugbot5000-jetson. This is the oxalis->jetson
+# half of the mesh; the jetson has run the other half since 2026-07-27.
+# The bridge relays through THIS node's own A2A server on :8201 (mrpink-a2a.service).
+# Wants, not Requires: a tick that cannot reach it logs a failure, holds its watermark,
+# and retries — it must not take the timer down with it.
+After=network-online.target mrpink-a2a.service
+Wants=network-online.target mrpink-a2a.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/rjmendez/.hermes/profiles/mrpink
+
+# Order is load-bearing: .bridge.env overrides HERMES_A2A_URL from .env. Do NOT reorder,
+# and do NOT move these values into a drop-in — on this box a drop-in Environment= loses
+# to the main unit's EnvironmentFile=, silently.
+EnvironmentFile=/home/rjmendez/.hermes/profiles/mrpink/.env
+EnvironmentFile=/home/rjmendez/.hermes/profiles/mrpink/.bridge.env
+
+ExecStart=/home/rjmendez/.hermes/hermes-agent/venv/bin/python3 \
+    /home/rjmendez/.hermes/profiles/mrpink/scripts/a2a_context_bridge.py
+
+# Nothing here is urgent and this box shares its GPU with k3s workloads.
+Nice=10
+MemoryMax=256M
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=mrpink-bridge
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/mrpink-context-bridge.timer
+++ b/scripts/systemd/mrpink-context-bridge.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Run the MrPink A2A context bridge periodically
+Documentation=https://github.com/rjmendez/loci
+
+[Timer]
+# 10 min, matching loci-context-bridge.timer on the jetson so the two halves of the
+# mesh converge on the same cadence.
+OnBootSec=3min
+OnUnitActiveSec=10min
+# The two nodes' timers drifting into lockstep is harmless, but staggering keeps each
+# node's server from handling both directions in the same instant.
+RandomizedDelaySec=45s
+Persistent=true
+Unit=mrpink-context-bridge.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The mesh has been two nodes since #144/#145, but only the jetson half was ever on a timer. The oxalis-mrpink half was not scheduled because, as written, it could not have worked.

### The bridge never authenticated to its own server

`a2a_context_bridge.py` relays through the **local** A2A server's `context_broadcast`, and sent only a bearer token. oxalis-mrpink enforces TOTP on `/a2a` (this box does not — check `"totp_enabled"` in `/health`), so every send came back `401`:

```
Bridge complete — ok=0 fail=4
```

That is the whole failure mode: a oneshot unit that exits 0 on a timer, forever, while moving nothing. Nothing in the journal says "broken."

Fixed by sending `X-TOTP` when `HERMES_A2A_TOTP_SEED` is set. The code is generated per send rather than once per run, so a run spanning a 30s step doesn't start failing halfway through. An empty seed emits no header, so nodes whose server doesn't enforce TOTP are unaffected — this is a no-op here. `pyotp` becomes a hard requirement only when a seed is actually set, and the script exits with a message rather than quietly sending unauthenticated requests.

### The watermark advanced over failed sends

Separately, and independent of the above: `state["last_run"]` was set to `now()` at the end of every run regardless of outcome. Anything that failed to send was never looked at again — a peer that was briefly down silently dropped whatever was in flight, permanently. On the oxalis side this was compounding the 401 above; each tick discarded four more memories.

The watermark is now held whenever any send fails, and the state file carries a bounded `sent_ids` list so that holding it back retries the failure without re-sending everything newer than it. A run that is holding back says so at WARNING level, so a stuck bridge is noisy rather than silent.

### Second-node units

`scripts/systemd/mrpink-context-bridge.{service,timer}` are the live oxalis units, here for the same reason #145 gave for the first pair. They differ in three ways that each cost time to work out, all documented in the README:

- user-scope units, so they need `loginctl enable-linger` to survive a reboot
- two `EnvironmentFile=` lines in a load-bearing order, because `.env` points `HERMES_A2A_URL` at that box's WSL `eth0` address, which is reassigned on reboot
- a drop-in `Environment=` silently loses to the main unit's `EnvironmentFile=` on that host, which is the opposite of what the docs imply — so the override cannot live in a drop-in

### Testing

Both nodes, against the live mesh:

- a locally-authored memory now crosses in **each** direction through the timer path, arriving stamped `broadcast:<peer>`
- failure path: forced a bad TOTP seed, confirmed the watermark held and all four memories were retried and delivered on the next run with a correct seed
- echo suppression still holds — three back-to-back ticks with both bridges firing left both databases flat, and both timers have since fired unprompted on their own schedules

Worth noting for anyone reading #145's "before enabling it on a second node" section: I AST-diffed the two copies of the bridge before scheduling, and the logic was already identical (only a `list[dict]` vs `list` annotation differed). The `store_local` concern that section raises was not the blocker — TOTP was.
