### PR TITLE
fix: close SQLite, psycopg2 and file handles properly

### DIFF
--- a/a2a_server/tests/test_totp_auth.py
+++ b/a2a_server/tests/test_totp_auth.py
@@ -1,0 +1,127 @@
+"""Tests for TOTP authentication paths in a2a_server (issues #98).
+
+Covers: 401 on bad TOTP code, 429 after rate-limit exceeded, and pass-through
+when TOTP_SEED is not set. No live Qdrant / pyotp TOTP generation required.
+"""
+
+import collections
+import time
+import unittest
+from unittest.mock import patch
+
+# a2a_server module is loaded by test_routing.py; reuse it.
+import importlib.util
+import os
+import pathlib
+
+os.environ.setdefault("HERMES_A2A_TOKEN", "test-token-abc123")
+os.environ.setdefault("HERMES_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_server_impl", _server_path)
+a2a_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a_server)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+_AUTH = {"Authorization": "Bearer test-token-abc123"}
+_JSON = {"Content-Type": "application/json"}
+_HEADERS = {**_AUTH, **_JSON}
+
+_TEST_SEED = "JBSWY3DPEHPK3PXP"  # valid base32 seed for testing
+
+
+def _rpc(method: str, params: dict = None) -> dict:
+    body = {"jsonrpc": "2.0", "id": "t-1", "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+class TestTOTPAuth(unittest.TestCase):
+    """TOTP 401 / 429 / disabled paths."""
+
+    def setUp(self):
+        # Reset rate-limit counters before every test.
+        a2a_server._totp_attempts.clear()
+
+    def _client_with_totp(self) -> TestClient:
+        return TestClient(a2a_server.app, raise_server_exceptions=False)
+
+    def test_401_on_missing_totp_header_when_seed_set(self):
+        """When TOTP_SEED is set, requests without X-TOTP return 401."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED):
+            client = self._client_with_totp()
+            resp = client.post("/a2a", json=_rpc("tasks/list"), headers=_HEADERS)
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("X-TOTP", resp.json().get("detail", ""))
+
+    def test_401_on_bad_totp_code(self):
+        """A wrong TOTP code returns 401 even if the auth token is valid."""
+        mock_totp = unittest.mock.MagicMock()
+        mock_totp.return_value.verify.return_value = False  # always reject
+
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = False
+            client = self._client_with_totp()
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "000000"},
+            )
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("Invalid TOTP", resp.json().get("detail", ""))
+
+    def test_429_after_max_attempts_from_same_ip(self):
+        """After _TOTP_MAX_ATTEMPTS failed attempts the next call returns 429."""
+        max_attempts = a2a_server._TOTP_MAX_ATTEMPTS
+        now = time.monotonic()
+
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = False
+
+            client = self._client_with_totp()
+
+            # Prefill the attempts counter to simulate previous failures.
+            # TestClient uses "testclient" as the host by default.
+            client_ip = "testclient"
+            a2a_server._totp_attempts[client_ip] = [
+                now - i for i in range(max_attempts)
+            ]
+
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "000000"},
+            )
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Too many", resp.json().get("detail", ""))
+
+    def test_pass_through_when_totp_seed_not_set(self):
+        """When TOTP_SEED is empty, X-TOTP is not required and requests succeed."""
+        with patch.object(a2a_server, "TOTP_SEED", ""):
+            client = self._client_with_totp()
+            resp = client.post("/a2a", json=_rpc("tasks/list"), headers=_HEADERS)
+        # 200 OK or a JSON-RPC result (not 401/429)
+        self.assertNotIn(resp.status_code, (401, 429))
+
+    def test_valid_totp_code_passes(self):
+        """A TOTP code accepted by pyotp.TOTP.verify allows the request through."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = True
+            client = self._client_with_totp()
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "123456"},
+            )
+        self.assertNotIn(resp.status_code, (401, 429))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest configuration for mcp/tests/.
+
+Inserts the mcp/ directory at the front of sys.path so that every test in
+this package can do ``import server`` and resolve the MCP server module —
+regardless of which directory pytest is invoked from or whether a2a_server
+tests are collected in the same session.
+"""
+import sys
+from pathlib import Path
+
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+
+
+def pytest_configure(config):  # noqa: ARG001
+    if _MCP_DIR not in sys.path:
+        sys.path.insert(0, _MCP_DIR)

--- a/mcp/tests/test_mnemosyne_backend.py
+++ b/mcp/tests/test_mnemosyne_backend.py
@@ -1,0 +1,232 @@
+"""Tests for MnemosyneBackend defensive filtering.
+
+No live Qdrant/mnemosyne connection required — all callables are injected
+via unittest.mock.
+"""
+
+import asyncio
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+from memcheck.mnemosyne import MnemosyneBackend, _extract_metadata  # noqa: E402
+from memcheck.verdict import new_verdict  # noqa: E402
+
+
+def _make_verdict(kind: str = "memory") -> object:
+    return new_verdict(
+        subject_kind=kind,
+        subject_signature="sig-" + uuid.uuid4().hex[:8],
+        subject_excerpt="test excerpt",
+        verdict_type="contradiction",
+        decision="flag",
+        confidence=0.9,
+        rationale="test",
+        source="rule",
+    )
+
+
+def _valid_result(verdict_obj, score: float = 0.85) -> dict:
+    """Build a flat mnemosyne result envelope containing a memcheck verdict."""
+    payload = verdict_obj.to_payload()
+    payload["memcheck"] = True
+    return {"metadata": payload, "score": score}
+
+
+class TestExtractMetadata(unittest.TestCase):
+    """_extract_metadata() handles all four envelope shapes."""
+
+    def test_flat_metadata_key(self):
+        meta = {"answer": 42}
+        result = {"metadata": meta}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_memory_wrapper(self):
+        meta = {"answer": 1}
+        result = {"memory": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_item_wrapper(self):
+        meta = {"answer": 2}
+        result = {"item": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_payload_wrapper(self):
+        meta = {"answer": 3}
+        result = {"payload": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_data_wrapper(self):
+        meta = {"answer": 4}
+        result = {"data": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_non_dict_returns_empty(self):
+        self.assertEqual(_extract_metadata("not a dict"), {})
+        self.assertEqual(_extract_metadata(None), {})
+        self.assertEqual(_extract_metadata([]), {})
+
+    def test_missing_metadata_returns_empty(self):
+        self.assertEqual(_extract_metadata({}), {})
+
+    def test_non_dict_nested_metadata_falls_through(self):
+        # metadata is a string, not a dict → should check fallback keys
+        result = {"metadata": "oops", "memory": {"metadata": {"real": True}}}
+        self.assertEqual(_extract_metadata(result), {"real": True})
+
+
+class TestMemcheckFiltering(unittest.IsolatedAsyncioTestCase):
+    """recall() drops results where memcheck != True."""
+
+    async def test_memcheck_true_passes(self):
+        v = _make_verdict("memory")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict.subject_kind, "memory")
+
+    async def test_memcheck_missing_filtered(self):
+        v = _make_verdict("memory")
+        payload = v.to_payload()  # no memcheck key
+        recall_mock = MagicMock(return_value=[{"metadata": payload, "score": 0.9}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_memcheck_false_filtered(self):
+        v = _make_verdict("memory")
+        payload = {**v.to_payload(), "memcheck": False}
+        recall_mock = MagicMock(return_value=[{"metadata": payload, "score": 0.9}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+
+class TestSubjectKindFiltering(unittest.IsolatedAsyncioTestCase):
+    """recall() keeps only results matching the requested kind."""
+
+    async def test_matching_kind_returned(self):
+        v = _make_verdict("action")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "action", top_k=5)
+        self.assertEqual(len(results), 1)
+
+    async def test_wrong_kind_filtered(self):
+        v = _make_verdict("output")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_mixed_kinds_only_matching_returned(self):
+        v_memory = _make_verdict("memory")
+        v_action = _make_verdict("action")
+        recall_mock = MagicMock(
+            return_value=[_valid_result(v_memory), _valid_result(v_action)]
+        )
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict.subject_kind, "memory")
+
+
+class TestMalformedPayloadTolerance(unittest.IsolatedAsyncioTestCase):
+    """recall() skips malformed payloads without raising."""
+
+    async def test_missing_required_field_skipped(self):
+        bad = {"memcheck": True, "subject_kind": "memory"}  # missing id etc.
+        recall_mock = MagicMock(return_value=[{"metadata": bad, "score": 0.5}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_completely_empty_metadata_skipped(self):
+        recall_mock = MagicMock(return_value=[{"metadata": {}, "score": 0.5}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_non_dict_result_skipped(self):
+        recall_mock = MagicMock(return_value=["not a dict", None, 42])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_good_and_bad_mixed(self):
+        v = _make_verdict("memory")
+        recall_mock = MagicMock(
+            return_value=[
+                {"metadata": {"memcheck": True}, "score": 0.9},  # bad: no kind/id
+                _valid_result(v),
+            ]
+        )
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+
+
+class TestForgetNoOp(unittest.IsolatedAsyncioTestCase):
+    """forget() always returns 0 — mnemosyne has no delete tool."""
+
+    async def test_forget_returns_zero(self):
+        backend = MnemosyneBackend()
+        result = await backend.forget("some text", "memory")
+        self.assertEqual(result, 0)
+
+    async def test_forget_with_recall_injected_still_returns_zero(self):
+        recall_mock = MagicMock(return_value=[])
+        backend = MnemosyneBackend(recall=recall_mock)
+        result = await backend.forget("text", "action")
+        self.assertEqual(result, 0)
+
+
+class TestNoneCallableSafetyGuard(unittest.IsolatedAsyncioTestCase):
+    """None remember/recall callables are safe no-ops."""
+
+    async def test_recall_none_returns_empty(self):
+        backend = MnemosyneBackend(recall=None)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_record_none_does_not_raise(self):
+        backend = MnemosyneBackend(remember=None)
+        v = _make_verdict("memory")
+        await backend.record(v)  # should not raise
+
+    async def test_both_none_recall_empty(self):
+        backend = MnemosyneBackend()
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_empty_results_from_recall_returns_empty(self):
+        recall_mock = MagicMock(return_value=[])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_none_results_from_recall_returns_empty(self):
+        recall_mock = MagicMock(return_value=None)
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_record_calls_remember(self):
+        remember_mock = MagicMock(return_value=True)
+        backend = MnemosyneBackend(remember=remember_mock)
+        v = _make_verdict("memory")
+        await backend.record(v)
+        remember_mock.assert_called_once()
+        _, kwargs = remember_mock.call_args
+        self.assertTrue(kwargs["metadata"].get("memcheck"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_reflection_loop.py
+++ b/mcp/tests/test_reflection_loop.py
@@ -1,10 +1,17 @@
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-import server
+# Ensure mcp/ is on sys.path (also handled by conftest.py; belt-and-suspenders
+# guard for direct `python test_reflection_loop.py` invocations).
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+import server  # noqa: E402
 
 
 class ReflectionLoopTests(unittest.TestCase):

--- a/mlops/finetune/collect.py
+++ b/mlops/finetune/collect.py
@@ -59,20 +59,22 @@ def load_agentHER_from_db(db_path: str) -> list[dict]:
         return results
     try:
         conn = sqlite3.connect(db_path)
-        conn.row_factory = sqlite3.Row
-        cur = conn.execute(
-            "SELECT content, session_id FROM working_memory WHERE source = 'agentHER'"
-        )
-        for row in cur.fetchall():
-            content = row["content"] or ""
-            session_id = row["session_id"] or ""
-            results.append({
-                "type": "agentHER",
-                "content": content,
-                "source": "mnemosyne",
-                "session_id": session_id,
-            })
-        conn.close()
+        try:
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(
+                "SELECT content, session_id FROM working_memory WHERE source = 'agentHER'"
+            )
+            for row in cur.fetchall():
+                content = row["content"] or ""
+                session_id = row["session_id"] or ""
+                results.append({
+                    "type": "agentHER",
+                    "content": content,
+                    "source": "mnemosyne",
+                    "session_id": session_id,
+                })
+        finally:
+            conn.close()
     except sqlite3.Error as exc:
         print(f"[collect] sqlite error reading agentHER rows: {exc}", file=sys.stderr)
     return results

--- a/mlops/memory/decay.py
+++ b/mlops/memory/decay.py
@@ -50,35 +50,35 @@ def apply_decay(
     now = datetime.now(timezone.utc)
 
     try:
-        rows = conn.execute(
-            "SELECT id, importance, created_at FROM working_memory WHERE importance IS NOT NULL"
-        ).fetchall()
-    except sqlite3.OperationalError as exc:
-        conn.close()
-        return {"error": str(exc), "n_rows": 0, "n_decayed": 0}
-
-    updates = []
-    retentions = []
-    for row in rows:
-        created_raw = row["created_at"] or ""
         try:
-            created_dt = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
-            age_days = (now - created_dt).total_seconds() / 86400.0
-        except Exception:
-            continue
+            rows = conn.execute(
+                "SELECT id, importance, created_at FROM working_memory WHERE importance IS NOT NULL"
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            return {"error": str(exc), "n_rows": 0, "n_decayed": 0}
 
-        retention = weibull_retention(age_days, lambda_days, k)
-        retentions.append(retention)
-        current = float(row["importance"] or 0.0)
-        decayed = max(min_importance, current * retention)
-        if abs(decayed - current) > 1e-6:
-            updates.append((decayed, row["id"]))
+        updates = []
+        retentions = []
+        for row in rows:
+            created_raw = row["created_at"] or ""
+            try:
+                created_dt = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+                age_days = (now - created_dt).total_seconds() / 86400.0
+            except Exception:
+                continue
 
-    if not dry_run and updates:
-        conn.executemany("UPDATE working_memory SET importance = ? WHERE id = ?", updates)
-        conn.commit()
+            retention = weibull_retention(age_days, lambda_days, k)
+            retentions.append(retention)
+            current = float(row["importance"] or 0.0)
+            decayed = max(min_importance, current * retention)
+            if abs(decayed - current) > 1e-6:
+                updates.append((decayed, row["id"]))
 
-    conn.close()
+        if not dry_run and updates:
+            conn.executemany("UPDATE working_memory SET importance = ? WHERE id = ?", updates)
+            conn.commit()
+    finally:
+        conn.close()
 
     return {
         "n_rows": len(rows),

--- a/mlops/memory/live_evo.py
+++ b/mlops/memory/live_evo.py
@@ -107,16 +107,18 @@ def adapt(
     if not failures:
         return {"n_failures": 0, "n_correlated": 0, "n_penalized": 0, "dry_run": dry_run}
     conn = sqlite3.connect(db_path)
-    correlated = _find_correlated_entries(conn, failures)
-    updates = []
-    for mem_id, current_importance, event in correlated:
-        penalized = max(importance_floor, current_importance * (1.0 - penalty))
-        if abs(penalized - current_importance) > 1e-6:
-            updates.append((penalized, mem_id))
-    if not dry_run and updates:
-        conn.executemany("UPDATE working_memory SET importance = ? WHERE id = ?", updates)
-        conn.commit()
-    conn.close()
+    try:
+        correlated = _find_correlated_entries(conn, failures)
+        updates = []
+        for mem_id, current_importance, event in correlated:
+            penalized = max(importance_floor, current_importance * (1.0 - penalty))
+            if abs(penalized - current_importance) > 1e-6:
+                updates.append((penalized, mem_id))
+        if not dry_run and updates:
+            conn.executemany("UPDATE working_memory SET importance = ? WHERE id = ?", updates)
+            conn.commit()
+    finally:
+        conn.close()
     record = {
         "run_at": datetime.now(timezone.utc).isoformat(),
         "n_failures_loaded": len(failures),

--- a/scripts/generate_memory_md.py
+++ b/scripts/generate_memory_md.py
@@ -74,27 +74,28 @@ def _try_postgres():
             user=PG_USER, password=PG_PASS,
             dbname=PG_DB, connect_timeout=3
         )
-        cur = conn.cursor()
+        try:
+            cur = conn.cursor()
 
-        rows = []
+            rows = []
 
-        # Try common table schemas
-        for table in ("user_profile", "memory_config", "agent_facts", "facts"):
-            try:
-                cur.execute(f"SELECT * FROM {table} LIMIT 1;")
-                cols = [d[0] for d in cur.description]
-                cur.execute(f"SELECT * FROM {table};")
-                for row in cur.fetchall():
-                    rec = dict(zip(cols, row))
-                    # Guess group/value shape
-                    group = rec.get("group") or rec.get("category") or rec.get("section") or "Key Facts"
-                    value = rec.get("value") or rec.get("content") or str(rec)
-                    rows.append((group, value))
-                break
-            except Exception:
-                continue
-
-        conn.close()
+            # Try common table schemas
+            for table in ("user_profile", "memory_config", "agent_facts", "facts"):
+                try:
+                    cur.execute(f"SELECT * FROM {table} LIMIT 1;")
+                    cols = [d[0] for d in cur.description]
+                    cur.execute(f"SELECT * FROM {table};")
+                    for row in cur.fetchall():
+                        rec = dict(zip(cols, row))
+                        # Guess group/value shape
+                        group = rec.get("group") or rec.get("category") or rec.get("section") or "Key Facts"
+                        value = rec.get("value") or rec.get("content") or str(rec)
+                        rows.append((group, value))
+                    break
+                except Exception:
+                    continue
+        finally:
+            conn.close()
         return rows if rows else None
 
     except Exception as e:

--- a/scripts/grounding_daemon.py
+++ b/scripts/grounding_daemon.py
@@ -151,15 +151,18 @@ def main():
     log.info("listening on %s  pid=%d", SOCK_PATH, os.getpid())
     print(f"grounding_daemon ready  sock={SOCK_PATH}  pid={os.getpid()}", flush=True)
 
-    while True:
-        try:
-            conn, _ = srv.accept()
-            _handle(conn, mod)
-        except KeyboardInterrupt:
-            break
-        except Exception as e:
-            log.error("accept error: %s", e)
-            time.sleep(0.1)
+    try:
+        while True:
+            try:
+                conn, _ = srv.accept()
+                _handle(conn, mod)
+            except KeyboardInterrupt:
+                break
+            except Exception as e:
+                log.error("accept error: %s", e)
+                time.sleep(0.1)
+    finally:
+        srv.close()
 
     _cleanup(SOCK_PATH, PID_PATH)
 

--- a/scripts/hooks/session_end_sync.py
+++ b/scripts/hooks/session_end_sync.py
@@ -162,13 +162,15 @@ def cache_path(session_id: str) -> str:
 def cached_msg_count(session_id: str) -> int:
     p = cache_path(session_id)
     try:
-        return int(open(p).read().strip())
+        with open(p) as f:
+            return int(f.read().strip())
     except Exception:
         return -1
 
 def write_cache(session_id: str, count: int):
     try:
-        open(cache_path(session_id), "w").write(str(count))
+        with open(cache_path(session_id), "w") as f:
+            f.write(str(count))
     except Exception:
         pass
 

--- a/scripts/mnem_fix.py
+++ b/scripts/mnem_fix.py
@@ -58,74 +58,75 @@ for bank, path in DBS.items():
     print(f"\n{'='*50}")
     print(f"Processing bank: {bank}")
     db = sqlite3.connect(path)
-    cur = db.cursor()
+    try:
+        cur = db.cursor()
 
-    # --- Step 1: Purge garbage consolidated_facts ---
-    cur.execute("SELECT id, subject, predicate, object, confidence FROM consolidated_facts")
-    rows = cur.fetchall()
-    to_purge = []
-    for row in rows:
-        id_, subject, predicate, obj, confidence = row
-        if is_garbage_fact(subject, predicate, obj, confidence):
-            to_purge.append(id_)
-            print(f"  PURGE cf id={id_} conf={confidence}: {subject} | {predicate} | {repr(str(obj)[:60])}")
+        # --- Step 1: Purge garbage consolidated_facts ---
+        cur.execute("SELECT id, subject, predicate, object, confidence FROM consolidated_facts")
+        rows = cur.fetchall()
+        to_purge = []
+        for row in rows:
+            id_, subject, predicate, obj, confidence = row
+            if is_garbage_fact(subject, predicate, obj, confidence):
+                to_purge.append(id_)
+                print(f"  PURGE cf id={id_} conf={confidence}: {subject} | {predicate} | {repr(str(obj)[:60])}")
 
-    if to_purge and not DRY_RUN:
-        cur.executemany("DELETE FROM consolidated_facts WHERE id = ?", [(id_,) for id_ in to_purge])
-        db.commit()
-        print(f"  Purged {len(to_purge)} garbage facts from {bank}")
-    elif to_purge:
-        print(f"  [DRY RUN] Would purge {len(to_purge)} facts")
-    else:
-        print(f"  No garbage facts to purge")
-    total_purged += len(to_purge)
+        if to_purge and not DRY_RUN:
+            cur.executemany("DELETE FROM consolidated_facts WHERE id = ?", [(id_,) for id_ in to_purge])
+            db.commit()
+            print(f"  Purged {len(to_purge)} garbage facts from {bank}")
+        elif to_purge:
+            print(f"  [DRY RUN] Would purge {len(to_purge)} facts")
+        else:
+            print(f"  No garbage facts to purge")
+        total_purged += len(to_purge)
 
-    # --- Step 2: Re-embed missing working_memory rows ---
-    cur.execute("""
-        SELECT wm.id, wm.content FROM working_memory wm
-        LEFT JOIN memory_embeddings me ON me.memory_id = wm.id
-        WHERE me.memory_id IS NULL
-    """)
-    missing = cur.fetchall()
-    print(f"\n  Missing embeddings: {len(missing)}")
+        # --- Step 2: Re-embed missing working_memory rows ---
+        cur.execute("""
+            SELECT wm.id, wm.content FROM working_memory wm
+            LEFT JOIN memory_embeddings me ON me.memory_id = wm.id
+            WHERE me.memory_id IS NULL
+        """)
+        missing = cur.fetchall()
+        print(f"\n  Missing embeddings: {len(missing)}")
 
-    for mem_id, content in missing:
-        if not content or not content.strip():
-            print(f"    SKIP empty content id={mem_id}")
-            continue
-        print(f"    Embedding id={mem_id}: {repr(content[:60])}")
-        if not DRY_RUN:
-            vec = model.encode(content, normalize_embeddings=True)
-            embedding_json = json.dumps(vec.tolist())
-            cur.execute(
-                "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model, created_at) VALUES (?, ?, ?, datetime('now'))",
-                (mem_id, embedding_json, MODEL_NAME)
-            )
-        total_embedded += 1
+        for mem_id, content in missing:
+            if not content or not content.strip():
+                print(f"    SKIP empty content id={mem_id}")
+                continue
+            print(f"    Embedding id={mem_id}: {repr(content[:60])}")
+            if not DRY_RUN:
+                vec = model.encode(content, normalize_embeddings=True)
+                embedding_json = json.dumps(vec.tolist())
+                cur.execute(
+                    "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model, created_at) VALUES (?, ?, ?, datetime('now'))",
+                    (mem_id, embedding_json, MODEL_NAME)
+                )
+            total_embedded += 1
 
-    if not DRY_RUN and missing:
-        db.commit()
-        print(f"  Embedded {len(missing)} rows in {bank}")
+        if not DRY_RUN and missing:
+            db.commit()
+            print(f"  Embedded {len(missing)} rows in {bank}")
 
-    # --- Step 3: Resolve unresolved conflicts ---
-    cur.execute("SELECT id, fact_a_id, fact_b_id, conflict_type FROM conflicts WHERE resolution IS NULL OR resolution = ''")
-    conflicts = cur.fetchall()
-    print(f"\n  Unresolved conflicts: {len(conflicts)}")
-    for conf_id, fa, fb, ctype in conflicts:
-        # Fetch both facts
-        cur.execute("SELECT subject, predicate, object, confidence FROM consolidated_facts WHERE id IN (?, ?)", (fa, fb))
-        facts = cur.fetchall()
-        resolution = f"AUTO: Both facts retained; conflict_type={ctype}. Manual review recommended."
-        print(f"    Conflict id={conf_id} ({ctype}): {fa} vs {fb}")
-        for f in facts:
-            print(f"      fact: {f[0]} | {f[1]} | {f[2]} conf={f[3]}")
-        if not DRY_RUN:
-            cur.execute("UPDATE conflicts SET resolution = ?, resolved_at = datetime('now') WHERE id = ?",
-                        (resolution, conf_id))
-    if not DRY_RUN and conflicts:
-        db.commit()
-
-    db.close()
+        # --- Step 3: Resolve unresolved conflicts ---
+        cur.execute("SELECT id, fact_a_id, fact_b_id, conflict_type FROM conflicts WHERE resolution IS NULL OR resolution = ''")
+        conflicts = cur.fetchall()
+        print(f"\n  Unresolved conflicts: {len(conflicts)}")
+        for conf_id, fa, fb, ctype in conflicts:
+            # Fetch both facts
+            cur.execute("SELECT subject, predicate, object, confidence FROM consolidated_facts WHERE id IN (?, ?)", (fa, fb))
+            facts = cur.fetchall()
+            resolution = f"AUTO: Both facts retained; conflict_type={ctype}. Manual review recommended."
+            print(f"    Conflict id={conf_id} ({ctype}): {fa} vs {fb}")
+            for f in facts:
+                print(f"      fact: {f[0]} | {f[1]} | {f[2]} conf={f[3]}")
+            if not DRY_RUN:
+                cur.execute("UPDATE conflicts SET resolution = ?, resolved_at = datetime('now') WHERE id = ?",
+                            (resolution, conf_id))
+        if not DRY_RUN and conflicts:
+            db.commit()
+    finally:
+        db.close()
 
 print(f"\n{'='*50}")
 print(f"DONE. Total purged={total_purged} re-embedded={total_embedded}")

--- a/scripts/mnemosyne_activity_check.py
+++ b/scripts/mnemosyne_activity_check.py
@@ -22,14 +22,16 @@ DAMA_DB = os.path.expanduser(
 
 def _read_state(path: str) -> int:
     try:
-        return int(open(path).read().strip())
+        with open(path) as f:
+            return int(f.read().strip())
     except Exception:
         return 0
 
 
 def _write_state(path: str, count: int) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    open(path, "w").write(str(count))
+    with open(path, "w") as f:
+        f.write(str(count))
 
 
 def get_default_wm_count() -> int:

--- a/scripts/mnemosyne_qdrant_sync.py
+++ b/scripts/mnemosyne_qdrant_sync.py
@@ -9,7 +9,8 @@ import sqlite3, json, hashlib, sys, time, subprocess, os, base64, urllib.request
 # Load .env before anything else — override path with HERMES_ENV_FILE
 _ENV_FILE = os.path.expanduser(os.environ.get("HERMES_ENV_FILE", "~/.hermes/.env"))
 if os.path.exists(_ENV_FILE):
-    for _line in open(_ENV_FILE):
+    with open(_ENV_FILE) as _env_fh:
+        for _line in _env_fh:
         _line = _line.strip()
         if _line and not _line.startswith("#") and "=" in _line:
             _k, _v = _line.split("=", 1)

--- a/scripts/qdrant_payload_indexes.py
+++ b/scripts/qdrant_payload_indexes.py
@@ -28,7 +28,8 @@ QDRANT_KEY = os.environ.get("QDRANT_API_KEY", "")
 if not QDRANT_KEY:
     try:
         import json as _json
-        _cfg = _json.load(open(os.path.join(_HOME, ".claude", "settings.json")))
+        with open(os.path.join(_HOME, ".claude", "settings.json")) as _f:
+            _cfg = _json.load(_f)
         _servers = _cfg["mcpServers"]
         # "loci" is the current registration name; "hermes_memory" is what older
         # settings.json files used. Accept either.

--- a/scripts/score_trace_collector.py
+++ b/scripts/score_trace_collector.py
@@ -219,17 +219,19 @@ def load_agenthr_positives() -> list[dict]:
         return results
     try:
         conn = sqlite3.connect(MNEMOSYNE_DB)
-        conn.row_factory = sqlite3.Row
-        cur = conn.execute(
-            "SELECT content, session_id FROM working_memory WHERE source = 'agentHER'"
-        )
-        for row in cur.fetchall():
-            results.append({
-                "trace_type": "positive_relabeled",
-                "content": row["content"] or "",
-                "session_id": row["session_id"] or "",
-            })
-        conn.close()
+        try:
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(
+                "SELECT content, session_id FROM working_memory WHERE source = 'agentHER'"
+            )
+            for row in cur.fetchall():
+                results.append({
+                    "trace_type": "positive_relabeled",
+                    "content": row["content"] or "",
+                    "session_id": row["session_id"] or "",
+                })
+        finally:
+            conn.close()
     except sqlite3.Error:
         pass
     return results


### PR DESCRIPTION
Closes #87
Closes #88
Closes #103

## Changes
- psycopg2 connection wrapped in try/finally (#88)
- SQLite connections in mlops scripts use try/finally with conn.close() (#87)
- Bare file/URL/socket handles wrapped in context managers (#103)

*Generated by loci-fix-sweep*