### PR TITLE
fix(memory): call the Qdrant API that still exists

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1719,6 +1719,50 @@ def _has_negation(text: str) -> bool:
     return any(marker in lower for marker in _NEGATION_MARKERS)
 
 
+_CONFLICT_NEGATION_HEURISTIC = os.environ.get("LOCI_CONFLICT_NEGATION_HEURISTIC", "") == "1"
+
+
+def _query_points_compat(
+    client,
+    collection: str,
+    dense_vec,
+    *,
+    limit: int,
+    query_filter=None,
+    score_threshold: Optional[float] = None,
+    search_params=None,
+) -> list:
+    """Dense vector search over ``collection``, returning the raw point list.
+
+    ``QdrantClient.search()`` was removed in qdrant-client 1.16 — inside this
+    project's own ``>=1.17.0,<1.19.0`` pin — so on every supported client the
+    attribute lookup raised before any request was made. Both callers wrapped
+    that in a bare except, so the removal read as "found nothing" rather than as
+    a fault. ``query_points()`` is the replacement.
+
+    Named-vector collections need ``using="dense"`` and flat ones reject it, so
+    try named first and fall back rather than probing the collection config.
+    """
+    kwargs = {
+        "collection_name": collection,
+        "query": dense_vec,
+        "limit": limit,
+        "with_payload": True,
+    }
+    if query_filter is not None:
+        kwargs["query_filter"] = query_filter
+    if score_threshold is not None:
+        kwargs["score_threshold"] = score_threshold
+    if search_params is not None:
+        kwargs["search_params"] = search_params
+
+    try:
+        return client.query_points(using="dense", **kwargs).points
+    except Exception as exc:
+        logger.debug("_query_points_compat: named-vector query failed (%r); retrying flat", exc)
+        return client.query_points(**kwargs).points
+
+
 def _detect_conflicts(investigation_id: str, new_finding: dict) -> list[dict]:
     """
     Search Qdrant for near-neighbors of new_finding (same investigation, cosine
@@ -1751,17 +1795,15 @@ def _detect_conflicts(investigation_id: str, new_finding: dict) -> list[dict]:
         try:
             from qdrant_client.models import SearchParams, QuantizationSearchParams
             _sp = SearchParams(quantization=QuantizationSearchParams(rescore=True, oversampling=2.0))
-            result = client.search(
-                collection_name=col,
-                query_vector=dense_vec,
+            result = _query_points_compat(
+                client, col, dense_vec,
                 query_filter=search_filter,
                 limit=10,
                 score_threshold=0.82,
-                with_payload=True,
                 search_params=_sp,
             )
-        except Exception:
-            # Some collection configurations use named vectors; fall back gracefully.
+        except Exception as exc:
+            logger.warning("_detect_conflicts: neighbour search failed: %r", exc)
             return []
 
         new_id = new_finding.get("id", "")
@@ -1792,8 +1834,14 @@ def _detect_conflicts(investigation_id: str, new_finding: dict) -> list[dict]:
             elif neighbor_type == "assumed" and new_type != "assumed":
                 is_conflict = True
 
-            # Heuristic 3: opposing negation markers
-            elif new_neg != neighbor_neg:
+            # Heuristic 3: opposing negation markers. Off by default — this is a
+            # bare token-presence scan, not a polarity comparison, and phrases like
+            # "no adverse records found" or "did not appear" are common enough that
+            # it manufactures conflicts from incidental wording. Measured in the
+            # 2026-08-19 upgrade pack against live hermes_memory: feeding a finding
+            # back verbatim flagged two `observed` neighbours at 0.892 and 0.8679
+            # through this heuristic alone, and an exact duplicate is agreement.
+            elif _CONFLICT_NEGATION_HEURISTIC and new_neg != neighbor_neg:
                 is_conflict = True
 
             if is_conflict:
@@ -6689,15 +6737,13 @@ def _confidence_retrieve(query: str, top_k: int) -> tuple[list, Optional[str]]:
         return [], "embed_failed"
 
     try:
-        results = client.search(
-            collection_name=col,
-            query_vector={"dense": emb} if isinstance(emb, list) else emb,
-            limit=top_k,
-            with_payload=True,
-        )
+        results = _query_points_compat(client, col, emb, limit=top_k)
     except Exception as exc:
-        logger.debug("memory_confidence search failed: %r", exc)
-        results = []
+        # NOT "no_trace": an empty list from a broken search is a different claim
+        # from an empty list from a healthy one, and the caller has to be able to
+        # tell them apart.
+        logger.warning("memory_confidence search failed: %r", exc)
+        return [], "search_failed"
 
     return results, None
 

--- a/mcp/tests/test_qdrant_backend.py
+++ b/mcp/tests/test_qdrant_backend.py
@@ -22,8 +22,18 @@ import types as _types
 import sys as _sys
 
 def _install_qdrant_stub():
-    """Install a minimal qdrant_client stub so qdrant.py's lazy imports succeed."""
-    if "qdrant_client" in _sys.modules:
+    """Install a minimal qdrant_client stub so qdrant.py's lazy imports succeed.
+
+    Only when the real package is genuinely absent. The guard used to be
+    `if "qdrant_client" in sys.modules` — whether it had been *imported yet*,
+    not whether it was installed — so on a normal run this stub landed first and
+    shadowed the installed client for the rest of the session. Every later test
+    that imported a model this stub does not define (SearchParams,
+    QuantizationSearchParams, ...) then took its except branch instead.
+    """
+    import importlib.util
+
+    if "qdrant_client" in _sys.modules or importlib.util.find_spec("qdrant_client"):
         return
 
     @dataclass

