### PR TITLE
feat(groom): passive grooming tier — index reconciliation and local-model tagging

### DIFF
--- a/deep_think_loci/STEERING.md
+++ b/deep_think_loci/STEERING.md
@@ -1,0 +1,178 @@
+# Steerable deep-think — design note
+
+Today a run is fire-and-forget: `Workflow({scriptPath})`, seven agents, one answer,
+~$5, and the only way to change your mind is to kill it and start over. The goal
+is to be able to redirect the thinking *while it thinks* — and to move model
+routing from five string literals in the script to a decision that can be revised
+mid-run.
+
+This note is the design, not the implementation. It is written against what the
+tools actually permit, which turns out to shape most of it.
+
+## The one constraint that shapes everything
+
+**A workflow script cannot read Loci.** It has `agent()`, `parallel()`,
+`pipeline()`, `phase()` and `log()` — no filesystem, no MCP. `loci-native.js`
+already documents this: grounding is produced *before* the workflow starts and
+injected through `args`, precisely because the script itself cannot fetch it.
+
+But **agents can**. deep-think's own prompts tell them to call
+`mcp__loci__rag_context_search`. So the script cannot poll for guidance — an agent
+can, and hand the result back as the return value of a stage.
+
+That single fact settles the shape: **steering is a cheap agent between phases,
+not a callback into the script.**
+
+## The substrate already exists
+
+Nothing here needs new storage. Three things are already in place:
+
+| primitive | what it gives us |
+|---|---|
+| `investigation_note(id, field, value)` | an operator-writable manifest per investigation — `hypothesis`, `next_step`, `open_question_add`, `context`. This *is* a steering surface; deep-think simply never reads it. |
+| `memory_hints(id, since_ts)` | incremental poll of what a run has produced since a timestamp — built for exactly this. |
+| `record_type` | not validated against a fixed vocabulary, so a `directive` record is a convention, not a schema change. |
+
+The investigation is already the run's shared state. Making it the *control plane*
+costs a read.
+
+## Design: the investigation is the control plane
+
+### 1. Directives
+
+An operator (or a supervising model) writes a directive into the same
+investigation the run is writing to:
+
+```
+investigation_store(investigation_id=RUN, record_type="directive",
+                    text="drop target 3, it is out of scope",
+                    tags=["phase:ideate", "priority:high"])
+```
+
+Or, for the coarse steer, just `investigation_note(RUN, "next_step", "...")`.
+
+Directives are scoped by tag: `phase:*` targets a stage, untagged applies to all
+remaining stages. They are findings, so they are timestamped, attributable and
+auditable — the run records not just what it concluded but what it was told.
+
+### 2. The steering agent
+
+Between phases, one cheap agent — haiku, single purpose:
+
+```
+read investigation RUN's manifest and every record_type="directive" since <ts>;
+return {directives: [...], hypothesis, next_step, halt: bool}
+```
+
+Its return value is threaded into the next phase's prompts, the same way `args.ground`
+is threaded today. Cost is one small agent per phase boundary — call it 4 extra
+agents on a 7-agent run, well under the `~$0.15-per-agent` floor the README already
+records.
+
+### 3. Phase gates that cannot hang
+
+After writing its checkpoint, a phase may wait for an acknowledging directive —
+but **always with a deadline and a default of proceed**. An unattended run must
+behave exactly as it does today; a watched run pauses long enough to be redirected.
+
+```
+gate(phase) := poll for directives up to T seconds
+               → halt directive  : stop, write closed_summary
+               → steer directive : fold into the next phase's prompt
+               → nothing by T    : proceed unchanged
+```
+
+`halt` is the one directive that must be honoured immediately, because the reason
+to want it is usually "this run is going the wrong way and costing money".
+
+## Model routing as data
+
+Routing is currently `model: 'haiku'` ×4 and `model: 'opus'` ×2, literal in the
+script. Make it a policy the run carries and a directive can revise:
+
+```
+tiers: {
+  ideate:   { tier: "cheap-parallel" },
+  write:    { tier: "mechanical"     },
+  verify:   { tier: "reason"         },
+  synth:    { tier: "judgement"      },
+}
+```
+
+and resolve `tier → concrete model` at dispatch. The resolver is the ladder built
+for the passive tier, extended with the Claude tiers:
+
+| tier | resolves to | because |
+|---|---|---|
+| `mechanical` | embeddings, or a free/cheap remote model | measured: kNN beat every model at tagging, 2× the precision at a tenth of the time |
+| `cheap-parallel` | free ladder → cheap paid → haiku | high volume, low judgement; free availability is opportunistic and the ladder absorbs the 429s |
+| `reason` | haiku / sonnet | needs to be right, not deep |
+| `judgement` | **opus** | adversarial synthesis and red-teaming. v3.2 removed the external tier for good reason and nothing here revisits that — this is where Anthropic models are the correct tool, not a cost to optimise |
+
+Two things this buys beyond flexibility. A directive can say *"you are going in
+circles, escalate the next synthesis to opus"* — or the reverse, *"this target is
+mechanical, stop spending judgement on it"*. And the run records which tier served
+each finding, so "did the expensive tier actually earn it" becomes a measurable
+question instead of an intuition.
+
+## Merging Loci's memory into the thinking
+
+Today each run re-derives its grounding from raw RAG. The corpus now has structure
+the run never sees:
+
+- **code links** — `Finding → CodeSymbol` edges, so a target named as a subsystem
+  can pull the findings that touch its symbols, not just the ones that read similar
+- **related prior investigations** — `investigation_related_cases` and
+  `related_investigations_via_code` already answer "who has thought about this
+  before"; a fresh run currently starts as though nobody had
+- **conflicts** — `_detect_conflicts` has produced records since it started working;
+  a contradiction found in an earlier run is exactly what a new one should open with
+- **the manifest** — prior `hypothesis` / `open_question` entries are the cheapest
+  possible seed for ideation
+
+So phase 0 becomes *assemble*, not *retrieve*: build the run's opening context from
+the groomed graph, and let RAG fill the gaps rather than carry the whole load. That
+is the merge — the passive tier maintains the structure, deep-think consumes it, and
+each run's findings feed back into what the passive tier grooms next.
+
+## Two modes, one set of phases
+
+The phases should be **separately invocable**. Then:
+
+- **unattended** — a wrapper runs them back to back with `T=0` gates. Identical to
+  today's behaviour.
+- **driven** — the session invokes one phase at a time and the operator steers
+  between them in conversation. No control plane needed at all; the gate is the
+  human.
+
+The second mode is worth building first *because it is nearly free*: it is the
+current script split at its existing phase boundaries. The directive channel is
+what makes the first mode as steerable as the second, and it can follow.
+
+## Order of work
+
+1. **Split the workflow at its phase boundaries** so each phase can be invoked
+   alone. Buys interactive steering immediately, with no new machinery.
+2. **Phase 0 assembles from the graph** — code links, related cases, prior
+   manifest — instead of RAG-only grounding.
+3. **Tier table**, replacing the literal model names; routing recorded per finding.
+4. **Steering agent + directive records**, giving mode one the same steerability as
+   mode two.
+5. **Escalation directives** — the point at which a supervising model, not just a
+   person, can redirect a run.
+
+Steps 1 and 2 are worth doing regardless of whether the rest ever happens: one
+makes the run interruptible, the other makes it start from what is already known.
+
+## Open questions
+
+- **What does a directive mean to work already dispatched?** A `parallel()` stage
+  is in flight; a directive arriving mid-stage cannot reach it. Simplest honest
+  answer: directives apply at the next boundary and the run says so.
+- **How is a steering agent's read authenticated?** It reads the same investigation
+  the run writes. If a directive can redirect an expensive run, writing one is a
+  privileged act, and today anything with MCP access can.
+- **Does steering actually improve outcomes?** Unmeasured, and it should not be
+  assumed. The comparison to run is: same targets, steered against unsteered,
+  judged on the resulting findings — the same discipline the grounding gate was
+  held to when its in-sample numbers looked better than they were.

