### PR TITLE
fix: re-indent the .env loader in mnemosyne_qdrant_sync

### DIFF
--- a/scripts/mnemosyne_qdrant_sync.py
+++ b/scripts/mnemosyne_qdrant_sync.py
@@ -11,10 +11,10 @@ _ENV_FILE = os.path.expanduser(os.environ.get("HERMES_ENV_FILE", "~/.hermes/.env
 if os.path.exists(_ENV_FILE):
     with open(_ENV_FILE) as _env_fh:
         for _line in _env_fh:
-        _line = _line.strip()
-        if _line and not _line.startswith("#") and "=" in _line:
-            _k, _v = _line.split("=", 1)
-            os.environ.setdefault(_k.strip(), _v.strip())
+            _line = _line.strip()
+            if _line and not _line.startswith("#") and "=" in _line:
+                _k, _v = _line.split("=", 1)
+                os.environ.setdefault(_k.strip(), _v.strip())
 
 QDRANT       = os.environ.get("QDRANT_URL")
 EMBED_WORKER = os.environ.get("EMBED_WORKER_URL")


### PR DESCRIPTION
`scripts/mnemosyne_qdrant_sync.py` has not parsed since #166. That PR replaced

```python
for _line in open(_ENV_FILE):
```

with a `with open(...) as _env_fh:` block and left the loop body at its original
indentation, so line 14 is an `IndentationError`.

Fallout on `main` since 2026-08-20:

| CI job | why it fails |
|---|---|
| Lint (ruff) | `invalid-syntax` on the file |
| Dead code (vulture) | same parse error |
| Sync script tests | `test_qdrant_sync_collections.py` imports it → collection aborts for the whole directory, so **0 of 566 tests ran** |

And the sync script itself dies at import, so the Mnemosyne→Qdrant cron has been
a no-op for four days.

Verified locally on this branch: ruff clean, vulture clean, whitelist check clean,
565/566 scripts tests pass (the one failure, `test_beam_fallback_returns_empty_when_mnemosyne_missing`,
is host-specific — it fails wherever `~/.hermes/mnemosyne` actually exists, since
the hook re-imports it from a hard-coded path; it passes on a clean runner).

The A2A job is red for an unrelated reason — tracked separately.