### PR TITLE
fix: thread-safe cache, bounded manifest cache, safe error responses

### DIFF
--- a/a2a_server/tests/test_totp_auth.py
+++ b/a2a_server/tests/test_totp_auth.py
@@ -1,0 +1,127 @@
+"""Tests for TOTP authentication paths in a2a_server (issues #98).
+
+Covers: 401 on bad TOTP code, 429 after rate-limit exceeded, and pass-through
+when TOTP_SEED is not set. No live Qdrant / pyotp TOTP generation required.
+"""
+
+import collections
+import time
+import unittest
+from unittest.mock import patch
+
+# a2a_server module is loaded by test_routing.py; reuse it.
+import importlib.util
+import os
+import pathlib
+
+os.environ.setdefault("HERMES_A2A_TOKEN", "test-token-abc123")
+os.environ.setdefault("HERMES_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_server_impl", _server_path)
+a2a_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a_server)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+_AUTH = {"Authorization": "Bearer test-token-abc123"}
+_JSON = {"Content-Type": "application/json"}
+_HEADERS = {**_AUTH, **_JSON}
+
+_TEST_SEED = "JBSWY3DPEHPK3PXP"  # valid base32 seed for testing
+
+
+def _rpc(method: str, params: dict = None) -> dict:
+    body = {"jsonrpc": "2.0", "id": "t-1", "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+class TestTOTPAuth(unittest.TestCase):
+    """TOTP 401 / 429 / disabled paths."""
+
+    def setUp(self):
+        # Reset rate-limit counters before every test.
+        a2a_server._totp_attempts.clear()
+
+    def _client_with_totp(self) -> TestClient:
+        return TestClient(a2a_server.app, raise_server_exceptions=False)
+
+    def test_401_on_missing_totp_header_when_seed_set(self):
+        """When TOTP_SEED is set, requests without X-TOTP return 401."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED):
+            client = self._client_with_totp()
+            resp = client.post("/a2a", json=_rpc("tasks/list"), headers=_HEADERS)
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("X-TOTP", resp.json().get("detail", ""))
+
+    def test_401_on_bad_totp_code(self):
+        """A wrong TOTP code returns 401 even if the auth token is valid."""
+        mock_totp = unittest.mock.MagicMock()
+        mock_totp.return_value.verify.return_value = False  # always reject
+
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = False
+            client = self._client_with_totp()
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "000000"},
+            )
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("Invalid TOTP", resp.json().get("detail", ""))
+
+    def test_429_after_max_attempts_from_same_ip(self):
+        """After _TOTP_MAX_ATTEMPTS failed attempts the next call returns 429."""
+        max_attempts = a2a_server._TOTP_MAX_ATTEMPTS
+        now = time.monotonic()
+
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = False
+
+            client = self._client_with_totp()
+
+            # Prefill the attempts counter to simulate previous failures.
+            # TestClient uses "testclient" as the host by default.
+            client_ip = "testclient"
+            a2a_server._totp_attempts[client_ip] = [
+                now - i for i in range(max_attempts)
+            ]
+
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "000000"},
+            )
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Too many", resp.json().get("detail", ""))
+
+    def test_pass_through_when_totp_seed_not_set(self):
+        """When TOTP_SEED is empty, X-TOTP is not required and requests succeed."""
+        with patch.object(a2a_server, "TOTP_SEED", ""):
+            client = self._client_with_totp()
+            resp = client.post("/a2a", json=_rpc("tasks/list"), headers=_HEADERS)
+        # 200 OK or a JSON-RPC result (not 401/429)
+        self.assertNotIn(resp.status_code, (401, 429))
+
+    def test_valid_totp_code_passes(self):
+        """A TOTP code accepted by pyotp.TOTP.verify allows the request through."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = True
+            client = self._client_with_totp()
+            resp = client.post(
+                "/a2a",
+                json=_rpc("tasks/list"),
+                headers={**_HEADERS, "X-TOTP": "123456"},
+            )
+        self.assertNotIn(resp.status_code, (401, 429))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/inv_store.py
+++ b/mcp/inv_store.py
@@ -89,6 +89,7 @@ def _inv_dir(investigation_id: str) -> Path:
 
 
 _manifest_cache: dict[str, str] = {}  # investigation_id → raw JSON string (write-through)
+_MANIFEST_CACHE_MAXSIZE = 256
 
 
 def _load_manifest(investigation_id: str) -> dict | None:
@@ -98,6 +99,8 @@ def _load_manifest(investigation_id: str) -> dict | None:
         if not p.exists():
             return None
         raw = p.read_text()
+        if len(_manifest_cache) >= _MANIFEST_CACHE_MAXSIZE:
+            _manifest_cache.pop(next(iter(_manifest_cache)))
         _manifest_cache[investigation_id] = raw
     manifest = json.loads(raw)
     # Backward compat: initialize ACL fields if missing (old investigations)
@@ -133,6 +136,8 @@ def _save_manifest(manifest: dict) -> None:
     p = _inv_dir(manifest["id"]) / "manifest.json"
     data = json.dumps(manifest, indent=2)
     _atomic_write_text(p, data)
+    if len(_manifest_cache) >= _MANIFEST_CACHE_MAXSIZE:
+        _manifest_cache.pop(next(iter(_manifest_cache)))
     _manifest_cache[manifest["id"]] = data  # keep cache in sync with what we wrote
 
 

--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from typing import Optional
 
@@ -27,6 +28,7 @@ VECTOR_DIM = int(os.environ.get("MNEMOSYNE_EMBEDDING_DIM", 768))
 
 # --- Lazy singletons / fail-open latches ---
 _sparse_model = None
+_sparse_model_lock = threading.Lock()          # guards _sparse_model lazy-init (#106)
 _qdrant_client: tuple | None = None    # (QdrantClient, collection_name) singleton
 _qdrant_failed_at: float | None = None  # monotonic timestamp of last connection failure
 _QDRANT_RETRY_SECONDS = 60             # backoff before retrying after a transient failure
@@ -35,12 +37,14 @@ _QDRANT_RETRY_SECONDS = 60             # backoff before retrying after a transie
 def _get_sparse_embedder():
     global _sparse_model
     if _sparse_model is None:
-        try:
-            from fastembed import SparseTextEmbedding
-            _sparse_model = SparseTextEmbedding("Qdrant/bm25", language="english", avg_len=200, disable_stemmer=True)
-        except Exception as exc:
-            logger.warning("SparseTextEmbedding unavailable: %s", exc)
-            _sparse_model = False
+        with _sparse_model_lock:
+            if _sparse_model is None:
+                try:
+                    from fastembed import SparseTextEmbedding
+                    _sparse_model = SparseTextEmbedding("Qdrant/bm25", language="english", avg_len=200, disable_stemmer=True)
+                except Exception as exc:
+                    logger.warning("SparseTextEmbedding unavailable: %s", exc)
+                    _sparse_model = False
     return _sparse_model if _sparse_model is not False else None
 
 
@@ -81,9 +85,10 @@ def _embed_sparse(text: str):
         result = list(model.embed([text]))[0]
         indices = result.indices.tolist()
         values = result.values.tolist()
-        if len(_embed_sparse_cache) >= _EMBED_CACHE_MAXSIZE:
-            _embed_sparse_cache.pop(next(iter(_embed_sparse_cache)))
-        _embed_sparse_cache[text] = (tuple(indices), tuple(values))
+        with _embed_sparse_cache_lock:
+            if len(_embed_sparse_cache) >= _EMBED_CACHE_MAXSIZE:
+                _embed_sparse_cache.pop(next(iter(_embed_sparse_cache)))
+            _embed_sparse_cache[text] = (tuple(indices), tuple(values))
         return SparseVector(indices=indices, values=values)
     except Exception as exc:
         logger.debug("sparse embed failed: %s", exc)
@@ -264,6 +269,8 @@ _EMBED_API_KEY_HEADER = os.environ.get("EMBED_API_KEY_HEADER", "Authorization")
 _EMBED_CACHE_MAXSIZE = 512
 _embed_cache: dict[str, list[float]] = {}         # text → dense vector (bounded, FIFO eviction)
 _embed_sparse_cache: dict[str, tuple] = {}        # text → (indices_tuple, values_tuple)
+_embed_cache_lock = threading.Lock()              # guards _embed_cache check-evict-insert (#86)
+_embed_sparse_cache_lock = threading.Lock()       # guards _embed_sparse_cache check-evict-insert (#86)
 
 # Startup validation — warn clearly when required backends are not configured.
 # Server runs in degraded mode (keyword-only) rather than refusing to start.
@@ -309,9 +316,10 @@ def _embed(text: str) -> list[float] | None:
         data = r.json().get("data", [])
         result = list(data[0]["embedding"]) if data else None
         if result is not None:
-            if len(_embed_cache) >= _EMBED_CACHE_MAXSIZE:
-                _embed_cache.pop(next(iter(_embed_cache)))
-            _embed_cache[text] = result
+            with _embed_cache_lock:
+                if len(_embed_cache) >= _EMBED_CACHE_MAXSIZE:
+                    _embed_cache.pop(next(iter(_embed_cache)))
+                _embed_cache[text] = result
         return result
     except Exception as exc:
         logger.warning("embed failed: %s", exc)

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -55,6 +55,7 @@ import tempfile
 import threading
 import time
 import uuid
+import weakref
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -213,7 +214,7 @@ from inv_store import (  # noqa: E402,F401
 # Optional Qdrant + fastembed
 # ---------------------------------------------------------------------------
 
-_investigation_locks: dict[str, threading.Lock] = {}  # per-investigation lock for atomic JSONL appends
+_investigation_locks: weakref.WeakValueDictionary = weakref.WeakValueDictionary()  # per-investigation lock; auto-evicted when caller releases
 _investigation_locks_lock = threading.Lock()          # guards _investigation_locks dict itself
 
 
@@ -221,9 +222,15 @@ def _investigation_lock(investigation_id: str) -> threading.Lock:
     """Return the per-investigation lock, creating it under the dict-guard lock if absent.
 
     Returns the lock UNACQUIRED — callers are responsible for `with` on the result.
+    Uses WeakValueDictionary so entries are evicted automatically once no caller
+    holds a strong reference, preventing unbounded accumulation (#101).
     """
     with _investigation_locks_lock:
-        return _investigation_locks.setdefault(investigation_id, threading.Lock())
+        lock = _investigation_locks.get(investigation_id)
+        if lock is None:
+            lock = threading.Lock()
+            _investigation_locks[investigation_id] = lock
+        return lock
 
 # ---------------------------------------------------------------------------
 # LadybugDB graph store (primary relationship/graph backend) — fail-open like Qdrant.
@@ -6598,7 +6605,8 @@ def memory_consolidate(dry_run: bool = False) -> str:
     except Exception as e:
         return _json.dumps({
             "status": "error",
-            "error": str(e),
+            "error": "internal error",
+            "type": type(e).__name__,
             "causal_edges_inferred": causal_edges_inferred,
         })
 

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest configuration for mcp/tests/.
+
+Inserts the mcp/ directory at the front of sys.path so that every test in
+this package can do ``import server`` and resolve the MCP server module —
+regardless of which directory pytest is invoked from or whether a2a_server
+tests are collected in the same session.
+"""
+import sys
+from pathlib import Path
+
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+
+
+def pytest_configure(config):  # noqa: ARG001
+    if _MCP_DIR not in sys.path:
+        sys.path.insert(0, _MCP_DIR)

--- a/mcp/tests/test_mnemosyne_backend.py
+++ b/mcp/tests/test_mnemosyne_backend.py
@@ -1,0 +1,232 @@
+"""Tests for MnemosyneBackend defensive filtering.
+
+No live Qdrant/mnemosyne connection required — all callables are injected
+via unittest.mock.
+"""
+
+import asyncio
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+from memcheck.mnemosyne import MnemosyneBackend, _extract_metadata  # noqa: E402
+from memcheck.verdict import new_verdict  # noqa: E402
+
+
+def _make_verdict(kind: str = "memory") -> object:
+    return new_verdict(
+        subject_kind=kind,
+        subject_signature="sig-" + uuid.uuid4().hex[:8],
+        subject_excerpt="test excerpt",
+        verdict_type="contradiction",
+        decision="flag",
+        confidence=0.9,
+        rationale="test",
+        source="rule",
+    )
+
+
+def _valid_result(verdict_obj, score: float = 0.85) -> dict:
+    """Build a flat mnemosyne result envelope containing a memcheck verdict."""
+    payload = verdict_obj.to_payload()
+    payload["memcheck"] = True
+    return {"metadata": payload, "score": score}
+
+
+class TestExtractMetadata(unittest.TestCase):
+    """_extract_metadata() handles all four envelope shapes."""
+
+    def test_flat_metadata_key(self):
+        meta = {"answer": 42}
+        result = {"metadata": meta}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_memory_wrapper(self):
+        meta = {"answer": 1}
+        result = {"memory": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_item_wrapper(self):
+        meta = {"answer": 2}
+        result = {"item": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_payload_wrapper(self):
+        meta = {"answer": 3}
+        result = {"payload": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_data_wrapper(self):
+        meta = {"answer": 4}
+        result = {"data": {"metadata": meta}}
+        self.assertEqual(_extract_metadata(result), meta)
+
+    def test_non_dict_returns_empty(self):
+        self.assertEqual(_extract_metadata("not a dict"), {})
+        self.assertEqual(_extract_metadata(None), {})
+        self.assertEqual(_extract_metadata([]), {})
+
+    def test_missing_metadata_returns_empty(self):
+        self.assertEqual(_extract_metadata({}), {})
+
+    def test_non_dict_nested_metadata_falls_through(self):
+        # metadata is a string, not a dict → should check fallback keys
+        result = {"metadata": "oops", "memory": {"metadata": {"real": True}}}
+        self.assertEqual(_extract_metadata(result), {"real": True})
+
+
+class TestMemcheckFiltering(unittest.IsolatedAsyncioTestCase):
+    """recall() drops results where memcheck != True."""
+
+    async def test_memcheck_true_passes(self):
+        v = _make_verdict("memory")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict.subject_kind, "memory")
+
+    async def test_memcheck_missing_filtered(self):
+        v = _make_verdict("memory")
+        payload = v.to_payload()  # no memcheck key
+        recall_mock = MagicMock(return_value=[{"metadata": payload, "score": 0.9}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_memcheck_false_filtered(self):
+        v = _make_verdict("memory")
+        payload = {**v.to_payload(), "memcheck": False}
+        recall_mock = MagicMock(return_value=[{"metadata": payload, "score": 0.9}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+
+class TestSubjectKindFiltering(unittest.IsolatedAsyncioTestCase):
+    """recall() keeps only results matching the requested kind."""
+
+    async def test_matching_kind_returned(self):
+        v = _make_verdict("action")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "action", top_k=5)
+        self.assertEqual(len(results), 1)
+
+    async def test_wrong_kind_filtered(self):
+        v = _make_verdict("output")
+        recall_mock = MagicMock(return_value=[_valid_result(v)])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_mixed_kinds_only_matching_returned(self):
+        v_memory = _make_verdict("memory")
+        v_action = _make_verdict("action")
+        recall_mock = MagicMock(
+            return_value=[_valid_result(v_memory), _valid_result(v_action)]
+        )
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict.subject_kind, "memory")
+
+
+class TestMalformedPayloadTolerance(unittest.IsolatedAsyncioTestCase):
+    """recall() skips malformed payloads without raising."""
+
+    async def test_missing_required_field_skipped(self):
+        bad = {"memcheck": True, "subject_kind": "memory"}  # missing id etc.
+        recall_mock = MagicMock(return_value=[{"metadata": bad, "score": 0.5}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_completely_empty_metadata_skipped(self):
+        recall_mock = MagicMock(return_value=[{"metadata": {}, "score": 0.5}])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_non_dict_result_skipped(self):
+        recall_mock = MagicMock(return_value=["not a dict", None, 42])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_good_and_bad_mixed(self):
+        v = _make_verdict("memory")
+        recall_mock = MagicMock(
+            return_value=[
+                {"metadata": {"memcheck": True}, "score": 0.9},  # bad: no kind/id
+                _valid_result(v),
+            ]
+        )
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(len(results), 1)
+
+
+class TestForgetNoOp(unittest.IsolatedAsyncioTestCase):
+    """forget() always returns 0 — mnemosyne has no delete tool."""
+
+    async def test_forget_returns_zero(self):
+        backend = MnemosyneBackend()
+        result = await backend.forget("some text", "memory")
+        self.assertEqual(result, 0)
+
+    async def test_forget_with_recall_injected_still_returns_zero(self):
+        recall_mock = MagicMock(return_value=[])
+        backend = MnemosyneBackend(recall=recall_mock)
+        result = await backend.forget("text", "action")
+        self.assertEqual(result, 0)
+
+
+class TestNoneCallableSafetyGuard(unittest.IsolatedAsyncioTestCase):
+    """None remember/recall callables are safe no-ops."""
+
+    async def test_recall_none_returns_empty(self):
+        backend = MnemosyneBackend(recall=None)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_record_none_does_not_raise(self):
+        backend = MnemosyneBackend(remember=None)
+        v = _make_verdict("memory")
+        await backend.record(v)  # should not raise
+
+    async def test_both_none_recall_empty(self):
+        backend = MnemosyneBackend()
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_empty_results_from_recall_returns_empty(self):
+        recall_mock = MagicMock(return_value=[])
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_none_results_from_recall_returns_empty(self):
+        recall_mock = MagicMock(return_value=None)
+        backend = MnemosyneBackend(recall=recall_mock)
+        results = await backend.recall("query", [], "memory", top_k=5)
+        self.assertEqual(results, [])
+
+    async def test_record_calls_remember(self):
+        remember_mock = MagicMock(return_value=True)
+        backend = MnemosyneBackend(remember=remember_mock)
+        v = _make_verdict("memory")
+        await backend.record(v)
+        remember_mock.assert_called_once()
+        _, kwargs = remember_mock.call_args
+        self.assertTrue(kwargs["metadata"].get("memcheck"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_reflection_loop.py
+++ b/mcp/tests/test_reflection_loop.py
@@ -1,10 +1,17 @@
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-import server
+# Ensure mcp/ is on sys.path (also handled by conftest.py; belt-and-suspenders
+# guard for direct `python test_reflection_loop.py` invocations).
+_MCP_DIR = str(Path(__file__).resolve().parent.parent)
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+import server  # noqa: E402
 
 
 class ReflectionLoopTests(unittest.TestCase):

--- a/mcp/verdict_ops.py
+++ b/mcp/verdict_ops.py
@@ -19,6 +19,7 @@ logger = logging.getLogger("loci-mcp")
 
 _verdict_backend = None                # QdrantBackend for hermes_verdicts (pre_answer_check)
 _verdict_backend_failed = False        # permanent-failure sentinel — don't retry
+_verdict_backend_lock = threading.Lock()  # guards _verdict_backend lazy-init (#106)
 
 
 def _get_verdict_backend():
@@ -33,25 +34,30 @@ def _get_verdict_backend():
         return None
     if _verdict_backend is not None:
         return _verdict_backend
-    qdrant_url = os.environ.get("QDRANT_URL", "")
-    if not qdrant_url:
-        return None
-    try:
-        from memcheck.qdrant import QdrantBackend
-        from qdrant_client import QdrantClient
-        _vb_api_key = os.environ.get("QDRANT_API_KEY", "") or None
-        client = QdrantClient(url=qdrant_url, api_key=_vb_api_key, timeout=5)
-        _verdict_backend = QdrantBackend(
-            client,
-            collection="hermes_verdicts",
-            embed=_embed,
-            vector_name="dense",
-        )
-        return _verdict_backend
-    except Exception as exc:
-        logger.debug("Verdict backend unavailable: %s", exc)
-        _verdict_backend_failed = True
-        return None
+    with _verdict_backend_lock:
+        if _verdict_backend_failed:
+            return None
+        if _verdict_backend is not None:
+            return _verdict_backend
+        qdrant_url = os.environ.get("QDRANT_URL", "")
+        if not qdrant_url:
+            return None
+        try:
+            from memcheck.qdrant import QdrantBackend
+            from qdrant_client import QdrantClient
+            _vb_api_key = os.environ.get("QDRANT_API_KEY", "") or None
+            client = QdrantClient(url=qdrant_url, api_key=_vb_api_key, timeout=5)
+            _verdict_backend = QdrantBackend(
+                client,
+                collection="hermes_verdicts",
+                embed=_embed,
+                vector_name="dense",
+            )
+            return _verdict_backend
+        except Exception as exc:
+            logger.debug("Verdict backend unavailable: %s", exc)
+            _verdict_backend_failed = True
+            return None
 
 
 def _record_claim_verdicts(


### PR DESCRIPTION
Closes #86
Closes #89
Closes #101
Closes #105
Closes #106

## Changes
- Thread-safe FIFO eviction for embed caches (#86)
- Bounded _manifest_cache with FIFO eviction (#89)
- WeakValueDictionary for _investigation_locks (#101)
- Sanitized error responses, no raw repr() in outputs (#105)
- Locked lazy-init globals (#106)

*Generated by loci-fix-sweep*