### PR TITLE
fix(security): drop the hardcoded Qdrant key default in ua-ingest (#79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,15 @@ jobs:
                      --select E9,F401,F811,F821,F841 \
                      --ignore E402
 
+      # A live Qdrant key shipped for two months as an os.environ.get() default
+      # (#79). Anything key-shaped in that position is a secret, not a default.
+      - name: Reject secret-shaped env defaults
+        run: |
+          if git grep -nIE 'os\.(environ\.get|getenv)\([^)]*"[0-9a-fA-F]{32,}"' -- '*.py'; then
+            echo "::error::hardcoded secret as an environment-variable default"
+            exit 1
+          fi
+
   type-check:
     name: Type check (mypy)
     runs-on: ubuntu-latest

--- a/scripts/ua-ingest.py
+++ b/scripts/ua-ingest.py
@@ -39,7 +39,7 @@ from datetime import datetime, timezone
 
 # ── Config from env or defaults ────────────────────────────────────────────
 QDRANT_URL  = os.environ.get("QDRANT_URL")
-QDRANT_KEY  = os.environ.get("QDRANT_KEY",  "8324728be0accd776f7450ae9e5e4f8ebd155c48a4cfbc3d3d94e7490aaa60ab")
+QDRANT_KEY  = os.environ.get("QDRANT_KEY", "")
 OLLAMA_URL  = os.environ.get("OLLAMA_URL")
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 COLLECTION  = os.environ.get("UA_COLLECTION", "understand_anything")
@@ -142,6 +142,9 @@ def main():
     if len(sys.argv) < 2:
         print("Usage: ua-ingest.py <project_root>")
         sys.exit(1)
+
+    if not QDRANT_URL:
+        sys.exit("ERROR: QDRANT_URL is required")
 
     project_root = os.path.abspath(sys.argv[1])
     ua_dir       = os.path.join(project_root, ".understand-anything")


### PR DESCRIPTION
Closes nothing on its own — see the caveat at the bottom.

`scripts/ua-ingest.py:42` shipped a live 64-hex Qdrant API key as the default
value of `os.environ.get("QDRANT_KEY", ...)`. The repo has been public since
2026-06-18, has one fork and has been cloneable with those credentials the whole
time. `QDRANT_URL` has no default, which is the only thing that kept this from
being point-and-shoot.

This PR:

- defaults `QDRANT_KEY` to `""` (a keyless Qdrant is still valid, so it is not
  made mandatory) and makes `QDRANT_URL` a hard requirement instead of letting
  the script build `Nonehttp://...` URLs;
- adds a CI gate in the lint job that fails on any secret-shaped
  `os.environ.get()` / `os.getenv()` default. Verified it fires on `main` and is
  clean on this branch.

**Still outstanding, and neither is a code change:**

1. **Rotate the key.** It is in git history and in at least one fork; removing
   it from `main` does not revoke it.
2. Decide whether to rewrite history (`git filter-repo`) — a force-push on a
   public repo with an existing fork, so it needs a deliberate call rather than
   a drive-by.

Worth enabling GitHub secret scanning + push protection on the repo as well;
it is free for public repos and would have caught this at push time.