### PR TITLE
test: conftest path guard, MnemosyneBackend, TOTP auth coverage

### DIFF
--- a/a2a_server/tests/test_totp_auth.py
+++ b/a2a_server/tests/test_totp_auth.py
@@ -1,0 +1,127 @@
+"""Tests for TOTP authentication paths in a2a_server (issues #98).
+
+Covers: 401 on bad TOTP code, 429 after rate-limit exceeded, and pass-through
+when TOTP_SEED is not set. No live Qdrant / pyotp TOTP generation required.
+"""
+
+import collections
+import time
+import unittest
+from unittest.mock import patch
+
+# a2a_server module is loaded by test_routing.py; reuse it.
+import importlib.util
+import os
+import pathlib
+
+os.environ.setdefault("HERMES_A2A_TOKEN", "test-token-abc123")
+os.environ.setdefault("HERMES_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_server_impl", _server_path)
+a2a_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a_server)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+_AUTH = {"Authorization": "Bearer test-token-abc123"}
+_JSON = {"Content-Type": "application/json"}
+_HEADERS = {**_AUTH, **_JSON}
+
+_TEST_SEED = "JBSWY3DPEHPK3PXP"  # valid base32 seed for testing
+
+
+def _rpc(method: str, params: dict = None) -> dict:
+    body = {"jsonrpc": "2.0", "id": "t-1", "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+class TestTOTPAuth(unittest.TestCase):
+    """TOTP 401 / 429 / disabled paths."""
+
+    def setUp(self):
+        # Reset rate-limit counters before every test.
+        a2a_server._totp_attempts.clear()
+
+    def _client_with_totp(self) -> TestClient:
+        return TestClient(a2a_server.app, raise_server_exceptions=False)
+
+    def test_401_on_missing_totp_header_when_seed_set(self):
+        """When TOTP_SEED is set, requests without X-TOTP return 401."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED):
+            client = self._client_with_totp()
+            resp = client.post("/a2a", json=_rpc("tasks/list"), headers=_HEADERS)
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("X-TOTP", resp.json().get("detail", ""))
+
+    def test_401_on_bad_totp_code(self):
+        """A wrong TOTP code returns 401 even if the auth token is valid."""
+        mock_totp = unittest.mock.MagicMock()
+        mock_totp.return_value.verify.return_value = False  # always reject
+
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = False
+            client = self._client_with_totp()
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "000000"},
+            )
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("Invalid TOTP", resp.json().get("detail", ""))
+
+    def test_429_after_max_attempts_from_same_ip(self):
+        """After _TOTP_MAX_ATTEMPTS failed attempts the next call returns 429."""
+        max_attempts = a2a_server._TOTP_MAX_ATTEMPTS
+        now = time.monotonic()
+
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = False
+
+            client = self._client_with_totp()
+
+            # Prefill the attempts counter to simulate previous failures.
+            # TestClient uses "testclient" as the host by default.
+            client_ip = "testclient"
+            a2a_server._totp_attempts[client_ip] = [
+                now - i for i in range(max_attempts)
+            ]
+
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "000000"},
+            )
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Too many", resp.json().get("detail", ""))
+
+    def test_pass_through_when_totp_seed_not_set(self):
+        """When TOTP_SEED is empty, X-TOTP is not required and requests succeed."""
+        with patch.object(a2a_server, "TOTP_SEED", ""):
+            client = self._client_with_totp()
+            resp = client.post("/a2a", json=_rpc("tasks/list"), headers=_HEADERS)
+        # 200 OK or a JSON-RPC result (not 401/429)
+        self.assertNotIn(resp.status_code, (401, 429))
+
+    def test_valid_totp_code_passes(self):
+        """A TOTP code accepted by pyotp.TOTP.verify allows the request through."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = True
+            client = self._client_with_totp()
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "123456"},
+            )
+        self.assertNotIn(resp.status_code, (401, 429))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest configuration for mcp/tests/.
+
+Inserts the mcp/ directory at the front of sys.path so that every test in
+this package can do ``import server`` and resolve the MCP server module —
+regardless of which directory pytest is invoked from or whether a2a_server
+tests are collected in the same session.
+"""
+import sys
+from pathlib import Path
+
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+
+
+def pytest_configure(config):  # noqa: ARG001
+    if _MCP_DIR not in sys.path:
+        sys.path.insert(0, _MCP_DIR)

--- a/mcp/tests/test_mnemosyne_backend.py
+++ b/mcp/tests/test_mnemosyne_backend.py
@@ -1,0 +1,232 @@
+"""Tests for MnemosyneBackend defensive filtering.
+
+No live Qdrant/mnemosyne connection required — all callables are injected
+via unittest.mock.
+"""
+
+import asyncio
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+from memcheck.mnemosyne import MnemosyneBackend, _extract_metadata  # noqa: E402
+from memcheck.verdict import new_verdict  # noqa: E402
+
+
+def _make_verdict(kind: str = "memory") -> object:
+    return new_verdict(
+        subject_kind=kind,
+        subject_signature="sig-" + uuid.uuid4().hex[:8],
+        subject_excerpt="test excerpt",
+        verdict_type="contradiction",
+        decision="flag",
+        confidence=0.9,
+        rationale="test",
+        source="rule",
+    )
+
+
+def _valid_result(verdict_obj, score: float = 0.85) -> dict:
+    """Build a flat mnemosyne result envelope containing a memcheck verdict."""
+    payload = verdict_obj.to_payload()
+    payload["memcheck"] = True
+    return {"metadata": payload, "score": score}
+
+
+class TestExtractMetadata(unittest.TestCase):
+    """_extract_metadata() handles all four envelope shapes."""
+
+    def test_flat_metadata_key(self):
+        meta = {"answer": 42}
+        result = {"metadata": meta}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_memory_wrapper(self):
+        meta = {"answer": 1}
+        result = {"memory": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_item_wrapper(self):
+        meta = {"answer": 2}
+        result = {"item": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_payload_wrapper(self):
+        meta = {"answer": 3}
+        result = {"payload": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_data_wrapper(self):
+        meta = {"answer": 4}
+        result = {"data": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_non_dict_returns_empty(self):
+        self.assertEqual(_extract_metadata("not a dict"), {})
+        self.assertEqual(_extract_metadata(None), {})
+        self.assertEqual(_extract_metadata([]), {})
+
+    def test_missing_metadata_returns_empty(self):
+        self.assertEqual(_extract_metadata({}), {})
+
+    def test_non_dict_nested_metadata_falls_through(self):
+        # metadata is a string, not a dict → should check fallback keys
+        result = {"metadata": "oops", "memory": {"metadata": {"real": True}}}
+        self.assertEqual(_extract_metadata(result), {"real": True})
+
+
+class TestMemcheckFiltering(unittest.IsolatedAsyncioTestCase):
+    """recall() drops results where memcheck != True."""
+
+    async def test_memcheck_true_passes(self):
+        v = _make_verdict("memory")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict.subject_kind, "memory")
+
+    async def test_memcheck_missing_filtered(self):
+        v = _make_verdict("memory")
+        payload = v.to_payload()  # no memcheck key
+        recall_mock = MagicMock(return_value=[{"metadata": payload, "score": 0.9}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_memcheck_false_filtered(self):
+        v = _make_verdict("memory")
+        payload = {**v.to_payload(), "memcheck": False}
+        recall_mock = MagicMock(return_value=[{"metadata": payload, "score": 0.9}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+
+class TestSubjectKindFiltering(unittest.IsolatedAsyncioTestCase):
+    """recall() keeps only results matching the requested kind."""
+
+    async def test_matching_kind_returned(self):
+        v = _make_verdict("action")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "action", top_k=5)
+        self.assertEqual(len(results), 1)
+
+    async def test_wrong_kind_filtered(self):
+        v = _make_verdict("output")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_mixed_kinds_only_matching_returned(self):
+        v_memory = _make_verdict("memory")
+        v_action = _make_verdict("action")
+        recall_mock = MagicMock(
+            return_value=[_valid_result(v_memory), _valid_result(v_action)]
+        )
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict.subject_kind, "memory")
+
+
+class TestMalformedPayloadTolerance(unittest.IsolatedAsyncioTestCase):
+    """recall() skips malformed payloads without raising."""
+
+    async def test_missing_required_field_skipped(self):
+        bad = {"memcheck": True, "subject_kind": "memory"}  # missing id etc.
+        recall_mock = MagicMock(return_value=[{"metadata": bad, "score": 0.5}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_completely_empty_metadata_skipped(self):
+        recall_mock = MagicMock(return_value=[{"metadata": {}, "score": 0.5}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_non_dict_result_skipped(self):
+        recall_mock = MagicMock(return_value=["not a dict", None, 42])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_good_and_bad_mixed(self):
+        v = _make_verdict("memory")
+        recall_mock = MagicMock(
+            return_value=[
+                {"metadata": {"memcheck": True}, "score": 0.9},  # bad: no kind/id
+                _valid_result(v),
+            ]
+        )
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+
+
+class TestForgetNoOp(unittest.IsolatedAsyncioTestCase):
+    """forget() always returns 0 — mnemosyne has no delete tool."""
+
+    async def test_forget_returns_zero(self):
+        backend = MnemosyneBackend()
+        result = await backend.forget("some text", "memory")
+        self.assertEqual(result, 0)
+
+    async def test_forget_with_recall_injected_still_returns_zero(self):
+        recall_mock = MagicMock(return_value=[])
+        backend = MnemosyneBackend(recall=recall_mock)
+        result = await backend.forget("text", "action")
+        self.assertEqual(result, 0)
+
+
+class TestNoneCallableSafetyGuard(unittest.IsolatedAsyncioTestCase):
+    """None remember/recall callables are safe no-ops."""
+
+    async def test_recall_none_returns_empty(self):
+        backend = MnemosyneBackend(recall=None)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_record_none_does_not_raise(self):
+        backend = MnemosyneBackend(remember=None)
+        v = _make_verdict("memory")
+        await backend.record(v)  # should not raise
+
+    async def test_both_none_recall_empty(self):
+        backend = MnemosyneBackend()
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_empty_results_from_recall_returns_empty(self):
+        recall_mock = MagicMock(return_value=[])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_none_results_from_recall_returns_empty(self):
+        recall_mock = MagicMock(return_value=None)
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_record_calls_remember(self):
+        remember_mock = MagicMock(return_value=True)
+        backend = MnemosyneBackend(remember=remember_mock)
+        v = _make_verdict("memory")
+        await backend.record(v)
+        remember_mock.assert_called_once()
+        _, kwargs = remember_mock.call_args
+        self.assertTrue(kwargs["metadata"].get("memcheck"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_reflection_loop.py
+++ b/mcp/tests/test_reflection_loop.py
@@ -1,10 +1,17 @@
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-import server
+# Ensure mcp/ is on sys.path (also handled by conftest.py; belt-and-suspenders
+# guard for direct `python test_reflection_loop.py` invocations).
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+import server  # noqa: E402
 
 
 class ReflectionLoopTests(unittest.TestCase):


### PR DESCRIPTION
Closes #98
Closes #99
Closes #104

## Changes
- **mcp/tests/conftest.py** — shared `sys.path` guard so all mcp tests resolve `import server` to the MCP server regardless of pytest invocation order (#99)
- **mcp/tests/test_reflection_loop.py** — belt-and-suspenders path guard added for direct `python test_reflection_loop.py` invocations (#99)
- **mcp/tests/test_mnemosyne_backend.py** — 20 tests covering: `memcheck=True` filtering, `subject_kind` filtering, all four `_extract_metadata()` envelope shapes, malformed payload tolerance, `forget()` no-op, and `None` callable safety guard (#104)
- **a2a_server/tests/test_totp_auth.py** — `TestTOTPAuth` covering: 401 on missing X-TOTP, 401 on invalid code, 429 after rate-limit exhausted, pass-through when seed unset, and valid-code pass-through (#98)

## Note
`test_mcp_integration.py` mutates `server.MEMORY_DIR` globally. Not addressed here — requires pytest-xdist isolation to fix safely.

*Generated by loci-fix-sweep*