--- a/docs/companion-service.md
+++ b/docs/companion-service.md
@@ -1,0 +1,151 @@
+# A companion service for Loci — where the passive tier should run
+
+`scripts/loci_groom.py` needs a home. It is unattended, batch-shaped, and wants a
+generation tier that is *there* rather than one that is fast. That is a different
+requirement from the retrieval path, and the two have been conflated.
+
+This note records why the previous serving attempts went badly — measured on the
+live cluster, not recalled — and what shape survives it.
+
+## Why the previous attempts went badly
+
+Not model choice. The substrate.
+
+### The node advertises 32 GPUs and owns roughly one
+
+```
+$ kubectl get node desktop-bvrdk4j -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
+32
+```
+
+The NVIDIA device plugin under WSL2 advertises a bogus device count. Kubernetes
+believes it, so nothing stops it scheduling many `nvidia.com/gpu: 1` pods onto a
+node with one physical card. They admit successfully and then contend for the
+same device.
+
+### Which produces exactly the failures on record
+
+```
+$ kubectl -n dama describe pod vllm-gpu-66d44bdd86-fhth7
+Status:   Failed
+Reason:   UnexpectedAdmissionError
+Message:  Pod was rejected: Allocate failed due to no healthy devices present;
+          cannot allocate unhealthy devices nvidia.com/gpu, which is unexpected
+```
+
+The device plugin daemonset has restarted **9 times in 52 days**. Each restart is
+a window in which devices report unhealthy: running GPU pods die with
+`ContainerStatusUnknown` and their replacements are rejected outright. The
+ReplicaSet leaves a graveyard behind it — `vllm-gpu` currently shows 1 Running
+against 3 dead over 9 days, and `qdrant-mcp-server` the same shape.
+
+Cluster-wide right now: 93 Running, 21 Error, 2 OOMKilled, 2
+UnexpectedAdmissionError, 2 ContainerStatusUnknown.
+
+### On a node already promising more than it has
+
+```
+Allocated resources:
+  cpu     19 (67%) requests    114050m (407%) limits
+  memory  55596Mi (57%)        216198Mi (223%) limits
+```
+
+`infra/qdrant` — the store everything else depends on — has restarted **32 times
+in 93 days**.
+
+**So: a Loci companion service that assumes a GPU pod stays admitted will inherit
+all of this.** Every previous attempt did. That is the thing to design around,
+and it is not fixed by picking a better model.
+
+## What the work actually needs
+
+The two tiers have been treated as one and they have opposite requirements.
+
+| | retrieval path | passive grooming |
+|---|---|---|
+| on a user's critical path | yes | no |
+| latency budget | milliseconds | hours |
+| failure cost | a request degrades | a batch retries later |
+| per-call cost tolerance | must be ~0 | a fraction of a cent is fine |
+| can it leave the machine | reranker/embedder: no | mostly yes, with a gate |
+
+The reranker and the embedder must stay local — they are called on every
+retrieval, and network round-trips would dominate. Nothing about that changes.
+
+The grooming passes are the opposite: idempotent, shadow-first, and resumable by
+construction. A pass that fails costs one wasted batch and re-runs on the next
+tick. That is precisely the workload that should *not* be pinned to the least
+reliable thing in the system.
+
+## The shape: a router, not a server
+
+`mcp/batched_gen.py` already has the right idea — vLLM primary, Ollama fallback,
+never raises. Generalise it into a small companion service that owns three tiers
+and demotes on health rather than on hope:
+
+| tier | what it is | when it is chosen |
+|---|---|---|
+| **local batched** | vLLM on the GPU node | healthy, and the batch is large enough to be worth continuous batching |
+| **local serial** | Ollama, `keep_alive`-pinned | vLLM absent or the device plugin is mid-flap |
+| **remote** | OpenRouter | both local tiers are down, or the pass is explicitly marked remote-eligible |
+
+The service's job is small and worth stating precisely, because scope creep here
+is how the previous attempts got heavy:
+
+- resolve a tier per request, from live health, with hysteresis so a flapping
+  device plugin does not cause a flapping router
+- normalise the model name per tier (`qwen2.5:3b` vs `Qwen/Qwen2.5-3B-Instruct`
+  vs `qwen/qwen-2.5-7b-instruct` are the same intent and three different strings —
+  this exact mismatch already cost one debugging round in `loci_groom`)
+- expose a batch endpoint whose result list is always 1:1 with the prompt list,
+  degraded entries included, so callers never have to align by hand
+- account for what it spent, per tier, per pass
+
+It should NOT own: the queue (cron owns scheduling), the corpus (JSONL owns it),
+promotion (the adjudication tier owns it), or embeddings (they stay local).
+
+## On OpenRouter specifically
+
+The attraction is precise: it is the only tier whose availability is uncorrelated
+with this node. When the device plugin flaps, that is exactly when a passive tier
+would otherwise stall, so a remote fallback converts an outage into a slightly
+more expensive hour.
+
+Three things to decide before wiring it up.
+
+**Redaction is not optional.** The corpus is infrastructure findings. It contains
+internal IPs, hostnames, k3s topology, and at least historically a live API key
+(#79). A pass that ships finding text to a third party needs either a redaction
+gate or an explicit per-pass allow-list. The cleanest rule: **passes declare
+`remote_ok`, and it defaults to false.** `recall`'s generated questions and
+`codelink`'s disambiguation prompts are low-risk and short; whole-finding
+summarisation is not.
+
+**Cost has to be bounded per run, not per call.** A grooming pass over 2,435
+findings that silently falls back to a remote tier is a bill, not a degradation.
+Give the router a per-invocation budget and let it return `ok: False` when
+exhausted — the passes already handle that, since every one of them counts its
+rejections.
+
+**Pick the tier per pass, not globally.** `knn_tags` needs no generation at all.
+`codelink` needs it only for the ~1,081 ambiguous tokens. `recall` needs one
+short question per sampled finding. These have very different remote-cost
+profiles and should not share one switch.
+
+## Fixing the substrate anyway
+
+Independent of where generation runs, three things on the node are worth doing
+because everything else inherits them:
+
+1. **Stop the device plugin advertising 32 GPUs.** Whatever the count should be,
+   32 is not it, and it is what lets the scheduler oversubscribe the card. This
+   is the single highest-leverage change on the list.
+2. **Set limits that are not 407%/223% of the node.** Overcommitted limits are
+   how a memory spike in one pod evicts an unrelated one.
+3. **Reap the Failed pods.** Four dead ReplicaSet children have been sitting for
+   9 days. They cost nothing but they hide the next real failure in the noise —
+   the same "a broken thing that looks like a normal thing" pattern the rest of
+   this codebase's audits keep finding.
+
+None of that needs to happen before the companion service exists. The router
+design assumes the node is unreliable, which is what the evidence says it is.

--- a/docs/companion-service.md
+++ b/docs/companion-service.md
@@ -132,6 +132,42 @@ rejections.
 short question per sampled finding. These have very different remote-cost
 profiles and should not share one switch.
 
+## Measured, 2026-08-24 — which tier is worth using for what
+
+One protocol for every method: hold out findings that carry vocabulary tags, hide
+them, re-derive, score against what the author wrote. Same 60-finding sample.
+
+| method | completed | mean precision | wall time |
+|---|---|---|---|
+| kNN over the embeddings, no model | **60/60** | **0.361** | 6.4s |
+| `mistralai/mistral-nemo` (paid, ~$0.0000145/call) | 36/60 | 0.194 | 63.6s |
+| `nvidia/nemotron-3-super-120b:free` | 2/60 | — | 19.9s |
+| `z-ai/glm-5.2:free` | 1/60 | — | 12.0s |
+| local vLLM Qwen2.5-3B | **0/60** | — | 0.3s |
+
+Three conclusions, and one caveat.
+
+**Tagging does not want a model.** The embedding method beat the only model that
+finished enough of the sample to judge — twice the precision, a tenth of the wall
+time, no tokens. Everything the vectors can already answer should be answered
+that way; generation belongs where embeddings cannot help, which is extraction
+and disambiguation, not classification.
+
+**The free pool cannot carry a bulk pass.** 1/60 and 2/60 completion is not a
+quality signal, it is a quota signal — the shared upstream pool 429s under any
+sustained load. Free models are fine for the low-volume work (`codelink`'s ~1,081
+ambiguous tokens, `recall`'s one short question per sample) and unusable for a
+sweep over thousands. The ladder is what makes that survivable rather than fatal.
+
+**The local tier went down during the benchmark.** `vllm-gpu` restarted mid-run —
+`Running 4 (2m25s ago)`, `0/1` not ready, forwarder returning nothing — which is
+why its column is 0/60. That is this document's argument happening unprompted:
+the local tier is least available exactly when there is bulk work to do.
+
+*Caveat.* The absolute numbers are low for every method because the ground truth
+is itself noisy — 4,267 distinct tags of which 2,809 are used exactly once. What
+is robust here is the ordering and the completion rates, not the third decimal.
+
 ## Fixing the substrate anyway
 
 Independent of where generation runs, three things on the node are worth doing

--- a/mcp/backends.py
+++ b/mcp/backends.py
@@ -132,6 +132,17 @@ def qdrant() -> tuple[str, str]:
             os.environ.get("QDRANT_API_KEY") or _cfg("qdrant", "api_key", "") or "")
 
 
+def openrouter() -> tuple[str, str]:
+    """(base_url, api_key) for the OpenRouter tier: env -> config -> ('', '').
+
+    The key belongs in ~/.loci/backends.toml, which is outside any git tree —
+    never in the repo. See docs/companion-service.md.
+    """
+    return (os.environ.get("OPENROUTER_BASE_URL")
+            or _cfg("openrouter", "url", "") or "https://openrouter.ai/api/v1",
+            os.environ.get("OPENROUTER_API_KEY") or _cfg("openrouter", "key", "") or "")
+
+
 def memory_dir() -> str:
     """Curated MEMORY.md dir for the grounding memory lane: env -> config -> HERMES_MEMORY_DIR -> ''.
     No machine/user-specific default (the old ~/.claude/.../-home-<user>/memory default is gone)."""

--- a/mcp/openrouter.py
+++ b/mcp/openrouter.py
@@ -1,0 +1,218 @@
+"""OpenRouter tier — the generation backend whose availability is not this node's.
+
+The local tiers (vLLM on the GPU node, Ollama) share a failure domain: one WSL2
+node whose device plugin advertises phantom GPUs and periodically reports none
+healthy, taking running pods down with it. That is precisely when a passive
+grooming pass would otherwise stall. A remote tier turns that outage into a
+slower hour instead.
+
+Contract, identical to ``batched_gen.generate_batch`` so the tiers are
+interchangeable::
+
+    generate_batch(prompts, model=...) -> list[dict]   # {"text": str, "ok": bool}
+
+The result list is ALWAYS 1:1 with ``prompts`` — a failed prompt yields
+``{"text": "", "ok": False}`` — so no caller ever has to realign by hand.
+
+Never enabled implicitly. Findings carry internal addressing, host names and
+cluster topology; shipping them to a third party is a decision a pass makes
+explicitly, not a fallback it drifts into. See docs/companion-service.md.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import logging
+import os
+from typing import Callable, Optional
+
+logger = logging.getLogger("loci-mcp.openrouter")
+
+DEFAULT_BASE = "https://openrouter.ai/api/v1"
+
+# Free-tier ladder, cheapest-to-run first. Free models rate-limit and come and go,
+# so a pass names a *preference* and the caller falls down the list. Ordered by
+# measured fitness for short structured-output work, not by parameter count.
+FREE_LADDER = (
+    "google/gemma-4-31b-it:free",
+    "z-ai/glm-5.2:free",
+    "nvidia/nemotron-3-super-120b-a12b:free",
+    "google/gemma-4-26b-a4b-it:free",
+    "openrouter/free",
+)
+
+# Paid but negligible: ~$0.0000145 for a 700-in/40-out grooming call, i.e. the
+# whole 2.4k-finding corpus for about four cents. Worth it when a pass needs a
+# result rather than a best effort.
+CHEAP_LADDER = (
+    "mistralai/mistral-nemo",
+    "qwen/qwen3.7-flash",
+    "openai/gpt-oss-20b",
+)
+
+# Free first, then the negligible-cost tier as the safety net. The free pool is a
+# SHARED upstream quota — "temporarily rate-limited upstream" is its normal state
+# under load, not a fault — so a ladder that stops at free stalls exactly when the
+# work is biggest.
+DEFAULT_LADDER = FREE_LADDER + CHEAP_LADDER
+
+_MAX_INFLIGHT = int(os.environ.get("LOCI_OPENROUTER_CONCURRENCY", "6"))
+_TIMEOUT = float(os.environ.get("LOCI_OPENROUTER_TIMEOUT", "90"))
+
+
+def credentials() -> tuple:
+    """(base_url, api_key). Env first, then ~/.loci/backends.toml."""
+    key = os.environ.get("OPENROUTER_API_KEY", "")
+    base = os.environ.get("OPENROUTER_BASE_URL", "")
+    if not (key and base):
+        try:
+            import backends
+            cfg_base, cfg_key = backends.openrouter()
+            base = base or cfg_base
+            key = key or cfg_key
+        except Exception as exc:
+            logger.debug("openrouter: config read failed: %r", exc)
+    return (base or DEFAULT_BASE), key
+
+
+def available() -> bool:
+    return bool(credentials()[1])
+
+
+def _extract_json(text: str) -> Optional[str]:
+    """The outermost JSON object in `text`, or None.
+
+    A reasoning model asked for JSON writes several paragraphs and then the JSON.
+    Demanding a bare object throws away a correct answer for a presentation
+    difference, so find it — from the end, since the answer follows the thinking.
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    try:
+        json.loads(stripped)
+        return stripped
+    except ValueError:
+        pass
+    for start in range(len(text)):
+        if text[start] != "{":
+            continue
+        depth = 0
+        for end in range(start, len(text)):
+            if text[end] == "{":
+                depth += 1
+            elif text[end] == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start:end + 1]
+                    try:
+                        json.loads(candidate)
+                        return candidate
+                    except ValueError:
+                        break
+    return None
+
+
+def _one(session, base: str, key: str, model: str, prompt: str,
+         max_tokens: int, fmt: Optional[str], temperature: float) -> dict:
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if fmt == "json":
+        body["response_format"] = {"type": "json_object"}
+    try:
+        r = session.post(
+            f"{base.rstrip('/')}/chat/completions",
+            headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+            json=body, timeout=_TIMEOUT,
+        )
+        try:
+            payload = r.json()
+        except ValueError:
+            logger.warning("openrouter: %s returned a non-JSON body (%s)", model, r.status_code)
+            return {"text": "", "ok": False, "status": r.status_code}
+
+        # OpenRouter reports upstream failures as HTTP 200 with an `error` object
+        # and empty choices. Reading only the status code turns a rate-limit into
+        # something indistinguishable from a model that answered with nothing.
+        err = payload.get("error")
+        if err:
+            code = err.get("code") or r.status_code
+            logger.warning("openrouter: %s failed (%s): %s",
+                           model, code, str(err.get("message"))[:120])
+            return {"text": "", "ok": False, "status": code}
+        if r.status_code != 200:
+            logger.warning("openrouter: %s returned %s: %s", model, r.status_code, r.text[:200])
+            return {"text": "", "ok": False, "status": r.status_code}
+
+        text = (payload.get("choices") or [{}])[0].get("message", {}).get("content") or ""
+        if fmt == "json":
+            # Reasoning models narrate before answering. Extracting the object is
+            # not the same as accepting invented content — callers still validate.
+            extracted = _extract_json(text)
+            if extracted is None:
+                logger.warning("openrouter: %s returned no JSON object under fmt=json", model)
+                return {"text": text, "ok": False}
+            text = extracted
+        usage = payload.get("usage") or {}
+        return {
+            "text": text, "ok": bool(text.strip()), "model": payload.get("model", model),
+            "prompt_tokens": usage.get("prompt_tokens"),
+            "completion_tokens": usage.get("completion_tokens"),
+        }
+    except Exception as exc:
+        logger.warning("openrouter: %s call failed: %r", model, exc)
+        return {"text": "", "ok": False}
+
+
+def generate_batch(prompts: list, model: Optional[str] = None, max_tokens: int = 256,
+                   fmt: Optional[str] = None, temperature: float = 0.2,
+                   ladder: Optional[tuple] = None,
+                   session_fn: Optional[Callable] = None) -> list:
+    """Generate for every prompt. Always returns len(prompts) results.
+
+    ``ladder`` retries the prompts that failed against the next model in the list,
+    which is what makes a free tier usable: a 429 on one free model is not an
+    outage, it is a hint to ask a different one.
+    """
+    if not prompts:
+        return []
+    base, key = credentials()
+    if not key:
+        logger.warning("openrouter: no API key configured — returning no generations")
+        return [{"text": "", "ok": False} for _ in prompts]
+
+    if session_fn is None:
+        def session_fn():
+            import requests
+            return requests.Session()
+    try:
+        session = session_fn()
+    except Exception as exc:
+        logger.warning("openrouter: no HTTP client: %r", exc)
+        return [{"text": "", "ok": False} for _ in prompts]
+
+    candidates = list(ladder or ([model] if model else DEFAULT_LADDER))
+    results: list = [{"text": "", "ok": False} for _ in prompts]
+
+    for candidate in candidates:
+        todo = [i for i, r in enumerate(results) if not r.get("ok")]
+        if not todo:
+            break
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_MAX_INFLIGHT) as pool:
+            futures = {
+                pool.submit(_one, session, base, key, candidate, prompts[i],
+                            max_tokens, fmt, temperature): i
+                for i in todo
+            }
+            for fut in concurrent.futures.as_completed(futures):
+                i = futures[fut]
+                try:
+                    results[i] = fut.result()
+                except Exception:
+                    results[i] = {"text": "", "ok": False}
+
+    return results

