### PR TITLE
feat(retrieval): retrieval_selftest — prove every collection is queryable

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -87,6 +87,7 @@ _ = health
 _ = finding_resolve
 _ = investigation_verify_all
 _ = loci_health
+_ = retrieval_selftest
 
 # ── socketserver hooks and tuning attributes, read by the stdlib base class
 # MemcheckDaemon subclasses ThreadingUnixStreamServer; _Handler subclasses

--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -549,6 +549,98 @@ def _qdrant_similarity_search(
     return {"ok": True, "reason": mode, "results": rows}
 
 
+def _collection_shape(client, name: str) -> dict:
+    """Vector layout of one collection: dense width(s), sparse presence, points.
+
+    Returns {"points", "dense_dims", "named", "sparse"} — dense_dims is a list
+    because a named-vector collection can carry several dense vectors.
+    """
+    info = client.get_collection(name)
+    params = info.config.params
+    vectors = params.vectors
+    named = isinstance(vectors, dict)
+    if named:
+        dims = sorted({int(v.size) for k, v in vectors.items() if getattr(v, "size", None)})
+    elif vectors is not None:
+        dims = [int(vectors.size)]
+    else:
+        dims = []
+    sparse = bool(getattr(params, "sparse_vectors", None))
+    points = int(getattr(info, "points_count", 0) or 0)
+    return {"points": points, "dense_dims": dims, "named": named, "sparse": sparse}
+
+
+def probe_collection(query_vec, client, name: str, limit: int = 3) -> dict:
+    """Can this collection be retrieved from at all? Never raises.
+
+    Deliberately NOT _qdrant_search_collection: that path cross-encodes and
+    applies a relevance floor, so a collection of terse rows legitimately
+    returns nothing and would look identical to a broken one. This asks about
+    wiring, not relevance.
+
+    status is one of:
+      ok             rows came back
+      empty          the collection holds no points — not a fault
+      width_mismatch this server's embedder is the wrong width for it, so every
+                     query it makes against this collection will fail
+      no_results     queryable, nothing matched
+      error          the probe raised
+    """
+    out = {"collection": name, "hits": 0, "status": "error", "detail": ""}
+    try:
+        shape = _collection_shape(client, name)
+    except Exception as exc:
+        out["detail"] = f"get_collection failed: {exc}"
+        return out
+
+    out.update({
+        "points": shape["points"],
+        "dense_dims": shape["dense_dims"],
+        "sparse": shape["sparse"],
+    })
+
+    if shape["points"] == 0:
+        out["status"] = "empty"
+        out["detail"] = "no points stored"
+        return out
+
+    our_dim = len(query_vec) if query_vec is not None else None
+    if our_dim is None:
+        out["status"] = "error"
+        out["detail"] = "no embedder — dense vector unavailable"
+        out["remediation"] = "Set OLLAMA_BASE_URL or EMBED_API_KEY so the server can embed."
+        return out
+
+    if shape["dense_dims"] and our_dim not in shape["dense_dims"]:
+        out["status"] = "width_mismatch"
+        out["detail"] = (
+            f"collection is {'/'.join(str(d) for d in shape['dense_dims'])}-dim, "
+            f"this server embeds at {our_dim}"
+        )
+        out["remediation"] = (
+            f"Nothing this server asks can match a {shape['dense_dims'][0]}-dim collection "
+            f"while it embeds at {our_dim}. Re-embed the collection, or query it with an "
+            f"embedder of its own width."
+        )
+        return out
+
+    kwargs = {"collection_name": name, "query": query_vec, "limit": limit, "with_payload": False}
+    try:
+        if shape["named"]:
+            points = client.query_points(using="dense", **kwargs).points
+        else:
+            points = client.query_points(**kwargs).points
+    except Exception as exc:
+        out["status"] = "error"
+        out["detail"] = f"query failed: {exc}"
+        return out
+
+    out["hits"] = len(points)
+    out["status"] = "ok" if points else "no_results"
+    out["detail"] = f"{len(points)} row(s)" if points else "queryable, nothing matched"
+    return out
+
+
 def _qdrant_search_collection(
     query: str,
     collection_name: str,

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -176,6 +176,7 @@ from qdrant_ops import (  # noqa: E402,F401
     _get_sparse_embedder, _get_cross_encoder, _embed_sparse, _create_payload_indexes,
     _purge_old_records, _get_qdrant, _embed_auth_headers, _embed, _qdrant_upsert,
     _qdrant_degraded_mode, _ce_rerank, _qdrant_similarity_search, _qdrant_search_collection,
+    probe_collection,
 )
 REFLECTION_STATE_DIR = MEMORY_DIR / "_reflection-loop"
 REFLECTION_STATE_FILE = REFLECTION_STATE_DIR / "state.json"
@@ -4933,6 +4934,104 @@ def _health_rollup(checks: list[dict]) -> tuple[str, str]:
         f"{len(checks) - n_fail - n_warn} ok -> {status}"
     )
     return status, summary
+
+
+def _selftest_rollup(rows: list[dict]) -> tuple[str, str]:
+    """ok | degraded | unhealthy, plus a one-line summary.
+
+    An empty collection is not a fault — nothing to retrieve is not the same as
+    unable to retrieve.
+    """
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    broken = counts.get("width_mismatch", 0) + counts.get("error", 0)
+    if broken and broken >= len(rows):
+        status = "unhealthy"
+    elif broken:
+        status = "degraded"
+    else:
+        status = "ok"
+    parts = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    return status, f"{len(rows)} collection(s): {parts} -> {status}"
+
+
+@mcp.tool()
+def retrieval_selftest(query: str = "system architecture", limit: int = 3) -> str:
+    """
+    Prove every Qdrant collection can actually be retrieved from.
+
+    memory_health inspects the substrate — is Qdrant up, do the embedders load —
+    but only for the collections it knows by name. A store usually holds more,
+    written by other ingests at other embedding widths, and those fail in a way
+    nothing reports: the query raises on a width mismatch, the caller catches it
+    per-collection, and the collection becomes indistinguishable from one that
+    simply had no match.
+
+    This sweeps the whole store and answers the operational question directly:
+    if I ask this collection something, do rows come back? Per collection it
+    reports points, dense width, sparse presence and hit count, classified as
+    ok | empty | no_results | width_mismatch | error, rolling up to
+    ok | degraded | unhealthy. Remediations are deduplicated — one unmapped
+    width usually explains many collections at once.
+
+    Read-only. Bypasses the cross-encoder and its relevance floor on purpose:
+    the floor is a relevance judgement and this is a question about wiring.
+
+    Args:
+        query: Probe text. Any in-domain phrase works; the point is retrievability.
+        limit: Rows to request per collection (default 3).
+
+    Returns:
+        JSON with {status, summary, collections, remediations}.
+    """
+    client, _col = _get_qdrant()
+    if client is None:
+        return json.dumps({
+            "status": "unhealthy",
+            "summary": "Qdrant unavailable — nothing could be probed",
+            "collections": [],
+            "remediations": ["Check QDRANT_URL and QDRANT_API_KEY."],
+        }, indent=2)
+
+    try:
+        names = sorted(c.name for c in client.get_collections().collections)
+    except Exception as exc:
+        return json.dumps({
+            "status": "unhealthy",
+            "summary": f"could not list collections: {exc}",
+            "collections": [],
+            "remediations": ["Check Qdrant connectivity and API key scope."],
+        }, indent=2)
+
+    if not names:
+        return json.dumps({
+            "status": "ok", "summary": "no collections exist",
+            "collections": [], "remediations": [],
+        }, indent=2)
+
+    try:
+        query_vec = _embed(query)
+    except Exception as exc:
+        logger.warning("retrieval_selftest: embed failed: %r", exc)
+        query_vec = None
+
+    rows = [probe_collection(query_vec, client, name, limit=limit) for name in names]
+    status, summary = _selftest_rollup(rows)
+
+    remediations: list[str] = []
+    for r in rows:
+        rem = r.get("remediation")
+        if rem and rem not in remediations:
+            remediations.append(rem)
+
+    return json.dumps({
+        "status": status,
+        "summary": summary,
+        "embedder_dim": len(query_vec) if query_vec else None,
+        "collections": rows,
+        "remediations": remediations,
+    }, indent=2)
 
 
 @mcp.tool()

--- a/mcp/tests/test_retrieval_selftest.py
+++ b/mcp/tests/test_retrieval_selftest.py
@@ -1,0 +1,115 @@
+"""retrieval_selftest against a real in-memory Qdrant.
+
+The failure this exists to catch — a collection written at one embedding width
+and queried at another — is invisible per-query: it raises, the caller catches
+per-collection, and a broken collection looks exactly like one that had no
+match. These build that store for real rather than mocking it.
+"""
+import json
+import unittest
+from unittest import mock
+
+import pytest
+
+qdrant_client = pytest.importorskip("qdrant_client")
+from qdrant_client import QdrantClient                       # noqa: E402
+from qdrant_client.models import Distance, PointStruct, VectorParams   # noqa: E402
+
+import server                                                # noqa: E402
+
+DIM = 8
+
+
+def _store():
+    """Three collections: our width, a foreign width, and an empty one."""
+    c = QdrantClient(location=":memory:")
+    c.create_collection("hermes_memory",
+                        vectors_config={"dense": VectorParams(size=DIM, distance=Distance.COSINE)})
+    c.create_collection("legacy_chunks",
+                        vectors_config=VectorParams(size=DIM * 2, distance=Distance.COSINE))
+    c.create_collection("empty_shelf",
+                        vectors_config={"dense": VectorParams(size=DIM, distance=Distance.COSINE)})
+    c.upsert("hermes_memory", points=[
+        PointStruct(id=1, vector={"dense": [0.1] * DIM}, payload={"text": "a finding"}),
+    ])
+    c.upsert("legacy_chunks", points=[
+        PointStruct(id=1, vector=[0.1] * (DIM * 2), payload={"text": "a chunk"}),
+    ])
+    return c
+
+
+_UNSET = object()
+
+
+def _run(client, vec=_UNSET):
+    embedding = [0.1] * DIM if vec is _UNSET else vec
+    with mock.patch.object(server, "_get_qdrant", lambda: (client, "hermes_memory")), \
+         mock.patch.object(server, "_embed", lambda _q: embedding):
+        return json.loads(server.retrieval_selftest("anything"))
+
+
+def _by_name(out):
+    return {r["collection"]: r for r in out["collections"]}
+
+
+class TestRetrievalSelftest(unittest.TestCase):
+    def test_a_foreign_width_collection_is_named_not_silently_empty(self):
+        out = _run(_store())
+        rows = _by_name(out)
+        self.assertEqual(rows["legacy_chunks"]["status"], "width_mismatch")
+        self.assertIn("16-dim", rows["legacy_chunks"]["detail"])
+        self.assertIn("8", rows["legacy_chunks"]["detail"])
+        self.assertEqual(out["status"], "degraded")
+
+    def test_a_healthy_collection_reports_hits(self):
+        rows = _by_name(_run(_store()))
+        self.assertEqual(rows["hermes_memory"]["status"], "ok")
+        self.assertEqual(rows["hermes_memory"]["hits"], 1)
+
+    def test_an_empty_collection_is_not_a_fault(self):
+        out = _run(_store())
+        self.assertEqual(_by_name(out)["empty_shelf"]["status"], "empty")
+        self.assertEqual(out["status"], "degraded")  # from legacy_chunks alone
+
+    def test_all_collections_broken_rolls_up_to_unhealthy(self):
+        c = QdrantClient(location=":memory:")
+        c.create_collection("a", vectors_config=VectorParams(size=DIM * 2, distance=Distance.COSINE))
+        c.create_collection("b", vectors_config=VectorParams(size=DIM * 4, distance=Distance.COSINE))
+        c.upsert("a", points=[PointStruct(id=1, vector=[0.1] * (DIM * 2))])
+        c.upsert("b", points=[PointStruct(id=1, vector=[0.1] * (DIM * 4))])
+        out = _run(c)
+        self.assertEqual(out["status"], "unhealthy")
+
+    def test_remediations_are_deduplicated_across_collections(self):
+        c = QdrantClient(location=":memory:")
+        for name in ("a", "b", "c"):
+            c.create_collection(name, vectors_config=VectorParams(size=DIM * 2, distance=Distance.COSINE))
+            c.upsert(name, points=[PointStruct(id=1, vector=[0.1] * (DIM * 2))])
+        out = _run(c)
+        self.assertEqual(len(out["collections"]), 3)
+        self.assertEqual(len(out["remediations"]), 1)
+
+    def test_a_healthy_store_is_ok(self):
+        c = QdrantClient(location=":memory:")
+        c.create_collection("only", vectors_config={"dense": VectorParams(size=DIM, distance=Distance.COSINE)})
+        c.upsert("only", points=[PointStruct(id=1, vector={"dense": [0.1] * DIM})])
+        out = _run(c)
+        self.assertEqual(out["status"], "ok")
+        self.assertEqual(out["embedder_dim"], DIM)
+
+    def test_no_embedder_is_reported_rather_than_read_as_empty(self):
+        out = _run(_store(), vec=None)
+        statuses = {r["collection"]: r["status"] for r in out["collections"]}
+        self.assertEqual(statuses["hermes_memory"], "error")
+        self.assertEqual(statuses["empty_shelf"], "empty")
+        self.assertTrue(any("OLLAMA_BASE_URL" in r for r in out["remediations"]))
+
+    def test_qdrant_down_is_unhealthy_not_ok(self):
+        with mock.patch.object(server, "_get_qdrant", lambda: (None, None)):
+            out = json.loads(server.retrieval_selftest("anything"))
+        self.assertEqual(out["status"], "unhealthy")
+        self.assertEqual(out["collections"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -315,7 +315,7 @@ def _check_real_corpus():
     assert bad == [], [n.id for n in bad]
     from collections import Counter
     by_rule = Counter(e.attrs["rule"] for e in store.edges_of_kind("REGISTERS"))
-    assert by_rule["DEC-tool"] == 41, dict(by_rule)
+    assert by_rule["DEC-tool"] == 42, dict(by_rule)
     assert by_rule["DEC-route"] == 6, dict(by_rule)
     assert by_rule["DEC-mcp-route"] == 1, dict(by_rule)
     assert by_rule["MAN-LOOP"] == 31, dict(by_rule)

--- a/scripts/callgraph/tests/test_cli.py
+++ b/scripts/callgraph/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_registry_lists_known_surfaces(capsys):
     code, out = _run(capsys, ["registry", "--rev", "HEAD"])
     assert code == 0
     assert "reg:mcp/server.py::mcp.tool" in out
-    assert "members= 40" in out or "members=40" in out
+    assert "members= 41" in out or "members=41" in out
     assert "reg:a2a_server/server.py::_SKILL_MAP" in out
 
 

--- a/scripts/callgraph/tests/test_dead_false_positives.py
+++ b/scripts/callgraph/tests/test_dead_false_positives.py
@@ -34,11 +34,11 @@ from .helpers import build_fixture_store
 
 
 def test_no_registered_function_is_ever_reported_dead(head_build):
-    """40 @mcp.tool(), 31 register()d, 13 _SKILL_MAP, 6 FastAPI routes,
-    1 resource, 1 custom_route = 92 registered functions. None may be dead."""
+    """41 @mcp.tool(), 31 register()d, 13 _SKILL_MAP, 6 FastAPI routes,
+    1 resource, 1 custom_route = 93 registered functions. None may be dead."""
     store = head_build.store
     registered = {e.dst for e in store.edges_of_kind("REGISTERS")}
-    assert len(registered) == 92, f"registration surface changed: {len(registered)}"
+    assert len(registered) == 93, f"registration surface changed: {len(registered)}"
 
     offenders = registered_but_dead(store)
     assert offenders == [], (
@@ -59,7 +59,7 @@ def test_mcp_tool_and_manifest_surfaces_specifically(head_build):
                 if (src := store.get(e.src)) is not None
                 and src.attrs.get("mechanism") == "manifest-tuple"}
 
-    assert len(tools) == 40, f"@mcp.tool() count changed: {len(tools)}"
+    assert len(tools) == 41, f"@mcp.tool() count changed: {len(tools)}"
     assert len(manifest) == 31, f"register() manifest count changed: {len(manifest)}"
     assert tools & dead_ids == set()
     assert manifest & dead_ids == set()

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -60,13 +60,13 @@ def test_mcp_top_level_module_level_function_count(head_build):
     assert 265 <= len(module_level) <= 330, len(module_level)
 
 
-def test_forty_mcp_tool_decorators_classified_registering(head_build):
+def test_every_mcp_tool_decorator_is_classified_registering(head_build):
     registering = [
         e for e in head_build.store.edges_of_kind("DECORATED_BY")
         if e.attrs["classification"] == "registering" and e.attrs["raw"].startswith("mcp.tool")
         and e.src.startswith("fn:mcp/server.py::")
     ]
-    assert len(registering) == 40
+    assert len(registering) == 41
 
 
 def test_no_unknown_decorators_in_real_corpus(head_build):
@@ -191,11 +191,11 @@ def test_registry_counts_match_the_real_corpus(head_build):
     from collections import Counter
     store = head_build.store
     by_rule = Counter(e.attrs["rule"] for e in store.edges_of_kind("REGISTERS"))
-    # 40 @mcp.tool() + 1 @mcp.resource(), both DEC-tool (both make a
+    # 41 @mcp.tool() + 1 @mcp.resource(), both DEC-tool (both make a
     # function externally callable by its own Python name — the specific
     # decorator classification, tool vs resource, isn't the resolution's
     # concern here). Verified independently via `git grep '^@mcp\.tool'`.
-    assert by_rule["DEC-tool"] == 41
+    assert by_rule["DEC-tool"] == 42
     assert by_rule["DEC-route"] == 6         # a2a_server's @app.get/@app.post
     assert by_rule["DEC-mcp-route"] == 1     # mcp/server.py's @mcp.custom_route("/health", ...)
     assert by_rule["MAN-LOOP"] == 31         # graph_tools(11) + investigation_tools(11) + llm_tools(9)


### PR DESCRIPTION
Backlog item 4 from the 2026-08-19 pack's hunt guide, and the tool that turns
signature **S1 — global assumption over a heterogeneous store** from invisible
into a single call.

## The gap it closes

`memory_health` asks whether the substrate is up — Qdrant reachable, embedders
loading, mirror wired — and checks dimensions for the collections it knows by
name against one global `VECTOR_DIM` (`server.py:4805`). But `_qdrant_search_collection`
embeds once, at this server's width, and queries **any** collection name with
that vector:

```python
dense_vec = _embed(query)          # one width
...
client.query_points(collection_name=collection_name, query=dense_vec, ...)
```

A collection written at a different width raises. `_rag_search_collections`
catches it per-collection and moves on. Reproduced against a real in-memory
Qdrant:

```
hermes_memory        -> 1 hit(s)
agent_core_chunks    -> RAISED ValueError: shapes (1,384) and (768,) not aligned
```

Per query, that is indistinguishable from "nothing matched". This is the shape
that left 21 of 29 collections unqueryable for months in the deployment the lens
came from — every individual signal said "no results", which is also what a
healthy collection says.

## What the tool does

`retrieval_selftest(query, limit)` — read-only. Lists every collection and, for
each, reports `points` / `dense_dims` / `sparse` / `hits` and classifies:

| status | meaning |
|---|---|
| `ok` | rows came back |
| `empty` | no points stored — **not** a fault |
| `width_mismatch` | this server embeds at a width the collection cannot accept, so every query it makes there will fail |
| `no_results` | queryable, nothing matched |
| `error` | the probe raised |

Rolls up to `ok` / `degraded` / `unhealthy`, and deduplicates remediations —
one foreign width usually explains many collections at once, and a wall of
identical advice buries the count.

`width_mismatch` is checked *before* the query rather than inferred from the
exception, so the report names the two widths instead of quoting a numpy shape
error.

Deliberately bypasses `_qdrant_search_collection`'s cross-encoder and relevance
floor, going straight to `query_points`. The floor is a relevance judgement; a
self-test asks about wiring. A catalog of terse rows can score below the floor
while being perfectly healthy, and conflating the two is what this tool exists
to stop.

## Tests

`mcp/tests/test_retrieval_selftest.py` — 8 tests against a **real** Qdrant
(`QdrantClient(location=":memory:")`), not a mock, because the failure being
caught is one only a real client raises. Covers: a foreign-width collection is
named rather than silently empty; a healthy one reports hits; an empty one is
not counted as a fault; all-broken rolls up to `unhealthy`; three collections
sharing a width produce one remediation; a healthy store is `ok`; a missing
embedder is reported rather than read as empty; Qdrant down is `unhealthy`, not
a clean zero.

Full `mcp/tests/`: 539 passed. Ruff and vulture clean —
`_ = retrieval_selftest` added to the whitelist alongside the other
`@mcp.tool()` entry points, and `check_vulture_whitelist.py` still reports every
entry live (58/58).

## Not in this PR

Actually *fixing* retrieval for foreign-width collections — a per-collection
embedder map, so the server embeds at each collection's own width — is a
behaviour change and wants its own PR. This one only makes the situation
reportable, which is the part that was missing: today the only way to discover a
foreign-width collection is to notice that a search which should have matched
did not.