### PR TITLE
fix(qdrant): resolve the dense vector's name instead of assuming it is "dense"

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -580,6 +580,46 @@ def _qdrant_similarity_search(
     return {"ok": True, "reason": mode, "results": rows}
 
 
+# Cache of collection -> dense vector name. Vector layout does not change under a
+# running process, and the alternative is a get_collection on every query.
+_dense_name_cache: dict = {}
+
+
+def _dense_vector_name(client, collection: str) -> Optional[str]:
+    """Name of the dense vector on ``collection``, or None when it is unnamed.
+
+    ``_qdrant_search_collection`` and ``probe_collection`` take a collection name
+    from the caller, so they run against collections this server did not create and
+    whose vector is not necessarily called ``dense``. Asking for a name that is not
+    there returns ``400 Not existing vector name error`` — which the retrieval path
+    catches per-collection and reports as "no results", indistinguishable from a
+    collection that genuinely had no match.
+
+    Cheap insurance rather than a live fault: every collection currently in the
+    store either uses ``dense`` or is unnamed. Where we create the collection
+    ourselves the name is ours and the call sites keep passing it directly.
+
+    When a collection carries several dense vectors, prefer one whose width matches
+    this server's embedder; a vector we cannot produce is not a candidate.
+    """
+    if collection in _dense_name_cache:
+        return _dense_name_cache[collection]
+    name = None
+    try:
+        vectors = client.get_collection(collection).config.params.vectors
+        if isinstance(vectors, dict) and vectors:
+            if "dense" in vectors:
+                name = "dense"
+            else:
+                same_width = [k for k, v in vectors.items()
+                              if getattr(v, "size", None) == VECTOR_DIM]
+                name = same_width[0] if same_width else sorted(vectors)[0]
+    except Exception as exc:
+        logger.debug("_dense_vector_name(%s): %r", collection, exc)
+    _dense_name_cache[collection] = name
+    return name
+
+
 def _collection_shape(client, name: str) -> dict:
     """Vector layout of one collection: dense width(s), sparse presence, points.
 
@@ -657,8 +697,9 @@ def probe_collection(query_vec, client, name: str, limit: int = 3) -> dict:
 
     kwargs = {"collection_name": name, "query": query_vec, "limit": limit, "with_payload": False}
     try:
-        if shape["named"]:
-            points = client.query_points(using="dense", **kwargs).points
+        dense_name = _dense_vector_name(client, name) if shape["named"] else None
+        if dense_name:
+            points = client.query_points(using=dense_name, **kwargs).points
         else:
             points = client.query_points(**kwargs).points
     except Exception as exc:
@@ -707,13 +748,18 @@ def _qdrant_search_collection(
         has_named_vectors = False
         has_sparse_index = False
 
+    # The dense vector is not always called "dense" — see _dense_vector_name.
+    dense_name = _dense_vector_name(client, collection_name) if has_named_vectors else None
+    if has_named_vectors and dense_name is None:
+        has_named_vectors = False        # nothing nameable to query; fall through to flat
+
     _qsp = SearchParams(quantization=QuantizationSearchParams(rescore=True, oversampling=2.0))
 
     if has_named_vectors and has_sparse_index and sparse_vec is not None:
         result = client.query_points(
             collection_name=collection_name,
             prefetch=[
-                Prefetch(query=dense_vec, using="dense", limit=fetch_limit * 2),
+                Prefetch(query=dense_vec, using=dense_name, limit=fetch_limit * 2),
                 Prefetch(query=sparse_vec, using="sparse", limit=fetch_limit * 2),
             ],
             query=FusionQuery(fusion=Fusion.RRF),
@@ -726,7 +772,7 @@ def _qdrant_search_collection(
         result = client.query_points(
             collection_name=collection_name,
             query=dense_vec,
-            using="dense",
+            using=dense_name,
             limit=fetch_limit,
             with_payload=True,
             query_filter=query_filter,

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -4957,7 +4957,8 @@ def _selftest_rollup(rows: list[dict]) -> tuple[str, str]:
 
 
 @mcp.tool()
-def retrieval_selftest(query: str = "system architecture", limit: int = 3) -> str:
+def retrieval_selftest(query: str = "system architecture", limit: int = 3,
+                       collections: Optional[list] = None, scope: str = "queried") -> str:
     """
     Prove every Qdrant collection can actually be retrieved from.
 
@@ -4978,12 +4979,26 @@ def retrieval_selftest(query: str = "system architecture", limit: int = 3) -> st
     Read-only. Bypasses the cross-encoder and its relevance floor on purpose:
     the floor is a relevance judgement and this is a question about wiring.
 
+    Scope matters more than it looks. A store accumulates collections this server
+    never queries — feature vectors at their own widths, corpora left over from
+    other tools — and sweeping them rolls a dozen irrelevant width mismatches into
+    the health verdict. A diagnostic that reports `degraded` because of things
+    nobody asks about teaches you to ignore it, which is the exact failure this
+    tool exists to prevent. So the default scope is what the server would actually
+    retrieve from.
+
     Args:
         query: Probe text. Any in-domain phrase works; the point is retrievability.
         limit: Rows to request per collection (default 3).
+        collections: Probe exactly these. Overrides ``scope``.
+        scope: ``queried`` (default) — the collections this server retrieves from:
+               the findings collection plus the configured code-chunks collection.
+               ``all`` — every collection in the store, for an inventory; width
+               mismatches outside the queried set are reported but do NOT count
+               against health, since nothing asks them anything.
 
     Returns:
-        JSON with {status, summary, collections, remediations}.
+        JSON with {status, summary, scope, collections, remediations}.
     """
     client, _col = _get_qdrant()
     if client is None:
@@ -4995,7 +5010,15 @@ def retrieval_selftest(query: str = "system architecture", limit: int = 3) -> st
         }, indent=2)
 
     try:
-        names = sorted(c.name for c in client.get_collections().collections)
+        present = sorted(c.name for c in client.get_collections().collections)
+        queried = [QDRANT_COLLECTION_PREFIX] + (
+            [_CODE_CHUNKS_COLLECTION] if _CODE_CHUNKS_COLLECTION else [])
+        if collections:
+            names, in_scope = list(collections), set(collections)
+        elif scope == "all":
+            names, in_scope = present, set(queried)
+        else:
+            names, in_scope = [n for n in queried if n in present], set(queried)
     except Exception as exc:
         return json.dumps({
             "status": "unhealthy",
@@ -5017,17 +5040,24 @@ def retrieval_selftest(query: str = "system architecture", limit: int = 3) -> st
         query_vec = None
 
     rows = [probe_collection(query_vec, client, name, limit=limit) for name in names]
-    status, summary = _selftest_rollup(rows)
+    for r in rows:
+        r["queried_by_server"] = r["collection"] in in_scope
+    # Only the collections this server actually retrieves from can make it unhealthy.
+    status, summary = _selftest_rollup([r for r in rows if r["queried_by_server"]] or rows)
 
     remediations: list[str] = []
-    for r in rows:
+    for r in (r for r in rows if r["queried_by_server"]):
         rem = r.get("remediation")
         if rem and rem not in remediations:
             remediations.append(rem)
 
+    out_of_scope = [r["collection"] for r in rows if not r["queried_by_server"]]
     return json.dumps({
         "status": status,
-        "summary": summary,
+        "summary": summary + (
+            f" (+{len(out_of_scope)} not queried by this server, excluded from health)"
+            if out_of_scope else ""),
+        "scope": "explicit" if collections else scope,
         "embedder_dim": len(query_vec) if query_vec else None,
         "collections": rows,
         "remediations": remediations,

--- a/mcp/tests/test_retrieval_selftest.py
+++ b/mcp/tests/test_retrieval_selftest.py
@@ -113,3 +113,84 @@ class TestRetrievalSelftest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class _NamedVectorParams:
+    def __init__(self, size):
+        self.size = size
+
+
+class _Cfg:
+    def __init__(self, vectors, sparse=None):
+        self.config = type("C", (), {"params": type("P", (), {
+            "vectors": vectors, "sparse_vectors": sparse})()})()
+        self.points_count = 1
+
+
+class TestDenseVectorName(unittest.TestCase):
+    """The call sites that take a collection name from the caller run against
+    collections this server did not create, whose dense vector is not necessarily
+    called `dense`. Asking for a name that is not there is a 400, which the
+    retrieval path reports as 'no results'."""
+
+    def setUp(self):
+        import qdrant_ops
+        qdrant_ops._dense_name_cache.clear()
+
+    def _name(self, vectors):
+        import qdrant_ops
+        client = mock.Mock()
+        client.get_collection.return_value = _Cfg(vectors)
+        return qdrant_ops._dense_vector_name(client, "c")
+
+    def test_dense_is_preferred_when_present(self):
+        self.assertEqual(self._name({"dense": _NamedVectorParams(768),
+                                     "other": _NamedVectorParams(768)}), "dense")
+
+    def test_a_differently_named_vector_is_found(self):
+        self.assertEqual(
+            self._name({"fast-nomic-embed-text-v1.5": _NamedVectorParams(768)}),
+            "fast-nomic-embed-text-v1.5")
+
+    def test_the_one_matching_the_embedder_width_wins(self):
+        import qdrant_ops
+        got = self._name({"small": _NamedVectorParams(384),
+                          "big": _NamedVectorParams(qdrant_ops.VECTOR_DIM)})
+        self.assertEqual(got, "big")
+
+    def test_an_unnamed_flat_collection_returns_none(self):
+        self.assertIsNone(self._name(_NamedVectorParams(768)))
+
+    def test_no_vectors_returns_none(self):
+        self.assertIsNone(self._name({}))
+
+    def test_a_failing_get_collection_returns_none_rather_than_raising(self):
+        import qdrant_ops
+        client = mock.Mock()
+        client.get_collection.side_effect = RuntimeError("gone")
+        self.assertIsNone(qdrant_ops._dense_vector_name(client, "c"))
+
+    def test_the_answer_is_cached_not_refetched(self):
+        import qdrant_ops
+        client = mock.Mock()
+        client.get_collection.return_value = _Cfg({"dense": _NamedVectorParams(768)})
+        for _ in range(3):
+            qdrant_ops._dense_vector_name(client, "c")
+        self.assertEqual(client.get_collection.call_count, 1)
+
+
+class TestProbeUsesTheResolvedName(unittest.TestCase):
+    def test_a_collection_whose_vector_is_not_called_dense_probes_ok(self):
+        import qdrant_ops
+        qdrant_ops._dense_name_cache.clear()
+        c = QdrantClient(location=":memory:")
+        c.create_collection("odd", vectors_config={
+            "fast-nomic-embed-text-v1.5": VectorParams(size=DIM, distance=Distance.COSINE)})
+        c.upsert("odd", points=[PointStruct(
+            id=1, vector={"fast-nomic-embed-text-v1.5": [0.1] * DIM})])
+        with mock.patch.object(server, "_get_qdrant", lambda: (c, "odd")), \
+             mock.patch.object(server, "_embed", lambda _q: [0.1] * DIM):
+            out = json.loads(server.retrieval_selftest("anything"))
+        row = {r["collection"]: r for r in out["collections"]}["odd"]
+        self.assertEqual(row["status"], "ok", row.get("detail"))
+        self.assertEqual(row["hits"], 1)

--- a/mcp/tests/test_retrieval_selftest.py
+++ b/mcp/tests/test_retrieval_selftest.py
@@ -42,10 +42,17 @@ _UNSET = object()
 
 
 def _run(client, vec=_UNSET):
+    """Probe every collection in the store, explicitly.
+
+    The tool's DEFAULT scope is only what the server retrieves from; these cases
+    are about probe classification and rollup, so they name their collections and
+    thereby opt them in — see TestScope for the scoping behaviour itself.
+    """
     embedding = [0.1] * DIM if vec is _UNSET else vec
+    names = sorted(c.name for c in client.get_collections().collections)
     with mock.patch.object(server, "_get_qdrant", lambda: (client, "hermes_memory")), \
          mock.patch.object(server, "_embed", lambda _q: embedding):
-        return json.loads(server.retrieval_selftest("anything"))
+        return json.loads(server.retrieval_selftest("anything", collections=names))
 
 
 def _by_name(out):
@@ -190,7 +197,66 @@ class TestProbeUsesTheResolvedName(unittest.TestCase):
             id=1, vector={"fast-nomic-embed-text-v1.5": [0.1] * DIM})])
         with mock.patch.object(server, "_get_qdrant", lambda: (c, "odd")), \
              mock.patch.object(server, "_embed", lambda _q: [0.1] * DIM):
-            out = json.loads(server.retrieval_selftest("anything"))
+            out = json.loads(server.retrieval_selftest("anything", collections=["odd"]))
         row = {r["collection"]: r for r in out["collections"]}["odd"]
         self.assertEqual(row["status"], "ok", row.get("detail"))
         self.assertEqual(row["hits"], 1)
+
+
+class TestScope(unittest.TestCase):
+    """A store accumulates collections nobody queries. Rolling their width
+    mismatches into the verdict makes the tool cry wolf, and a diagnostic you
+    learn to ignore is worse than no diagnostic."""
+
+    def _store(self):
+        c = QdrantClient(location=":memory:")
+        c.create_collection("hermes_memory", vectors_config={
+            "dense": VectorParams(size=DIM, distance=Distance.COSINE)})
+        c.upsert("hermes_memory", points=[
+            PointStruct(id=1, vector={"dense": [0.1] * DIM})])
+        # junk at a foreign width — feature vectors, leftovers, someone else's corpus
+        for name, w in (("old_junk", DIM * 2), ("ant_features", DIM * 4)):
+            c.create_collection(name, vectors_config=VectorParams(
+                size=w, distance=Distance.COSINE))
+            c.upsert(name, points=[PointStruct(id=1, vector=[0.1] * w)])
+        return c
+
+    def _run(self, **kw):
+        import qdrant_ops
+        qdrant_ops._dense_name_cache.clear()
+        c = self._store()
+        with mock.patch.object(server, "_get_qdrant", lambda: (c, "hermes_memory")), \
+             mock.patch.object(server, "_embed", lambda _q: [0.1] * DIM), \
+             mock.patch.object(server, "QDRANT_COLLECTION_PREFIX", "hermes_memory"), \
+             mock.patch.object(server, "_CODE_CHUNKS_COLLECTION", ""):
+            return json.loads(server.retrieval_selftest("anything", **kw))
+
+    def test_default_scope_ignores_collections_the_server_never_queries(self):
+        out = self._run()
+        self.assertEqual(out["status"], "ok")
+        self.assertEqual([r["collection"] for r in out["collections"]], ["hermes_memory"])
+
+    def test_scope_all_inventories_everything_but_health_stays_ok(self):
+        out = self._run(scope="all")
+        self.assertEqual(len(out["collections"]), 3)
+        self.assertEqual(out["status"], "ok", "junk must not make the store unhealthy")
+        self.assertIn("not queried by this server", out["summary"])
+
+    def test_scope_all_still_reports_the_junk_for_inventory(self):
+        out = self._run(scope="all")
+        by = {r["collection"]: r for r in out["collections"]}
+        self.assertEqual(by["old_junk"]["status"], "width_mismatch")
+        self.assertFalse(by["old_junk"]["queried_by_server"])
+        self.assertTrue(by["hermes_memory"]["queried_by_server"])
+
+    def test_remediations_only_cover_collections_that_are_queried(self):
+        out = self._run(scope="all")
+        self.assertEqual(out["remediations"], [],
+                         "advice about collections nobody asks is noise")
+
+    def test_an_explicit_list_overrides_scope(self):
+        out = self._run(collections=["old_junk"])
+        self.assertEqual([r["collection"] for r in out["collections"]], ["old_junk"])
+        self.assertEqual(out["scope"], "explicit")
+        self.assertEqual(out["status"], "unhealthy",
+                         "asked about it explicitly, so it counts")


### PR DESCRIPTION
`retrieval_selftest`'s first live sweep returned one `error` among 29 collections:

```
mcp_memory: query failed: 400 — "Not existing vector name error: dense"
vectors config: {"fast-nomic-embed-text-v1.5": {"size": 768, "distance": "Cosine"}}
```

## The general shape

`_qdrant_search_collection(collection_name=...)` and `probe_collection` take the
collection name **from the caller** — `rag_context_search` accepts a `collections`
list — so both run against collections this server did not create. Their dense
vector is not necessarily called `dense`, and asking for a name that is not there
is a 400.

On the retrieval path that 400 is caught per-collection and reported as *no
results*, which is indistinguishable from a collection that genuinely had no
match. It showed up as an outright error here only because `retrieval_selftest`
reports faults rather than swallowing them — which is the entire reason that tool
exists.

## Honest scope

**This is insurance, not a live outage.** Every collection currently in the store
either uses `dense` or is unnamed, so nothing real is failing today. The one
collection that exposed it holds a single point and is not something the design
should be built around.

What justifies the change anyway is narrower: a diagnostic whose job is truthful
reporting must not emit a false `error`, and a function that accepts arbitrary
collection names should not assume it created them.

The three sites that write to, or query, the collection **we** create keep passing
`"dense"` directly — there the name is ours to know, and routing it through a
lookup would add a call for nothing.

## Change

`_dense_vector_name(client, collection)` reads the layout, prefers `dense` when
present, otherwise a vector whose width matches this server's embedder, otherwise
the first by name; returns `None` for unnamed/flat collections so the caller omits
`using` entirely. Cached per process — vector layout does not change under a
running one — and fail-open to `None`.

## Tests

`mcp/tests/test_retrieval_selftest.py` +8: `dense` preferred when present, a
differently-named vector found, width-match wins among several, flat returns
`None`, empty returns `None`, a failing `get_collection` returns `None` rather
than raising, and the result is cached rather than refetched.

Plus an end-to-end case against a **real** `QdrantClient(location=":memory:")`
whose vector is deliberately named `fast-nomic-embed-text-v1.5` — it probes `ok`
with 1 hit, where before it would have been an `error`.

`mcp/tests/`: 587 passed. The 7 failures and 7 errors in `test_analytics.py` /
`test_graph_integration.py` reproduce identically on unmodified `main` here
(missing graph deps locally; green in CI).