### PR TITLE
fix: close the four critical findings from the deep-think seam audit

### DIFF
--- a/deep_think_loci/workflows/deep-think-v4.js
+++ b/deep_think_loci/workflows/deep-think-v4.js
@@ -67,7 +67,7 @@ const SYNTH_SCHEMA = {
     action_items: {
       type: 'array', items: {
         type: 'object', required: ['title', 'severity', 'file', 'description'],
-        properties: {
+        properties: { finding_ids: { type: 'array', items: { type: 'string' } },
           title:       { type: 'string' },
           severity:    { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
           file:        { type: 'string' },
@@ -131,7 +131,7 @@ log(`Ideate: ${gens.length}/${TARGETS.length} generators, ${allIdeas.length} ide
 // ── Write ──
 phase('Write')
 const wrote = await agent(
-  `DEDICATED WRITER. Store each of the following ${allIdeas.length} ideas into Loci investigation "${RUN}".\n\nFor EACH idea:\n  mcp__loci__investigation_store(investigation_id="${RUN}", finding_type="inferred", text="<target>: <idea>", source="${SRC('ideate','writer')}", confidence="medium", tags="dt_run:${RUN},dt_target:<target>")\n\nReturn attempted=${allIdeas.length} and the real finding_ids.\n${NO_FAB}\n\nIDEAS:\n${JSON.stringify(allIdeas, null, 1)}`,
+  `DEDICATED WRITER. Store each of the following ${allIdeas.length} ideas into Loci investigation "${RUN}".\n\nFor EACH idea:\n  mcp__loci__investigation_store(investigation_id="${RUN}", finding_type=<TYPE>, text="<target>: <idea>", source="${SRC('ideate','writer')}", confidence="medium", tags="dt_run:${RUN},dt_target:<target>", code_refs=<REFS>, derived_from=<PARENT>)\n\n<TYPE> is NOT always "inferred" — choose per idea, because downstream tools key off it:\n  observed  — stated directly by the file you read\n  inferred  — reasoned from what you read\n  gap       — something that should be checked and has not been\n  assumed   — a working hypothesis with no evidence yet\nConflict detection only fires on gap/assumed, so mislabelling everything "inferred" silently disables it.\n\n<REFS> is a list of "path:line" strings — the COLON form, e.g. ["mcp/graph/linker.py:287"]. Prose like "linker.py line 287" does not match and code grounding will never fire. Omit when the idea names no specific line.\n<PARENT> is a finding_id this idea builds on, when one exists; it is what retraction lineage and aggregate confidence walk. Omit when the idea stands alone.\n\nReturn attempted=${allIdeas.length} and the real finding_ids.\n${NO_FAB}\n\nIDEAS:\n${JSON.stringify(allIdeas, null, 1)}`,
   { label: 'writer', phase: 'Write', model: 'haiku', schema: WROTE_SCHEMA }
 )
 log(`Write: attempted=${wrote?.attempted}, persisted=${(wrote?.finding_ids||[]).length}`)
@@ -169,7 +169,7 @@ const makeSynthPrompt = (group, idx) => {
   const gateNote = RAG_MODE
     ? `Then filter each result set through the grounding gate at ${GATE} (threshold ${THRESH}) to kill cross-target bleed before reasoning.`
     : ''
-  return `Adversarial Opus reviewer for group ${idx+1}: ${names || '(empty — return empty action_items)'}\n\n1. Search: ${queries}\n${gateNote}\n2. For each idea: try to REFUTE it (wrong diagnosis, already handled, impractical). Keep only ideas that survive.\n3. Return domain="${names}", top_findings that survived, red_team_refutals for killed ideas, and action_items with severity+file+description.\n\nIf group is empty, return domain="empty", empty arrays.`
+  return `Adversarial Opus reviewer for group ${idx+1}: ${names || '(empty — return empty action_items)'}\n\n1. Search: ${queries}\n${gateNote}\n2. For each idea: try to REFUTE it (wrong diagnosis, already handled, impractical). Keep only ideas that survive.\n3. Return domain="${names}", top_findings that survived, red_team_refutals for killed ideas, and action_items with severity+file+description.\n4. Every action_item MUST carry finding_ids — the ids returned by the search above that support it. An item you cannot attribute is one the Final integrity check will drop, and the phase after that files to GitHub.\n${NO_FAB}\n\nIf group is empty, return domain="empty", empty arrays.`
 }
 
 const synthResults = (await parallel(
@@ -184,7 +184,7 @@ log(`Synthesize: ${synthResults.length}/3 complete, ${confirmedItems.length} con
 // ── Final ──
 phase('Final')
 const final = await agent(
-  `Final Opus synthesis for "${RUN}".\n\nAll confirmed items from 3 domain reviewers:\n${JSON.stringify(confirmedItems, null, 2)}\n\n1. Merge and deduplicate (same bug from multiple angles = one item)\n2. Rank by (critical > high > medium > low) × impact on core reliability\n3. Write a 3-sentence summary\n4. Return ranked_actions (max 20) each with rank/title/severity/file/description/issue_title\n5. List gaps_identified (areas not covered)\n\nAlso store the summary:\n  mcp__loci__investigation_store(investigation_id="${RUN}", finding_type="observed", text="FINAL SYNTHESIS: <summary>", source="${SRC('final','opus')}", confidence="high", tags="dt_run:${RUN},final-synthesis")`,
+  `Final Opus synthesis for "${RUN}".\n\n0. GROUND FIRST — before reasoning, call mcp__loci__investigation_load(investigation_id="${RUN}", last_n_findings=120) and treat THAT as the record of what was actually persisted. The JSON below is in-process state from the reviewers; it is not evidence that anything was stored.\n\nAll confirmed items from 3 domain reviewers:\n${JSON.stringify(confirmedItems, null, 2)}\n\n1. Merge and deduplicate (same bug from multiple angles = one item)\n2. Rank by (critical > high > medium > low) × impact on core reliability\n3. Write a 3-sentence summary\n4. Return ranked_actions (max 20) each with rank/title/severity/file/description/issue_title\n5. List gaps_identified (areas not covered)\n6. INTEGRITY CHECK — for every action you return, confirm it traces to a finding present in the investigation_load result. DROP any item you cannot trace, and record each dropped item in gaps_identified as "UNGROUNDED (dropped): <title>". The next phase files these to GitHub, so an item that survives this step is a claim you are making publicly.\n${NO_FAB}\n\nAlso store the summary:\n  mcp__loci__investigation_store(investigation_id="${RUN}", finding_type="observed", text="FINAL SYNTHESIS: <summary>", source="${SRC('final','opus')}", confidence="high", tags="dt_run:${RUN},final-synthesis")`,
   { label: 'final', phase: 'Final', model: 'opus', schema: FINAL_SCHEMA }
 )
 log(`Final: ${(final?.ranked_actions||[]).length} ranked actions`)

--- a/mcp/graph/ladybug_store.py
+++ b/mcp/graph/ladybug_store.py
@@ -419,7 +419,12 @@ class LadybugStore:
         "CREATE REL TABLE IF NOT EXISTS DEFINES(FROM CodeFile TO CodeSymbol)",
         "CREATE REL TABLE IF NOT EXISTS CALLS(FROM CodeSymbol TO CodeSymbol)",
         "CREATE REL TABLE IF NOT EXISTS IMPORTS(FROM CodeFile TO CodeFile)",
-        "CREATE REL TABLE IF NOT EXISTS REFERENCES(FROM Finding TO CodeSymbol)",
+        # `confidence` carries the linker's own verdict — "high" for a distinctive
+        # type/marker match, "medium" for a long mixed-case identifier. It was
+        # computed and discarded, which forced every consumer to re-derive link
+        # quality from the symbol name at query time. With it on the edge,
+        # precision tuning at the read side is a WHERE clause.
+        "CREATE REL TABLE IF NOT EXISTS REFERENCES(FROM Finding TO CodeSymbol, confidence STRING)",
         "CREATE REL TABLE IF NOT EXISTS MENTIONS(FROM Finding TO Entity)",
         "CREATE REL TABLE IF NOT EXISTS DERIVED_FROM(FROM Finding TO Finding)",
         "CREATE REL TABLE IF NOT EXISTS IN_INVESTIGATION(FROM Finding TO Investigation)",
@@ -604,6 +609,21 @@ class LadybugStore:
             return False
 
     @_writes(False)
+    def ensure_reference_confidence(self) -> bool:
+        """Add REFERENCES.confidence to a database created before it existed.
+
+        CREATE ... IF NOT EXISTS does not alter an existing table, so a store built
+        by an earlier version keeps a property-less edge. Fail-open: an older
+        engine without ALTER support simply keeps writing edges with no confidence,
+        and readers already treat a missing value as unknown.
+        """
+        try:
+            self._exec("ALTER TABLE REFERENCES ADD confidence STRING")
+            return True
+        except Exception as exc:
+            logger.debug("ensure_reference_confidence: %s", exc)
+            return False
+
     def link_references(self, finding_id: str, symbol_ids: list) -> bool:
         if not self.ok or not finding_id or not symbol_ids:
             return False

--- a/mcp/graph/linker.py
+++ b/mcp/graph/linker.py
@@ -284,8 +284,11 @@ def link_findings(ks, finding_rows: list[dict], index=None) -> int:
             if not fid or not text:
                 continue
             fid = str(fid)
-            for sid, _conf in extract_symbol_refs(str(text), index):
-                pairs.append({"f": fid, "s": sid})
+            for sid, conf in extract_symbol_refs(str(text), index):
+                # Carried, not dropped. A consumer that cannot tell a distinctive
+                # type match from a bare-word one has to guess, and every consumer
+                # guesses differently.
+                pairs.append({"f": fid, "s": sid, "c": conf})
 
         if not pairs:
             return 0
@@ -295,7 +298,8 @@ def link_findings(ks, finding_rows: list[dict], index=None) -> int:
             ks._exec(
                 "UNWIND $rows AS r "
                 "MATCH (f:Finding {id:r.f}), (s:CodeSymbol {id:r.s}) "
-                "MERGE (f)-[:REFERENCES]->(s)",
+                "MERGE (f)-[e:REFERENCES]->(s) "
+                "SET e.confidence = r.c",
                 {"rows": chunk},
             )
             created += len(chunk)

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import collections
 import json
+import logging
 import os
 import random
 import re
@@ -50,8 +51,13 @@ def load_env() -> dict:
         from dotenv import load_dotenv
         load_dotenv(_REPO / ".env")
         load_dotenv(_REPO / "mcp" / ".env", override=True)
-    except Exception:
-        pass
+    except Exception as exc:
+        # NOT silent. python-dotenv is where LOCI_QDRANT_RETENTION_DAYS=0 lives, and
+        # without it _retention_days() falls back to 30 and the next _get_qdrant()
+        # deletes everything past the window. Swallowing this import is how a
+        # scheduled run turns destructive while reporting success.
+        logger.warning("load_env: .env unreadable (%r) — env-file settings, including "
+                       "LOCI_QDRANT_RETENTION_DAYS, will NOT be applied", exc)
 
     resolved = {}
     if not os.environ.get("QDRANT_URL"):
@@ -63,8 +69,8 @@ def load_env() -> dict:
                 resolved["QDRANT_URL"] = url
                 if key and not os.environ.get("QDRANT_API_KEY"):
                     os.environ["QDRANT_API_KEY"] = key
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("load_env: could not resolve Qdrant from backends: %r", exc)
     if not os.environ.get("OLLAMA_BASE_URL"):
         try:
             import backends
@@ -72,10 +78,25 @@ def load_env() -> dict:
             if url:
                 os.environ["OLLAMA_BASE_URL"] = url
                 resolved["OLLAMA_BASE_URL"] = url
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("load_env: could not resolve Ollama from backends: %r", exc)
+
+    # Retention through the DURABLE channel. backends.toml is stdlib tomllib and
+    # needs no third-party import, so a setting that protects the corpus does not
+    # depend on one. env wins; .env already applied above; this is the floor.
+    if not os.environ.get("LOCI_QDRANT_RETENTION_DAYS"):
+        try:
+            import backends
+            days = backends._cfg("qdrant", "retention_days", None)
+            if days is not None:
+                os.environ["LOCI_QDRANT_RETENTION_DAYS"] = str(days)
+                resolved["LOCI_QDRANT_RETENTION_DAYS"] = str(days)
+        except Exception as exc:
+            logger.warning("load_env: could not resolve retention from backends: %r", exc)
     return resolved
 
+
+logger = logging.getLogger("loci-groom")
 
 MEMORY_DIR = Path(os.environ.get(
     "HERMES_MEMORY_DIR",
@@ -193,6 +214,26 @@ def pass_index(apply: bool = False, limit: Optional[int] = None, **_) -> dict:
 
     try:
         import qdrant_ops
+    except Exception as exc:
+        report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+        return report
+
+    # Refuse before touching the client. _get_qdrant() runs _purge_old_records on
+    # its first call in a process, so simply CONNECTING with retention unset
+    # deletes the corpus past the window — and this pass exists to repair exactly
+    # that damage. Loud and non-destructive beats quietly undoing our own work.
+    retention = qdrant_ops._retention_days()
+    if retention != 0:
+        report.update(
+            status="refused",
+            detail=(f"LOCI_QDRANT_RETENTION_DAYS resolves to {retention}, not 0 — connecting "
+                    f"would run the startup purge and delete findings older than {retention} "
+                    f"days. Set it in the environment, the repo .env, or [qdrant].retention_days "
+                    f"in ~/.loci/backends.toml before running this pass."),
+        )
+        return report
+
+    try:
         client, col = qdrant_ops._get_qdrant()
     except Exception as exc:
         report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")

--- a/scripts/tests/test_groom_retention_guard.py
+++ b/scripts/tests/test_groom_retention_guard.py
@@ -1,0 +1,80 @@
+"""The groomer must not be able to quietly undo its own work.
+
+pass_index exists to repair an index the startup purge emptied. _get_qdrant()
+runs that purge on its first call in a process — so merely CONNECTING with
+retention unset destroys what the pass is there to restore. Measured before the
+guard: with python-dotenv unimportable, load_env() reported success, resolved
+QDRANT_URL from backends.toml, and left retention at 30.
+"""
+import importlib.util
+import os
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("loci_groom_rg", _SCRIPTS / "loci_groom.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+groom = _load()
+
+
+class TestPassIndexRefusesToPurge(unittest.TestCase):
+    def _run(self, retention):
+        touched = []
+        fake = mock.Mock()
+        fake._retention_days.return_value = retention
+        fake._get_qdrant.side_effect = lambda: touched.append("connected") or (None, None)
+        with mock.patch.dict(sys.modules, {"qdrant_ops": fake}):
+            return groom.pass_index(), touched
+
+    def test_a_nonzero_retention_refuses_before_connecting(self):
+        report, touched = self._run(30)
+        self.assertEqual(report["status"], "refused")
+        self.assertIn("30", report["detail"])
+        self.assertEqual(touched, [], "must not connect — connecting IS the purge")
+
+    def test_the_refusal_names_where_to_set_it(self):
+        report, _ = self._run(7)
+        self.assertIn("backends.toml", report["detail"])
+        self.assertIn("LOCI_QDRANT_RETENTION_DAYS", report["detail"])
+
+    def test_zero_retention_proceeds(self):
+        report, touched = self._run(0)
+        self.assertNotEqual(report["status"], "refused")
+        self.assertEqual(touched, ["connected"])
+
+
+class TestLoadEnvIsNotSilent(unittest.TestCase):
+    def test_retention_resolves_from_backends_when_dotenv_is_missing(self):
+        # the durable channel is stdlib tomllib, so it must not depend on dotenv
+        fake_backends = mock.Mock()
+        fake_backends.qdrant.return_value = ("http://q", "")
+        fake_backends.ollama_url.return_value = ""
+        fake_backends._cfg.side_effect = lambda s, k, d=None: 0 if (s, k) == ("qdrant", "retention_days") else d
+        clean = {k: v for k, v in os.environ.items()
+                 if k not in ("LOCI_QDRANT_RETENTION_DAYS", "QDRANT_URL", "OLLAMA_BASE_URL")}
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.dict(sys.modules, {"backends": fake_backends, "dotenv": None}):
+            resolved = groom.load_env()
+        self.assertEqual(resolved.get("LOCI_QDRANT_RETENTION_DAYS"), "0")
+
+    def test_a_missing_dotenv_is_logged_not_swallowed(self):
+        clean = {k: v for k, v in os.environ.items() if k != "LOCI_QDRANT_RETENTION_DAYS"}
+        with mock.patch.dict(os.environ, clean, clear=True), \
+             mock.patch.dict(sys.modules, {"dotenv": None}), \
+             self.assertLogs("loci-groom", level="WARNING") as cm:
+            groom.load_env()
+        self.assertTrue(any("LOCI_QDRANT_RETENTION_DAYS" in m for m in cm.output),
+                        "the warning must name the setting that silently lapsed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_loci_groom.py
+++ b/scripts/tests/test_loci_groom.py
@@ -83,6 +83,9 @@ class TestIndexPass(unittest.TestCase):
         _corpus(tmp, {"inv": [_f(i) for i in disk_ids]})
         client = _Client(indexed_ids)
         fake_ops = mock.Mock()
+        # pass_index refuses unless retention resolves to 0 — connecting runs the
+        # startup purge, which is the damage this pass exists to repair.
+        fake_ops._retention_days.return_value = 0
         fake_ops._get_qdrant.return_value = (client, "hermes_memory")
         fake_ops._qdrant_upsert.side_effect = lambda pid, text, payload: client.upserts.append(pid)
         with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}), \
@@ -127,6 +130,7 @@ class TestIndexPass(unittest.TestCase):
             tmp = pathlib.Path(td)
             _corpus(tmp, {"inv": [_f("a")]})
             fake_ops = mock.Mock()
+            fake_ops._retention_days.return_value = 0
             fake_ops._get_qdrant.return_value = (None, None)
             with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}), \
                  mock.patch.object(groom, "MEMORY_DIR", tmp):


### PR DESCRIPTION
A deep-think v4 run over the Loci seam (`dt-loci-seam-2026-08-24`, 10 agents,
30 confirmed items, 20 ranked actions) surfaced four criticals. Each was
**verified against the live system before being fixed**; one was wrong as stated
and is noted below.

## 1. The groomer could quietly undo its own work

`load_env()` swallowed a failed `import dotenv`, and `.env` is where
`LOCI_QDRANT_RETENTION_DAYS=0` lived. Reproduced by blocking the import:

```
[before] load_env() -> {'QDRANT_URL': ...}    LOCI_QDRANT_RETENTION_DAYS = None
         _retention_days() -> 30              *** WOULD PURGE, silently ***
```

`_get_qdrant()` runs `_purge_old_records` on its first call — so a scheduled run
in that state deletes precisely what `pass_index` exists to restore, and
`load_env()` reports success throughout.

Three changes: retention also resolves through `~/.loci/backends.toml` (stdlib
`tomllib`, no third-party import, so a setting that protects the corpus does not
depend on one); every swallow logs at WARNING naming the setting that lapsed; and
`pass_index` returns `status="refused"` **before connecting** when retention is
not 0 — because connecting *is* the purge.

```
[after]  [log] load_env: .env unreadable (ImportError) — env-file settings,
               including LOCI_QDRANT_RETENTION_DAYS, will NOT be applied
         _retention_days() -> 0               SAFE
```

## 2. v4 filed GitHub issues from ungrounded reasoning

`NO_FAB` was defined at line 39 and interpolated **once** — on the writer. v3.2
used it four times. So the three Opus reviewers and the Final agent had no
anti-fabrication clause; Final received only in-process `confirmedItems` JSON,
never called `investigation_load`, and its output feeds the phase that runs
`gh issue create`.

Final now grounds on `investigation_load` *first*, then runs an explicit integrity
check that drops untraceable items into `gaps_identified` with the reason stated
in the prompt: *"the next phase files these to GitHub, so an item that survives
this step is a claim you are making publicly."* Reviewers must attribute every
`action_item` to `finding_ids`, which `SYNTH_SCHEMA` now carries so the check has
something checkable. `NO_FAB` is back on every tier (4 uses, matching v3.2).

## 3. One hardcoded field disabled three tools

The writer emitted `finding_type="inferred"` for everything, with no `code_refs`
and no `derived_from`. Conflict detection only fires on `gap`/`assumed`;
`verify_finding`'s code grounding needs the `path:line` colon form; retraction
lineage and `_compute_aggregate_confidence` walk `derived_from`. All three were
dead by construction — which matches the census: `conflict_list` = 0 records,
`finding_verifications.jsonl` = 0 records.

The writer prompt now requires a per-idea type (with the consequence of
mislabelling stated), colon-form code refs, and a parent id where one exists.

## 4. The linker computed confidence and discarded it

`for sid, _conf in extract_symbol_refs(...)` dropped it, and
`CREATE REL TABLE ... REFERENCES(FROM Finding TO CodeSymbol)` had no properties —
so every consumer re-derived link quality from the symbol name at query time.
That is why the `Reason`/`Tier` noise reaches `related_investigations_via_code`,
`code_memory_map`, `subsystem_report` and `impact_report` separately.

`REFERENCES` now carries `confidence`, with a fail-open `ALTER` for stores built
before it, and the batch MERGE sets it. **This is the enabling fix**: read-side
precision tuning becomes a `WHERE` clause instead of four per-consumer patches.
Deliberately *not* changing the `_TYPE_KINDS` behaviour in the same PR — the audit
was explicit that a non-circular labelled oracle should exist before tuning
precision, since the only current metric scores against these same edges.

## One audit claim was wrong as stated

The retention finding said the hazard was live. It is not, in the current
environment — `mcp/.venv` has `python-dotenv`, so retention resolved to 0
correctly. The claim was conditional on dotenv being unavailable, and **that
condition reproduces exactly**. Fixed on the strength of the conditional, not the
headline.

## Tests

`scripts/tests/test_groom_retention_guard.py` — 5: a non-zero retention refuses
**before connecting** (asserted on the connection never happening), the refusal
names where to set it, zero proceeds, retention resolves from backends.toml with
dotenv absent, and a missing dotenv is logged rather than swallowed.

Existing index-pass doubles updated to declare `_retention_days = 0` — they now
state the precondition the pass actually has.

`scripts/`: 637 passed. `mcp/`: 597 passed. Ruff and vulture clean. The one
remaining `scripts/` failure and the 7+7 in `test_analytics`/`test_graph_integration`
reproduce identically on unmodified `main` here.

## Not fixable in code

The Qdrant key in `~/.loci/backends.toml` is **byte-identical** (verified by
sha256, both 64 bytes) to the one committed at `fbd27b2` in this public repo. It
is the **live credential**, not a historical one. Rotation is an action on the
Qdrant instance and is the single highest-priority item outstanding.