### PR TITLE
fix: give each consolidation script its own batch-size knob (#186)

### DIFF
--- a/scripts/agentHER_relabeler.py
+++ b/scripts/agentHER_relabeler.py
@@ -25,7 +25,14 @@ QDRANT_URL   = os.environ.get("QDRANT_URL")
 OLLAMA_URL   = os.environ.get("OLLAMA_URL")
 EMBED_MODEL  = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 GEN_MODEL    = os.environ.get("AGENTHER_GEN_MODEL", "llama3.2:latest")
-MAX_PER_RUN  = int(os.environ.get("MAX_PER_RUN", "20"))
+# Batch size. Own name, because the three consolidation scripts each had a
+# different budget under the shared MAX_PER_RUN; setting it for one silently
+# reconfigured the others. MAX_PER_RUN is still honoured as a fallback.
+MAX_PER_RUN = int(
+    os.environ.get("AGENTHER_MAX_PER_RUN")
+    or os.environ.get("MAX_PER_RUN")
+    or 20
+)
 COLLECTION   = "mnemosyne"
 
 # ---------------------------------------------------------------------------

--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -27,7 +27,14 @@ EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 AMEM_LINK_THRESHOLD = float(os.environ.get("AMEM_LINK_THRESHOLD", "0.88"))
 AMEM_CONFLICT_THRESHOLD = float(os.environ.get("AMEM_CONFLICT_THRESHOLD", "0.96"))
 AMEM_UPDATE_THRESHOLD = float(os.environ.get("AMEM_UPDATE_THRESHOLD", "0.92"))  # near-copy with temporal ordering → updated_by
-MAX_PER_RUN = int(os.environ.get("MAX_PER_RUN", "100"))
+# Batch size. Own name, because the three consolidation scripts each had a
+# different budget under the shared MAX_PER_RUN; setting it for one silently
+# reconfigured the others. MAX_PER_RUN is still honoured as a fallback.
+MAX_PER_RUN = int(
+    os.environ.get("AMEM_MAX_PER_RUN")
+    or os.environ.get("MAX_PER_RUN")
+    or 100
+)
 
 # Keyword pairs whose co-presence signals a potential conflict.
 CONFLICT_KEYWORD_PAIRS = [

--- a/scripts/ebbinghaus_consolidation.py
+++ b/scripts/ebbinghaus_consolidation.py
@@ -38,7 +38,14 @@ QDRANT_URL = os.environ.get("QDRANT_URL")
 OLLAMA_URL = os.environ.get("OLLAMA_URL")
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 FORGET_THRESH = float(os.environ.get("FORGET_THRESH", "0.3"))
-MAX_PER_RUN = int(os.environ.get("MAX_PER_RUN", "50"))
+# Batch size. Own name, because the three consolidation scripts each had a
+# different budget under the shared MAX_PER_RUN; setting it for one silently
+# reconfigured the others. MAX_PER_RUN is still honoured as a fallback.
+MAX_PER_RUN = int(
+    os.environ.get("EBBINGHAUS_MAX_PER_RUN")
+    or os.environ.get("MAX_PER_RUN")
+    or 50
+)
 QDRANT_COLLECTION = "mnemosyne"
 
 # FSRS-inspired stability model parameters

--- a/scripts/tests/test_batch_size_env.py
+++ b/scripts/tests/test_batch_size_env.py
@@ -1,0 +1,61 @@
+"""Each consolidation script owns its batch-size knob.
+
+They shared MAX_PER_RUN with three different defaults (100 / 50 / 20), so
+exporting it to tune one silently reconfigured the other two.
+"""
+import importlib.util
+import os
+import pathlib
+import unittest
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+CASES = [
+    ("amem_consolidation.py", "AMEM_MAX_PER_RUN", 100),
+    ("ebbinghaus_consolidation.py", "EBBINGHAUS_MAX_PER_RUN", 50),
+    ("agentHER_relabeler.py", "AGENTHER_MAX_PER_RUN", 20),
+]
+
+_ALL_NAMES = ["MAX_PER_RUN"] + [n for _, n, _ in CASES]
+
+
+def _load(fname):
+    spec = importlib.util.spec_from_file_location(f"_bs_{fname}", _SCRIPTS / fname)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _max_per_run(fname, env):
+    clean = {k: v for k, v in os.environ.items() if k not in _ALL_NAMES}
+    with mock.patch.dict(os.environ, {**clean, **env}, clear=True):
+        return _load(fname).MAX_PER_RUN
+
+
+class TestBatchSizeEnv(unittest.TestCase):
+    def test_defaults_are_unchanged(self):
+        for fname, _, default in CASES:
+            self.assertEqual(_max_per_run(fname, {}), default, fname)
+
+    def test_own_name_wins(self):
+        for fname, own, _ in CASES:
+            self.assertEqual(_max_per_run(fname, {own: "7"}), 7, fname)
+
+    def test_shared_name_is_still_honoured(self):
+        for fname, _, _ in CASES:
+            self.assertEqual(_max_per_run(fname, {"MAX_PER_RUN": "11"}), 11, fname)
+
+    def test_own_name_overrides_the_shared_one(self):
+        for fname, own, _ in CASES:
+            self.assertEqual(_max_per_run(fname, {"MAX_PER_RUN": "11", own: "3"}), 3, fname)
+
+    def test_tuning_one_script_leaves_the_others_alone(self):
+        env = {"AMEM_MAX_PER_RUN": "500"}
+        self.assertEqual(_max_per_run("amem_consolidation.py", env), 500)
+        self.assertEqual(_max_per_run("ebbinghaus_consolidation.py", env), 50)
+        self.assertEqual(_max_per_run("agentHER_relabeler.py", env), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #186 — the unambiguous half.

Three unrelated cron scripts read one env name with three different defaults:

| script | default | caps |
|---|---|---|
| `amem_consolidation.py` | 100 | rows pulled from `working_memory` for pairwise cross-linking |
| `ebbinghaus_consolidation.py` | 50 | decayed rows processed per run |
| `agentHER_relabeler.py` | 20 | failure rows relabelled per run |

The defaults differ on purpose — the amem script does O(n²) pairwise embedding
comparisons where the relabeller does one LLM call per row — but they are all
reachable through `MAX_PER_RUN`. Exporting `MAX_PER_RUN=200` to give the
relabeller more work also doubles the amem batch (quadrupling its pair count) and
quadruples the ebbinghaus batch, silently, on whichever hosts export it.

Each script now reads `AMEM_MAX_PER_RUN` / `EBBINGHAUS_MAX_PER_RUN` /
`AGENTHER_MAX_PER_RUN` first and falls back to `MAX_PER_RUN`, so nothing breaks
for anyone already setting the shared name.

`scripts/tests/test_batch_size_env.py` — defaults unchanged, own name wins, shared
name still honoured, own name beats shared, and tuning one script leaves the other
two at their own defaults.

Non-vacuous per the guide's S12 — reverting only the three scripts and keeping the
test gives 3 behavioural failures (`100 != 7`, `11 != 3`, `100 != 500`).

The rest of #186 — `HERMES_AGENT_ID`'s four defaults, `HERMES_A2A_TOKEN`
defaulting to `changeme` in the bridge, `EMBED_MODEL` — is left open there; those
need a decision about what the right single value is, this one only needed the
names split.