### PR TITLE
feat(qdrant): make the startup TTL purge configurable, and say what it deletes

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -151,21 +151,59 @@ def _create_payload_indexes(client, col: str) -> None:
             logger.debug("payload index %r creation skipped: %s", field_name, exc)
 
 
-def _purge_old_records(client, col: str, retention_days: int = 30) -> None:
-    """Delete records older than retention_days. Requires created_at_ts payload index."""
-    from qdrant_client.models import Filter, FieldCondition, Range, FilterSelector
-    cutoff = int(time.time()) - (retention_days * 86400)
+def _retention_days() -> int:
+    """Startup purge window, in days. 0 disables the purge entirely.
+
+    Read at call time, not import time, so a test or a caller can set it."""
+    raw = os.environ.get("LOCI_QDRANT_RETENTION_DAYS", "30").strip()
     try:
+        days = int(raw)
+    except ValueError:
+        logger.warning("LOCI_QDRANT_RETENTION_DAYS=%r is not an integer; using 30", raw)
+        return 30
+    return max(0, days)
+
+
+def _purge_old_records(client, col: str, retention_days: Optional[int] = None) -> None:
+    """Delete records older than retention_days. Requires created_at_ts payload index.
+
+    This DESTROYS data: findings carry created_at_ts (server._store_finding), so
+    anything past the window goes on the next process start. Set
+    LOCI_QDRANT_RETENTION_DAYS=0 to keep the store durable.
+    """
+    if retention_days is None:
+        retention_days = _retention_days()
+    if retention_days <= 0:
+        logger.debug("Qdrant TTL purge disabled (LOCI_QDRANT_RETENTION_DAYS=0)")
+        return
+
+    from qdrant_client.models import Filter, FieldCondition, Range, FilterSelector
+
+    cutoff = int(time.time()) - (retention_days * 86400)
+    stale = Filter(must=[FieldCondition(key="created_at_ts", range=Range(lt=cutoff))])
+    try:
+        # Count first: the delete runs with wait=False, so without this the log
+        # line cannot say whether it removed nothing or removed the corpus.
+        try:
+            doomed = int(client.count(collection_name=col, count_filter=stale, exact=True).count)
+        except Exception as exc:
+            logger.debug("Qdrant TTL purge: count failed: %s", exc)
+            doomed = -1
+
+        if doomed == 0:
+            logger.debug("Qdrant TTL purge: nothing older than %d days", retention_days)
+            return
+
         client.delete(
             collection_name=col,
-            points_selector=FilterSelector(
-                filter=Filter(must=[
-                    FieldCondition(key="created_at_ts", range=Range(lt=cutoff))
-                ])
-            ),
+            points_selector=FilterSelector(filter=stale),
             wait=False,
         )
-        logger.info("Qdrant TTL purge: deleted records older than %d days", retention_days)
+        logger.warning(
+            "Qdrant TTL purge: deleting %s point(s) older than %d days from %r "
+            "(set LOCI_QDRANT_RETENTION_DAYS=0 to disable)",
+            doomed if doomed >= 0 else "an unknown number of", retention_days, col,
+        )
     except Exception as exc:
         logger.debug("Qdrant TTL purge failed (non-fatal): %s", exc)
 
@@ -251,8 +289,10 @@ def _get_qdrant():
             # Create payload indexes — idempotent, safe on existing collection
             _create_payload_indexes(client, col)
 
-            # Purge records older than 30 days on startup
-            _purge_old_records(client, col, retention_days=30)
+            # Purge on startup — window from LOCI_QDRANT_RETENTION_DAYS (0 disables).
+            # Passing no literal here: pinning one at the call site is what made the
+            # default unreachable.
+            _purge_old_records(client, col)
 
             _qdrant_client = (client, col)
         except Exception as exc:

