### PR TITLE
fix: make the container build and the HTTP transports start (#174, #175)

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -106,3 +106,8 @@ _ = recall_decision
 # `conn.row_factory = sqlite3.Row` is a write the stdlib reads back; there is
 # no root model that makes this resolvable, so it is suppressed by name.
 _ = row_factory
+
+# ── FastMCP settings written by main()
+# `mcp.settings.port` is read inside FastMCP.run() when it builds the uvicorn
+# config; there is no in-repo read, so vulture calls the write dead.
+_ = port

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -8,12 +8,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Dependencies first — layer cache friendly
-COPY requirements.txt pyproject.toml ./
-COPY memcheck/ ./memcheck/
-RUN pip install --no-cache-dir -e .
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
-COPY server.py .env.example ./
+# Then the source. server.py imports its siblings by module name, so they all
+# have to be here; the editable install goes last, with the packages present.
+COPY pyproject.toml .env.example ./
+COPY *.py ./
+COPY memcheck/ ./memcheck/
+COPY graph/ ./graph/
 COPY tests/ ./tests/
+RUN pip install --no-cache-dir --no-deps -e .
 
 # fastembed downloads ONNX models on first embed; mount a cache volume to
 # avoid re-downloading across restarts.

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -7722,9 +7722,11 @@ def main() -> None:
         logger.debug("main: fail-open swallow: %r", exc)
     transport = os.environ.get("HERMES_MCP_TRANSPORT", "stdio")
     if transport in ("sse", "streamable-http"):
-        host = os.environ.get("HERMES_MCP_HOST", "0.0.0.0")
-        port = int(os.environ.get("HERMES_MCP_PORT", "8000"))
-        mcp.run(transport=transport, host=host, port=port)
+        # FastMCP.run() takes only transport and mount_path; the bind address
+        # lives on settings.
+        mcp.settings.host = os.environ.get("HERMES_MCP_HOST", "0.0.0.0")
+        mcp.settings.port = int(os.environ.get("HERMES_MCP_PORT", "8000"))
+        mcp.run(transport=transport)
     else:
         mcp.run(transport="stdio")
 

--- a/mcp/tests/test_main_transport.py
+++ b/mcp/tests/test_main_transport.py
@@ -1,0 +1,46 @@
+"""main()'s transport dispatch.
+
+FastMCP.run() accepts only (transport, mount_path) — passing host/port raises
+TypeError, so every non-stdio transport died at startup. The bind address has to
+go on mcp.settings instead.
+"""
+import os
+from unittest import mock
+
+import server
+
+
+def _run_main(env):
+    with mock.patch.dict(os.environ, env, clear=True), \
+         mock.patch.object(server.mcp, "run") as run, \
+         mock.patch.object(server, "logger"):
+        server.main()
+    return run
+
+
+def test_stdio_is_the_default():
+    run = _run_main({})
+    run.assert_called_once_with(transport="stdio")
+
+
+def test_sse_binds_via_settings():
+    run = _run_main({
+        "HERMES_MCP_TRANSPORT": "sse",
+        "HERMES_MCP_HOST": "127.0.0.1",
+        "HERMES_MCP_PORT": "9001",
+    })
+    run.assert_called_once_with(transport="sse")
+    assert server.mcp.settings.host == "127.0.0.1"
+    assert server.mcp.settings.port == 9001
+
+
+def test_streamable_http_defaults_the_bind():
+    run = _run_main({"HERMES_MCP_TRANSPORT": "streamable-http"})
+    run.assert_called_once_with(transport="streamable-http")
+    assert server.mcp.settings.host == "0.0.0.0"
+    assert server.mcp.settings.port == 8000
+
+
+def test_unknown_transport_falls_back_to_stdio():
+    run = _run_main({"HERMES_MCP_TRANSPORT": "carrier-pigeon"})
+    run.assert_called_once_with(transport="stdio")


### PR DESCRIPTION
Closes #174. Closes #175. Both reported by @SamG0ld against `0311181`, both reproduced.

### #174 — the image never had the application in it

`mcp/Dockerfile` copied `server.py` and nothing else, so the container
crash-looped on `ModuleNotFoundError: No module named 'qdrant_ops'`, and
`pip install -e .` ran before any source existed.

Reordered so the layer cache still works: `requirements.txt` (identical list to
the `pyproject.toml` dependencies) installs first, then the source, then
`pip install --no-deps -e .` with the packages actually present.

`ls /app` in the rebuilt image now has all 20 modules plus `graph/` and
`memcheck/`.

### #175 — `FastMCP.run()` does not take host/port

```python
mcp.run(transport=transport, host=host, port=port)
```

`FastMCP.run()` is `(transport, mount_path)`; the bind address lives on
`settings`. This is not new in 1.29 — 1.27 has the same signature, so any
non-stdio transport has been dead across most of the `mcp[cli]>=1.2.0,<2` range,
in venv installs as well as Docker. Now:

```python
mcp.settings.host = os.environ.get("HERMES_MCP_HOST", "0.0.0.0")
mcp.settings.port = int(os.environ.get("HERMES_MCP_PORT", "8000"))
mcp.run(transport=transport)
```

`mcp/tests/test_main_transport.py` covers stdio, sse, streamable-http and an
unrecognised transport — 4 passed. The pin is left alone; setting `settings`
works on both sides of the signature change.

### Verified end to end

```
$ docker build -t loci-mcp-verify:pr ./mcp        # Successfully built
$ docker run -d -e HERMES_MCP_TRANSPORT=sse ...
$ docker ps -a --format '{{.Status}}'
Up 37 seconds (healthy)
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:35440 - "GET /health HTTP/1.1" 200 OK
$ docker exec loci-verify python3 -c "...urlopen('http://localhost:8000/health')..."
200 b'{"status":"ok","server":"loci"}'
```

`a2a_server/Dockerfile` was checked for the same defect — `server.py` and
`client.py` really are the whole module set there, so it is fine.