### PR TITLE
fix(rag): give every row an id, and fix the second cross-encoder

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -794,6 +794,11 @@ def _qdrant_search_collection(
         payload = dict(p.payload or {})
         rows.append({
             "score": round(float(p.score), 4),
+            # The point id, BEFORE the payload spread so a payload that carries its
+            # own id still wins. Callers dedup on (origin, id); a row without one
+            # collapses its whole collection to a single hit — measured: a 5-row
+            # result from dama_gotchi_code had 1 distinct id, all None.
+            "id": str(p.id),
             **payload,
             "origin": collection_name,
         })

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -178,6 +178,7 @@ from qdrant_ops import (  # noqa: E402,F401
     _qdrant_degraded_mode, _ce_rerank, _qdrant_similarity_search, _qdrant_search_collection,
     probe_collection,
 )
+from qdrant_ops import RERANK_MAX_CHARS as _RERANK_MAX_CHARS  # noqa: E402
 REFLECTION_STATE_DIR = MEMORY_DIR / "_reflection-loop"
 REFLECTION_STATE_FILE = REFLECTION_STATE_DIR / "state.json"
 REFLECTION_DEFAULT_INVESTIGATION = os.environ.get(
@@ -6254,7 +6255,12 @@ def _rag_cross_encode(results: list[dict], query: str) -> None:
     if ce is None or len(results) <= 1:
         return
     try:
-        pairs = [(query, str(r.get('text', r.get('content', '')))[:512]) for r in results[:20]]
+        # Same budget as qdrant_ops._ce_rerank — this is the SECOND cross-encoder,
+        # on rag_context_search's final cross-collection re-pass, and it was missed
+        # when the first was fixed. 512 chars against a 1,048-char median finding
+        # scored below using no reranker at all.
+        pairs = [(query, str(r.get('text', r.get('content', '')))[:_RERANK_MAX_CHARS])
+                 for r in results[:20]]
         for r, sc in zip(results[:20], ce.predict(pairs)):
             r['final_ce_score'] = round(float(sc), 4)
         results[:20] = sorted(results[:20], key=lambda r: r.get('final_ce_score', -999), reverse=True)

--- a/mcp/tests/test_rag_row_identity.py
+++ b/mcp/tests/test_rag_row_identity.py
@@ -1,0 +1,99 @@
+"""Rows must carry an id, and both cross-encoders must see the same passage.
+
+Two defects that shipped together and hid each other. `_rag_search_collections`
+dedups on `(origin, id)`; when `_qdrant_search_collection` returned rows without
+an `id`, every row of a collection keyed to `(origin, None)` and the whole
+collection folded to one hit. Measured on the live store before the fix:
+`dama_gotchi_code` returned 5 rows with 1 distinct id, all None. `hermes_memory`
+escaped only because a finding stores its own id in the payload.
+"""
+import unittest
+from unittest import mock
+
+import qdrant_ops
+import server
+
+
+class _P:
+    def __init__(self, pid, score, payload):
+        self.id = pid
+        self.score = score
+        self.payload = payload
+
+
+class _Res:
+    def __init__(self, points):
+        self.points = points
+
+
+class _Client:
+    def __init__(self, points, named=True):
+        self._points = points
+        self._named = named
+
+    def get_collection(self, name):
+        from types import SimpleNamespace
+        vec = {"dense": SimpleNamespace(size=qdrant_ops.VECTOR_DIM)} if self._named \
+            else SimpleNamespace(size=qdrant_ops.VECTOR_DIM)
+        return SimpleNamespace(config=SimpleNamespace(params=SimpleNamespace(
+            vectors=vec, sparse_vectors=None)), points_count=len(self._points))
+
+    def query_points(self, **kw):
+        return _Res(list(self._points))
+
+
+def _search(points, payload_has_id=False):
+    client = _Client(points)
+    with mock.patch.object(qdrant_ops, "_get_qdrant", lambda: (client, "c")), \
+         mock.patch.object(qdrant_ops, "_embed", lambda _t: [0.1] * qdrant_ops.VECTOR_DIM), \
+         mock.patch.object(qdrant_ops, "_embed_sparse", lambda _t: None), \
+         mock.patch.object(qdrant_ops, "_ce_rerank", lambda q, rows, k: (rows[:k], False)):
+        qdrant_ops._dense_name_cache.clear()
+        return qdrant_ops._qdrant_search_collection("q", collection_name="c", limit=5)
+
+
+class TestRowIdentity(unittest.TestCase):
+    def test_a_payload_without_an_id_still_yields_distinct_rows(self):
+        pts = [_P(f"pt{i}", 0.9 - i / 100, {"text": f"chunk {i}"}) for i in range(5)]
+        rows = _search(pts)
+        ids = [r.get("id") for r in rows]
+        self.assertEqual(len(set(ids)), 5, "each row must be distinguishable")
+        self.assertNotIn(None, ids)
+
+    def test_a_payload_that_carries_its_own_id_keeps_it(self):
+        # findings store their id in the payload; the point id must not clobber it
+        pts = [_P("point-uuid", 0.9, {"id": "finding-uuid", "text": "a finding"})]
+        self.assertEqual(_search(pts)[0]["id"], "finding-uuid")
+
+    def test_dedup_no_longer_folds_a_collection_to_one_hit(self):
+        rows = _search([_P(f"pt{i}", 0.9, {"text": f"c{i}", "origin": "col"}) for i in range(5)])
+        best = {}
+        for h in rows:                      # mirrors _rag_search_collections
+            best[(h.get("origin"), h.get("id"))] = h
+        self.assertEqual(len(best), 5)
+
+
+class TestBothCrossEncodersShareTheBudget(unittest.TestCase):
+    def test_the_rag_re_pass_uses_the_same_budget_as_the_first(self):
+        seen = {}
+
+        class _CE:
+            def predict(self, pairs):
+                seen["len"] = len(pairs[0][1])
+                return [0.5] * len(pairs)
+
+        rows = [{"text": "x" * 5000}, {"text": "y" * 5000}]
+        with mock.patch.object(server, "_get_cross_encoder", lambda: _CE()):
+            server._rag_cross_encode(rows, "q")
+        self.assertEqual(seen["len"], qdrant_ops.RERANK_MAX_CHARS)
+        self.assertGreater(seen["len"], 512, "512 scored below using no reranker at all")
+
+    def test_no_512_literal_survives_in_either_module(self):
+        import inspect
+        for mod in (qdrant_ops, server):
+            src = inspect.getsource(mod)
+            self.assertNotIn("[:512]", src, f"{mod.__name__} still truncates at 512")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two defects that shipped together and hid each other. Both found by a workflow
agent auditing **this morning's own reranker work** — which is the useful part of
the story, since I measured that work and reported it as done.

## 1. `rag_context_search` collapsed whole collections to one hit

`_rag_search_collections` dedups on `(origin, id)`. `_qdrant_search_collection`
returned rows with **no `id`**, so every row of a collection keyed to
`(origin, None)` and the last one won.

Measured on the live store, before:

```
dama_gotchi_code    rows=5  distinct ids=1   (all None)
agent_core_chunks   rows=5  distinct ids=1   (all None)
hermes_memory       rows=5  distinct ids=5
```

`hermes_memory` escaped only because a finding stores its own `id` in the payload.
Code collections — which is exactly what deep-think grounds ideation on — returned
**one row regardless of how many matched.**

The point id is now stamped *before* the payload spread, so a payload carrying its
own id still wins. After:

```
dama_gotchi_code    rows=5  distinct ids=5
agent_core_chunks   rows=5  distinct ids=5
hermes_memory       rows=5  distinct ids=5

rag_context_search(collections=['dama_gotchi_code'])  ->  result_count=10   (was 1)
```

## 2. The reranker fix missed a second cross-encoder

There are two. #190 fixed `qdrant_ops._ce_rerank` and measured **+28 points of
identity recall@1** across four samples. That path is `_qdrant_similarity_search`
— which is precisely what the recall probe exercises.

`server.py:6257` `_rag_cross_encode`, the final cross-collection re-pass that
`rag_context_search` actually calls, still truncated at `[:512]` against a
1,048-char median finding. At 512 the reranker measured *below* using no reranker
at all.

So the improvement was real, correctly measured, and **did not reach the path that
matters**. The probe tested the path I had fixed and told me what I wanted to hear.
Both call sites now share `RERANK_MAX_CHARS`.

## Tests

`mcp/tests/test_rag_row_identity.py` — 5:

- a payload without an id still yields distinct rows
- a payload carrying its **own** id keeps it (the point id must not clobber a
  finding's id)
- dedup no longer folds a collection to one hit, asserted against a mirror of
  `_rag_search_collections`' keying
- the RAG re-pass uses the same budget as the first cross-encoder
- **no `[:512]` literal survives in either module** — the assertion that would
  have caught this one the first time

`mcp/tests/`: 597 passed. The 7 failures / 7 errors in `test_analytics.py` and
`test_graph_integration.py` reproduce identically on unmodified `main` here
(missing graph deps locally; green in CI).

## Consequence for what was claimed earlier

The deep-think A/B I proposed would have measured noise: neither retrieval fix
reached its ideation path, and its grounding was being served one row per
collection. That is now worth re-examining — but after these land, not before.