--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -423,19 +423,25 @@ def _qdrant_degraded_mode(enabled: bool, available: bool, errors, query_success:
 # rather than relevance. bge-reranker-v2-m3 accepts 8192 TOKENS; 512 characters
 # is roughly a sixteenth of that.
 #
-# Swept against identity recall (scripts/loci_groom.py recall, n=90), which is
-# what this should be re-tuned against if the corpus shape changes:
+# Swept against identity recall (scripts/loci_groom.py recall, n=90 per arm,
+# three seeds), which is what this should be re-tuned against if the corpus shape
+# changes. identity r@1:
 #
-#     passage chars   r@1     r@5     MRR
-#     (no CE)         0.967   1.000   0.982
-#     512             0.744   0.956   0.832   <- the value this replaces
-#     1024            1.000   1.000   1.000
-#     2048/4096/8192  0.944   1.000   0.969
+#     passage chars   seed 5   seed 11   seed 12
+#     (no CE)          0.967    0.929     0.933
+#     512              0.744    0.811     0.822   <- the value this replaces
+#     1024             1.000    0.978     0.956
+#     2048             0.944    0.978     0.956
 #
-# 1024 lands on the corpus median (1,048 chars) — about one whole finding. Less
-# truncates the evidence; more appears to dilute the relevance signal. Note the
-# reranker EARNS its place at 1024 (it beats no-CE); at 512 it was costing more
-# than it returned.
+# Two results replicate across all three seeds: 512 is worse than switching the
+# reranker OFF, and >=1024 is better than both. So the reranker was not the
+# problem — it had never been given enough of a passage to judge, on a corpus
+# whose median finding is 1,048 characters.
+#
+# What did NOT replicate: the first seed showed 1024 beating 2048, which looked
+# like longer passages diluting the signal. Two further seeds show them identical.
+# 1024 stays the default because it is never worse and it is one median finding,
+# but anything >= 1024 is defensible and the 1024-vs-2048 gap was noise.
 RERANK_MAX_CHARS = int(os.environ.get("LOCI_RERANK_MAX_CHARS", "1024"))
 
 

--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -414,6 +414,31 @@ def _qdrant_degraded_mode(enabled: bool, available: bool, errors, query_success:
     return degraded_active, degraded_reason
 
 
+# How much of a passage the cross-encoder is allowed to see, in CHARACTERS.
+#
+# This was a hardcoded 512. The corpus median finding is 1,048 characters and
+# 73.6% of findings are longer than 512, so for three findings in four the
+# reranker was scoring a truncated head against a query drawn from the whole
+# text — and short findings, scored complete, won the comparison on presentation
+# rather than relevance. bge-reranker-v2-m3 accepts 8192 TOKENS; 512 characters
+# is roughly a sixteenth of that.
+#
+# Swept against identity recall (scripts/loci_groom.py recall, n=90), which is
+# what this should be re-tuned against if the corpus shape changes:
+#
+#     passage chars   r@1     r@5     MRR
+#     (no CE)         0.967   1.000   0.982
+#     512             0.744   0.956   0.832   <- the value this replaces
+#     1024            1.000   1.000   1.000
+#     2048/4096/8192  0.944   1.000   0.969
+#
+# 1024 lands on the corpus median (1,048 chars) — about one whole finding. Less
+# truncates the evidence; more appears to dilute the relevance signal. Note the
+# reranker EARNS its place at 1024 (it beats no-CE); at 512 it was costing more
+# than it returned.
+RERANK_MAX_CHARS = int(os.environ.get("LOCI_RERANK_MAX_CHARS", "1024"))
+
+
 def _ce_rerank(query: str, rows: list[dict], top_k: int) -> tuple[list[dict], bool]:
     """Cross-encoder rerank of ``rows`` against ``query``, truncated to ``top_k``.
 
@@ -425,7 +450,7 @@ def _ce_rerank(query: str, rows: list[dict], top_k: int) -> tuple[list[dict], bo
     ce = _get_cross_encoder()
     if ce is not None and rows:
         try:
-            pairs = [(query, str(r.get("text", ""))[:512]) for r in rows]
+            pairs = [(query, str(r.get("text", ""))[:RERANK_MAX_CHARS]) for r in rows]
             ce_scores = ce.predict(pairs)
             for row, ce_score in zip(rows, ce_scores):
                 row["ce_score"] = round(float(ce_score), 4)

--- a/mcp/tests/test_openrouter.py
+++ b/mcp/tests/test_openrouter.py
@@ -1,0 +1,191 @@
+"""The OpenRouter tier.
+
+Two behaviours carry most of the weight here. OpenRouter reports upstream
+failures as **HTTP 200 with an `error` object**, so a status-code check alone
+turns a rate-limit into something indistinguishable from a model that answered
+with nothing — which is the exact failure shape this codebase keeps finding
+elsewhere. And the free pool is a shared upstream quota, so 429 is its normal
+state under load and the ladder has to treat it as a hint, not an outage.
+"""
+import json
+import unittest
+from unittest import mock
+
+import openrouter
+
+
+class _Resp:
+    def __init__(self, payload, status=200, raw=None):
+        self.status_code = status
+        self._payload = payload
+        self.text = raw if raw is not None else json.dumps(payload)
+
+    def json(self):
+        if self._payload is _BAD:
+            raise ValueError("not json")
+        return self._payload
+
+
+_BAD = object()
+
+
+def _ok(content, model="m", usage=None):
+    return {"choices": [{"message": {"content": content}}],
+            "model": model, "usage": usage or {}}
+
+
+class _Session:
+    """Answers per model name, so ladder behaviour is observable."""
+
+    def __init__(self, by_model, default=None):
+        self.by_model = by_model
+        self.default = default
+        self.calls = []
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        model = (json or {}).get("model")
+        self.calls.append(model)
+        resp = self.by_model.get(model, self.default)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+def _creds():
+    return mock.patch.object(openrouter, "credentials", lambda: ("https://x/api/v1", "k"))
+
+
+class TestErrorEnvelope(unittest.TestCase):
+    def test_a_200_carrying_an_error_object_is_a_failure(self):
+        sess = _Session({}, default=_Resp(
+            {"error": {"code": 429, "message": "temporarily rate-limited upstream"}}))
+        with _creds():
+            out = openrouter.generate_batch(["p"], model="m", session_fn=lambda: sess)
+        self.assertFalse(out[0]["ok"])
+        self.assertEqual(out[0]["status"], 429)
+
+    def test_a_real_non_200_is_still_a_failure(self):
+        sess = _Session({}, default=_Resp({"choices": []}, status=500))
+        with _creds():
+            out = openrouter.generate_batch(["p"], model="m", session_fn=lambda: sess)
+        self.assertFalse(out[0]["ok"])
+        self.assertEqual(out[0]["status"], 500)
+
+    def test_an_unparseable_body_does_not_raise(self):
+        sess = _Session({}, default=_Resp(_BAD, status=200, raw="<html>"))
+        with _creds():
+            out = openrouter.generate_batch(["p"], model="m", session_fn=lambda: sess)
+        self.assertFalse(out[0]["ok"])
+
+    def test_a_transport_exception_does_not_raise(self):
+        sess = _Session({}, default=RuntimeError("connection reset"))
+        with _creds():
+            out = openrouter.generate_batch(["p"], model="m", session_fn=lambda: sess)
+        self.assertEqual(out, [{"text": "", "ok": False}])
+
+
+class TestJsonExtraction(unittest.TestCase):
+    def test_a_bare_object_passes_through(self):
+        self.assertEqual(openrouter._extract_json('{"tags": ["a"]}'), '{"tags": ["a"]}')
+
+    def test_an_object_after_reasoning_prose_is_found(self):
+        text = 'We need to consider the vocabulary.\n\nSo:\n{"tags": ["mqtt"]}'
+        self.assertEqual(json.loads(openrouter._extract_json(text)), {"tags": ["mqtt"]})
+
+    def test_nested_objects_are_balanced_correctly(self):
+        text = 'thinking... {"a": {"b": 1}, "c": 2} done'
+        self.assertEqual(json.loads(openrouter._extract_json(text)), {"a": {"b": 1}, "c": 2})
+
+    def test_prose_with_no_object_returns_none(self):
+        self.assertIsNone(openrouter._extract_json("I cannot answer that."))
+        self.assertIsNone(openrouter._extract_json(""))
+
+    def test_a_brace_that_is_not_json_is_not_mistaken_for_one(self):
+        self.assertIsNone(openrouter._extract_json("the set {a, b} of tags"))
+
+    def test_fmt_json_rejects_a_response_with_no_object(self):
+        sess = _Session({}, default=_Resp(_ok("no json here")))
+        with _creds():
+            out = openrouter.generate_batch(["p"], model="m", fmt="json",
+                                            session_fn=lambda: sess)
+        self.assertFalse(out[0]["ok"])
+
+    def test_fmt_json_accepts_an_object_buried_in_prose(self):
+        sess = _Session({}, default=_Resp(_ok('sure!\n{"tags": ["mqtt"]}')))
+        with _creds():
+            out = openrouter.generate_batch(["p"], model="m", fmt="json",
+                                            session_fn=lambda: sess)
+        self.assertTrue(out[0]["ok"])
+        self.assertEqual(json.loads(out[0]["text"]), {"tags": ["mqtt"]})
+
+
+class TestLadder(unittest.TestCase):
+    def test_it_falls_through_to_the_next_model_on_a_rate_limit(self):
+        sess = _Session({
+            "a": _Resp({"error": {"code": 429, "message": "rate limited"}}),
+            "b": _Resp(_ok("answer")),
+        })
+        with _creds():
+            out = openrouter.generate_batch(["p"], ladder=("a", "b"),
+                                            session_fn=lambda: sess)
+        self.assertTrue(out[0]["ok"])
+        self.assertEqual(out[0]["text"], "answer")
+        self.assertEqual(sess.calls, ["a", "b"])
+
+    def test_it_stops_as_soon_as_every_prompt_is_answered(self):
+        sess = _Session({"a": _Resp(_ok("answer"))})
+        with _creds():
+            openrouter.generate_batch(["p"], ladder=("a", "b", "c"),
+                                      session_fn=lambda: sess)
+        self.assertEqual(sess.calls, ["a"], "b and c must not be called")
+
+    def test_only_the_prompts_that_failed_are_retried(self):
+        calls = []
+
+        class S:
+            def post(self, url, headers=None, json=None, timeout=None):
+                model, prompt = json["model"], json["messages"][0]["content"]
+                calls.append((model, prompt))
+                if model == "a" and prompt == "p2":
+                    return _Resp({"error": {"code": 429, "message": "x"}})
+                return _Resp(_ok(f"{model}:{prompt}"))
+
+        with _creds():
+            out = openrouter.generate_batch(["p1", "p2"], ladder=("a", "b"),
+                                            session_fn=lambda: S())
+        self.assertEqual(out[0]["text"], "a:p1")
+        self.assertEqual(out[1]["text"], "b:p2")
+        self.assertEqual(sorted(calls), [("a", "p1"), ("a", "p2"), ("b", "p2")])
+
+    def test_the_result_list_always_aligns_with_the_prompts(self):
+        sess = _Session({}, default=_Resp({"error": {"code": 429, "message": "x"}}))
+        with _creds():
+            out = openrouter.generate_batch(["p1", "p2", "p3"], ladder=("a",),
+                                            session_fn=lambda: sess)
+        self.assertEqual(len(out), 3)
+        self.assertTrue(all(r == {"text": "", "ok": False, "status": 429} for r in out))
+
+    def test_the_default_ladder_tries_free_before_paid(self):
+        self.assertEqual(openrouter.DEFAULT_LADDER[:len(openrouter.FREE_LADDER)],
+                         openrouter.FREE_LADDER)
+        self.assertTrue(set(openrouter.CHEAP_LADDER) <= set(openrouter.DEFAULT_LADDER))
+
+
+class TestCredentials(unittest.TestCase):
+    def test_no_key_returns_degraded_results_rather_than_raising(self):
+        with mock.patch.object(openrouter, "credentials", lambda: ("https://x", "")):
+            out = openrouter.generate_batch(["p1", "p2"])
+        self.assertEqual(out, [{"text": "", "ok": False}] * 2)
+
+    def test_available_reflects_the_key(self):
+        with mock.patch.object(openrouter, "credentials", lambda: ("https://x", "")):
+            self.assertFalse(openrouter.available())
+        with mock.patch.object(openrouter, "credentials", lambda: ("https://x", "k")):
+            self.assertTrue(openrouter.available())
+
+    def test_an_empty_prompt_list_costs_nothing(self):
+        self.assertEqual(openrouter.generate_batch([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_reranker.py
+++ b/mcp/tests/test_reranker.py
@@ -126,8 +126,9 @@ class TestRerankPassageBudget(unittest.TestCase):
         pairs = self._pairs_seen("short finding")
         self.assertEqual(pairs[0][1], "short finding")
 
-    def test_the_default_is_the_swept_optimum(self):
+    def test_the_default_clears_the_replicated_floor(self):
         import qdrant_ops
-        # n=90 sweep: 512 -> r@1 0.744, 1024 -> 1.000, 2048+ -> 0.944, no-CE 0.967.
-        # 1024 is the corpus median (1,048 chars) — about one whole finding.
-        self.assertEqual(qdrant_ops.RERANK_MAX_CHARS, 1024)
+        # Across three seeds, 512 scored BELOW no-reranker and >=1024 scored above
+        # both. 1024 vs 2048 did not separate, so the assertion is the floor that
+        # replicated, not the single-seed winner.
+        self.assertGreaterEqual(qdrant_ops.RERANK_MAX_CHARS, 1024)

--- a/mcp/tests/test_reranker.py
+++ b/mcp/tests/test_reranker.py
@@ -3,8 +3,11 @@
 Scores are stubbed via an injected model_fn; NO model is downloaded and no GPU/network
 is touched (mirrors test_embed_ops.py style + the [pattern:injectable] contract).
 """
+import contextlib
 import os
 import sys
+import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -87,3 +90,44 @@ def test_model_id_reads_env(monkeypatch, tmp_path):
     monkeypatch.setenv("RERANK_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
     assert R._model_id() == "cross-encoder/ms-marco-MiniLM-L-6-v2"
     B._reset_cache()
+
+
+class TestRerankPassageBudget(unittest.TestCase):
+    """The passage budget was a hardcoded 512 CHARACTERS against a model that
+    accepts 8192 tokens, while 73.6% of this corpus's findings are longer than
+    512 — so for most passages the reranker scored a truncated head and short
+    findings won on presentation rather than relevance."""
+
+    def _pairs_seen(self, text, budget=None):
+        import qdrant_ops
+        seen = {}
+
+        class _CE:
+            def predict(self, pairs):
+                seen["pairs"] = pairs
+                return [0.5] * len(pairs)
+
+        ctx = mock.patch.object(qdrant_ops, "_get_cross_encoder", lambda: _CE())
+        budget_ctx = (mock.patch.object(qdrant_ops, "RERANK_MAX_CHARS", budget)
+                      if budget is not None else contextlib.nullcontext())
+        with ctx, budget_ctx:
+            qdrant_ops._ce_rerank("q", [{"text": text, "id": "a"}], top_k=1)
+        return seen["pairs"]
+
+    def test_a_long_passage_is_no_longer_cut_at_512(self):
+        pairs = self._pairs_seen("x" * 5000)
+        self.assertGreater(len(pairs[0][1]), 512)
+
+    def test_the_budget_is_honoured(self):
+        pairs = self._pairs_seen("x" * 5000, budget=1024)
+        self.assertEqual(len(pairs[0][1]), 1024)
+
+    def test_a_short_passage_is_passed_whole(self):
+        pairs = self._pairs_seen("short finding")
+        self.assertEqual(pairs[0][1], "short finding")
+
+    def test_the_default_is_the_swept_optimum(self):
+        import qdrant_ops
+        # n=90 sweep: 512 -> r@1 0.744, 1024 -> 1.000, 2048+ -> 0.944, no-CE 0.967.
+        # 1024 is the corpus median (1,048 chars) — about one whole finding.
+        self.assertEqual(qdrant_ops.RERANK_MAX_CHARS, 1024)

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -309,7 +309,7 @@ def _check_lazy_import():
 def _check_real_corpus():
     result = build_graph(rev="HEAD")
     store = result.store
-    assert result.meta.file_count == 115, result.meta.file_count
+    assert result.meta.file_count == 116, result.meta.file_count
     assert result.meta.error_count == 0, result.meta.errors
     bad = registered_but_dead(store)
     assert bad == [], [n.id for n in bad]

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -309,7 +309,7 @@ def _check_lazy_import():
 def _check_real_corpus():
     result = build_graph(rev="HEAD")
     store = result.store
-    assert result.meta.file_count == 116, result.meta.file_count
+    assert result.meta.file_count == 117, result.meta.file_count
     assert result.meta.error_count == 0, result.meta.errors
     bad = registered_but_dead(store)
     assert bad == [], [n.id for n in bad]

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,13 +1,13 @@
 from .conftest import needs_corpus_deps, needs_git_history  # noqa: F401
 """config.py against the REAL repo: acceptance criterion is an exact file
-count (116), not a vibe. If this drifts, either the repo changed shape or
+count (117), not a vibe. If this drifts, either the repo changed shape or
 the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
-def test_corpus_is_exactly_116_files():
+def test_corpus_is_exactly_117_files():
     files = config.iter_corpus_files_worktree()
-    assert len(files) == 116, sorted(files)
+    assert len(files) == 117, sorted(files)
 
 
 def test_corpus_excludes_test_directories():

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,13 +1,13 @@
 from .conftest import needs_corpus_deps, needs_git_history  # noqa: F401
 """config.py against the REAL repo: acceptance criterion is an exact file
-count (115), not a vibe. If this drifts, either the repo changed shape or
+count (116), not a vibe. If this drifts, either the repo changed shape or
 the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
-def test_corpus_is_exactly_115_files():
+def test_corpus_is_exactly_116_files():
     files = config.iter_corpus_files_worktree()
-    assert len(files) == 115, sorted(files)
+    assert len(files) == 116, sorted(files)
 
 
 def test_corpus_excludes_test_directories():

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -4,10 +4,10 @@ from .. import ingest
 from ..tests.helpers import source_file
 
 
-def test_load_corpus_worktree_parses_116_files_with_no_errors():
+def test_load_corpus_worktree_parses_117_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
-    assert len(sources) == 116
+    assert len(sources) == 117
     errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
     assert errors == []
     assert all(sf.tree is not None for sf in sources)
@@ -16,7 +16,7 @@ def test_load_corpus_worktree_parses_116_files_with_no_errors():
 def test_load_corpus_rev_head_reads_git_blobs():
     sources, origin = ingest.load_corpus(rev="HEAD")
     assert origin.startswith("rev ")
-    assert len(sources) == 116
+    assert len(sources) == 117
     assert all(sf.error is None for sf in sources)
     server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
     assert "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -4,10 +4,10 @@ from .. import ingest
 from ..tests.helpers import source_file
 
 
-def test_load_corpus_worktree_parses_115_files_with_no_errors():
+def test_load_corpus_worktree_parses_116_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
-    assert len(sources) == 115
+    assert len(sources) == 116
     errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
     assert errors == []
     assert all(sf.tree is not None for sf in sources)
@@ -16,7 +16,7 @@ def test_load_corpus_worktree_parses_115_files_with_no_errors():
 def test_load_corpus_rev_head_reads_git_blobs():
     sources, origin = ingest.load_corpus(rev="HEAD")
     assert origin.startswith("rev ")
-    assert len(sources) == 115
+    assert len(sources) == 116
     assert all(sf.error is None for sf in sources)
     server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
     assert "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -15,7 +15,7 @@ from ..pipeline import build_graph
 
 
 def test_build_is_clean_and_fast(head_build):
-    assert head_build.meta.file_count == 116
+    assert head_build.meta.file_count == 117
     assert head_build.meta.error_count == 0
     # The 2s figure in ingest.py's own docstring is about ast.parse'ing the
     # corpus (steps 1-3's budget). Steps 4-6 (CALLSITE/CALLS resolution over

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -15,7 +15,7 @@ from ..pipeline import build_graph
 
 
 def test_build_is_clean_and_fast(head_build):
-    assert head_build.meta.file_count == 115
+    assert head_build.meta.file_count == 116
     assert head_build.meta.error_count == 0
     # The 2s figure in ingest.py's own docstring is about ast.parse'ing the
     # corpus (steps 1-3's budget). Steps 4-6 (CALLSITE/CALLS resolution over

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -43,8 +43,9 @@ def test_module_level_function_count_matches_census_within_tolerance(head_build)
         n for n in head_build.store.nodes_of_kind("FUNCTION")
         if not n.attrs["is_nested"] and not n.attrs["is_method"]
     ]
-    # docs/census.txt estimate: ~890 module-level functions corpus-wide.
-    assert 850 <= len(module_level) <= 930, len(module_level)
+    # docs/census.txt estimate was ~890 corpus-wide; scripts/loci_groom.py and
+    # mcp/openrouter.py moved it to ~951. Band re-centred, same +-5% tolerance.
+    assert 900 <= len(module_level) <= 1000, len(module_level)
 
 
 def test_mcp_top_level_module_level_function_count(head_build):
@@ -56,8 +57,8 @@ def test_mcp_top_level_module_level_function_count(head_build):
         if n.path is not None and n.path.startswith("mcp/") and n.path.count("/") == 1
         and not n.attrs["is_nested"] and not n.attrs["is_method"]
     ]
-    # docs/census.txt estimate: 297 in mcp/ top-level.
-    assert 265 <= len(module_level) <= 330, len(module_level)
+    # docs/census.txt estimate was 297; mcp/openrouter.py moved it to ~334.
+    assert 300 <= len(module_level) <= 370, len(module_level)
 
 
 def test_every_mcp_tool_decorator_is_classified_registering(head_build):

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -78,6 +78,6 @@ def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, 
     finally:
         monkeypatch.setattr(Path, "read_text", original_read_text)
     assert origin.startswith("rev ")
-    assert len(sources) == 116
+    assert len(sources) == 117
     server = _source_for(sources, "mcp/server.py")
     assert server.error is None and "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -78,6 +78,6 @@ def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, 
     finally:
         monkeypatch.setattr(Path, "read_text", original_read_text)
     assert origin.startswith("rev ")
-    assert len(sources) == 115
+    assert len(sources) == 116
     server = _source_for(sources, "mcp/server.py")
     assert server.error is None and "loci-mcp" in server.source[:200]

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -27,6 +27,7 @@ import argparse
 import collections
 import json
 import os
+import random
 import sys
 import time
 from pathlib import Path
@@ -152,6 +153,20 @@ def write_proposals(rows: list[dict], groom_dir: Optional[Path] = None) -> int:
 
 # --- pass: index ------------------------------------------------------------
 
+def indexed_ids(client, col: str) -> set:
+    """Every point id in the collection, paged."""
+    out: set = set()
+    offset = None
+    while True:
+        points, offset = client.scroll(
+            collection_name=col, limit=1024, offset=offset,
+            with_payload=False, with_vectors=False,
+        )
+        out.update(str(p.id) for p in points)
+        if offset is None:
+            return out
+
+
 def pass_index(apply: bool = False, limit: Optional[int] = None, **_) -> dict:
     """Reconcile the JSONL corpus against the Qdrant index.
 
@@ -185,17 +200,8 @@ def pass_index(apply: bool = False, limit: Optional[int] = None, **_) -> dict:
         report.update(status="degraded", detail="qdrant unreachable")
         return report
 
-    indexed = set()
-    offset = None
     try:
-        while True:
-            points, offset = client.scroll(
-                collection_name=col, limit=1024, offset=offset,
-                with_payload=False, with_vectors=False,
-            )
-            indexed.update(str(p.id) for p in points)
-            if offset is None:
-                break
+        indexed = indexed_ids(client, col)
     except Exception as exc:
         report.update(status="degraded", detail=f"scroll failed: {exc!r}")
         return report
@@ -357,9 +363,160 @@ def pass_tags(limit: Optional[int] = None, gen_fn: Optional[Callable] = None,
     return report
 
 
+# --- pass: recall -----------------------------------------------------------
+
+_QUESTION_PROMPT = (
+    "Below is a finding from an engineering investigation. Write ONE short question "
+    "that this finding answers — the question someone would type if they wanted this "
+    "finding back. Use the finding's own vocabulary. No preamble, no quotes.\n\n"
+    "FINDING:\n{text}\n\nQUESTION:"
+)
+
+
+def _rank_of(finding_id: str, results: list) -> Optional[int]:
+    for i, row in enumerate(results, start=1):
+        if str(row.get("id") or "") == finding_id:
+            return i
+    return None
+
+
+def _score(ranks: list, k: int, attempted: int) -> dict:
+    hits1 = sum(1 for r in ranks if r == 1)
+    hitsk = sum(1 for r in ranks if r is not None and r <= k)
+    mrr = sum(1.0 / r for r in ranks if r) / max(attempted, 1)
+    return {
+        "attempted": attempted,
+        "recall_at_1": round(hits1 / max(attempted, 1), 4),
+        f"recall_at_{k}": round(hitsk / max(attempted, 1), 4),
+        "mrr": round(mrr, 4),
+    }
+
+
+def pass_recall(sample: int = 40, k: int = 5, paraphrase: bool = True,
+                gen_fn: Optional[Callable] = None, memory_dir: Optional[Path] = None,
+                groom_dir: Optional[Path] = None, search_fn: Optional[Callable] = None,
+                seed: int = 0, limit: Optional[int] = None, rerank: bool = True,
+                **_) -> dict:
+    """Ask the retriever for findings it already holds, and see if it returns them.
+
+    Two probes, kept apart on purpose, because today they fail identically:
+
+      identity   query = the finding's own text. A miss here is WIRING — wrong
+                 embedder, wrong width, a collection that cannot be queried at all.
+                 No model is involved, so a regression is unambiguous.
+      paraphrase query = a question the local model writes from the finding. A miss
+                 here with identity intact is SEMANTIC reach, not breakage.
+
+    Only findings that are actually indexed are sampled — otherwise this measures
+    the index gap that ``index`` already reports, and reads as a retrieval failure.
+    """
+    sample = limit or sample          # --limit is the CLI's name for the sample size
+    report = {"pass": "recall", "k": k, "sample": sample, "rerank": rerank, "status": "ok"}
+
+    try:
+        import qdrant_ops
+        client, col = qdrant_ops._get_qdrant()
+    except Exception as exc:
+        report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+        return report
+    if client is None:
+        report.update(status="degraded", detail="qdrant unreachable")
+        return report
+
+    by_id = {}
+    for f in iter_findings(memory_dir):
+        fid = f.get("id")
+        if fid and (f.get("text") or "").strip():
+            by_id[str(fid)] = f
+    try:
+        live = sorted(indexed_ids(client, col) & set(by_id))
+    except Exception as exc:
+        report.update(status="degraded", detail=f"scroll failed: {exc!r}")
+        return report
+
+    report["indexed_with_text"] = len(live)
+    if not live:
+        report.update(status="degraded", detail="nothing indexed to probe")
+        return report
+
+    rnd = random.Random(seed)
+    chosen = rnd.sample(live, min(sample, len(live)))
+    search = search_fn or (
+        lambda q: qdrant_ops._qdrant_similarity_search(q, limit=k, rerank=rerank))
+
+    ident_ranks, errors = [], 0
+    for fid in chosen:
+        try:
+            res = search(str(by_id[fid]["text"])[:1000])
+        except Exception:
+            errors += 1
+            continue
+        if not (res or {}).get("ok"):
+            errors += 1
+            continue
+        ident_ranks.append(_rank_of(fid, res.get("results") or []))
+    report["identity"] = _score(ident_ranks, k, len(ident_ranks))
+    report["search_errors"] = errors
+
+    if not paraphrase:
+        _append_recall(report, groom_dir)
+        return report
+
+    if gen_fn is None:
+        try:
+            import batched_gen
+            gen_fn = lambda prompts: batched_gen.generate_batch(  # noqa: E731
+                prompts, model=GROOM_MODEL, max_tokens=64)
+        except Exception as exc:
+            report["paraphrase"] = {"status": "degraded", "detail": f"no generation tier: {exc!r}"}
+            _append_recall(report, groom_dir)
+            return report
+
+    para_ranks, unusable = [], 0
+    for i in range(0, len(chosen), GROOM_BATCH):
+        chunk = chosen[i:i + GROOM_BATCH]
+        prompts = [_QUESTION_PROMPT.format(text=str(by_id[f]["text"])[:1000]) for f in chunk]
+        try:
+            gen = gen_fn(prompts)
+        except Exception:
+            unusable += len(chunk)
+            continue
+        for fid, g in zip(chunk, gen or []):
+            question = (g or {}).get("text", "").strip()
+            if not (g or {}).get("ok") or len(question) < 8:
+                unusable += 1
+                continue
+            try:
+                res = search(question)
+            except Exception:
+                unusable += 1
+                continue
+            if not (res or {}).get("ok"):
+                unusable += 1
+                continue
+            para_ranks.append(_rank_of(fid, res.get("results") or []))
+    report["paraphrase"] = {**_score(para_ranks, k, len(para_ranks)), "unusable": unusable}
+
+    _append_recall(report, groom_dir)
+    return report
+
+
+def _append_recall(report: dict, groom_dir: Optional[Path] = None) -> None:
+    """One row per run. The number matters far less than its trend."""
+    root = groom_dir or GROOM_DIR
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        with open(root / "recall.jsonl", "a") as fh:
+            fh.write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime()),
+                                 **report}) + "\n")
+    except OSError:
+        pass
+
+
 PASSES = {
     "index": {"fn": pass_index, "applyable": True},
     "tags": {"fn": pass_tags, "applyable": False},
+    "recall": {"fn": pass_recall, "applyable": False},
 }
 
 
@@ -371,6 +528,8 @@ def main(argv: Optional[list] = None) -> int:
                     help="promote results for passes that allow it (index only)")
     ap.add_argument("--limit", type=int, default=None)
     ap.add_argument("--json", action="store_true")
+    ap.add_argument("--no-rerank", action="store_true",
+                    help="recall: probe the bi-encoder stage alone, without the cross-encoder")
     args = ap.parse_args(argv)
     load_env()
 
@@ -387,7 +546,8 @@ def main(argv: Optional[list] = None) -> int:
         if args.apply and not spec["applyable"]:
             print(f"[groom] {name}: --apply ignored (proposals only)", file=sys.stderr)
         try:
-            reports.append(spec["fn"](apply=apply, limit=args.limit))
+            reports.append(spec["fn"](apply=apply, limit=args.limit,
+                                      rerank=not args.no_rerank))
         except Exception as exc:      # a pass must never take the cron job down
             reports.append({"pass": name, "status": "error", "detail": repr(exc)})
 

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -285,7 +285,7 @@ def build_vocabulary(findings: Iterable[dict], min_uses: int = 5, top_n: int = 6
 
 def pass_tags(limit: Optional[int] = None, gen_fn: Optional[Callable] = None,
               memory_dir: Optional[Path] = None, groom_dir: Optional[Path] = None,
-              **_) -> dict:
+              calibrate: bool = False, seed: int = 0, **_) -> dict:
     """Propose vocabulary tags for findings that carry none.
 
     Proposals only — an author's tags are evidence about what they meant, and a 3B
@@ -301,7 +301,15 @@ def pass_tags(limit: Optional[int] = None, gen_fn: Optional[Callable] = None,
         report.update(status="degraded", detail="no vocabulary could be derived")
         return report
 
-    candidates = [f for f in findings if not (f.get("tags") or []) and f.get("text")]
+    if calibrate:
+        # Hold out findings that DO have vocabulary tags, hide them, and score the
+        # model's pick against what the author actually wrote. Same protocol as
+        # knn_tags --calibrate, so every method lands on one comparable scale.
+        candidates = [f for f in findings
+                      if f.get("text") and set(_tags_of(f)) & set(vocab)]
+        random.Random(seed).shuffle(candidates)
+    else:
+        candidates = [f for f in findings if not (f.get("tags") or []) and f.get("text")]
     report["candidates"] = len(candidates)
     if limit:
         candidates = candidates[:limit]
@@ -323,6 +331,7 @@ def pass_tags(limit: Optional[int] = None, gen_fn: Optional[Callable] = None,
     # A zero here has several causes and they are not interchangeable, so each is
     # counted rather than folded into one silent 0.
     rej = collections.Counter()
+    scored: list = []
 
     for i in range(0, len(candidates), GROOM_BATCH):
         chunk = candidates[i:i + GROOM_BATCH]
@@ -352,15 +361,25 @@ def pass_tags(limit: Optional[int] = None, gen_fn: Optional[Callable] = None,
             if not kept:
                 rej["out_of_vocabulary"] += 1
                 continue
+            if calibrate:
+                truth = set(_tags_of(finding)) & vocab_set
+                scored.append(len(set(kept) & truth) / max(len(kept), 1))
+                continue
             proposals.append(_proposal(
                 "tags", str(finding["id"]), "tags", kept,
                 model=GROOM_MODEL,
                 investigation_id=finding.get("investigation_id"),
             ))
 
+    report["rejected"] = dict(rej)
+    if calibrate:
+        report["checked"] = len(scored)
+        report["mean_precision"] = round(sum(scored) / max(len(scored), 1), 4)
+        report["any_correct_rate"] = round(
+            sum(1 for x in scored if x > 0) / max(len(scored), 1), 4)
+        return report
     report["generated"] = len(proposals)
     report["proposed"] = write_proposals(proposals, groom_dir)
-    report["rejected"] = dict(rej)
     return report
 
 

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -649,6 +649,24 @@ _IDENT_STOP = frozenset({
 })
 
 
+def _is_distinctive(tok: str) -> bool:
+    """Does this token name a symbol, or is it just a word that happens to be one?
+
+    Measured, not guessed: the first live calibration linked `device`, `roll`,
+    `train`, `report`, `baseline` and `confirmed` to real symbols, because each is
+    genuinely a symbol name *somewhere* in an 11k-symbol graph across three
+    languages. A bare lowercase word carries no evidence that the author meant the
+    code. Structure does — an underscore, an internal case change, or real length.
+    This is the same judgement `code_memory_relink` encodes as "distinctive", and
+    it is why its coverage is conservative rather than broken.
+    """
+    if "_" in tok:
+        return True
+    if any(c.isupper() for c in tok[1:]) and any(c.islower() for c in tok):
+        return True
+    return len(tok) >= 12
+
+
 def _candidate_symbols(text: str, index: dict) -> tuple:
     """(unique_hits, ambiguous_hits) for the identifier-shaped tokens in `text`.
 
@@ -659,7 +677,7 @@ def _candidate_symbols(text: str, index: dict) -> tuple:
     unique, ambiguous = {}, {}
     for raw in set(_IDENT_RE.findall(text or "")):
         tok = raw.split(".")[-1]
-        if len(tok) < 4 or tok.lower() in _IDENT_STOP:
+        if len(tok) < 4 or tok.lower() in _IDENT_STOP or not _is_distinctive(tok):
             continue
         hits = index.get(tok) or []
         if len(hits) == 1:

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Passive grooming tier for the Loci corpus — runs unattended, on cron.
+
+Three rules hold for every pass:
+
+  IDEMPOTENT   a second run over unchanged input proposes nothing new.
+  FAIL-OPEN    a dead backend degrades the pass to a report; it never raises and
+               never leaves the corpus half-written.
+  SHADOW-FIRST model-derived output is written to _groom/proposals.jsonl with its
+               provenance (pass, model, score) and is NEVER merged into
+               findings.jsonl. A proposal is a claim awaiting adjudication, and it
+               has to stay distinguishable from an author-written field.
+
+``--apply`` promotes only for passes that declare ``applyable`` — today just
+``index``, whose write is a re-upsert of the record already on disk, so it can
+restore but cannot invent.
+
+Usage:
+    loci_groom.py index                    # report Qdrant/disk drift
+    loci_groom.py index --apply            # re-embed and re-upsert what is missing
+    loci_groom.py tags --limit 200         # propose canonical tags via the local model
+    loci_groom.py all --json
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+_REPO = Path(os.path.dirname(os.path.abspath(__file__))).parent
+sys.path.insert(0, str(_REPO / "mcp"))
+
+
+def load_env() -> dict:
+    """Resolve backend config the way the server does, then from the config file.
+
+    A cron job does not inherit the MCP launcher's environment, and the running
+    server's QDRANT_URL currently lives only in its own process env — so without
+    this a scheduled pass silently reports 'qdrant unreachable' forever.
+    Precedence: existing env -> repo .env files -> ~/.loci/backends.toml.
+    """
+    try:
+        from dotenv import load_dotenv
+        load_dotenv(_REPO / ".env")
+        load_dotenv(_REPO / "mcp" / ".env", override=True)
+    except Exception:
+        pass
+
+    resolved = {}
+    if not os.environ.get("QDRANT_URL"):
+        try:
+            import backends
+            url, key = backends.qdrant()
+            if url:
+                os.environ["QDRANT_URL"] = url
+                resolved["QDRANT_URL"] = url
+                if key and not os.environ.get("QDRANT_API_KEY"):
+                    os.environ["QDRANT_API_KEY"] = key
+        except Exception:
+            pass
+    if not os.environ.get("OLLAMA_BASE_URL"):
+        try:
+            import backends
+            url = backends.ollama_url()
+            if url:
+                os.environ["OLLAMA_BASE_URL"] = url
+                resolved["OLLAMA_BASE_URL"] = url
+        except Exception:
+            pass
+    return resolved
+
+
+MEMORY_DIR = Path(os.environ.get(
+    "HERMES_MEMORY_DIR",
+    os.path.expanduser("~/.hermes/memory-sessions"),
+))
+GROOM_DIR = MEMORY_DIR / "_groom"
+
+# Left unset on purpose: the batched (vLLM) and Ollama tiers identify the same
+# model by different names — "Qwen/Qwen2.5-3B-Instruct" vs "qwen2.5:3b" — and a
+# name the serving tier does not recognise is rejected outright. None lets each
+# tier resolve its own. Set LOCI_GROOM_MODEL only to pin one deliberately.
+GROOM_MODEL = os.environ.get("LOCI_GROOM_MODEL") or None
+GROOM_BATCH = int(os.environ.get("LOCI_GROOM_BATCH", "16"))
+
+
+# --- corpus access ----------------------------------------------------------
+
+def iter_findings(memory_dir: Optional[Path] = None) -> Iterable[dict]:
+    """Every finding on disk. The JSONL files are the system of record."""
+    root = memory_dir or MEMORY_DIR
+    for path in sorted(root.glob("*/findings.jsonl")):
+        try:
+            with open(path, errors="ignore") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        yield json.loads(line)
+                    except ValueError:
+                        continue
+        except OSError:
+            continue
+
+
+def _proposal(pass_name: str, subject_id: str, kind: str, value, **extra) -> dict:
+    return {
+        "id": f"{pass_name}:{kind}:{subject_id}",
+        "pass": pass_name,
+        "subject_id": subject_id,
+        "kind": kind,
+        "value": value,
+        "proposed_by": f"loci_groom/{pass_name}",
+        "model": extra.pop("model", None),
+        "score": extra.pop("score", None),
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime()),
+        **extra,
+    }
+
+
+def write_proposals(rows: list[dict], groom_dir: Optional[Path] = None) -> int:
+    """Append proposals, skipping ids already on file. Returns the number written."""
+    if not rows:
+        return 0
+    root = groom_dir or GROOM_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "proposals.jsonl"
+
+    seen = set()
+    if path.exists():
+        with open(path, errors="ignore") as fh:
+            for line in fh:
+                try:
+                    seen.add(json.loads(line).get("id"))
+                except ValueError:
+                    continue
+
+    fresh = [r for r in rows if r.get("id") not in seen]
+    if not fresh:
+        return 0
+    with open(path, "a") as fh:
+        for r in fresh:
+            fh.write(json.dumps(r) + "\n")
+    return len(fresh)
+
+
+# --- pass: index ------------------------------------------------------------
+
+def pass_index(apply: bool = False, limit: Optional[int] = None, **_) -> dict:
+    """Reconcile the JSONL corpus against the Qdrant index.
+
+    Findings reach Qdrant only on write (``_qdrant_upsert`` at store time) and the
+    startup TTL purge deletes by ``created_at_ts``, so anything past the retention
+    window leaves the index and nothing ever puts it back. Disk keeps it; search
+    does not see it. This pass is the missing reconciliation.
+    """
+    on_disk = {}
+    for f in iter_findings():
+        fid = f.get("id")
+        if fid:
+            on_disk[str(fid)] = f
+
+    report = {
+        "pass": "index",
+        "on_disk": len(on_disk),
+        "indexed": 0,
+        "missing": 0,
+        "applied": 0,
+        "status": "ok",
+    }
+
+    try:
+        import qdrant_ops
+        client, col = qdrant_ops._get_qdrant()
+    except Exception as exc:
+        report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+        return report
+    if client is None:
+        report.update(status="degraded", detail="qdrant unreachable")
+        return report
+
+    indexed = set()
+    offset = None
+    try:
+        while True:
+            points, offset = client.scroll(
+                collection_name=col, limit=1024, offset=offset,
+                with_payload=False, with_vectors=False,
+            )
+            indexed.update(str(p.id) for p in points)
+            if offset is None:
+                break
+    except Exception as exc:
+        report.update(status="degraded", detail=f"scroll failed: {exc!r}")
+        return report
+
+    # _qdrant_upsert stores the finding id verbatim as the point id.
+    missing = [f for fid, f in on_disk.items() if fid not in indexed]
+
+    report["indexed"] = len(indexed)
+    report["missing"] = len(missing)
+    report["coverage"] = round(1.0 - len(missing) / max(len(on_disk), 1), 4)
+
+    if not apply:
+        report["sample_missing"] = [f.get("id") for f in missing[:5]]
+        return report
+
+    for finding in missing[: (limit or len(missing))]:
+        text = str(finding.get("text") or "")
+        if not text:
+            continue
+        try:
+            qdrant_ops._qdrant_upsert(str(finding["id"]), text, finding)
+            report["applied"] += 1
+        except Exception:
+            continue
+    return report
+
+
+# --- pass: tags -------------------------------------------------------------
+
+_TAG_PROMPT = (
+    "You are labelling an engineering finding with tags from a fixed vocabulary.\n\n"
+    "VOCABULARY (the only permitted values):\n{vocab}\n\n"
+    "FINDING:\n{text}\n\n"
+    "Pick the 1-4 vocabulary terms that genuinely describe this finding. If none fit, "
+    "return an empty list. Do not invent terms. Do not explain.\n"
+    'Output exactly one JSON object of the form {{"tags": ["term", "term"]}} and nothing else.\n'
+    'Example output: {{"tags": ["mqtt", "wiring-gap"]}}'
+)
+
+
+def _parse_tags(raw: str) -> Optional[list]:
+    """Pull a tag list out of a small model's JSON. None = unparseable.
+
+    A 3B model asked for {"tags": [...]} will sometimes answer with a bare list or
+    put the list under a key of its own choosing. Accepting those shapes is not the
+    same as accepting invented content — every term still has to survive the
+    vocabulary filter downstream.
+    """
+    try:
+        obj = json.loads(raw or "")
+    except ValueError:
+        return None
+    if isinstance(obj, list):
+        return obj
+    if isinstance(obj, dict):
+        if isinstance(obj.get("tags"), list):
+            return obj["tags"]
+        lists = [v for v in obj.values() if isinstance(v, list)]
+        if len(lists) == 1:
+            return lists[0]
+    return None
+
+
+def build_vocabulary(findings: Iterable[dict], min_uses: int = 5, top_n: int = 60) -> list[str]:
+    """The tags that carry signal — ones reused across the corpus.
+
+    4,267 distinct tags exist on this corpus and 2,809 of them are used exactly
+    once, so the raw tag set is closer to free text than to a vocabulary. Terms
+    that recur are the ones a reader could actually filter on.
+    """
+    counts: collections.Counter = collections.Counter()
+    for f in findings:
+        for t in (f.get("tags") or []):
+            t = str(t).strip().lower()
+            # dt_* are per-run provenance stamps, not subject tags.
+            if t and not t.startswith("dt_"):
+                counts[t] += 1
+    return [t for t, n in counts.most_common(top_n) if n >= min_uses]
+
+
+def pass_tags(limit: Optional[int] = None, gen_fn: Optional[Callable] = None,
+              memory_dir: Optional[Path] = None, groom_dir: Optional[Path] = None,
+              **_) -> dict:
+    """Propose vocabulary tags for findings that carry none.
+
+    Proposals only — an author's tags are evidence about what they meant, and a 3B
+    model's guess must not become indistinguishable from them.
+    """
+    findings = list(iter_findings(memory_dir))
+    vocab = build_vocabulary(findings)
+    report = {
+        "pass": "tags", "corpus": len(findings), "vocabulary": len(vocab),
+        "candidates": 0, "proposed": 0, "status": "ok",
+    }
+    if not vocab:
+        report.update(status="degraded", detail="no vocabulary could be derived")
+        return report
+
+    candidates = [f for f in findings if not (f.get("tags") or []) and f.get("text")]
+    report["candidates"] = len(candidates)
+    if limit:
+        candidates = candidates[:limit]
+    if not candidates:
+        return report
+
+    if gen_fn is None:
+        try:
+            import batched_gen
+            gen_fn = lambda prompts: batched_gen.generate_batch(  # noqa: E731
+                prompts, model=GROOM_MODEL, max_tokens=96, fmt="json")
+        except Exception as exc:
+            report.update(status="degraded", detail=f"no generation tier: {exc!r}")
+            return report
+
+    vocab_block = ", ".join(vocab)
+    vocab_set = set(vocab)
+    proposals = []
+    # A zero here has several causes and they are not interchangeable, so each is
+    # counted rather than folded into one silent 0.
+    rej = collections.Counter()
+
+    for i in range(0, len(candidates), GROOM_BATCH):
+        chunk = candidates[i:i + GROOM_BATCH]
+        prompts = [
+            _TAG_PROMPT.format(vocab=vocab_block, text=str(f.get("text"))[:1200])
+            for f in chunk
+        ]
+        try:
+            results = gen_fn(prompts)
+        except Exception:
+            rej["generation_error"] += len(chunk)
+            continue
+        for finding, res in zip(chunk, results or []):
+            if not (res or {}).get("ok"):
+                rej["generation_failed"] += 1
+                continue
+            tags = _parse_tags(res.get("text") or "")
+            if tags is None:
+                rej["unparseable"] += 1
+                continue
+            # A term outside the vocabulary is the model inventing one; drop it
+            # rather than letting the pass widen the vocabulary it was given.
+            if not tags:
+                rej["declined"] += 1        # the model saw no fitting term — a real answer
+                continue
+            kept = [t for t in (str(x).strip().lower() for x in tags) if t in vocab_set][:4]
+            if not kept:
+                rej["out_of_vocabulary"] += 1
+                continue
+            proposals.append(_proposal(
+                "tags", str(finding["id"]), "tags", kept,
+                model=GROOM_MODEL,
+                investigation_id=finding.get("investigation_id"),
+            ))
+
+    report["generated"] = len(proposals)
+    report["proposed"] = write_proposals(proposals, groom_dir)
+    report["rejected"] = dict(rej)
+    return report
+
+
+PASSES = {
+    "index": {"fn": pass_index, "applyable": True},
+    "tags": {"fn": pass_tags, "applyable": False},
+}
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("passes", nargs="*", default=["all"],
+                    help=f"one or more of: {', '.join(PASSES)}, all")
+    ap.add_argument("--apply", action="store_true",
+                    help="promote results for passes that allow it (index only)")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+    load_env()
+
+    names = list(PASSES) if (not args.passes or "all" in args.passes) else args.passes
+    unknown = [n for n in names if n not in PASSES]
+    if unknown:
+        print(f"unknown pass(es): {', '.join(unknown)}", file=sys.stderr)
+        return 2
+
+    reports = []
+    for name in names:
+        spec = PASSES[name]
+        apply = args.apply and spec["applyable"]
+        if args.apply and not spec["applyable"]:
+            print(f"[groom] {name}: --apply ignored (proposals only)", file=sys.stderr)
+        try:
+            reports.append(spec["fn"](apply=apply, limit=args.limit))
+        except Exception as exc:      # a pass must never take the cron job down
+            reports.append({"pass": name, "status": "error", "detail": repr(exc)})
+
+    if args.json:
+        print(json.dumps(reports, indent=2))
+    else:
+        for r in reports:
+            head = f"[groom] {r['pass']}: {r.get('status')}"
+            rest = " ".join(f"{k}={v}" for k, v in r.items()
+                            if k not in ("pass", "status") and not isinstance(v, (list, dict)))
+            print(f"{head} {rest}".rstrip())
+    return 0 if all(r.get("status") != "error" for r in reports) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -28,6 +28,7 @@ import collections
 import json
 import os
 import random
+import re
 import sys
 import time
 from pathlib import Path
@@ -513,10 +514,293 @@ def _append_recall(report: dict, groom_dir: Optional[Path] = None) -> None:
         pass
 
 
+# --- pass: knn_tags ---------------------------------------------------------
+
+def _tags_of(row: dict) -> list:
+    """Payload tags, normalised. Some write paths store a comma-joined string."""
+    raw = row.get("tags")
+    if isinstance(raw, str):
+        raw = raw.split(",")
+    if not isinstance(raw, list):
+        return []
+    return [t for t in (str(x).strip().lower() for x in raw) if t and not t.startswith("dt_")]
+
+
+def _knn_vote(neighbours: list, self_id: str, vocab: set, min_weight: float) -> list:
+    """Similarity-weighted tag vote over retrieved neighbours.
+
+    Weighting by score rather than counting means one very close neighbour can
+    carry a tag that five loose ones cannot — which is the whole reason to use
+    the embedding rather than a bag of words.
+    """
+    weights: dict = {}
+    for row in neighbours:
+        if str(row.get("id") or "") == self_id:
+            continue
+        score = float(row.get("score") or 0.0)
+        if score <= 0:
+            continue
+        for tag in _tags_of(row):
+            if vocab and tag not in vocab:
+                continue
+            weights[tag] = weights.get(tag, 0.0) + score
+    ranked = sorted(weights.items(), key=lambda kv: -kv[1])
+    return [(t, round(w, 4)) for t, w in ranked if w >= min_weight]
+
+
+def pass_knn_tags(limit: Optional[int] = None, k: int = 8, min_weight: float = 1.0,
+                  max_tags: int = 3, calibrate: bool = False, seed: int = 0,
+                  memory_dir: Optional[Path] = None, groom_dir: Optional[Path] = None,
+                  search_fn: Optional[Callable] = None, **_) -> dict:
+    """Transfer tags from a finding's nearest already-tagged neighbours.
+
+    No generation involved. The embeddings are already in the index, the author's
+    own tags are the labels, and the whole thing is deterministic — so unlike a
+    model's guess it can be scored against held-out truth before anyone promotes
+    it. ``calibrate=True`` does exactly that: it hides the tags of findings that
+    have them, re-derives them from neighbours, and reports how often it agrees.
+    """
+    report = {"pass": "knn_tags", "k": k, "min_weight": min_weight,
+              "calibrate": calibrate, "status": "ok"}
+
+    findings = list(iter_findings(memory_dir))
+    vocab = set(build_vocabulary(findings))
+    report["vocabulary"] = len(vocab)
+    if not vocab:
+        report.update(status="degraded", detail="no vocabulary could be derived")
+        return report
+
+    if search_fn is None:
+        try:
+            import qdrant_ops
+            if qdrant_ops._get_qdrant()[0] is None:
+                report.update(status="degraded", detail="qdrant unreachable")
+                return report
+            search_fn = lambda q: qdrant_ops._qdrant_similarity_search(  # noqa: E731
+                q, limit=k + 1, rerank=False)
+        except Exception as exc:
+            report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+            return report
+
+    if calibrate:
+        subjects = [f for f in findings
+                    if f.get("text") and set(_tags_of(f)) & vocab]
+        rnd = random.Random(seed)
+        rnd.shuffle(subjects)
+    else:
+        subjects = [f for f in findings if f.get("text") and not _tags_of(f)]
+    report["candidates"] = len(subjects)
+    if limit:
+        subjects = subjects[:limit]
+
+    proposals, agree, checked = [], [], 0
+    for f in subjects:
+        try:
+            res = search_fn(str(f["text"])[:1000])
+        except Exception:
+            continue
+        if not (res or {}).get("ok"):
+            continue
+        voted = _knn_vote(res.get("results") or [], str(f.get("id") or ""), vocab, min_weight)
+        picked = [t for t, _w in voted[:max_tags]]
+
+        if calibrate:
+            truth = set(_tags_of(f)) & vocab
+            if not truth:
+                continue
+            checked += 1
+            agree.append(len(set(picked) & truth) / max(len(picked), 1) if picked else 0.0)
+            continue
+
+        if picked:
+            proposals.append(_proposal(
+                "knn_tags", str(f["id"]), "tags", picked,
+                model=None, score=voted[0][1],
+                method=f"knn/{k}", investigation_id=f.get("investigation_id"),
+            ))
+
+    if calibrate:
+        report["checked"] = checked
+        report["mean_precision"] = round(sum(agree) / max(checked, 1), 4)
+        report["exact_or_partial_hit_rate"] = round(
+            sum(1 for a in agree if a > 0) / max(checked, 1), 4)
+        return report
+
+    report["generated"] = len(proposals)
+    report["proposed"] = write_proposals(proposals, groom_dir)
+    return report
+
+
+# --- pass: codelink ---------------------------------------------------------
+
+# Identifier-shaped tokens: snake_case, CamelCase, dotted paths, File.ext.
+_IDENT_RE = re.compile(r"\b(?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]{3,}\b")
+
+# Words that look like identifiers to a regex and like noise to a reader.
+_IDENT_STOP = frozenset({
+    "which", "there", "these", "those", "where", "while", "would", "could",
+    "should", "because", "before", "after", "every", "never", "always", "still",
+    "value", "values", "return", "returns", "error", "errors", "false", "true",
+    "none", "null", "class", "function", "method", "module", "import", "input",
+    "output", "result", "results", "state", "check", "checks", "count", "counts",
+    "under", "above", "below", "about", "against", "without", "within", "into",
+    "test", "tests", "code", "path", "paths", "file", "files", "line", "lines",
+    "data", "type", "types", "name", "names", "call", "calls", "read", "write",
+})
+
+
+def _candidate_symbols(text: str, index: dict) -> tuple:
+    """(unique_hits, ambiguous_hits) for the identifier-shaped tokens in `text`.
+
+    A token that names exactly one symbol in the graph is evidence. A token that
+    names five is a question, and questions go to the model rather than being
+    guessed at — that asymmetry is the whole design.
+    """
+    unique, ambiguous = {}, {}
+    for raw in set(_IDENT_RE.findall(text or "")):
+        tok = raw.split(".")[-1]
+        if len(tok) < 4 or tok.lower() in _IDENT_STOP:
+            continue
+        hits = index.get(tok) or []
+        if len(hits) == 1:
+            unique[tok] = hits[0]
+        elif 1 < len(hits) <= 8:
+            ambiguous[tok] = hits
+    return unique, ambiguous
+
+
+_DISAMBIGUATE_PROMPT = (
+    "A finding mentions the symbol `{token}`. Several symbols share that name.\n\n"
+    "FINDING:\n{text}\n\nCANDIDATES:\n{options}\n\n"
+    "Which candidate does the finding mean? Answer with the number alone, or 0 if "
+    "the finding is not about any of them."
+)
+
+
+def pass_codelink(limit: Optional[int] = None, calibrate: bool = False,
+                  gen_fn: Optional[Callable] = None, symbols_fn: Optional[Callable] = None,
+                  linked_fn: Optional[Callable] = None, memory_dir: Optional[Path] = None,
+                  groom_dir: Optional[Path] = None, **_) -> dict:
+    """Propose Finding -> CodeSymbol links the strict lexical linker will not make.
+
+    ``code_memory_relink`` is precision-first by design and reaches 180 of 2,634
+    findings. This adds the two things it refuses to do: it treats a token that
+    resolves to exactly one symbol as evidence even when that token is not
+    'distinctive' by its rules, and it hands genuinely ambiguous tokens to the
+    local model with the candidate file paths attached. Proposals only — a wrong
+    code link is worse than no code link, because it survives as provenance.
+    """
+    report = {"pass": "codelink", "calibrate": calibrate, "status": "ok"}
+
+    if symbols_fn is None or linked_fn is None:
+        try:
+            from graph.ladybug_store import LadybugStore
+            ks = LadybugStore(str((memory_dir or MEMORY_DIR) / "graph.ladybug"))
+            if not ks.readable_probe():
+                report.update(status="degraded", detail="graph store unreadable")
+                return report
+            symbols_fn = symbols_fn or (lambda: ks._rows(
+                "MATCH (s:CodeSymbol) RETURN s.name, s.id, s.file"))
+            linked_fn = linked_fn or (lambda: ks._rows(
+                "MATCH (f:Finding)-[:REFERENCES]->(s:CodeSymbol) RETURN f.id, s.id"))
+        except Exception as exc:
+            report.update(status="degraded", detail=f"graph unavailable: {exc!r}")
+            return report
+
+    index: dict = {}
+    where: dict = {}
+    try:
+        for name, sid, sfile in symbols_fn():
+            index.setdefault(str(name), []).append(str(sid))
+            where[str(sid)] = str(sfile or "")
+    except Exception as exc:
+        report.update(status="degraded", detail=f"symbol read failed: {exc!r}")
+        return report
+    report["symbols"] = len(where)
+
+    already: dict = {}
+    try:
+        for fid, sid in linked_fn():
+            already.setdefault(str(fid), set()).add(str(sid))
+    except Exception as exc:
+        report.update(status="degraded", detail=f"link read failed: {exc!r}")
+        return report
+    report["already_linked"] = len(already)
+
+    findings = [f for f in iter_findings(memory_dir) if f.get("text") and f.get("id")]
+    if calibrate:
+        subjects = [f for f in findings if str(f["id"]) in already]
+    else:
+        subjects = [f for f in findings if str(f["id"]) not in already]
+    report["candidates"] = len(subjects)
+    if limit:
+        subjects = subjects[:limit]
+
+    proposals, hits, checked, ambiguous_total = [], [], 0, 0
+    for f in subjects:
+        unique, ambiguous = _candidate_symbols(str(f["text"]), index)
+        ambiguous_total += len(ambiguous)
+        picked = dict(unique)
+
+        if ambiguous and gen_fn is not None:
+            toks = list(ambiguous)[:4]
+            prompts = []
+            for tok in toks:
+                opts = "\n".join(
+                    f"{i}. {where.get(sid, '?')}" for i, sid in enumerate(ambiguous[tok], 1))
+                prompts.append(_DISAMBIGUATE_PROMPT.format(
+                    token=tok, text=str(f["text"])[:600], options=opts))
+            try:
+                answers = gen_fn(prompts)
+            except Exception:
+                answers = []
+            for tok, ans in zip(toks, answers or []):
+                if not (ans or {}).get("ok"):
+                    continue
+                digits = "".join(ch for ch in (ans.get("text") or "") if ch.isdigit())
+                if not digits:
+                    continue
+                choice = int(digits[:2])
+                if 1 <= choice <= len(ambiguous[tok]):
+                    picked[tok] = ambiguous[tok][choice - 1]
+
+        if calibrate:
+            truth = already.get(str(f["id"]), set())
+            if not truth:
+                continue
+            checked += 1
+            got = set(picked.values())
+            hits.append(len(got & truth) / max(len(got), 1) if got else 0.0)
+            continue
+
+        if picked:
+            proposals.append(_proposal(
+                "codelink", str(f["id"]), "code_refs",
+                [{"token": t, "symbol_id": sid, "file": where.get(sid, "")}
+                 for t, sid in picked.items()],
+                model=GROOM_MODEL if ambiguous and gen_fn else None,
+                investigation_id=f.get("investigation_id"),
+            ))
+
+    report["ambiguous_tokens"] = ambiguous_total
+    if calibrate:
+        report["checked"] = checked
+        report["mean_precision"] = round(sum(hits) / max(checked, 1), 4)
+        report["any_correct_rate"] = round(
+            sum(1 for h in hits if h > 0) / max(checked, 1), 4)
+        return report
+
+    report["generated"] = len(proposals)
+    report["proposed"] = write_proposals(proposals, groom_dir)
+    return report
+
+
 PASSES = {
     "index": {"fn": pass_index, "applyable": True},
     "tags": {"fn": pass_tags, "applyable": False},
     "recall": {"fn": pass_recall, "applyable": False},
+    "knn_tags": {"fn": pass_knn_tags, "applyable": False},
+    "codelink": {"fn": pass_codelink, "applyable": False},
 }
 
 

--- a/scripts/tests/test_loci_groom.py
+++ b/scripts/tests/test_loci_groom.py
@@ -377,3 +377,200 @@ class TestRecallPass(unittest.TestCase):
         with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
             r = groom.pass_recall()
         self.assertEqual(r["status"], "degraded")
+
+
+class TestKnnTags(unittest.TestCase):
+    """Label transfer over the embeddings. Deterministic, so unlike the generated
+    variant it can be scored against the author's own tags before promotion."""
+
+    def _corpus_and_search(self, tmp, neighbours):
+        rows = [_f(f"t{i}", tags=["mqtt", "acoustic"]) for i in range(6)]
+        rows += [_f("u0", text="the broker dropped the subscription", tags=[])]
+        _corpus(tmp, {"inv": rows})
+
+        def search(_query):
+            return {"ok": True, "results": neighbours}
+        return search
+
+    def test_a_close_neighbour_outweighs_several_loose_ones(self):
+        votes = groom._knn_vote(
+            [{"id": "n1", "score": 0.95, "tags": ["mqtt"]},
+             {"id": "n2", "score": 0.2, "tags": ["acoustic"]},
+             {"id": "n3", "score": 0.2, "tags": ["acoustic"]},
+             {"id": "n4", "score": 0.2, "tags": ["acoustic"]}],
+            self_id="self", vocab={"mqtt", "acoustic"}, min_weight=0.5)
+        self.assertEqual(votes[0][0], "mqtt")
+
+    def test_the_subject_never_votes_for_itself(self):
+        votes = groom._knn_vote(
+            [{"id": "self", "score": 1.0, "tags": ["mqtt"]}],
+            self_id="self", vocab={"mqtt"}, min_weight=0.1)
+        self.assertEqual(votes, [])
+
+    def test_tags_outside_the_vocabulary_do_not_vote(self):
+        votes = groom._knn_vote(
+            [{"id": "n1", "score": 0.9, "tags": ["not-in-vocab"]}],
+            self_id="s", vocab={"mqtt"}, min_weight=0.1)
+        self.assertEqual(votes, [])
+
+    def test_comma_joined_payload_tags_are_understood(self):
+        # one write path stores tags as ",".join(tags)
+        self.assertEqual(groom._tags_of({"tags": "mqtt,acoustic"}), ["mqtt", "acoustic"])
+        self.assertEqual(groom._tags_of({"tags": ["MQTT", "dt_run:x"]}), ["mqtt"])
+
+    def test_it_proposes_for_untagged_findings_only(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            search = self._corpus_and_search(
+                tmp, [{"id": "t1", "score": 0.9, "tags": ["mqtt"]},
+                      {"id": "t2", "score": 0.8, "tags": ["mqtt"]}])
+            gd = tmp / "_groom"
+            report = groom.pass_knn_tags(memory_dir=tmp, groom_dir=gd,
+                                         search_fn=search, min_weight=1.0)
+            rows = [json.loads(l) for l in open(gd / "proposals.jsonl") if l.strip()]
+        self.assertEqual(report["candidates"], 1)
+        self.assertEqual(report["proposed"], 1)
+        self.assertEqual(rows[0]["subject_id"], "u0")
+        self.assertEqual(rows[0]["value"], ["mqtt"])
+        self.assertIsNone(rows[0]["model"], "no model was involved")
+
+    def test_weak_agreement_proposes_nothing(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            search = self._corpus_and_search(
+                tmp, [{"id": "t1", "score": 0.1, "tags": ["mqtt"]}])
+            report = groom.pass_knn_tags(memory_dir=tmp, groom_dir=tmp / "_groom",
+                                         search_fn=search, min_weight=1.0)
+        self.assertEqual(report["proposed"], 0)
+
+    def test_calibrate_scores_against_the_authors_own_tags(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            self._corpus_and_search(tmp, [])
+            # every neighbour says "mqtt"; the held-out findings really are mqtt+acoustic
+            search = lambda _q: {"ok": True, "results": [  # noqa: E731
+                {"id": "other", "score": 0.9, "tags": ["mqtt"]}]}
+            report = groom.pass_knn_tags(memory_dir=tmp, groom_dir=tmp / "_groom",
+                                         search_fn=search, calibrate=True, min_weight=0.5)
+        self.assertEqual(report["checked"], 6)
+        self.assertEqual(report["mean_precision"], 1.0)
+        self.assertEqual(report["exact_or_partial_hit_rate"], 1.0)
+
+    def test_calibrate_reports_a_miss_as_zero_precision(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            self._corpus_and_search(tmp, [])
+            search = lambda _q: {"ok": True, "results": [  # noqa: E731
+                {"id": "other", "score": 0.9, "tags": ["build"]}]}
+            rows = [_f(f"b{i}", tags=["build"]) for i in range(6)]
+            _corpus(tmp, {"inv2": rows})
+            report = groom.pass_knn_tags(memory_dir=tmp, groom_dir=tmp / "_groom",
+                                         search_fn=search, calibrate=True, min_weight=0.5)
+        self.assertGreater(report["checked"], 0)
+
+    def test_calibrate_writes_no_proposals(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            self._corpus_and_search(tmp, [])
+            search = lambda _q: {"ok": True, "results": [  # noqa: E731
+                {"id": "other", "score": 0.9, "tags": ["mqtt"]}]}
+            gd = tmp / "_groom"
+            groom.pass_knn_tags(memory_dir=tmp, groom_dir=gd, search_fn=search,
+                                calibrate=True, min_weight=0.5)
+            self.assertFalse((gd / "proposals.jsonl").exists())
+
+
+class TestCodelink(unittest.TestCase):
+    """Finding -> CodeSymbol proposals. A wrong code link is worse than none —
+    it survives as provenance — so the unique/ambiguous split is the contract."""
+
+    SYMBOLS = [
+        ("_qdrant_upsert", "sym1", "mcp/qdrant_ops.py"),
+        ("handle", "sym2", "a2a_server/server.py"),
+        ("handle", "sym3", "mcp/memcheck/daemon.py"),
+        ("EskfFusion", "sym4", "android/EskfFusion.java"),
+    ]
+
+    def _run(self, text, *, gen=None, calibrate=False, linked=None):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f("f1", text=text)]})
+            gd = tmp / "_groom"
+            report = groom.pass_codelink(
+                memory_dir=tmp, groom_dir=gd, gen_fn=gen, calibrate=calibrate,
+                symbols_fn=lambda: list(self.SYMBOLS),
+                linked_fn=lambda: list(linked or []),
+            )
+            rows = []
+            if (gd / "proposals.jsonl").exists():
+                rows = [json.loads(l) for l in open(gd / "proposals.jsonl") if l.strip()]
+            return report, rows
+
+    def test_a_token_naming_exactly_one_symbol_is_evidence(self):
+        report, rows = self._run("the _qdrant_upsert path swallows the failure")
+        self.assertEqual(report["proposed"], 1)
+        self.assertEqual(rows[0]["value"][0]["symbol_id"], "sym1")
+        self.assertEqual(rows[0]["value"][0]["file"], "mcp/qdrant_ops.py")
+        self.assertIsNone(rows[0]["model"], "no model needed for an unambiguous token")
+
+    def test_an_ambiguous_token_is_not_guessed_at_without_a_model(self):
+        report, rows = self._run("the handle path is wrong")
+        self.assertEqual(report["ambiguous_tokens"], 1)
+        self.assertEqual(report["proposed"], 0)
+
+    def test_the_model_resolves_an_ambiguous_token(self):
+        gen = lambda prompts: [{"text": "2", "ok": True} for _ in prompts]  # noqa: E731
+        report, rows = self._run("the handle path is wrong", gen=gen)
+        self.assertEqual(report["proposed"], 1)
+        self.assertEqual(rows[0]["value"][0]["symbol_id"], "sym3")
+
+    def test_a_model_answer_of_zero_declines_rather_than_linking(self):
+        gen = lambda prompts: [{"text": "0", "ok": True} for _ in prompts]  # noqa: E731
+        report, _ = self._run("the handle path is wrong", gen=gen)
+        self.assertEqual(report["proposed"], 0)
+
+    def test_an_out_of_range_choice_is_refused(self):
+        gen = lambda prompts: [{"text": "99", "ok": True} for _ in prompts]  # noqa: E731
+        report, _ = self._run("the handle path is wrong", gen=gen)
+        self.assertEqual(report["proposed"], 0)
+
+    def test_prose_words_do_not_become_symbols(self):
+        report, _ = self._run("there should always be a result under these values")
+        self.assertEqual(report["proposed"], 0)
+        self.assertEqual(report["ambiguous_tokens"], 0)
+
+    def test_already_linked_findings_are_skipped(self):
+        report, _ = self._run("the _qdrant_upsert path", linked=[("f1", "sym1")])
+        self.assertEqual(report["candidates"], 0)
+        self.assertEqual(report["proposed"], 0)
+
+    def test_calibrate_scores_against_the_existing_edges(self):
+        report, rows = self._run("the _qdrant_upsert path", calibrate=True,
+                                 linked=[("f1", "sym1")])
+        self.assertEqual(report["checked"], 1)
+        self.assertEqual(report["mean_precision"], 1.0)
+        self.assertEqual(report["any_correct_rate"], 1.0)
+        self.assertEqual(rows, [], "calibration writes no proposals")
+
+    def test_calibrate_counts_a_wrong_link_as_zero(self):
+        report, _ = self._run("the EskfFusion update", calibrate=True,
+                              linked=[("f1", "sym1")])
+        self.assertEqual(report["checked"], 1)
+        self.assertEqual(report["mean_precision"], 0.0)
+
+    def test_an_unreadable_graph_degrades(self):
+        def boom():
+            raise RuntimeError("locked")
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f("f1", text="x")]})
+            report = groom.pass_codelink(memory_dir=tmp, groom_dir=tmp / "_groom",
+                                         symbols_fn=boom, linked_fn=lambda: [])
+        self.assertEqual(report["status"], "degraded")

--- a/scripts/tests/test_loci_groom.py
+++ b/scripts/tests/test_loci_groom.py
@@ -491,8 +491,8 @@ class TestCodelink(unittest.TestCase):
 
     SYMBOLS = [
         ("_qdrant_upsert", "sym1", "mcp/qdrant_ops.py"),
-        ("handle", "sym2", "a2a_server/server.py"),
-        ("handle", "sym3", "mcp/memcheck/daemon.py"),
+        ("parse_frame", "sym2", "a2a_server/server.py"),
+        ("parse_frame", "sym3", "mcp/memcheck/daemon.py"),
         ("EskfFusion", "sym4", "android/EskfFusion.java"),
     ]
 
@@ -520,24 +520,24 @@ class TestCodelink(unittest.TestCase):
         self.assertIsNone(rows[0]["model"], "no model needed for an unambiguous token")
 
     def test_an_ambiguous_token_is_not_guessed_at_without_a_model(self):
-        report, rows = self._run("the handle path is wrong")
+        report, rows = self._run("the parse_frame path is wrong")
         self.assertEqual(report["ambiguous_tokens"], 1)
         self.assertEqual(report["proposed"], 0)
 
     def test_the_model_resolves_an_ambiguous_token(self):
         gen = lambda prompts: [{"text": "2", "ok": True} for _ in prompts]  # noqa: E731
-        report, rows = self._run("the handle path is wrong", gen=gen)
+        report, rows = self._run("the parse_frame path is wrong", gen=gen)
         self.assertEqual(report["proposed"], 1)
         self.assertEqual(rows[0]["value"][0]["symbol_id"], "sym3")
 
     def test_a_model_answer_of_zero_declines_rather_than_linking(self):
         gen = lambda prompts: [{"text": "0", "ok": True} for _ in prompts]  # noqa: E731
-        report, _ = self._run("the handle path is wrong", gen=gen)
+        report, _ = self._run("the parse_frame path is wrong", gen=gen)
         self.assertEqual(report["proposed"], 0)
 
     def test_an_out_of_range_choice_is_refused(self):
         gen = lambda prompts: [{"text": "99", "ok": True} for _ in prompts]  # noqa: E731
-        report, _ = self._run("the handle path is wrong", gen=gen)
+        report, _ = self._run("the parse_frame path is wrong", gen=gen)
         self.assertEqual(report["proposed"], 0)
 
     def test_prose_words_do_not_become_symbols(self):
@@ -574,3 +574,23 @@ class TestCodelink(unittest.TestCase):
             report = groom.pass_codelink(memory_dir=tmp, groom_dir=tmp / "_groom",
                                          symbols_fn=boom, linked_fn=lambda: [])
         self.assertEqual(report["status"], "degraded")
+
+
+class TestDistinctiveness(unittest.TestCase):
+    """A bare lowercase word that happens to name a symbol is not evidence that
+    the author meant the code. The first live calibration linked `device`, `roll`
+    and `train` to real symbols on exactly that mistake."""
+
+    def test_bare_words_are_rejected(self):
+        for tok in ("device", "position", "confirmed", "roll", "train", "report",
+                    "baseline", "remaining", "consumer", "trigger", "refusal"):
+            self.assertFalse(groom._is_distinctive(tok), tok)
+
+    def test_structured_identifiers_are_accepted(self):
+        for tok in ("_qdrant_upsert", "disarmBeam", "SensorCollectionService",
+                    "schroederRt60Ms", "estimateRt60ApproxMs", "parse_frame"):
+            self.assertTrue(groom._is_distinctive(tok), tok)
+
+    def test_a_long_lowercase_identifier_still_counts(self):
+        self.assertTrue(groom._is_distinctive("triangulationsolver"))
+        self.assertFalse(groom._is_distinctive("triangulate"))

--- a/scripts/tests/test_loci_groom.py
+++ b/scripts/tests/test_loci_groom.py
@@ -254,3 +254,126 @@ class TestCli(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRecallPass(unittest.TestCase):
+    """The two probes must stay separable: identity is a wiring test, paraphrase
+    is a semantic one, and collapsing them is what makes an outage look like a
+    quality dip."""
+
+    def _run(self, *, ranks_for_identity=None, ranks_for_paraphrase=None,
+             gen=None, paraphrase=True, sample=3, k=5):
+        import tempfile
+        self._td = tempfile.TemporaryDirectory()
+        tmp = pathlib.Path(self._td.name)
+        ids = ["a", "b", "c"]
+        _corpus(tmp, {"inv": [_f(i, text=f"finding text {i}") for i in ids]})
+
+        def search(query):
+            # identity queries carry the finding text; paraphrase queries do not
+            is_identity = query.startswith("finding text ")
+            table = ranks_for_identity if is_identity else ranks_for_paraphrase
+            if table is None:
+                return {"ok": False, "reason": "boom", "results": []}
+            fid = query.split()[-1] if is_identity else query.split(":")[-1].strip()
+            rank = table.get(fid)
+            rows = [{"id": f"filler{n}"} for n in range(k)]
+            if rank:
+                rows[rank - 1] = {"id": fid}
+            return {"ok": True, "reason": "hybrid", "results": rows}
+
+        client = _Client(ids)
+        fake_ops = mock.Mock()
+        fake_ops._get_qdrant.return_value = (client, "hermes_memory")
+        with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
+            return groom.pass_recall(
+                sample=sample, k=k, paraphrase=paraphrase, gen_fn=gen,
+                memory_dir=tmp, groom_dir=tmp / "_groom", search_fn=search,
+            )
+
+    def tearDown(self):
+        if getattr(self, "_td", None):
+            self._td.cleanup()
+
+    def test_perfect_identity_recall(self):
+        r = self._run(ranks_for_identity={"a": 1, "b": 1, "c": 1}, paraphrase=False)
+        self.assertEqual(r["identity"]["recall_at_1"], 1.0)
+        self.assertEqual(r["identity"]["mrr"], 1.0)
+        self.assertEqual(r["identity"]["attempted"], 3)
+
+    def test_a_finding_the_retriever_cannot_return_is_a_miss_not_an_error(self):
+        r = self._run(ranks_for_identity={"a": 1, "b": None, "c": None}, paraphrase=False)
+        self.assertAlmostEqual(r["identity"]["recall_at_1"], 1 / 3, places=3)
+        self.assertAlmostEqual(r["identity"]["recall_at_5"], 1 / 3, places=3)
+        self.assertEqual(r["search_errors"], 0)
+
+    def test_rank_position_shows_up_in_mrr_not_just_recall_at_1(self):
+        r = self._run(ranks_for_identity={"a": 1, "b": 2, "c": 4}, paraphrase=False)
+        self.assertAlmostEqual(r["identity"]["recall_at_1"], 1 / 3, places=3)
+        self.assertEqual(r["identity"]["recall_at_5"], 1.0)
+        self.assertAlmostEqual(r["identity"]["mrr"], (1 + 0.5 + 0.25) / 3, places=4)
+
+    def test_identity_and_paraphrase_are_scored_apart(self):
+        gen = lambda prompts: [{"text": f"question: {p.split('finding text ')[1][0]}", "ok": True}  # noqa: E731
+                               for p in prompts]
+        r = self._run(ranks_for_identity={"a": 1, "b": 1, "c": 1},
+                      ranks_for_paraphrase={"a": 1, "b": None, "c": None}, gen=gen)
+        self.assertEqual(r["identity"]["recall_at_1"], 1.0)
+        self.assertAlmostEqual(r["paraphrase"]["recall_at_1"], 1 / 3, places=3)
+
+    def test_a_search_that_reports_not_ok_is_counted_as_an_error(self):
+        r = self._run(ranks_for_identity=None, paraphrase=False)
+        self.assertEqual(r["search_errors"], 3)
+        self.assertEqual(r["identity"]["attempted"], 0)
+
+    def test_an_empty_generated_question_is_unusable_not_a_miss(self):
+        gen = lambda prompts: [{"text": "  ", "ok": True} for _ in prompts]  # noqa: E731
+        r = self._run(ranks_for_identity={"a": 1, "b": 1, "c": 1},
+                      ranks_for_paraphrase={}, gen=gen)
+        self.assertEqual(r["paraphrase"]["unusable"], 3)
+        self.assertEqual(r["paraphrase"]["attempted"], 0)
+
+    def test_it_only_probes_findings_that_are_actually_indexed(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f(i, text=f"finding text {i}") for i in ["a", "b", "c", "d"]]})
+            client = _Client(["a", "b"])          # only two of the four are indexed
+            fake_ops = mock.Mock()
+            fake_ops._get_qdrant.return_value = (client, "hermes_memory")
+            seen = []
+
+            def search(q):
+                seen.append(q)
+                return {"ok": True, "reason": "hybrid", "results": []}
+
+            with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
+                r = groom.pass_recall(sample=10, paraphrase=False, memory_dir=tmp,
+                                      groom_dir=tmp / "_groom", search_fn=search)
+        self.assertEqual(r["indexed_with_text"], 2)
+        self.assertEqual(len(seen), 2)
+
+    def test_it_appends_one_row_per_run_for_trend(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f("a", text="finding text a")]})
+            client = _Client(["a"])
+            fake_ops = mock.Mock()
+            fake_ops._get_qdrant.return_value = (client, "hermes_memory")
+            gd = tmp / "_groom"
+            with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
+                for _ in range(2):
+                    groom.pass_recall(sample=1, paraphrase=False, memory_dir=tmp,
+                                      groom_dir=gd,
+                                      search_fn=lambda q: {"ok": True, "results": [{"id": "a"}]})
+            rows = [json.loads(l) for l in open(gd / "recall.jsonl") if l.strip()]
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r["identity"]["recall_at_1"] == 1.0 for r in rows))
+
+    def test_an_unreachable_qdrant_degrades(self):
+        fake_ops = mock.Mock()
+        fake_ops._get_qdrant.return_value = (None, None)
+        with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
+            r = groom.pass_recall()
+        self.assertEqual(r["status"], "degraded")

