### PR TITLE
test: find the dispatch callsite by graph, not by line number

### DIFF
--- a/scripts/callgraph/tests/test_cli.py
+++ b/scripts/callgraph/tests/test_cli.py
@@ -190,15 +190,12 @@ def test_callers_skill_shows_dispatch_row_as_one_of_thirteen(capsys):
 
 
 def test_explain_dispatch_callsite_lists_all_thirteen_candidates(capsys):
-    code, out = _run(capsys, ["explain", "a2a_server/server.py:1444", "--rev", "HEAD", "--scope", "a2a_server/"])
-    if "no CALLSITE found" in out:
-        # The dispatch callsite's line can drift; fall back to locating it
-        # via the JSON callers output for skill_memory_recall instead of a
-        # hardcoded line number.
-        _, callers_out = _run(capsys, ["callers", "a2a_server/server.py::skill_memory_recall", "--rev", "HEAD", "--format", "json"])
-        rows = json.loads(callers_out)
-        disp = [r for r in rows if r["kind"] == "DISPATCHES"][0]
-        code, out = _run(capsys, ["explain", disp["src"], "--rev", "HEAD"])
+    # Locate the callsite through the graph. A hardcoded line number drifts with
+    # every edit above it, and the miss is reported on stderr, so a fallback
+    # keyed on stdout never fires.
+    _, callers_out = _run(capsys, ["callers", "a2a_server/server.py::skill_memory_recall", "--rev", "HEAD", "--format", "json"])
+    disp = [r for r in json.loads(callers_out) if r["kind"] == "DISPATCHES"][0]
+    code, out = _run(capsys, ["explain", disp["src"], "--rev", "HEAD", "--scope", "a2a_server/"])
     assert code == 0
     assert out.count("DISPATCHES ->") == 13
     assert "1 of 13" in out


### PR DESCRIPTION
`test_explain_dispatch_callsite_lists_all_thirteen_candidates` fails on `main`
with `assert 2 == 0`.

The test starts from a hardcoded `a2a_server/server.py:1444` and has a fallback
for exactly the drift that happened — #168 moved the dispatch callsite to 1477 —
but the fallback is guarded on

```python
if "no CALLSITE found" in out:
```

and `explain` prints that message to **stderr**. `out` is stdout, which is empty,
so the branch never fires and the initial exit code 2 falls through to the
assert. Confirmed by capturing both streams:

```
STEP1 2 '' ERR "# no CALLSITE found for 'a2a_server/server.py:1444' ..."
```

The fallback was the right idea, so it is now the only path: locate the callsite
from the JSON `callers` output and pass that id to `explain`. No line number to
drift, and `--scope a2a_server/` keeps the build at 2 files instead of 115.

`scripts/callgraph/tests/test_cli.py`: 28 passed, 1 skipped.

The other seven callgraph failures on `main` are all downstream of the
`mnemosyne_qdrant_sync.py` parse error and clear with #176 — 8 failed → 1 failed
with that fix alone, and this is the one.