--- a/mcp/tests/test_qdrant_search_api_removal.py
+++ b/mcp/tests/test_qdrant_search_api_removal.py
@@ -1,0 +1,163 @@
+"""QdrantClient.search() was removed in qdrant-client 1.16.
+
+The pin in mcp/requirements.txt is >=1.17.0,<1.19.0, so on every supported
+client the attribute lookup raised before a request was made — and both call
+sites caught that in a bare except, turning a hard API break into "found
+nothing". These tests use a client double that models the real surface: it has
+query_points and NOT search, so anything reaching for .search fails.
+"""
+import json
+import unittest
+from unittest import mock
+
+import server
+
+
+class _Point:
+    def __init__(self, pid, score, payload):
+        self.id = pid
+        self.score = score
+        self.payload = payload
+
+
+class _Response:
+    def __init__(self, points):
+        self.points = points
+
+
+class _Client:
+    """Models qdrant-client >=1.16: query_points exists, search does not."""
+
+    def __init__(self, points, named_ok=True):
+        self._points = points
+        self._named_ok = named_ok
+        self.calls = []
+
+    def __getattr__(self, name):  # search must not be reachable
+        raise AttributeError(f"'_Client' object has no attribute '{name}'")
+
+    def query_points(self, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs.get("using") == "dense" and not self._named_ok:
+            raise ValueError("collection has a flat vector config")
+        return _Response(list(self._points))
+
+
+class _RaisingClient(_Client):
+    def query_points(self, **kwargs):
+        raise RuntimeError("qdrant is down")
+
+
+def _patch(client, embed=(0.1, 0.2, 0.3)):
+    return (
+        mock.patch.object(server, "_get_qdrant", lambda: (client, "hermes_memory")),
+        mock.patch.object(server, "_embed", lambda _t: list(embed)),
+    )
+
+
+class TestDetectConflicts(unittest.TestCase):
+    """Heuristic 1: a `gap` neighbour filled by an `observed` finding."""
+
+    def _run(self, neighbour_payload, finding):
+        client = _Client([_Point("n1", 0.9, neighbour_payload)])
+        p1, p2 = _patch(client)
+        with p1, p2:
+            return client, server._detect_conflicts("inv-1", finding)
+
+    def test_gap_filled_by_observation_is_detected(self):
+        client, conflicts = self._run(
+            {"id": "n1", "record_type": "gap", "text": "unknown whether the host phoned home"},
+            {"id": "f1", "record_type": "observed", "text": "the host phoned home at 03:14"},
+        )
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(conflicts[0]["neighbor_id"], "n1")
+        self.assertEqual(conflicts[0]["neighbor_type"], "gap")
+
+    def test_it_uses_query_points_and_keeps_the_score_gate(self):
+        client, _ = self._run(
+            {"id": "n1", "record_type": "gap", "text": "unknown"},
+            {"id": "f1", "record_type": "observed", "text": "known"},
+        )
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(client.calls[0]["score_threshold"], 0.82)
+        self.assertEqual(client.calls[0]["limit"], 10)
+
+    def test_flat_collection_falls_back_from_the_named_vector(self):
+        client = _Client(
+            [_Point("n1", 0.9, {"id": "n1", "record_type": "gap", "text": "unknown"})],
+            named_ok=False,
+        )
+        p1, p2 = _patch(client)
+        with p1, p2:
+            conflicts = server._detect_conflicts(
+                "inv-1", {"id": "f1", "record_type": "observed", "text": "known"}
+            )
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual([c.get("using") for c in client.calls], ["dense", None])
+
+    def test_search_failure_still_fails_open(self):
+        client = _RaisingClient([])
+        p1, p2 = _patch(client)
+        with p1, p2:
+            self.assertEqual(
+                server._detect_conflicts("inv-1", {"id": "f1", "record_type": "observed", "text": "x"}),
+                [],
+            )
+
+
+class TestConflictNegationHeuristic(unittest.TestCase):
+    """Heuristic 3 is a token-presence scan, so it is off unless asked for."""
+
+    def _conflicts(self):
+        client = _Client([_Point("n1", 0.9, {
+            "id": "n1", "record_type": "observed",
+            "text": "no adverse records were found for the account",
+        })])
+        p1, p2 = _patch(client)
+        with p1, p2:
+            return server._detect_conflicts(
+                "inv-1", {"id": "f1", "record_type": "observed",
+                          "text": "adverse records were found for the account"},
+            )
+
+    def test_off_by_default(self):
+        with mock.patch.object(server, "_CONFLICT_NEGATION_HEURISTIC", False):
+            self.assertEqual(self._conflicts(), [])
+
+    def test_opt_in_restores_it(self):
+        with mock.patch.object(server, "_CONFLICT_NEGATION_HEURISTIC", True):
+            self.assertEqual(len(self._conflicts()), 1)
+
+
+class TestMemoryConfidence(unittest.TestCase):
+    def test_it_reports_a_trace_when_the_store_has_one(self):
+        points = [
+            _Point("p1", 0.81, {"text": "ryan was granted contractor access", "investigation_id": "i1", "confidence": "high"}),
+            _Point("p2", 0.74, {"text": "contractor access was reviewed", "investigation_id": "i2", "confidence": "medium"}),
+        ]
+        client = _Client(points)
+        p1, p2 = _patch(client)
+        with p1, p2:
+            payload = json.loads(server.memory_confidence("contractor access"))
+        self.assertNotEqual(payload["basis"], "no_trace")
+        self.assertGreater(payload["confidence"], 0.0)
+        self.assertEqual(payload["cues"]["fluency"], 0.81)
+
+    def test_a_broken_search_is_not_reported_as_no_trace(self):
+        client = _RaisingClient([])
+        p1, p2 = _patch(client)
+        with p1, p2:
+            payload = json.loads(server.memory_confidence("contractor access"))
+        self.assertEqual(payload["basis"], "search_failed")
+        self.assertEqual(payload["confidence"], 0.0)
+
+    def test_an_empty_store_is_still_no_trace(self):
+        client = _Client([])
+        p1, p2 = _patch(client)
+        with p1, p2:
+            payload = json.loads(server.memory_confidence("contractor access"))
+        self.assertEqual(payload["basis"], "no_trace")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by applying the output-census lens from the 2026-08-19 upgrade pack
(`HUNT-GUIDE.md`, signature **S13 — the never-worked feature**) to this repo. The
code reads correctly in both places; only asking "what has this actually emitted?"
exposes it.

## The break

`QdrantClient.search()` was deprecated in qdrant-client 1.10 and **removed in
1.16**. `mcp/requirements.txt` pins `qdrant-client>=1.17.0,<1.19.0`, so on every
client this project supports the attribute lookup itself raises — no request is
ever made:

```
$ pip install "qdrant-client>=1.17.0,<1.19.0"   # resolves 1.18.0
>>> hasattr(QdrantClient, 'search')
False
>>> hasattr(QdrantClient, 'query_points')
True
```

Two call sites, both inside a bare except:

| site | swallowed as | consequence |
|---|---|---|
| `server.py` `_detect_conflicts` | `return []` | `investigation_store` has never detected a conflict — `detected: false` always, and `_write_conflict` has never run |
| `server.py` `_confidence_retrieve` | `results = []`, `basis=None` | `memory_confidence` returns `{"confidence": 0.0, "basis": "no_trace"}` for **every** query |

`memory_confidence` is the sharper of the two: it is the tool an agent is told to
call before a high-stakes claim, and a caller reading `0.0` as "no supporting
evidence" is being actively misled rather than merely unserved.

## Why no test caught it

`tests/test_qdrant_backend.py` installs a stub `qdrant_client` into `sys.modules`
guarded by

```python
if "qdrant_client" in _sys.modules:
    return
```

— whether the module has been *imported yet*, not whether it is *installed*. On a
normal `pytest tests/` run that stub lands first and shadows the real client for
the whole session. Probed on `main` with qdrant-client 1.18.0 installed:

```
QDRANT MODULE: STUB/none
SearchParams: ImportError cannot import name 'SearchParams' from 'qdrant_client.models'
```

So every later test that imports a model the stub does not define takes its
except branch. The guard is now `importlib.util.find_spec`, and
`test_qdrant_backend.py`'s own 14 tests still pass against the real package.

## The fix

- `_query_points_compat()` — `query_points()`, named-vector (`using="dense"`)
  first with a flat-collection fallback, matching what `qdrant_ops.py` already
  does. Thresholds unchanged: 0.82 still gates conflicts, `limit=10` unchanged.
- Failed searches log at **warning**, not debug.
- `_confidence_retrieve` returns `"search_failed"` instead of letting a broken
  lane read as an empty one.
- Conflict heuristic 3 (opposing negation markers) is gated behind
  `LOCI_CONFLICT_NEGATION_HEURISTIC=1`, default off. It is a bare token-presence
  scan, not a polarity comparison — "no adverse records found" / "did not appear"
  are ubiquitous — and the upgrade pack measured it flagging two `observed`
  neighbours at 0.892/0.8679 when a finding was fed back **verbatim**, where an
  exact duplicate is agreement, not conflict. Heuristics 1 and 2 are structural
  and stay on.

**This turns on a write path for the first time.** `_store_conflicts` →
`_write_conflict` will start emitting records; consumers that have only ever seen
`detected: false` will see `true`. The pack's measurement against live
`hermes_memory` was 85 of 3,363 within-investigation pairs clearing 0.82, 37
tripping a heuristic, concentrated in bulk-ingest corpora. Budget for first-run
noise.

## Tests

`mcp/tests/test_qdrant_search_api_removal.py` — 9 tests against a client double
that models the real surface (`query_points` present, `search` **absent**, so
anything reaching for `.search` fails).

Proved non-vacuous per the guide's S12: reverting **only** `mcp/server.py` and
keeping the tests gives 7 failures, 5 of them behavioural rather than
missing-symbol —

```
FAILED ...::test_gap_filled_by_observation_is_detected - AssertionError: 0 != 1
FAILED ...::test_it_reports_a_trace_when_the_store_has_one - AssertionError: 'no_trace' == 'no_trace'
FAILED ...::test_a_broken_search_is_not_reported_as_no_trace - AssertionError: 'no_trace' != 'search_failed'
```

Full `mcp/tests/`: 527 passed with these changes. (The 7 failures and 7 errors in
`test_analytics.py` / `test_graph_integration.py` reproduce identically on
unmodified `main` in this environment — missing graph deps locally, green in CI.)