### PR TITLE
fix(embed): leave a trace when embedding fails open

### DIFF
--- a/mcp/embed_ops.py
+++ b/mcp/embed_ops.py
@@ -61,7 +61,11 @@ def embed_texts(texts: list[str]) -> list[list[float]]:
     """
     texts = [t if isinstance(t, str) else str(t) for t in texts]
     base, model = _resolve()
-    if not texts or not base:
+    if not texts:
+        return []
+    if not base:
+        logger.warning("embed_texts: no embedding endpoint configured "
+                       "(set OLLAMA_BASE_URL or EMBED_API_KEY) — returning no vectors")
         return []
     import requests
     transient = (requests.exceptions.Timeout, requests.exceptions.ConnectionError)
@@ -71,12 +75,19 @@ def embed_texts(texts: list[str]) -> list[list[float]]:
                               json={"model": model, "input": texts}, timeout=timeout)
             r.raise_for_status()
             embs = r.json().get("embeddings") or []
-            return embs if len(embs) == len(texts) else []
-        except transient:
+            if len(embs) == len(texts):
+                return embs
+            logger.warning("embed_texts: %s returned %d vector(s) for %d input(s) — "
+                           "returning no vectors", model, len(embs), len(texts))
+            return []
+        except transient as exc:
             if attempt == 0:
                 continue          # likely cold-load — retry once while the model warms
+            logger.warning("embed_texts: %s unreachable after retry: %r — "
+                           "returning no vectors", base, exc)
             return []             # persistent transient failure -> fail-open
-        except Exception:
+        except Exception as exc:
+            logger.warning("embed_texts: %s failed: %r — returning no vectors", base, exc)
             return []             # non-retryable (HTTP error, bad JSON) -> fail-open
     return []
 

--- a/mcp/memcheck/llm.py
+++ b/mcp/memcheck/llm.py
@@ -214,10 +214,15 @@ def embed_texts(texts: list[str], *, timeout: float = 60.0, batch: int = 16) -> 
         chunk = [t[:2000] for t in texts[i : i + batch]]
         data = _post_json(url, {"model": _embed_model(), "input": chunk}, {}, timeout)
         if not data or "data" not in data:
-            return []  # fail-open: partial embeds are useless for pairwise cosine
+            # fail-open: partial embeds are useless for pairwise cosine
+            _log.warning("embed_texts: %s returned no data for batch %d — "
+                         "returning no vectors", url, i // batch)
+            return []
         try:
             out.extend(d["embedding"] for d in data["data"])
-        except (KeyError, TypeError):
+        except (KeyError, TypeError) as exc:
+            _log.warning("embed_texts: malformed embedding payload from %s: %r — "
+                         "returning no vectors", url, exc)
             return []
     return out
 

--- a/mcp/tests/test_embed_failure_trace.py
+++ b/mcp/tests/test_embed_failure_trace.py
@@ -1,0 +1,78 @@
+"""Embedding failures fail open to [] — they must not do it silently.
+
+An empty vector list is a load-bearing claim: every caller treats it as "no
+embedding available" and degrades. Five different faults collapsed to the same
+[] with nothing logged, so "the embedder is not configured", "the embedder is
+down" and "the model returned the wrong count" were indistinguishable.
+"""
+import logging
+import unittest
+from unittest import mock
+
+import embed_ops
+
+
+class _Resp:
+    def __init__(self, payload=None, boom=None):
+        self._payload = payload or {}
+        self._boom = boom
+
+    def raise_for_status(self):
+        if self._boom:
+            raise self._boom
+
+    def json(self):
+        return self._payload
+
+
+class TestEmbedFailureTrace(unittest.TestCase):
+    def _run(self, resolve=("http://localhost:11434", "nomic-embed-text"), post=None):
+        with mock.patch.object(embed_ops, "_resolve", lambda: resolve), \
+             self.assertLogs("loci-mcp.embed_ops", level=logging.WARNING) as cm:
+            if post is None:
+                out = embed_ops.embed_texts(["a", "b"])
+            else:
+                with mock.patch("requests.post", post):
+                    out = embed_ops.embed_texts(["a", "b"])
+        return out, "\n".join(cm.output)
+
+    def test_no_endpoint_configured_says_so(self):
+        out, log = self._run(resolve=(None, "nomic-embed-text"))
+        self.assertEqual(out, [])
+        self.assertIn("no embedding endpoint configured", log)
+
+    def test_a_short_batch_is_reported_not_swallowed(self):
+        post = mock.Mock(return_value=_Resp({"embeddings": [[0.1]]}))   # 1 vector for 2 inputs
+        out, log = self._run(post=post)
+        self.assertEqual(out, [])
+        self.assertIn("returned 1 vector(s) for 2 input(s)", log)
+
+    def test_an_http_error_is_reported(self):
+        post = mock.Mock(return_value=_Resp(boom=RuntimeError("500 Server Error")))
+        out, log = self._run(post=post)
+        self.assertEqual(out, [])
+        self.assertIn("500 Server Error", log)
+
+    def test_a_persistent_connection_error_is_reported_after_the_retry(self):
+        import requests
+        post = mock.Mock(side_effect=requests.exceptions.ConnectionError("refused"))
+        out, log = self._run(post=post)
+        self.assertEqual(out, [])
+        self.assertIn("unreachable after retry", log)
+        self.assertEqual(post.call_count, 2)   # cold-load retry preserved
+
+    def test_the_happy_path_still_returns_vectors_and_logs_nothing(self):
+        post = mock.Mock(return_value=_Resp({"embeddings": [[0.1], [0.2]]}))
+        with mock.patch.object(embed_ops, "_resolve",
+                               lambda: ("http://localhost:11434", "nomic-embed-text")), \
+             mock.patch("requests.post", post), \
+             self.assertNoLogs("loci-mcp.embed_ops", level=logging.WARNING):
+            self.assertEqual(embed_ops.embed_texts(["a", "b"]), [[0.1], [0.2]])
+
+    def test_an_empty_input_list_is_not_a_failure(self):
+        with self.assertNoLogs("loci-mcp.embed_ops", level=logging.WARNING):
+            self.assertEqual(embed_ops.embed_texts([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signature **S6 — fail-open that is indistinguishable from empty**. The guide's
fix pattern is *keep failing open, but leave a trace*, and embedding is the most
load-bearing place in the repo that does not.

An AST sweep of `mcp/` for `except: return []` / `{}` / `None` / `pass` inside a
function found 70 fail-open handlers, **25 of which log nothing at any level**.
Most are fine — parser helpers returning `None` on a malformed node are answering
a question, not hiding a fault. `embed_texts` is not one of those.

`mcp/embed_ops.py`:

```python
    if not texts or not base:
        return []
    ...
            embs = r.json().get("embeddings") or []
            return embs if len(embs) == len(texts) else []
        except transient:
            if attempt == 0: continue
            return []
        except Exception:
            return []
```

Five distinct faults — **no endpoint configured**, **persistent connection
failure**, **HTTP error**, **malformed JSON**, **a short batch** — reach every
caller as the same `[]`, with nothing written to any log. And `[]` is not a
neutral value here: callers read it as "no embedding available" and degrade,
which is also what happens when you pass no text.

The short-batch case is the worst of them: the endpoint answered `200`, the model
ran, and a count mismatch is thrown away without a word.

## Change

Behaviour is unchanged — still fails open, still retries once on a cold load
(test asserts `post.call_count == 2`). Each branch now logs at **warning** saying
which fault it was and that no vectors are being returned. `mcp/memcheck/llm.py`
has its own `embed_texts` with the same two silent branches; same treatment.

Passing an empty list stays silent — that is a caller decision, not a fault.

## Tests

`mcp/tests/test_embed_failure_trace.py` — 6 tests, one per branch, plus
`assertNoLogs` on the happy path and on the empty-input path so this does not
become a source of warning noise.

`mcp/tests/`: 540 passed. Ruff and vulture clean.

The other 24 silent handlers are catalogued if you want them triaged; the rest of
the retrieval-path ones (`_search_benign_context_qdrant`, `_compute_code_refs`)
are the same shape but far less load-bearing.