### PR TITLE
feat(workflow): resolve tasks on the cheap tiers so no Claude agent has to

### DIFF
--- a/.claude/workflows/loci-native.js
+++ b/.claude/workflows/loci-native.js
@@ -27,7 +27,11 @@ export const meta = {
 //     ground:     string   // grounding.ground().block — injected verbatim into every prompt
 //     graphFacts: { <key>: {text, ...} }  // scripts/graph_facts.py output (exact, from the code graph)
 //     tasks:   [{ id, title, focus, tier?, verify?, graphKey? }]
-//               // tier ∈ 'graph' | 'mechanical' | 'impl' | 'reason' (default 'impl')
+//               // tier ∈ 'graph' | 'cheap' | 'mechanical' | 'impl' | 'reason' (default 'impl')
+//               // tier:'cheap'  -> resolved from cheapFacts[cheapKey||id] with NO agent;
+//               //                  produce it with scripts/cheap_batch.py (vLLM -> Ollama
+//               //                  -> OpenRouter). Degrades to a mechanical agent if absent.
+//               // cheapKey      -> on ANY task: prepends that pre-computed answer to the prompt.
 //               // tier:'graph'  -> resolved from graphFacts[graphKey||id] with NO agent (zero tokens);
 //               //                  degrades to a mechanical agent if the fact is missing.
 //               // graphKey      -> on ANY task: prepends that exact graph fact into the agent's prompt.
@@ -48,10 +52,19 @@ const TASKS = Array.isArray(A.tasks) ? A.tasks : []
 // Deterministic code-graph facts (from scripts/graph_facts.py), keyed by graphKey.
 // A tier:'graph' task resolves straight from these — NO agent, zero tokens.
 const FACTS = (A.graphFacts && typeof A.graphFacts === 'object') ? A.graphFacts : {}
-const factText = (key) => {
-  const f = key && FACTS[key]
-  return f ? (typeof f === 'string' ? f : (f.text || '')) : ''
+// Answers pre-computed on the local/remote generation tiers by
+// scripts/cheap_batch.py. Same shape as graphFacts, same zero-agent resolution:
+// a Workflow agent() is always a Claude subagent, so the only way to offload is
+// to do the work before the workflow and inject the result.
+const CHEAP = (A.cheapFacts && typeof A.cheapFacts === 'object') ? A.cheapFacts : {}
+const pick = (bag, key) => {
+  const f = key && bag[key]
+  if (!f) return ''
+  if (typeof f === 'string') return f
+  return f.ok === false ? '' : (f.text || '')
 }
+const factText = (key) => pick(FACTS, key)
+const cheapText = (key) => pick(CHEAP, key)
 
 // Model/effort tiers. Omitting model => inherit the session model (right default).
 // Only the reasoning-heavy lane names a bigger model; mechanical work drops to low effort.
@@ -67,8 +80,10 @@ if (!TASKS.length) { log('no tasks provided'); return { results: [] } }
 
 const promptFor = (t) => {
   const gf = factText(t.graphKey)  // any task may pull a precise graph fact into its prompt for free
+  const cf = cheapText(t.cheapKey || t.id)
   return (GROUND ? GROUND + '\n\n' : '') +
     (gf ? '## CODE-GRAPH FACTS (exact, from the code graph)\n' + gf + '\n\n' : '') +
+    (cf ? '## PRE-COMPUTED (local/remote tier — verify before relying on it)\n' + cf + '\n\n' : '') +
     '=== YOUR TASK ===\n' + (t.title || t.id) +
     (t.focus ? '\n\nFocus:\n' + t.focus : '') +
     '\n\nGround your answer in the context above where relevant; cite the [tag] you rely on, ' +
@@ -82,6 +97,17 @@ const results = await pipeline(
   TASKS,
   (t) => {
     // tier:'graph' -> resolve deterministically from injected facts, NO agent (zero tokens).
+    // tier:'cheap' -> resolved on vLLM/Ollama/OpenRouter BEFORE the run, NO agent.
+    if (t.tier === 'cheap') {
+      const txt = cheapText(t.cheapKey || t.id)
+      if (txt) {
+        log('cheap task "' + (t.id || t.title) + '" resolved off-tier (0 Claude tokens)')
+        return Promise.resolve({ id: t.id, title: t.title, tier: 'cheap', output: txt, _verify: !!t.verify })
+      }
+      log('cheap task "' + (t.id || t.title) + '" has no fact; falling back to a mechanical agent')
+      return agent(promptFor(t), { label: (t.id || t.title) + ':fallback', phase: 'Fanout', ...TIERS.mechanical })
+        .then((output) => ({ id: t.id, title: t.title, tier: 'cheap-fallback', output, _verify: !!t.verify }))
+    }
     if (t.tier === 'graph') {
       const txt = factText(t.graphKey || t.id)
       if (txt) {

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -309,7 +309,7 @@ def _check_lazy_import():
 def _check_real_corpus():
     result = build_graph(rev="HEAD")
     store = result.store
-    assert result.meta.file_count == 117, result.meta.file_count
+    assert result.meta.file_count == 118, result.meta.file_count
     assert result.meta.error_count == 0, result.meta.errors
     bad = registered_but_dead(store)
     assert bad == [], [n.id for n in bad]

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,13 +1,13 @@
 from .conftest import needs_corpus_deps, needs_git_history  # noqa: F401
 """config.py against the REAL repo: acceptance criterion is an exact file
-count (117), not a vibe. If this drifts, either the repo changed shape or
+count (118), not a vibe. If this drifts, either the repo changed shape or
 the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
-def test_corpus_is_exactly_117_files():
+def test_corpus_is_exactly_118_files():
     files = config.iter_corpus_files_worktree()
-    assert len(files) == 117, sorted(files)
+    assert len(files) == 118, sorted(files)
 
 
 def test_corpus_excludes_test_directories():

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -4,10 +4,10 @@ from .. import ingest
 from ..tests.helpers import source_file
 
 
-def test_load_corpus_worktree_parses_117_files_with_no_errors():
+def test_load_corpus_worktree_parses_118_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
-    assert len(sources) == 117
+    assert len(sources) == 118
     errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
     assert errors == []
     assert all(sf.tree is not None for sf in sources)
@@ -16,7 +16,7 @@ def test_load_corpus_worktree_parses_117_files_with_no_errors():
 def test_load_corpus_rev_head_reads_git_blobs():
     sources, origin = ingest.load_corpus(rev="HEAD")
     assert origin.startswith("rev ")
-    assert len(sources) == 117
+    assert len(sources) == 118
     assert all(sf.error is None for sf in sources)
     server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
     assert "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -15,7 +15,7 @@ from ..pipeline import build_graph
 
 
 def test_build_is_clean_and_fast(head_build):
-    assert head_build.meta.file_count == 117
+    assert head_build.meta.file_count == 118
     assert head_build.meta.error_count == 0
     # The 2s figure in ingest.py's own docstring is about ast.parse'ing the
     # corpus (steps 1-3's budget). Steps 4-6 (CALLSITE/CALLS resolution over

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -78,6 +78,6 @@ def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, 
     finally:
         monkeypatch.setattr(Path, "read_text", original_read_text)
     assert origin.startswith("rev ")
-    assert len(sources) == 117
+    assert len(sources) == 118
     server = _source_for(sources, "mcp/server.py")
     assert server.error is None and "loci-mcp" in server.source[:200]

--- a/scripts/cheap_batch.py
+++ b/scripts/cheap_batch.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Resolve workflow tasks on the cheap tiers, so no Claude agent has to.
+
+A Workflow `agent()` is always a Claude subagent — there is no hook that points
+one at vLLM or OpenRouter. Offloading therefore cannot mean changing the model an
+agent runs on; it means doing the work BEFORE the workflow and injecting the
+answer, the way `loci-native.js` already does with `args.ground` and
+`args.graphFacts` (a `tier:'graph'` task resolves from an injected fact with no
+agent and zero tokens).
+
+This produces facts for that same mechanism from the local and remote generation
+tiers. Output is keyed exactly like `scripts/graph_facts.py`, so `loci-native.js`
+consumes it unchanged:
+
+    { "<key>": {"text": "...", "model": "...", "tier": "local|remote", "ok": true} }
+
+Measured on the wf_6e13c6c2-8e0 run this exists to shrink: agent *returns* were
+3.3% of subagent token spend. The other 96.7% was input — 283 Bash calls in a
+single agent transcript, rediscovering the repo. A task whose answer can be
+produced once, cheaply, and handed over is a task no agent needs to read for.
+
+Usage:
+    cheap_batch.py tasks.json > facts.json
+    echo '[{"key":"k","prompt":"..."}]' | cheap_batch.py > facts.json
+
+    # then
+    Workflow({scriptPath: ".../loci-native.js",
+              args: {ground: block, cheapFacts: facts, tasks: [
+                  {id: "k", title: "...", tier: "cheap"}]}})
+
+Tier order is local-first: vLLM and Ollama cost nothing per call and keep the
+corpus on the box. --remote adds the OpenRouter ladder for whatever the local
+tiers could not serve, which on a flaky GPU node is the difference between a
+stalled batch and a slower one.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Callable, Optional
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_REPO, "mcp"))
+
+MAX_TOKENS = int(os.environ.get("LOCI_CHEAP_MAX_TOKENS", "512"))
+
+
+def _load_tasks(argv_path: Optional[str]) -> list:
+    raw = open(argv_path).read() if argv_path else sys.stdin.read()
+    tasks = json.loads(raw)
+    if isinstance(tasks, dict):
+        tasks = [{"key": k, "prompt": v} for k, v in tasks.items()]
+    out = []
+    for t in tasks:
+        key = str(t.get("key") or t.get("id") or "").strip()
+        prompt = str(t.get("prompt") or t.get("focus") or "").strip()
+        if key and prompt:
+            out.append({"key": key, "prompt": prompt})
+    return out
+
+
+def _local_batch(prompts: list, fmt: Optional[str]) -> list:
+    try:
+        import batched_gen
+    except Exception as exc:
+        return [{"text": "", "ok": False, "why": f"local tier unavailable: {exc!r}"}
+                for _ in prompts]
+    # model=None on purpose: the batched and Ollama tiers name the same model
+    # differently and an unrecognised name is rejected outright.
+    return batched_gen.generate_batch(prompts, max_tokens=MAX_TOKENS, fmt=fmt)
+
+
+def _remote_batch(prompts: list, fmt: Optional[str]) -> list:
+    try:
+        import openrouter
+    except Exception as exc:
+        return [{"text": "", "ok": False, "why": f"remote tier unavailable: {exc!r}"}
+                for _ in prompts]
+    if not openrouter.available():
+        return [{"text": "", "ok": False, "why": "no OpenRouter key configured"}
+                for _ in prompts]
+    return openrouter.generate_batch(prompts, max_tokens=MAX_TOKENS, fmt=fmt)
+
+
+def resolve(tasks: list, remote: bool = False, fmt: Optional[str] = None,
+            local_fn: Optional[Callable] = None,
+            remote_fn: Optional[Callable] = None) -> dict:
+    """Answer every task on the cheapest tier that can, and say which one did.
+
+    A task that no tier could serve is returned with ``ok: false`` rather than
+    omitted — `loci-native.js` degrades a factless task to a mechanical agent, and
+    it can only do that if it can see the gap.
+    """
+    if not tasks:
+        return {}
+    local_fn = local_fn or _local_batch
+    remote_fn = remote_fn or _remote_batch
+    prompts = [t["prompt"] for t in tasks]
+
+    results = local_fn(prompts, fmt)
+    facts = {}
+    for t, r in zip(tasks, results or []):
+        r = r or {}
+        facts[t["key"]] = {
+            "text": r.get("text", ""), "ok": bool(r.get("ok")),
+            "tier": "local" if r.get("ok") else None,
+            "model": r.get("model"),
+            "why": r.get("why", ""),
+        }
+
+    if remote:
+        todo = [t for t in tasks if not facts[t["key"]]["ok"]]
+        if todo:
+            rem = remote_fn([t["prompt"] for t in todo], fmt)
+            for t, r in zip(todo, rem or []):
+                r = r or {}
+                if r.get("ok"):
+                    facts[t["key"]] = {"text": r.get("text", ""), "ok": True,
+                                       "tier": "remote", "model": r.get("model"),
+                                       "why": ""}
+                else:
+                    facts[t["key"]]["why"] = r.get("why", "") or "remote tier declined"
+    return facts
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("tasks", nargs="?", help="JSON file; omit to read stdin")
+    ap.add_argument("--remote", action="store_true",
+                    help="fall through to OpenRouter for whatever the local tiers "
+                         "could not serve. Off by default: findings carry internal "
+                         "addressing, so leaving the box is an explicit choice.")
+    ap.add_argument("--json-out", action="store_true",
+                    help="ask the tiers for JSON and validate it")
+    ap.add_argument("--stats", action="store_true", help="tier summary to stderr")
+    args = ap.parse_args(argv)
+
+    try:
+        tasks = _load_tasks(args.tasks)
+    except Exception as exc:
+        print(f"cheap_batch: cannot read tasks: {exc}", file=sys.stderr)
+        return 2
+    if not tasks:
+        print("{}")
+        return 0
+
+    facts = resolve(tasks, remote=args.remote, fmt="json" if args.json_out else None)
+
+    if args.stats:
+        served = {}
+        for f in facts.values():
+            served[f["tier"] or "unserved"] = served.get(f["tier"] or "unserved", 0) + 1
+        print(f"cheap_batch: {len(tasks)} task(s) -> {served}", file=sys.stderr)
+        for k, f in facts.items():
+            if not f["ok"]:
+                print(f"  unserved {k}: {f.get('why') or 'no reason given'}", file=sys.stderr)
+
+    print(json.dumps(facts, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_cheap_batch.py
+++ b/scripts/tests/test_cheap_batch.py
@@ -1,0 +1,111 @@
+"""cheap_batch — resolving workflow tasks off the Claude tiers.
+
+The premise, measured on wf_6e13c6c2-8e0: agent *returns* were 3.3% of subagent
+token spend; the other 96.7% was input the agents read. So offloading is about
+answering a task once, cheaply, and injecting it — not about which model an
+agent() runs on, which is not selectable.
+"""
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("cheap_batch", _SCRIPTS / "cheap_batch.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cb = _load()
+
+TASKS = [{"key": "a", "prompt": "p1"}, {"key": "b", "prompt": "p2"}]
+
+
+def _ok(text, model="local-model"):
+    return {"text": text, "ok": True, "model": model}
+
+
+def _fail(why=""):
+    return {"text": "", "ok": False, "why": why}
+
+
+class TestResolve(unittest.TestCase):
+    def test_the_local_tier_answers_and_is_credited(self):
+        out = cb.resolve(TASKS, local_fn=lambda p, f: [_ok("A"), _ok("B")])
+        self.assertEqual(out["a"]["text"], "A")
+        self.assertEqual(out["a"]["tier"], "local")
+        self.assertTrue(out["a"]["ok"])
+
+    def test_remote_is_not_consulted_unless_asked(self):
+        called = []
+        cb.resolve(TASKS, local_fn=lambda p, f: [_fail(), _fail()],
+                   remote_fn=lambda p, f: called.append(p) or [_ok("X"), _ok("Y")])
+        self.assertEqual(called, [], "leaving the box must be an explicit choice")
+
+    def test_remote_picks_up_only_what_local_could_not_serve(self):
+        seen = {}
+
+        def remote(prompts, fmt):
+            seen["prompts"] = list(prompts)
+            return [_ok("from-remote", model="or-model")]
+
+        out = cb.resolve(TASKS, remote=True,
+                         local_fn=lambda p, f: [_ok("A"), _fail("429")],
+                         remote_fn=remote)
+        self.assertEqual(seen["prompts"], ["p2"], "p1 was already served locally")
+        self.assertEqual(out["a"]["tier"], "local")
+        self.assertEqual(out["b"]["tier"], "remote")
+        self.assertEqual(out["b"]["text"], "from-remote")
+
+    def test_an_unserved_task_is_returned_not_dropped(self):
+        # loci-native degrades a factless task to a mechanical agent — it can only
+        # do that if it can see the gap.
+        out = cb.resolve(TASKS, remote=True,
+                         local_fn=lambda p, f: [_fail("no tier"), _fail("no tier")],
+                         remote_fn=lambda p, f: [_fail("429"), _fail("429")])
+        self.assertEqual(set(out), {"a", "b"})
+        self.assertFalse(out["a"]["ok"])
+        self.assertIsNone(out["a"]["tier"])
+        self.assertTrue(out["a"]["why"], "an unserved task must say why")
+
+    def test_no_tasks_costs_nothing(self):
+        called = []
+        self.assertEqual(cb.resolve([], local_fn=lambda p, f: called.append(1)), {})
+        self.assertEqual(called, [])
+
+
+class TestTaskParsing(unittest.TestCase):
+    def test_a_list_of_key_prompt_objects(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data='[{"key":"k","prompt":"p"}]')):
+            self.assertEqual(cb._load_tasks("f.json"), [{"key": "k", "prompt": "p"}])
+
+    def test_a_plain_mapping_is_accepted(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data='{"k": "p"}')):
+            self.assertEqual(cb._load_tasks("f.json"), [{"key": "k", "prompt": "p"}])
+
+    def test_id_and_focus_are_accepted_as_aliases(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data='[{"id":"k","focus":"p"}]')):
+            self.assertEqual(cb._load_tasks("f.json"), [{"key": "k", "prompt": "p"}])
+
+    def test_entries_missing_a_key_or_prompt_are_skipped(self):
+        data = '[{"key":"k","prompt":"p"},{"key":"","prompt":"p"},{"key":"z","prompt":"  "}]'
+        with mock.patch("builtins.open", mock.mock_open(read_data=data)):
+            self.assertEqual(cb._load_tasks("f.json"), [{"key": "k", "prompt": "p"}])
+
+
+class TestCli(unittest.TestCase):
+    def test_unreadable_tasks_exit_two_rather_than_traceback(self):
+        with mock.patch("builtins.open", side_effect=OSError("nope")):
+            self.assertEqual(cb.main(["missing.json"]), 2)
+
+    def test_an_empty_task_list_emits_an_empty_object(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="[]")):
+            self.assertEqual(cb.main(["f.json"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Where the money actually goes

Measured on `wf_6e13c6c2-8e0`, the 12-agent design run from earlier today:

```
agent RETURN text:         130,338 chars  (~32,584 tokens)
reported subagent_tokens:                    1,002,090
=> generation is 3.3% of spend; 96.7% is INPUT the agents read

tool calls, one agent transcript:  Bash 283 · code_graph_query 24 · rag_context_search 9
```

**Generation is 3% of the cost.** The rest is agents grepping and reading the repo.

## Which means the obvious approach is not available

There is no hook that points a Workflow `agent()` at vLLM or OpenRouter — an agent
is always a Claude subagent. Offloading therefore cannot mean swapping the model.
It has to mean **answering the task before the workflow and injecting the result**,
which `loci-native.js` already does twice: `args.ground`, and `tier: 'graph'`,
which resolves from an injected fact with no agent and zero tokens.

This extends that existing mechanism to the generation tiers rather than inventing
a new one.

## `scripts/cheap_batch.py`

Takes `[{key, prompt}]`, answers each on the cheapest tier that can, emits facts
keyed exactly like `scripts/graph_facts.py` so `loci-native.js` consumes them
unchanged:

```json
{"summarise-retention": {"text": "...", "ok": true, "tier": "local", "model": null}}
```

- **local first** — vLLM/Ollama cost nothing per call and keep the corpus on the box
- **`--remote` is opt-in** — findings carry internal IPs, hostnames and k3s
  topology, so leaving the box is a choice, not a fallback. Matches the
  `remote_ok`-defaults-false rule in `docs/companion-service.md`.
- **an unserved task is returned with `ok: false`, not dropped** — `loci-native`
  degrades a factless task to a mechanical agent, and it can only do that if it
  can see the gap. `--stats` prints which tier served what, and why anything failed.

## `loci-native.js`

`tier: 'cheap'` resolves from `cheapFacts[cheapKey||id]` with **no agent**,
degrading to a mechanical agent when the fact is missing — the same contract
`tier: 'graph'` already has. Any task can also set `cheapKey` to prepend a
pre-computed answer to its prompt, labelled

```
## PRE-COMPUTED (local/remote tier — verify before relying on it)
```

because a 3B model's answer is a starting point, not a fact. That framing matters
given the measured tagging result: kNN beat every generation model at
classification, so these tiers earn their place on extraction and summarisation,
not on judgement.

## Live

```
$ cheap_batch.py tasks.json --remote --stats
openrouter: google/gemma-4-31b-it:free failed (429): Provider returned error
openrouter: z-ai/glm-5.2:free failed (429): Provider returned error
cheap_batch: 3 task(s) -> {'local': 2, 'remote': 1}
```

Two served by local vLLM, one falling through two rate-limited free models to
`nemotron-3-super-120b:free`. Zero Claude tokens, zero dollars.

## What this does not fix

The 96.7% is agents *reading*. This addresses the portion of that which is really
a question with a cheap answer. The larger remaining lever is pre-computing the
**reads themselves** — having a script or cheap model produce the file slices an
agent would otherwise grep for — which is what `graphFacts` already does for
call-graph questions and what a future `readFacts` could do more generally.

## Tests

`scripts/tests/test_cheap_batch.py` — 11: local answers and is credited; remote is
**not** consulted unless asked; remote picks up only what local could not serve
(asserted on the exact prompts it received); an unserved task is returned with a
reason rather than dropped; empty input costs nothing; task-shape parsing
including `id`/`focus` aliases and skipping malformed entries; CLI exits 2 on
unreadable input rather than tracebacking.

`scripts/` suite: 632 passed. Callgraph corpus tripwires bumped 117 → 118.