### PR TITLE
fix(rag): say when the search did not actually search

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6211,8 +6211,22 @@ def rag_context_search(
     _rag_record_access(all_results, query)
 
     ctx = context_assemble(all_results, query, budget_chars=budget_chars)
-    ctx["mode"] = "rag_hybrid"
+    # Report retrieval honestly. This used to claim mode="rag_hybrid" no matter
+    # what, so a search where EVERY collection raised was indistinguishable from
+    # a genuine zero-hit search: a misconfigured embedder or a dimension mismatch
+    # read back to the caller as "nothing is known about this topic".
+    # Count distinct collections, not error entries — one broken collection
+    # raises once per expanded query.
+    _failed_cols = {e.split(":", 1)[0] for e in errors}
+    _failed = len(_failed_cols)
+    if _failed and _failed >= len(_collections):
+        ctx["mode"] = "rag_failed"
+    elif _failed:
+        ctx["mode"] = "rag_degraded"
+    else:
+        ctx["mode"] = "rag_hybrid"
     ctx["collections_searched"] = _collections
+    ctx["collections_failed"] = sorted(_failed_cols)
     ctx["qdrant_available"] = True
     if expansion_info is not None:
         ctx["query_expansion"] = expansion_info

--- a/mcp/tests/test_rag_failure_mode.py
+++ b/mcp/tests/test_rag_failure_mode.py
@@ -1,0 +1,49 @@
+"""rag_context_search has to say when it did not actually search.
+
+mode was hardcoded to "rag_hybrid", so a run where every collection raised
+returned the same shape as a genuine zero-hit run — the caller could not tell a
+broken embedder from "nothing is known about this topic".
+"""
+import json
+import unittest
+from unittest import mock
+
+import server
+
+
+def _run(failing: set, collections=("hermes_memory", "agent_core_chunks")):
+    """Search `collections`, raising for any name in `failing`."""
+    def _fake(sq, collection_name=None, limit=None, query_filter=None):
+        if collection_name in failing:
+            raise RuntimeError("Wrong input: Vector dimension error")
+        return [{"origin": collection_name, "id": "p1", "score": 0.7, "text": "a finding"}]
+
+    with mock.patch.object(server, "_qdrant_search_collection", _fake), \
+         mock.patch.object(server, "_get_qdrant", lambda: (object(), "hermes_memory")), \
+         mock.patch.object(server, "_rag_cross_encode", lambda *a, **k: None), \
+         mock.patch.object(server, "_rag_record_access", lambda *a, **k: None):
+        raw = server.rag_context_search(
+            "contractor access", collections=list(collections), expand_query=False
+        )
+    return json.loads(raw)
+
+
+class TestRagFailureMode(unittest.TestCase):
+    def test_all_collections_failing_is_not_reported_as_a_successful_search(self):
+        out = _run({"hermes_memory", "agent_core_chunks"})
+        self.assertEqual(out["mode"], "rag_failed")
+        self.assertEqual(out["collections_failed"], ["agent_core_chunks", "hermes_memory"])
+
+    def test_one_collection_failing_is_degraded(self):
+        out = _run({"agent_core_chunks"})
+        self.assertEqual(out["mode"], "rag_degraded")
+        self.assertEqual(out["collections_failed"], ["agent_core_chunks"])
+
+    def test_a_clean_search_still_says_rag_hybrid(self):
+        out = _run(set())
+        self.assertEqual(out["mode"], "rag_hybrid")
+        self.assertEqual(out["collections_failed"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signature **S2 — success reported despite total failure**, from the 2026-08-19
silent-failure pack's hunt guide. Errors accumulate in a list; the return value
hardcodes a success mode and never consults it.

`mcp/server.py`, `rag_context_search`:

```python
ctx["mode"] = "rag_hybrid"
ctx["collections_searched"] = _collections
ctx["qdrant_available"] = True
...
if errors:
    ctx["collection_errors"] = errors
```

`_rag_search_collections` catches per-collection failures and appends to
`errors`, so a run where **every** collection raised returns
`mode: "rag_hybrid"`, `qdrant_available: true`, `results: []` — byte-identical
in the fields a caller gates on to a genuine zero-hit search. The evidence is
present in an extra key most callers never read.

That is the shape that hid a 21-of-29-collection outage for months in the
deployment this lens came from: a dimension mismatch or a dead embedder reads
back as "nothing is known about this topic".

## Change

`mode` becomes `rag_failed` when every searched collection raised,
`rag_degraded` when some did, `rag_hybrid` when none did. `collections_failed`
lists the collection **names**.

One deviation from the pack's version of this fix: it used `len(errors)` as the
failed-collection count, but `_rag_search_collections` loops
`for col ... for sq in search_queries`, so a single broken collection appends one
error per expanded query and the raw count can exceed the number of collections.
Counting distinct names avoids reporting `rag_failed` when only one of three
collections is down.

`qdrant_available` stays `True`: the client genuinely is reachable — it is the
per-collection queries that failed, and `rag_required` already covers a missing
client.

## Tests

`mcp/tests/test_rag_failure_mode.py` — all-fail, partial-fail, clean.

Non-vacuous per the guide's S12 — reverting only `mcp/server.py` and keeping the
tests:

```
FAILED ...::test_all_collections_failing_is_not_reported_as_a_successful_search - AssertionError: 'rag_hybrid' != 'rag_failed'
FAILED ...::test_one_collection_failing_is_degraded - AssertionError: 'rag_hybrid' != 'rag_degraded'
FAILED ...::test_a_clean_search_still_says_rag_hybrid - KeyError: 'collections_failed'
```

**Depends on #182** to be green in a full-suite run. Not for the source change —
that is independent — but `tests/test_qdrant_backend.py` shadows the installed
`qdrant_client` for the whole session, so `from qdrant_client.models import
MatchAny` inside `rag_context_search` raises ImportError for every test collected
after it. #182 fixes that guard. I will rebase once it lands.