### PR TITLE
test: pin the MMR test to the branch it means to exercise

### DIFF
--- a/scripts/hooks/tests/test_pre_llm_grounding.py
+++ b/scripts/hooks/tests/test_pre_llm_grounding.py
@@ -808,9 +808,22 @@ def test_mmr_select_empty_content_similarity_is_zero(hook):
     assert [x["_ms_score"] for x in out] == [0.9, 0.8]
 
 
-def test_mmr_select_requires_ms_score(hook):
+def test_mmr_select_requires_ms_score(hook, monkeypatch):
+    # _mmr_select fills its final slot from random.random() < PHERO_EPSILON, and
+    # that branch never reads ms_score — so unseeded this asserts nothing 5% of the
+    # time (measured: 4 failures in 80 runs against PHERO_EPSILON=0.05). Pin the
+    # draw above epsilon so the MMR path, which is the path under test, is taken.
+    monkeypatch.setattr(hook, "PHERO_EPSILON", 0.0)
     with pytest.raises(KeyError):
         hook._mmr_select([{"content": "a"}, {"content": "b"}], 1)
+
+
+def test_mmr_select_epsilon_branch_does_not_need_ms_score(hook, monkeypatch):
+    """The other side of the same coin: with epsilon at 1.0 the random slot is
+    always taken, and that path legitimately never touches ms_score."""
+    monkeypatch.setattr(hook, "PHERO_EPSILON", 1.0)
+    out = hook._mmr_select([{"content": "a"}, {"content": "b"}], 1)
+    assert len(out) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`Sync script tests` failed on #191 — a PR whose changes are confined to `mcp/` and
which `scripts/hooks/pre_llm_grounding.py` does not import.

```
hooks/tests/test_pre_llm_grounding.py::test_mmr_select_requires_ms_score FAILED
    with pytest.raises(KeyError):
E   Failed: DID NOT RAISE KeyError
```

## Not luck — the epsilon

```python
def test_mmr_select_requires_ms_score(hook):
    with pytest.raises(KeyError):
        hook._mmr_select([{"content": "a"}, {"content": "b"}], 1)
```

`_mmr_select` fills its final slot by ε-exploration:

```python
and _random.random() < PHERO_EPSILON):     # PHERO_EPSILON = 0.05
```

and **that branch never reads `ms_score`**. So whenever the draw lands under
epsilon, no `KeyError` is raised and the test fails. Measured before the change:

```
80 runs -> 4 failures  (5.0%, against PHERO_EPSILON=0.05)
```

The flake rate *is* the epsilon. This will fail roughly one CI run in twenty, on
any PR, regardless of what that PR changes — which is worse than a test that
always fails, because it trains you to re-run rather than read.

## Change

`monkeypatch.setattr(hook, "PHERO_EPSILON", 0.0)` selects the MMR path the test is
named for. After: **0 failures in 80 runs.**

Added a second case for the other side rather than leaving it uncovered — at
epsilon `1.0` the random slot is always taken and legitimately needs no
`ms_score`. Both branches now have a test that can only pass for the right reason,
which is the point: the original could pass for two different reasons and only one
of them was the assertion.

`scripts/` suite unaffected otherwise.