### PR TITLE
test: teach the rerank test double about the shared aiohttp session

### DIFF
--- a/a2a_server/tests/test_rag_rerank.py
+++ b/a2a_server/tests/test_rag_rerank.py
@@ -7,6 +7,7 @@ is acceptable, search erroring is not -- so most of these assert the fallback.
 """
 
 import asyncio
+import contextlib
 import importlib.util
 import os
 import pathlib
@@ -52,6 +53,9 @@ class _Resp:
 
 
 class _Session:
+    # _get_http_session() reuses the module-level session unless it is closed.
+    closed = False
+
     def __init__(self, resp=None, raise_on_post=None):
         self._resp = resp
         self._raise = raise_on_post
@@ -72,8 +76,17 @@ def run(coro):
     return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
 
 
+@contextlib.contextmanager
 def with_session(sess):
-    return mock.patch.object(a2a.aiohttp, "ClientSession", lambda *a, **kw: sess)
+    """Patch ClientSession and clear the cached one, so _get_http_session()
+    hands out `sess` and does not leak it into the next test."""
+    saved = a2a._http_session
+    a2a._http_session = None
+    try:
+        with mock.patch.object(a2a.aiohttp, "ClientSession", lambda *a, **kw: sess):
+            yield sess
+    finally:
+        a2a._http_session = saved
 
 
 class TestRerankDisabled(unittest.TestCase):


### PR DESCRIPTION
The A2A job on `main` is red:

```
FAILED tests/test_rag_rerank.py::TestRerankApplies::test_preserves_original_cosine_score - KeyError: 'cosine_score'
FAILED tests/test_rag_rerank.py::TestRerankApplies::test_reorders_by_relevance - AssertionError: False is not true
WARNING a2a_rerank_impl:server.py:853 rerank: AttributeError("'_Session' object has no attribute 'closed'") — keeping cosine order
```

#168 (issue #102) replaced the per-request `async with aiohttp.ClientSession()`
with a module-level `_get_http_session()`:

```python
if _http_session is None or _http_session.closed:
    _http_session = aiohttp.ClientSession(...)
```

Two consequences for the tests, neither of which affects production:

1. The `_Session` double has no `.closed`, so the attribute read raises and
   `_rerank` fails open — correct behaviour, wrong test outcome. Fixed with a
   `closed = False` class attribute.
2. `_get_http_session()` now *caches*. `with_session()` only patched the
   constructor, so the first fake installed was reused by every later test in
   the process regardless of what that test patched in. `with_session()` is now
   a context manager that clears `a2a._http_session` on entry and restores it on
   exit.

94/94 A2A tests pass on this branch.