### PR TITLE
fix: close the cron SQLite connections on the failure path (#80)

### DIFF
--- a/scripts/agentHER_relabeler.py
+++ b/scripts/agentHER_relabeler.py
@@ -217,60 +217,61 @@ def main():
         sys.exit(1)
 
     conn = sqlite3.connect(MNEMOSYNE_DB)
-    rows = load_failures(conn)
-    n_processed = 0
-    n_relabeled = 0
-    n_stored = 0
+    try:
+        rows = load_failures(conn)
+        n_processed = 0
+        n_relabeled = 0
+        n_stored = 0
 
-    for row in rows:
-        row_id, content, importance, created_at, session_id = row
-        n_processed += 1
+        for row in rows:
+            row_id, content, importance, created_at, session_id = row
+            n_processed += 1
 
-        # Step a: generate relabel via Ollama
-        try:
-            relabeled = generate_relabel(content)
-        except Exception as e:
-            print(f"[agentHER] gen error row {row_id}: {e}", file=sys.stderr)
-            continue
+            # Step a: generate relabel via Ollama
+            try:
+                relabeled = generate_relabel(content)
+            except Exception as e:
+                print(f"[agentHER] gen error row {row_id}: {e}", file=sys.stderr)
+                continue
 
-        if relabeled is None:
-            print(f"[agentHER] no response for row {row_id}", file=sys.stderr)
-            continue
+            if relabeled is None:
+                print(f"[agentHER] no response for row {row_id}", file=sys.stderr)
+                continue
 
-        # Step b: validate response
-        if not (relabeled.startswith("This trace") and len(relabeled) > 20):
-            continue
+            # Step b: validate response
+            if not (relabeled.startswith("This trace") and len(relabeled) > 20):
+                continue
 
-        n_relabeled += 1
+            n_relabeled += 1
 
-        synthetic = f"AGENTHER_POSITIVE: {relabeled}\nOriginal: {content[:200]}"
+            synthetic = f"AGENTHER_POSITIVE: {relabeled}\nOriginal: {content[:200]}"
 
-        # Step c: embed
-        vec = embed(synthetic)
-        if vec is None:
-            print(f"[agentHER] embed failed for row {row_id}", file=sys.stderr)
-            continue
+            # Step c: embed
+            vec = embed(synthetic)
+            if vec is None:
+                print(f"[agentHER] embed failed for row {row_id}", file=sys.stderr)
+                continue
 
-        # Step d: upsert to Qdrant
-        point_id = stable_id(synthetic)
-        qdrant_payload = {
-            "content": synthetic,
-            "importance": 6,
-            "source": "agentHER",
-            "original_id": str(row_id),
-        }
-        upserted = qdrant_upsert(point_id, vec, qdrant_payload)
-        if not upserted:
-            print(f"[agentHER] qdrant upsert failed for row {row_id}", file=sys.stderr)
+            # Step d: upsert to Qdrant
+            point_id = stable_id(synthetic)
+            qdrant_payload = {
+                "content": synthetic,
+                "importance": 6,
+                "source": "agentHER",
+                "original_id": str(row_id),
+            }
+            upserted = qdrant_upsert(point_id, vec, qdrant_payload)
+            if not upserted:
+                print(f"[agentHER] qdrant upsert failed for row {row_id}", file=sys.stderr)
 
-        # Step e: store in Mnemosyne DB
-        try:
-            store_synthetic(conn, synthetic)
-            n_stored += 1
-        except Exception as e:
-            print(f"[agentHER] db insert error row {row_id}: {e}", file=sys.stderr)
-
-    conn.close()
+            # Step e: store in Mnemosyne DB
+            try:
+                store_synthetic(conn, synthetic)
+                n_stored += 1
+            except Exception as e:
+                print(f"[agentHER] db insert error row {row_id}: {e}", file=sys.stderr)
+    finally:
+        conn.close()
     print(f"[agentHER] processed {n_processed}, relabeled {n_relabeled}, stored {n_stored}")
 
 

--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -145,129 +145,130 @@ def main() -> None:
         gate = None
 
     conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    cur = conn.cursor()
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
 
-    # ------------------------------------------------------------------
-    # Load recent entries
-    # ------------------------------------------------------------------
-    cur.execute(
-        "SELECT id, content, created_at FROM working_memory ORDER BY created_at DESC LIMIT ?",
-        (MAX_PER_RUN,),
-    )
-    rows = cur.fetchall()
+        # ------------------------------------------------------------------
+        # Load recent entries
+        # ------------------------------------------------------------------
+        cur.execute(
+            "SELECT id, content, created_at FROM working_memory ORDER BY created_at DESC LIMIT ?",
+            (MAX_PER_RUN,),
+        )
+        rows = cur.fetchall()
 
-    if len(rows) < 2:
-        print("[amem] not enough entries to compare — skipping")
-        conn.close()
-        return
+        if len(rows) < 2:
+            print("[amem] not enough entries to compare — skipping")
+            return
 
-    # ------------------------------------------------------------------
-    # Phase 1 — Embed all entries
-    # ------------------------------------------------------------------
-    entries: list[tuple[str, str, list[float], str]] = []
-    for row in rows:
-        vec = embed(row["content"])
-        entries.append((row["id"], row["content"], vec, row["created_at"] or ""))
+        # ------------------------------------------------------------------
+        # Phase 1 — Embed all entries
+        # ------------------------------------------------------------------
+        entries: list[tuple[str, str, list[float], str]] = []
+        for row in rows:
+            vec = embed(row["content"])
+            entries.append((row["id"], row["content"], vec, row["created_at"] or ""))
 
-    # ------------------------------------------------------------------
-    # Phase 1 — Pairwise cosine → cross-links
-    # ------------------------------------------------------------------
-    new_links = 0
-    flagged_conflicts = 0
+        # ------------------------------------------------------------------
+        # Phase 1 — Pairwise cosine → cross-links
+        # ------------------------------------------------------------------
+        new_links = 0
+        flagged_conflicts = 0
 
-    n = len(entries)
-    causal_links = 0
-    update_links = 0
+        n = len(entries)
+        causal_links = 0
+        update_links = 0
 
-    for i in range(n):
-        id_a, content_a, vec_a, ts_a = entries[i]
-        for j in range(i + 1, n):
-            id_b, content_b, vec_b, ts_b = entries[j]
+        for i in range(n):
+            id_a, content_a, vec_a, ts_a = entries[i]
+            for j in range(i + 1, n):
+                id_b, content_b, vec_b, ts_b = entries[j]
 
-            sim = cosine(vec_a, vec_b)
+                sim = cosine(vec_a, vec_b)
 
-            if sim > AMEM_LINK_THRESHOLD:
-                cur.execute(
-                    """
-                    INSERT OR IGNORE INTO graph_edges
-                        (source, target, edge_type, weight, timestamp, created_at)
-                    VALUES (?, ?, 'semantic_link', ?, ?, ?)
-                    """,
-                    (id_a, id_b, sim, now, now),
-                )
-                if cur.rowcount:
-                    new_links += 1
-
-                # ------------------------------------------------------
-                # Phase 2 — Conflict detection (subset of linked pairs)
-                # ------------------------------------------------------
-                if sim > AMEM_CONFLICT_THRESHOLD and has_contradiction(content_a, content_b):
-                    cur.execute(
-                        """
-                        INSERT OR IGNORE INTO conflicts
-                            (fact_a_id, fact_b_id, conflict_type, created_at)
-                        VALUES (?, ?, 'near_duplicate_divergent', ?)
-                        """,
-                        (id_a, id_b, now),
-                    )
-                    if cur.rowcount:
-                        flagged_conflicts += 1
-                    # Also add contradicts edge for causal traversal
+                if sim > AMEM_LINK_THRESHOLD:
                     cur.execute(
                         """
                         INSERT OR IGNORE INTO graph_edges
                             (source, target, edge_type, weight, timestamp, created_at)
-                        VALUES (?, ?, 'contradicts', ?, ?, ?)
+                        VALUES (?, ?, 'semantic_link', ?, ?, ?)
                         """,
                         (id_a, id_b, sim, now, now),
                     )
+                    if cur.rowcount:
+                        new_links += 1
 
-                # ------------------------------------------------------
-                # Phase 3 — Causal edge detection (ActMem/GAM pattern)
-                # updated_by: high similarity + B is newer + B has update signal
-                # caused_by: B explicitly references A or uses causal phrasing
-                # ------------------------------------------------------
-                if sim >= AMEM_UPDATE_THRESHOLD:
-                    newer, older = (id_b, id_a) if ts_b > ts_a else (id_a, id_b)
-                    newer_content = content_b if ts_b > ts_a else content_a
-                    if _has_update_signal(newer_content):
+                    # ------------------------------------------------------
+                    # Phase 2 — Conflict detection (subset of linked pairs)
+                    # ------------------------------------------------------
+                    if sim > AMEM_CONFLICT_THRESHOLD and has_contradiction(content_a, content_b):
+                        cur.execute(
+                            """
+                            INSERT OR IGNORE INTO conflicts
+                                (fact_a_id, fact_b_id, conflict_type, created_at)
+                            VALUES (?, ?, 'near_duplicate_divergent', ?)
+                            """,
+                            (id_a, id_b, now),
+                        )
+                        if cur.rowcount:
+                            flagged_conflicts += 1
+                        # Also add contradicts edge for causal traversal
                         cur.execute(
                             """
                             INSERT OR IGNORE INTO graph_edges
                                 (source, target, edge_type, weight, timestamp, created_at)
-                            VALUES (?, ?, 'updated_by', ?, ?, ?)
+                            VALUES (?, ?, 'contradicts', ?, ?, ?)
                             """,
-                            (older, newer, sim, now, now),
+                            (id_a, id_b, sim, now, now),
+                        )
+
+                    # ------------------------------------------------------
+                    # Phase 3 — Causal edge detection (ActMem/GAM pattern)
+                    # updated_by: high similarity + B is newer + B has update signal
+                    # caused_by: B explicitly references A or uses causal phrasing
+                    # ------------------------------------------------------
+                    if sim >= AMEM_UPDATE_THRESHOLD:
+                        newer, older = (id_b, id_a) if ts_b > ts_a else (id_a, id_b)
+                        newer_content = content_b if ts_b > ts_a else content_a
+                        if _has_update_signal(newer_content):
+                            cur.execute(
+                                """
+                                INSERT OR IGNORE INTO graph_edges
+                                    (source, target, edge_type, weight, timestamp, created_at)
+                                VALUES (?, ?, 'updated_by', ?, ?, ?)
+                                """,
+                                (older, newer, sim, now, now),
+                            )
+                            if cur.rowcount:
+                                update_links += 1
+
+                    if _has_causal_signal(content_b, id_a):
+                        cur.execute(
+                            """
+                            INSERT OR IGNORE INTO graph_edges
+                                (source, target, edge_type, weight, timestamp, created_at)
+                            VALUES (?, ?, 'caused_by', ?, ?, ?)
+                            """,
+                            (id_b, id_a, sim, now, now),
                         )
                         if cur.rowcount:
-                            update_links += 1
+                            causal_links += 1
+                    elif _has_causal_signal(content_a, id_b):
+                        cur.execute(
+                            """
+                            INSERT OR IGNORE INTO graph_edges
+                                (source, target, edge_type, weight, timestamp, created_at)
+                            VALUES (?, ?, 'caused_by', ?, ?, ?)
+                            """,
+                            (id_a, id_b, sim, now, now),
+                        )
+                        if cur.rowcount:
+                            causal_links += 1
 
-                if _has_causal_signal(content_b, id_a):
-                    cur.execute(
-                        """
-                        INSERT OR IGNORE INTO graph_edges
-                            (source, target, edge_type, weight, timestamp, created_at)
-                        VALUES (?, ?, 'caused_by', ?, ?, ?)
-                        """,
-                        (id_b, id_a, sim, now, now),
-                    )
-                    if cur.rowcount:
-                        causal_links += 1
-                elif _has_causal_signal(content_a, id_b):
-                    cur.execute(
-                        """
-                        INSERT OR IGNORE INTO graph_edges
-                            (source, target, edge_type, weight, timestamp, created_at)
-                        VALUES (?, ?, 'caused_by', ?, ?, ?)
-                        """,
-                        (id_a, id_b, sim, now, now),
-                    )
-                    if cur.rowcount:
-                        causal_links += 1
-
-    conn.commit()
-    conn.close()
+        conn.commit()
+    finally:
+        conn.close()
 
     print(f"[amem] {new_links} new cross-links created")
     print(f"[amem] {flagged_conflicts} conflicts flagged")

--- a/scripts/ebbinghaus_consolidation.py
+++ b/scripts/ebbinghaus_consolidation.py
@@ -263,80 +263,81 @@ def main() -> None:
         sys.exit(1)
 
     conn = sqlite3.connect(DB_PATH)
+    try:
 
-    print(f"[info] scanning working_memory + episodic_memory in {DB_PATH}")
-    all_rows = fetch_candidates(conn)
-    print(f"[info] {len(all_rows)} rows with content > 20 chars")
+        print(f"[info] scanning working_memory + episodic_memory in {DB_PATH}")
+        all_rows = fetch_candidates(conn)
+        print(f"[info] {len(all_rows)} rows with content > 20 chars")
 
-    decayed = []
-    for (table, row_id, content, recall_count, last_recalled, created_at, importance) in all_rows:
-        r = retention(recall_count or 0, last_recalled, created_at)
-        if r < FORGET_THRESH:
-            decayed.append((r, table, row_id, content, recall_count or 0, last_recalled, created_at, importance))
-
-    # Lowest retention first (most-forgotten first)
-    decayed.sort(key=lambda x: x[0])
-    batch = decayed[:MAX_PER_RUN]
-
-    print(f"[info] {len(decayed)} entries below forget threshold {FORGET_THRESH}, processing {len(batch)}")
-
-    processed = 0
-    errors = 0
-
-    for (r, table, row_id, content, recall_count, last_recalled, created_at, importance) in batch:
-        try:
-            print(f"  [{table}:{row_id}] R={r:.4f}  refreshing …", end=" ", flush=True)
-
-            # FSRS: read existing stability from Qdrant payload if available
-            # (first run: None → computed from recall_count + importance)
-            existing_stability = None  # will be overridden once payloads carry fsrs_stability
-            d_init = _init_difficulty(importance or 5.0)
-            s_current = existing_stability or _stability_from_count(recall_count or 0, d_init)
-
+        decayed = []
+        for (table, row_id, content, recall_count, last_recalled, created_at, importance) in all_rows:
+            r = retention(recall_count or 0, last_recalled, created_at)
             if r < FORGET_THRESH:
-                # Forgotten: penalise stability, increase difficulty
-                new_stability = _update_stability_failure(s_current)
-                grade = _grade_from_retention(r)
-                new_difficulty = _update_difficulty(d_init, grade)
-            else:
-                # Scheduled refresh (not forgotten): stability update on successful recall
-                grade = _grade_from_retention(r)
-                new_stability = _update_stability_success(s_current, r, d_init)
-                new_difficulty = _update_difficulty(d_init, grade)
+                decayed.append((r, table, row_id, content, recall_count or 0, last_recalled, created_at, importance))
 
-            # (a) Embed
-            vec = embed(content)
+        # Lowest retention first (most-forgotten first)
+        decayed.sort(key=lambda x: x[0])
+        batch = decayed[:MAX_PER_RUN]
 
-            # (b) Upsert to Qdrant
-            point_id = stable_id(content)
-            ts = now_iso()
-            qdrant_upsert(
-                point_id=point_id,
-                vector=vec,
-                payload={
-                    "content": content,
-                    "importance": importance,
-                    "last_refreshed": ts,
-                    "decay_score": r,
-                    "fsrs_stability": round(new_stability, 4),
-                    "fsrs_difficulty": round(new_difficulty, 4),
-                    "mnemosyne_id": str(row_id),
-                    "mnemosyne_table": table,
-                },
-                api_key=api_key,
-            )
+        print(f"[info] {len(decayed)} entries below forget threshold {FORGET_THRESH}, processing {len(batch)}")
 
-            # (c) Update SQLite
-            update_recall(conn, table, row_id, recall_count + 1, ts)
+        processed = 0
+        errors = 0
 
-            processed += 1
-            print(f"ok  S={new_stability:.3f} D={new_difficulty:.3f}")
+        for (r, table, row_id, content, recall_count, last_recalled, created_at, importance) in batch:
+            try:
+                print(f"  [{table}:{row_id}] R={r:.4f}  refreshing …", end=" ", flush=True)
 
-        except Exception as exc:  # noqa: BLE001
-            errors += 1
-            print(f"ERROR: {exc}")
+                # FSRS: read existing stability from Qdrant payload if available
+                # (first run: None → computed from recall_count + importance)
+                existing_stability = None  # will be overridden once payloads carry fsrs_stability
+                d_init = _init_difficulty(importance or 5.0)
+                s_current = existing_stability or _stability_from_count(recall_count or 0, d_init)
 
-    conn.close()
+                if r < FORGET_THRESH:
+                    # Forgotten: penalise stability, increase difficulty
+                    new_stability = _update_stability_failure(s_current)
+                    grade = _grade_from_retention(r)
+                    new_difficulty = _update_difficulty(d_init, grade)
+                else:
+                    # Scheduled refresh (not forgotten): stability update on successful recall
+                    grade = _grade_from_retention(r)
+                    new_stability = _update_stability_success(s_current, r, d_init)
+                    new_difficulty = _update_difficulty(d_init, grade)
+
+                # (a) Embed
+                vec = embed(content)
+
+                # (b) Upsert to Qdrant
+                point_id = stable_id(content)
+                ts = now_iso()
+                qdrant_upsert(
+                    point_id=point_id,
+                    vector=vec,
+                    payload={
+                        "content": content,
+                        "importance": importance,
+                        "last_refreshed": ts,
+                        "decay_score": r,
+                        "fsrs_stability": round(new_stability, 4),
+                        "fsrs_difficulty": round(new_difficulty, 4),
+                        "mnemosyne_id": str(row_id),
+                        "mnemosyne_table": table,
+                    },
+                    api_key=api_key,
+                )
+
+                # (c) Update SQLite
+                update_recall(conn, table, row_id, recall_count + 1, ts)
+
+                processed += 1
+                print(f"ok  S={new_stability:.3f} D={new_difficulty:.3f}")
+
+            except Exception as exc:  # noqa: BLE001
+                errors += 1
+                print(f"ERROR: {exc}")
+    finally:
+        conn.close()
     print(f"[done] processed={processed} errors={errors}")
 
 


### PR DESCRIPTION
Closes #80.

All three scripts had the same shape: `conn = sqlite3.connect(...)` at the top of
`main()`, `conn.close()` at the bottom, and nothing in between guarding the
exception path. Every cron invocation that died on an embed or upsert call —
which is the normal failure mode when Ollama or Qdrant is unreachable — leaked
the handle.

- `scripts/amem_consolidation.py` — also drops the early `conn.close()` on the
  "not enough entries" return, now handled by the `finally`
- `scripts/ebbinghaus_consolidation.py`
- `scripts/agentHER_relabeler.py`

Verified on `amem_consolidation`, with `sqlite3.connect` instrumented to hold the
connection:

```
raised as expected: URLError
RESULT: connection CLOSED by finally — Cannot operate on a closed database.
```

and the early-return path still prints `[amem] not enough entries to compare — skipping`
against a two-column temp DB. `scripts/` tests unchanged at 565 passing.