### PR TITLE
fix(groom): one gate to Qdrant, because a guard per call site gets forgotten

### DIFF
--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -175,6 +175,41 @@ def write_proposals(rows: list[dict], groom_dir: Optional[Path] = None) -> int:
 
 # --- pass: index ------------------------------------------------------------
 
+def connect(require_safe_retention: bool = True):
+    """(client, collection, refusal) — the ONLY way this module reaches Qdrant.
+
+    qdrant_ops._get_qdrant() runs _purge_old_records on its first call in a
+    process, so connecting is a destructive act when retention is not 0. Guarding
+    one pass is not enough: pass_index, pass_recall and pass_knn_tags all connect,
+    and a guard copied into each is a guard that will be forgotten by the fourth.
+    Everything goes through here instead.
+
+    Returns a refusal dict when it is not safe to connect, else None in that slot.
+    """
+    try:
+        import qdrant_ops
+    except Exception as exc:
+        return None, None, {"status": "degraded", "detail": f"qdrant_ops unavailable: {exc!r}"}
+
+    if require_safe_retention:
+        retention = qdrant_ops._retention_days()
+        if retention != 0:
+            return None, None, {
+                "status": "refused",
+                "detail": (f"LOCI_QDRANT_RETENTION_DAYS resolves to {retention}, not 0 — connecting "
+                           f"would run the startup purge and delete findings older than {retention} "
+                           f"days. Set it in the environment, the repo .env, or [qdrant].retention_days "
+                           f"in ~/.loci/backends.toml before running this pass."),
+            }
+    try:
+        client, col = qdrant_ops._get_qdrant()
+    except Exception as exc:
+        return None, None, {"status": "degraded", "detail": f"qdrant_ops unavailable: {exc!r}"}
+    if client is None:
+        return None, None, {"status": "degraded", "detail": "qdrant unreachable"}
+    return client, col, None
+
+
 def indexed_ids(client, col: str) -> set:
     """Every point id in the collection, paged."""
     out: set = set()
@@ -212,35 +247,11 @@ def pass_index(apply: bool = False, limit: Optional[int] = None, **_) -> dict:
         "status": "ok",
     }
 
-    try:
-        import qdrant_ops
-    except Exception as exc:
-        report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+    client, col, refusal = connect()
+    if refusal:
+        report.update(**refusal)
         return report
-
-    # Refuse before touching the client. _get_qdrant() runs _purge_old_records on
-    # its first call in a process, so simply CONNECTING with retention unset
-    # deletes the corpus past the window — and this pass exists to repair exactly
-    # that damage. Loud and non-destructive beats quietly undoing our own work.
-    retention = qdrant_ops._retention_days()
-    if retention != 0:
-        report.update(
-            status="refused",
-            detail=(f"LOCI_QDRANT_RETENTION_DAYS resolves to {retention}, not 0 — connecting "
-                    f"would run the startup purge and delete findings older than {retention} "
-                    f"days. Set it in the environment, the repo .env, or [qdrant].retention_days "
-                    f"in ~/.loci/backends.toml before running this pass."),
-        )
-        return report
-
-    try:
-        client, col = qdrant_ops._get_qdrant()
-    except Exception as exc:
-        report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
-        return report
-    if client is None:
-        report.update(status="degraded", detail="qdrant unreachable")
-        return report
+    import qdrant_ops
 
     try:
         indexed = indexed_ids(client, col)