--- a/mcp/tests/test_qdrant_retention.py
+++ b/mcp/tests/test_qdrant_retention.py
@@ -1,0 +1,86 @@
+"""The startup TTL purge deletes data, so its window has to be configurable.
+
+_get_qdrant() calls _purge_old_records on the first client construction of every
+process, and findings carry created_at_ts — so anything past the window is gone.
+The window used to be a literal at both the definition and the call site, which
+left no way to turn it off.
+"""
+import os
+import unittest
+from unittest import mock
+
+import qdrant_ops
+
+
+class _Count:
+    def __init__(self, count):
+        self.count = count
+
+
+class _Client:
+    def __init__(self, count=5):
+        self._count = count
+        self.deletes = []
+        self.counts = []
+
+    def count(self, **kwargs):
+        self.counts.append(kwargs)
+        return _Count(self._count)
+
+    def delete(self, **kwargs):
+        self.deletes.append(kwargs)
+
+
+def _purge(env, count=5):
+    client = _Client(count)
+    with mock.patch.dict(os.environ, env, clear=False):
+        qdrant_ops._purge_old_records(client, "hermes_memory")
+    return client
+
+
+class TestRetentionWindow(unittest.TestCase):
+    def test_default_is_thirty_days(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOCI_QDRANT_RETENTION_DAYS", None)
+            self.assertEqual(qdrant_ops._retention_days(), 30)
+
+    def test_zero_disables_the_purge(self):
+        client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "0"})
+        self.assertEqual(client.deletes, [])
+        self.assertEqual(client.counts, [])
+
+    def test_a_negative_window_is_treated_as_disabled(self):
+        client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "-1"})
+        self.assertEqual(client.deletes, [])
+
+    def test_garbage_falls_back_to_the_default_rather_than_deleting_everything(self):
+        with mock.patch.dict(os.environ, {"LOCI_QDRANT_RETENTION_DAYS": "banana"}):
+            self.assertEqual(qdrant_ops._retention_days(), 30)
+
+    def test_a_custom_window_is_honoured(self):
+        client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "90"})
+        self.assertEqual(len(client.deletes), 1)
+        rng = client.counts[0]["count_filter"].must[0].range
+        self.assertAlmostEqual(rng.lt, int(__import__("time").time()) - 90 * 86400, delta=5)
+
+    def test_nothing_stale_means_no_delete_call(self):
+        client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "30"}, count=0)
+        self.assertEqual(client.deletes, [])
+
+    def test_it_counts_before_it_deletes(self):
+        client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "30"}, count=7)
+        self.assertEqual(len(client.counts), 1)
+        self.assertTrue(client.counts[0]["exact"])
+        self.assertEqual(len(client.deletes), 1)
+
+
+class TestCallSiteDoesNotPinTheWindow(unittest.TestCase):
+    def test_get_qdrant_passes_no_literal(self):
+        import inspect
+        src = inspect.getsource(qdrant_ops._get_qdrant)
+        self.assertIn("_purge_old_records(client, col)", src)
+        self.assertNotIn("retention_days=30", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signature **S7 — env-configurable default defeated at the call site**, except
here there was no env to defeat.

## What runs today

`mcp/qdrant_ops.py`:

```python
def _purge_old_records(client, col, retention_days: int = 30) -> None:
    """Delete records older than retention_days. ..."""
    ...
    client.delete(collection_name=col, points_selector=FilterSelector(filter=...), wait=False)
    logger.info("Qdrant TTL purge: deleted records older than %d days", retention_days)
```

called from `_get_qdrant()`:

```python
# Purge records older than 30 days on startup
_purge_old_records(client, col, retention_days=30)
```

So on the **first Qdrant client construction of every process** — the MCP server,
any cron script, any test that touches the real client — loci deletes every point
whose `created_at_ts` is older than 30 days. There is no environment variable,
and the literal at the call site pins it even if the signature default changed.

This is not dormant. `created_at_ts` is stamped on every finding
(`server.py:2086`, `2324`, `3983`) and indexed
(`qdrant_ops.py:114` `IntegerIndexParams`), so the filter matches.

For a project whose one-line description is "Persistent memory MCP server for AI
agents", a 30-day hard delete with no off switch and an `info`-level log line
seems worth being able to turn off.

## Change

- `LOCI_QDRANT_RETENTION_DAYS`, read at call time. **Default stays 30**, so
  nothing changes for anyone who does not set it. `0` (or negative) disables the
  purge; a non-integer value logs a warning and falls back to 30 rather than
  being coerced into something destructive.
- The call site passes no literal.
- The purge `count()`s the matching points first and logs at **warning** when it
  is about to delete any — the delete runs `wait=False`, so the old `info` line
  was emitted unconditionally and could not distinguish "removed nothing" from
  "removed the corpus". Nothing stale means no `delete` call at all.
- The `qdrant_client.models` import moved below the disabled check, so turning
  the purge off does not depend on the client being importable.

## Not decided here

Whether 30 is the right default — i.e. whether Qdrant is a durable index or a hot
cache — is an architecture call, not a bug. This PR only makes the answer
expressible. If the intent is durability, the follow-up is a one-word change to
the default, and it is worth checking what has already aged out.

## Tests

`mcp/tests/test_qdrant_retention.py` — 8 tests: default, `0` disables, negative
disables, garbage falls back to 30 (rather than deleting everything), a custom
window builds the right cutoff, nothing-stale skips the delete, count precedes
delete, and the call site carries no literal.