--- a/scripts/tests/test_loci_groom.py
+++ b/scripts/tests/test_loci_groom.py
@@ -1,0 +1,256 @@
+"""loci_groom — the passive grooming passes.
+
+The index pass is the one that can write, so most of these pin its arithmetic and
+its refusal to write without --apply. The tags pass is asserted to stay in the
+proposal lane: nothing it produces may reach findings.jsonl, and nothing outside
+the vocabulary it was handed may reach a proposal.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("loci_groom", _SCRIPTS / "loci_groom.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+groom = _load()
+
+
+def _corpus(tmp, spec):
+    """spec: {investigation: [finding-dict, ...]} -> writes findings.jsonl files."""
+    for inv, rows in spec.items():
+        d = tmp / inv
+        d.mkdir(parents=True, exist_ok=True)
+        with open(d / "findings.jsonl", "w") as fh:
+            for r in rows:
+                fh.write(json.dumps({"investigation_id": inv, **r}) + "\n")
+    return tmp
+
+
+def _f(fid, text="a finding about the reranker", tags=None):
+    row = {"id": fid, "text": text}
+    if tags is not None:
+        row["tags"] = tags
+    return row
+
+
+class _Point:
+    def __init__(self, pid):
+        self.id = pid
+
+
+class _Client:
+    """Scrolls in pages, like the real one."""
+
+    def __init__(self, ids, page=2):
+        self._ids = list(ids)
+        self._page = page
+        self.upserts = []
+
+    def scroll(self, offset=None, **_kw):
+        start = offset or 0
+        chunk = self._ids[start:start + self._page]
+        nxt = start + self._page
+        return [_Point(i) for i in chunk], (nxt if nxt < len(self._ids) else None)
+
+
+class TestIterFindings(unittest.TestCase):
+    def test_it_reads_every_investigation_and_skips_junk_lines(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv-a": [_f("1"), _f("2")], "inv-b": [_f("3")]})
+            with open(tmp / "inv-a" / "findings.jsonl", "a") as fh:
+                fh.write("not json\n\n")
+            ids = sorted(f["id"] for f in groom.iter_findings(tmp))
+            self.assertEqual(ids, ["1", "2", "3"])
+
+
+class TestIndexPass(unittest.TestCase):
+    def _run(self, disk_ids, indexed_ids, apply=False, limit=None):
+        import tempfile
+        self._td = tempfile.TemporaryDirectory()
+        tmp = pathlib.Path(self._td.name)
+        _corpus(tmp, {"inv": [_f(i) for i in disk_ids]})
+        client = _Client(indexed_ids)
+        fake_ops = mock.Mock()
+        fake_ops._get_qdrant.return_value = (client, "hermes_memory")
+        fake_ops._qdrant_upsert.side_effect = lambda pid, text, payload: client.upserts.append(pid)
+        with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}), \
+             mock.patch.object(groom, "MEMORY_DIR", tmp):
+            return groom.pass_index(apply=apply, limit=limit), client
+
+    def tearDown(self):
+        if getattr(self, "_td", None):
+            self._td.cleanup()
+
+    def test_it_counts_the_drift_between_disk_and_the_index(self):
+        report, _ = self._run(["a", "b", "c", "d", "e"], ["a", "b"])
+        self.assertEqual(report["on_disk"], 5)
+        self.assertEqual(report["indexed"], 2)
+        self.assertEqual(report["missing"], 3)
+        self.assertEqual(report["coverage"], 0.4)
+
+    def test_a_full_index_reports_no_drift(self):
+        report, _ = self._run(["a", "b"], ["a", "b"])
+        self.assertEqual(report["missing"], 0)
+        self.assertEqual(report["coverage"], 1.0)
+
+    def test_without_apply_it_writes_nothing(self):
+        report, client = self._run(["a", "b", "c"], [])
+        self.assertEqual(client.upserts, [])
+        self.assertEqual(report["applied"], 0)
+
+    def test_with_apply_it_reupserts_exactly_the_missing_ones(self):
+        report, client = self._run(["a", "b", "c"], ["b"])
+        self.assertEqual(report["applied"], 0)      # sanity: default is report-only
+        report, client = self._run(["a", "b", "c"], ["b"], apply=True)
+        self.assertEqual(sorted(client.upserts), ["a", "c"])
+        self.assertEqual(report["applied"], 2)
+
+    def test_limit_caps_the_write(self):
+        report, client = self._run(["a", "b", "c", "d"], [], apply=True, limit=2)
+        self.assertEqual(len(client.upserts), 2)
+
+    def test_an_unreachable_qdrant_degrades_instead_of_raising(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f("a")]})
+            fake_ops = mock.Mock()
+            fake_ops._get_qdrant.return_value = (None, None)
+            with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}), \
+                 mock.patch.object(groom, "MEMORY_DIR", tmp):
+                report = groom.pass_index()
+        self.assertEqual(report["status"], "degraded")
+        self.assertEqual(report["applied"], 0)
+
+
+class TestVocabulary(unittest.TestCase):
+    def test_single_use_tags_are_not_vocabulary(self):
+        findings = [_f(str(i), tags=["mqtt"]) for i in range(6)]
+        findings += [_f("x", tags=["one-off-tag-nobody-reuses"])]
+        vocab = groom.build_vocabulary(findings, min_uses=5)
+        self.assertIn("mqtt", vocab)
+        self.assertNotIn("one-off-tag-nobody-reuses", vocab)
+
+    def test_run_provenance_stamps_are_excluded(self):
+        findings = [_f(str(i), tags=["dt_run:whatever", "dt_model:haiku", "acoustic"])
+                    for i in range(6)]
+        vocab = groom.build_vocabulary(findings, min_uses=5)
+        self.assertEqual(vocab, ["acoustic"])
+
+
+class TestTagsPass(unittest.TestCase):
+    def _run(self, gen, untagged=3):
+        import tempfile
+        self._td = tempfile.TemporaryDirectory()
+        tmp = pathlib.Path(self._td.name)
+        rows = [_f(f"t{i}", tags=["mqtt", "acoustic"]) for i in range(6)]
+        rows += [_f(f"u{i}", text="the broker dropped the subscription", tags=[])
+                 for i in range(untagged)]
+        _corpus(tmp, {"inv": rows})
+        groomdir = tmp / "_groom"
+        report = groom.pass_tags(gen_fn=gen, memory_dir=tmp, groom_dir=groomdir)
+        proposals = []
+        p = groomdir / "proposals.jsonl"
+        if p.exists():
+            proposals = [json.loads(l) for l in open(p) if l.strip()]
+        return report, proposals, tmp
+
+    def tearDown(self):
+        if getattr(self, "_td", None):
+            self._td.cleanup()
+
+    def test_it_proposes_vocabulary_tags_for_untagged_findings(self):
+        gen = lambda prompts: [{"text": '{"tags": ["mqtt"]}', "ok": True} for _ in prompts]  # noqa: E731
+        report, proposals, _ = self._run(gen)
+        self.assertEqual(report["candidates"], 3)
+        self.assertEqual(report["proposed"], 3)
+        self.assertTrue(all(p["value"] == ["mqtt"] for p in proposals))
+        self.assertTrue(all(p["proposed_by"] == "loci_groom/tags" for p in proposals))
+
+    def test_it_never_touches_findings_jsonl(self):
+        gen = lambda prompts: [{"text": '{"tags": ["mqtt"]}', "ok": True} for _ in prompts]  # noqa: E731
+        _, _, tmp = self._run(gen)
+        rows = [json.loads(l) for l in open(tmp / "inv" / "findings.jsonl") if l.strip()]
+        untagged = [r for r in rows if not r.get("tags")]
+        self.assertEqual(len(untagged), 3, "the pass must not write tags into the corpus")
+
+    def test_a_tag_outside_the_vocabulary_is_dropped(self):
+        gen = lambda prompts: [{"text": '{"tags": ["invented-label"]}', "ok": True} for _ in prompts]  # noqa: E731
+        report, proposals, _ = self._run(gen)
+        self.assertEqual(proposals, [])
+        self.assertEqual(report["proposed"], 0)
+
+    def test_a_failed_generation_proposes_nothing(self):
+        gen = lambda prompts: [{"text": "", "ok": False} for _ in prompts]  # noqa: E731
+        report, proposals, _ = self._run(gen)
+        self.assertEqual(report["proposed"], 0)
+        self.assertEqual(proposals, [])
+
+    def test_non_json_output_is_skipped_not_raised(self):
+        gen = lambda prompts: [{"text": "sure thing boss", "ok": True} for _ in prompts]  # noqa: E731
+        report, proposals, _ = self._run(gen)
+        self.assertEqual(report["proposed"], 0)
+
+    def test_a_second_run_is_idempotent(self):
+        gen = lambda prompts: [{"text": '{"tags": ["mqtt"]}', "ok": True} for _ in prompts]  # noqa: E731
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f(f"t{i}", tags=["mqtt", "acoustic"]) for i in range(6)]
+                                 + [_f("u0", text="broker dropped it", tags=[])]})
+            gd = tmp / "_groom"
+            first = groom.pass_tags(gen_fn=gen, memory_dir=tmp, groom_dir=gd)
+            second = groom.pass_tags(gen_fn=gen, memory_dir=tmp, groom_dir=gd)
+            self.assertEqual(first["proposed"], 1)
+            self.assertEqual(second["proposed"], 0)
+            self.assertEqual(second["generated"], 1)   # regenerated, then deduped
+
+    def test_no_generation_tier_degrades(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _corpus(tmp, {"inv": [_f(f"t{i}", tags=["mqtt"]) for i in range(6)]
+                                 + [_f("u0", text="x", tags=[])]})
+            with mock.patch.dict(sys.modules, {"batched_gen": None}):
+                report = groom.pass_tags(memory_dir=tmp, groom_dir=tmp / "_groom")
+        self.assertEqual(report["status"], "degraded")
+
+
+class TestCli(unittest.TestCase):
+    def test_apply_is_refused_for_proposal_only_passes(self):
+        calls = {}
+
+        def fake_tags(**kw):
+            calls.update(kw)
+            return {"pass": "tags", "status": "ok"}
+
+        with mock.patch.dict(groom.PASSES, {"tags": {"fn": fake_tags, "applyable": False}}):
+            groom.main(["tags", "--apply"])
+        self.assertFalse(calls["apply"])
+
+    def test_an_exploding_pass_does_not_take_the_run_down(self):
+        def boom(**kw):
+            raise RuntimeError("nope")
+
+        with mock.patch.dict(groom.PASSES, {"tags": {"fn": boom, "applyable": False}}):
+            rc = groom.main(["tags", "--json"])
+        self.assertEqual(rc, 1)
+
+    def test_unknown_pass_is_rejected(self):
+        self.assertEqual(groom.main(["nonsense"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First slice of a passive processing tier for the corpus. `scripts/loci_groom.py`
runs unattended; three rules hold for every pass:

- **idempotent** — a second run over unchanged input proposes nothing new
- **fail-open** — a dead backend degrades the pass to a report, never raises
- **shadow-first** — model output goes to `_groom/proposals.jsonl` with its
  provenance and **never** into `findings.jsonl`. A 3B model's guess must not
  become indistinguishable from what an author wrote.

`--apply` is honoured only by passes that declare `applyable` — today just
`index`, whose write re-upserts the record already on disk, so it can restore but
cannot invent.

## `index` — the reconciliation that was missing

Findings reach Qdrant only on write (`_qdrant_upsert` at store time). The startup
TTL purge deletes by `created_at_ts`. **Nothing has ever put an aged-out finding
back**, and no backfill path existed — `git grep findings.jsonl -- scripts/` finds
only `session_end_sync`.

Measured on the live store just now:

```
$ loci_groom.py index --json
{ "on_disk": 2615, "indexed": 637, "missing": 1978, "coverage": 0.2436 }
```

**75.6% of the corpus is on disk and in the code graph but invisible to semantic
search.** `--apply` re-embeds and re-upserts exactly the missing ids.

## `tags` — vocabulary labelling via the local model

The corpus has **4,267 distinct tags, 2,809 of them used exactly once** — that is
free text, not a vocabulary. The pass derives a working vocabulary from terms
reused at least 5 times (excluding `dt_*` run-provenance stamps), then asks the
local model to pick from it. Terms outside the vocabulary are dropped rather than
allowed to widen it.

Every rejection reason is counted — `generation_failed`, `unparseable`,
`declined`, `out_of_vocabulary` — so a zero says *which* zero it is. That paid for
itself on the first live run: all 12 candidates came back `generation_failed`
because `GROOM_MODEL` defaulted to the Ollama tag `qwen2.5:3b` while the batched
tier serves `Qwen/Qwen2.5-3B-Instruct` and rejects an unrecognised name. The model
is now unset by default so each tier resolves its own.

### Honest result on live data

36 untagged findings carry text (the other 480 untagged records are `access` rows
with no text at all). Of 36: **10 proposals, 10 declined, 16 generation failures.**

Reading the 10 proposals against their findings, **roughly 2-3 are good**. A
finding about call-graph recall was tagged `mypy, type-safety`; the
`investigation_store` god-function finding was tagged `dead-code`. Plausible and
wrong is exactly the failure mode this corpus is worst at detecting.

So: the pipeline works end to end against a live local model, and **the labelling
quality does not justify promotion**, which is why nothing here can promote. The
next iteration should try kNN label transfer over the embeddings already in
Qdrant — take tags from the k nearest already-tagged findings, weighted by
similarity — which is deterministic, calibratable against held-out tagged
findings, and probably beats a 3B model at this particular job. The generation
tier is better spent on extraction and adjudication than on classification.

## Config

A cron job does not inherit the MCP launcher's environment, and `QDRANT_URL`
currently exists **only inside the running server's process** — there is no `.env`
on disk and `~/.loci/backends.toml` has no `[qdrant]` section. `load_env()`
resolves env -> repo `.env` -> `backends.toml`, so a scheduled pass can find the
backend; filling in the `[qdrant]` section is the deploy step.

## Tests

`scripts/tests/test_loci_groom.py` — 19 tests. Index arithmetic, paged scroll,
refusal to write without `--apply`, `--limit` capping the write, degraded on an
unreachable Qdrant; vocabulary derivation excluding one-off and `dt_*` tags; and
for the tags pass specifically: **an assertion that `findings.jsonl` is unchanged
after a run**, out-of-vocabulary terms dropped, unparseable and failed generations
counted not raised, and a second run proposing nothing.

Full `scripts/` suite: 589 passed (the one failure,
`test_beam_fallback_returns_empty_when_mnemosyne_missing`, is the pre-existing
host-specific one that fails wherever `~/.hermes/mnemosyne` exists).