@@ -474,15 +485,11 @@ def pass_recall(sample: int = 40, k: int = 5, paraphrase: bool = True,
     sample = limit or sample          # --limit is the CLI's name for the sample size
     report = {"pass": "recall", "k": k, "sample": sample, "rerank": rerank, "status": "ok"}
 
-    try:
-        import qdrant_ops
-        client, col = qdrant_ops._get_qdrant()
-    except Exception as exc:
-        report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+    client, col, refusal = connect()
+    if refusal:
+        report.update(**refusal)
         return report
-    if client is None:
-        report.update(status="degraded", detail="qdrant unreachable")
-        return report
+    import qdrant_ops
 
     by_id = {}
     for f in iter_findings(memory_dir):
@@ -631,16 +638,13 @@ def pass_knn_tags(limit: Optional[int] = None, k: int = 8, min_weight: float = 1
         return report
 
     if search_fn is None:
-        try:
-            import qdrant_ops
-            if qdrant_ops._get_qdrant()[0] is None:
-                report.update(status="degraded", detail="qdrant unreachable")
-                return report
-            search_fn = lambda q: qdrant_ops._qdrant_similarity_search(  # noqa: E731
-                q, limit=k + 1, rerank=False)
-        except Exception as exc:
-            report.update(status="degraded", detail=f"qdrant_ops unavailable: {exc!r}")
+        client, _col, refusal = connect()
+        if refusal:
+            report.update(**refusal)
             return report
+        import qdrant_ops
+        search_fn = lambda q: qdrant_ops._qdrant_similarity_search(  # noqa: E731
+            q, limit=k + 1, rerank=False)
 
     if calibrate:
         subjects = [f for f in findings

--- a/scripts/tests/test_groom_retention_guard.py
+++ b/scripts/tests/test_groom_retention_guard.py
@@ -78,3 +78,54 @@ class TestLoadEnvIsNotSilent(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestEveryPassRoutesThroughTheGate(unittest.TestCase):
+    """The first version of this guard protected pass_index only, while
+    pass_recall and pass_knn_tags still connected directly — and connecting IS
+    the purge. A guard that has to be remembered at each call site is a guard
+    that gets forgotten, so the check lives in one place and this test asserts
+    nothing bypasses it."""
+
+    def test_no_pass_calls_get_qdrant_directly(self):
+        import re
+        src = (_SCRIPTS / "loci_groom.py").read_text()
+        parts = re.split(r"\ndef (pass_\w+|connect)\(", src)
+        offenders = [parts[i] for i in range(1, len(parts), 2)
+                     if parts[i] != "connect" and "_get_qdrant()" in parts[i + 1]]
+        self.assertEqual(offenders, [], f"these bypass connect(): {offenders}")
+
+    def _refuses(self, fn, **kw):
+        fake = mock.Mock()
+        fake._retention_days.return_value = 30
+        connected = []
+        fake._get_qdrant.side_effect = lambda: connected.append(1) or (None, None)
+        with mock.patch.dict(sys.modules, {"qdrant_ops": fake}):
+            report = fn(**kw)
+        return report, connected
+
+    def test_recall_refuses_too(self):
+        report, connected = self._refuses(groom.pass_recall)
+        self.assertEqual(report["status"], "refused")
+        self.assertEqual(connected, [])
+
+    def test_knn_tags_refuses_too(self):
+        import tempfile, json as _json, pathlib as _pl
+        with tempfile.TemporaryDirectory() as td:
+            tmp = _pl.Path(td); (tmp / "inv").mkdir()
+            with open(tmp / "inv" / "findings.jsonl", "w") as fh:
+                for i in range(6):
+                    fh.write(_json.dumps({"id": f"t{i}", "text": "x", "tags": ["mqtt"],
+                                          "investigation_id": "inv"}) + "\n")
+            report, connected = self._refuses(groom.pass_knn_tags, memory_dir=tmp)
+        self.assertEqual(report["status"], "refused")
+        self.assertEqual(connected, [])
+
+    def test_the_gate_itself_connects_when_safe(self):
+        fake = mock.Mock()
+        fake._retention_days.return_value = 0
+        fake._get_qdrant.return_value = ("client", "col")
+        with mock.patch.dict(sys.modules, {"qdrant_ops": fake}):
+            client, col, refusal = groom.connect()
+        self.assertIsNone(refusal)
+        self.assertEqual((client, col), ("client", "col"))

--- a/scripts/tests/test_loci_groom.py
+++ b/scripts/tests/test_loci_groom.py
@@ -83,6 +83,7 @@ class TestIndexPass(unittest.TestCase):
         _corpus(tmp, {"inv": [_f(i) for i in disk_ids]})
         client = _Client(indexed_ids)
         fake_ops = mock.Mock()
+        fake_ops._retention_days.return_value = 0  # connect() gate
         # pass_index refuses unless retention resolves to 0 — connecting runs the
         # startup purge, which is the damage this pass exists to repair.
         fake_ops._retention_days.return_value = 0
@@ -288,6 +289,7 @@ class TestRecallPass(unittest.TestCase):
 
         client = _Client(ids)
         fake_ops = mock.Mock()
+        fake_ops._retention_days.return_value = 0  # connect() gate
         fake_ops._get_qdrant.return_value = (client, "hermes_memory")
         with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
             return groom.pass_recall(
@@ -344,6 +346,7 @@ class TestRecallPass(unittest.TestCase):
             _corpus(tmp, {"inv": [_f(i, text=f"finding text {i}") for i in ["a", "b", "c", "d"]]})
             client = _Client(["a", "b"])          # only two of the four are indexed
             fake_ops = mock.Mock()
+            fake_ops._retention_days.return_value = 0  # connect() gate
             fake_ops._get_qdrant.return_value = (client, "hermes_memory")
             seen = []
 
@@ -364,6 +367,7 @@ class TestRecallPass(unittest.TestCase):
             _corpus(tmp, {"inv": [_f("a", text="finding text a")]})
             client = _Client(["a"])
             fake_ops = mock.Mock()
+            fake_ops._retention_days.return_value = 0  # connect() gate
             fake_ops._get_qdrant.return_value = (client, "hermes_memory")
             gd = tmp / "_groom"
             with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
@@ -377,6 +381,7 @@ class TestRecallPass(unittest.TestCase):
 
     def test_an_unreachable_qdrant_degrades(self):
         fake_ops = mock.Mock()
+        fake_ops._retention_days.return_value = 0  # connect() gate
         fake_ops._get_qdrant.return_value = (None, None)
         with mock.patch.dict(sys.modules, {"qdrant_ops": fake_ops}):
             r = groom.pass_recall()


### PR DESCRIPTION
The retention guard in #199 protected `pass_index` only.

```
pass_index       GUARDED
pass_recall      *** CONNECTS WITHOUT CHECKING RETENTION ***
pass_knn_tags    *** CONNECTS WITHOUT CHECKING RETENTION ***
```

Connecting **is** the purge — `_get_qdrant()` runs `_purge_old_records` on its
first call in a process. So scheduling `recall` or `knn_tags` would have destroyed
the corpus the guard was written to protect, and the guard would have reported
nothing, because it was never on that path.

## The pattern, not just the bug

This is the fourth time today the same shape has appeared **in my own work**:

- the reranker had two cross-encoder call sites; I fixed one, measured it with a
  probe that exercises only that one, and reported a win
- the dense vector name was assumed in several places; I fixed the two I found
- `[:512]` survived in a second module after the first was fixed
- now: a guard written into one of three functions that need it

Fixing the site you found rather than the class is the habit. So this PR does not
add the check to two more functions.

## `connect()`

One gate. It resolves retention, refuses **before** connecting when it is not 0,
and hands back a refusal dict the caller merges into its report:

```python
client, col, refusal = connect()
if refusal:
    report.update(**refusal)
    return report
```

All three passes route through it. And a test walks the module source:

```python
offenders = [fn for fn in pass_* if "_get_qdrant()" in body]
assert offenders == []
```

so the *next* pass added cannot quietly bypass it either. That assertion is the
actual deliverable — the refactor is only what makes it possible to state.

## Tests

`scripts/tests/test_groom_retention_guard.py` +4: no pass calls `_get_qdrant`
directly; `pass_recall` refuses and does not connect; `pass_knn_tags` refuses and
does not connect; the gate connects when retention is safe. Both refusal tests
assert on **the connection never happening**, not just on the status string.

Existing recall/knn doubles now declare `_retention_days = 0`, stating the
precondition those passes actually have — 2 doubles became 7.

`scripts/`: 641 passed. Ruff and vulture clean. The single remaining failure is
the pre-existing host-specific `test_beam_fallback_...` that fails wherever
`~/.hermes/mnemosyne` exists.