### PR TITLE
fix: three verified findings from the open-tasks audit

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,8 +18,8 @@ services:
     volumes:
       - qdrant-dev-data:/qdrant/storage
     ports:
-      - "0.0.0.0:6333:6333"   # REST + dashboard
-      - "0.0.0.0:6334:6334"   # gRPC
+      - "127.0.0.1:6333:6333"   # REST + dashboard
+      - "127.0.0.1:6334:6334"   # gRPC
     restart: unless-stopped
 
   ollama:
@@ -27,7 +27,7 @@ services:
     volumes:
       - ollama-dev-data:/root/.ollama
     ports:
-      - "0.0.0.0:11434:11434"
+      - "127.0.0.1:11434:11434"
     # GPU: uncomment if you have NVIDIA drivers + nvidia-container-toolkit
     # deploy:
     #   resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,12 @@ services:
     volumes:
       - hermes-mcp-data:/data
     ports:
-      - "0.0.0.0:8000:8000"
+      # Loopback, not 0.0.0.0 — this publishes an UNAUTHENTICATED tool server
+      # (issue #78). Publish-side only: do NOT set HERMES_MCP_HOST=127.0.0.1,
+      # which binds the server to the container's own loopback, makes this
+      # mapping unreachable, and leaves the in-container HEALTHCHECK passing —
+      # a dead service reporting healthy.
+      - "127.0.0.1:8000:8000"
     restart: unless-stopped
 
   hermes-a2a:
@@ -53,7 +58,7 @@ services:
     volumes:
       - hermes-a2a-data:/data
     ports:
-      - "0.0.0.0:8201:8201"
+      - "127.0.0.1:8201:8201"
     restart: unless-stopped
 
 volumes:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1661,8 +1661,9 @@ def _hallucination_candidates(
     # provenance check keeps its documented per-finding semantics; this is the
     # consumer declining to read a blanket verdict as evidence about any one
     # finding.
-    _observed_ids = {str(fid) for fid, f in (findings_by_id or {}).items()
-                     if str(f.get("record_type") or f.get("type") or "") == "observed"}
+    _observed_ids = {str(f.get("id", "")) for f in (findings or [])
+                     if str(f.get("record_type") or f.get("type") or "") == "observed"
+                     and f.get("id")}
     _blanket = bool(_observed_ids) and _observed_ids <= unsupported_ids
     if _blanket:
         logger.debug("_hallucination_candidates: every observed finding is unsupported "

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1647,6 +1647,28 @@ def _hallucination_candidates(
     NEVER auto-retracts. Pure over the in-memory findings/verdicts.
     """
     unsupported_ids = {r for v in (unsupported or []) for r in (v.refs or [])}
+
+    # An "unsupported" verdict means two very different things depending on
+    # whether an audit lane exists at all. run_provenance flags every observed
+    # finding that lacks a matching receipt — which, on an investigation with NO
+    # audit.jsonl, is every observed finding it is given. Measured: 1 of 140
+    # investigations on the live corpus has one. The `other in unsupported_ids`
+    # skip below then discards every observed-vs-observed contradiction, so the
+    # strongest hallucination signal available can never produce a candidate.
+    #
+    # When EVERY observed finding is unsupported the signal is uninformative
+    # rather than damning, so it must not gate the contradiction pass. The
+    # provenance check keeps its documented per-finding semantics; this is the
+    # consumer declining to read a blanket verdict as evidence about any one
+    # finding.
+    _observed_ids = {str(fid) for fid, f in (findings_by_id or {}).items()
+                     if str(f.get("record_type") or f.get("type") or "") == "observed"}
+    _blanket = bool(_observed_ids) and _observed_ids <= unsupported_ids
+    if _blanket:
+        logger.debug("_hallucination_candidates: every observed finding is unsupported "
+                     "(%d) — treating provenance as uninformative rather than gating on it",
+                     len(_observed_ids))
+
     if not unsupported_ids or not contradictions:
         return []
 
@@ -1670,7 +1692,7 @@ def _hallucination_candidates(
         for unsup, other in pairs:
             if unsup not in unsupported_ids:
                 continue
-            if other in unsupported_ids:
+            if other in unsupported_ids and not _blanket:
                 continue  # other also unsupported — no receipted counter
             if other not in findings_by_id:
                 continue

--- a/mcp/tests/test_hallucination_candidates.py
+++ b/mcp/tests/test_hallucination_candidates.py
@@ -1,0 +1,63 @@
+"""_hallucination_candidates: the blanket-provenance path, and the normal one.
+
+This function had no test at all, and its only call site swallows every
+exception into `candidates = []`. A NameError inside it therefore reads exactly
+like "no candidates found" — the feature disables itself and the caller reports
+a clean result. That is the failure these tests exist to make loud.
+"""
+import unittest
+
+from memcheck.verdict import Verdict
+from server import _hallucination_candidates
+
+
+def _v(vtype, refs):
+    return Verdict(id="v-" + "-".join(refs), subject_kind="memory",
+                   subject_signature=refs[0], subject_excerpt="", verdict_type=vtype,
+                   decision="flag", confidence=1.0, rationale="", source="rule", refs=list(refs))
+
+
+def _f(fid, text, rtype="observed"):
+    return {"id": fid, "text": text, "record_type": rtype}
+
+
+class HallucinationCandidatesTest(unittest.TestCase):
+
+    def test_receipted_counter_finding_yields_a_candidate(self):
+        """The documented case: unsupported positive vs a finding that IS receipted."""
+        findings = [_f("a", "the relay is up"), _f("b", "the relay is down")]
+        # only "a" is unsupported, so "b" counts as receipted
+        out = _hallucination_candidates(findings, [], [_v("unsupported_observed", ["a"])],
+                                        [_v("contradiction", ["a", "b"])])
+        self.assertEqual([c["finding_id"] for c in out], ["a"])
+        self.assertEqual(out[0]["contradicted_by"], "b")
+
+    def test_blanket_unsupported_still_produces_candidates(self):
+        """With no audit lane at all, EVERY observed finding is flagged unsupported.
+
+        The old `other in unsupported_ids: continue` skip then discarded every
+        observed-vs-observed contradiction, so the strongest hallucination signal
+        could never fire. An empty audit lane must not silently disable detection.
+        """
+        findings = [_f("a", "the relay is up"), _f("b", "the relay is down")]
+        unsupported = [_v("unsupported_observed", ["a"]), _v("unsupported_observed", ["b"])]
+        out = _hallucination_candidates(findings, [], unsupported,
+                                        [_v("contradiction", ["a", "b"])])
+        self.assertTrue(out, "blanket-unsupported must not suppress the contradiction pass")
+        self.assertIn(out[0]["finding_id"], {"a", "b"})
+
+    def test_partial_unsupported_keeps_the_receipted_gate(self):
+        """Not blanket: an unsupported-vs-unsupported pair has no receipted counter."""
+        findings = [_f("a", "up"), _f("b", "down"), _f("c", "sideways")]
+        unsupported = [_v("unsupported_observed", ["a"]), _v("unsupported_observed", ["b"])]
+        # c is observed and NOT unsupported -> not blanket
+        out = _hallucination_candidates(findings, [], unsupported,
+                                        [_v("contradiction", ["a", "b"])])
+        self.assertEqual(out, [], "a-vs-b both unsupported and c is receipted: no candidate")
+
+    def test_no_contradictions_is_empty_not_an_exception(self):
+        self.assertEqual(_hallucination_candidates([_f("a", "x")], [], [], []), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -523,8 +523,22 @@ def pass_recall(sample: int = 40, k: int = 5, paraphrase: bool = True,
             errors += 1
             continue
         ident_ranks.append(_rank_of(fid, res.get("results") or []))
-    report["identity"] = _score(ident_ranks, k, len(ident_ranks))
     report["search_errors"] = errors
+    report["identity"] = _score(ident_ranks, k, len(ident_ranks))
+    if not ident_ranks:
+        # attempted==0 means every search raised — typically the cross-encoder
+        # failing to load. _score would return recall_at_1=0.0 and _append_recall
+        # would publish it into the one longitudinal retrieval metric we keep,
+        # recording a dead GPU as total retrieval collapse. Refuse to write a
+        # point rather than write a false one.
+        # The report still carries identity (attempted=0) so its shape is stable,
+        # but nothing is WRITTEN to the trend: _score returns recall_at_1=0.0 for
+        # an empty sample, and persisting that records a dead GPU as total
+        # retrieval collapse in the one longitudinal metric we keep. A missing
+        # point is honest; a zero is a lie.
+        report.update(status="degraded",
+                      detail=f"all {errors} probe search(es) failed — no measurement taken")
+        return report
 
     if not paraphrase:
         _append_recall(report, groom_dir)
@@ -915,7 +929,10 @@ def main(argv: Optional[list] = None) -> int:
             reports.append(spec["fn"](apply=apply, limit=args.limit,
                                       rerank=not args.no_rerank))
         except Exception as exc:      # a pass must never take the cron job down
-            reports.append({"pass": name, "status": "error", "detail": repr(exc)})
+            import traceback
+            logger.error("pass %s raised:\n%s", name, traceback.format_exc())
+            reports.append({"pass": name, "status": "error", "detail": repr(exc),
+                            "traceback": traceback.format_exc()})
 
     if args.json:
         print(json.dumps(reports, indent=2))
@@ -925,7 +942,16 @@ def main(argv: Optional[list] = None) -> int:
             rest = " ".join(f"{k}={v}" for k, v in r.items()
                             if k not in ("pass", "status") and not isinstance(v, (list, dict)))
             print(f"{head} {rest}".rstrip())
-    return 0 if all(r.get("status") != "error" for r in reports) else 1
+    # Three-way, because a scheduler only ever sees the exit code. Every failure
+    # this tool actually produces — refused (retention not 0), degraded (qdrant
+    # unreachable, scroll failed, no generation tier, graph unreadable) — used to
+    # exit 0, so a cron run in which nothing happened recorded last_status=success.
+    # The refusal guard was built to be loud and was silent to its only consumer.
+    if any(r.get("status") == "error" for r in reports):
+        return 1
+    if any(r.get("status") in ("refused", "degraded") for r in reports):
+        return 3
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_groom_retention_guard.py
+++ b/scripts/tests/test_groom_retention_guard.py
@@ -129,3 +129,56 @@ class TestEveryPassRoutesThroughTheGate(unittest.TestCase):
             client, col, refusal = groom.connect()
         self.assertIsNone(refusal)
         self.assertEqual((client, col), ("client", "col"))
+
+
+class TestExitCodeReachesTheRunner(unittest.TestCase):
+    """A scheduler only ever sees the exit code. Every failure this tool actually
+    produces used to exit 0, so a cron run in which nothing happened recorded
+    success — the refusal guard was built to be loud and was silent to its only
+    consumer."""
+
+    def _rc(self, statuses):
+        passes = {f"p{i}": {"fn": (lambda st: lambda **kw: {"pass": "p", "status": st})(st),
+                            "applyable": False}
+                  for i, st in enumerate(statuses)}
+        with mock.patch.dict(groom.PASSES, passes, clear=True):
+            return groom.main(list(passes) + ["--json"])
+
+    def test_all_ok_exits_zero(self):
+        self.assertEqual(self._rc(["ok", "ok"]), 0)
+
+    def test_a_refusal_does_not_look_like_success(self):
+        self.assertEqual(self._rc(["ok", "refused"]), 3)
+
+    def test_degraded_does_not_look_like_success(self):
+        self.assertEqual(self._rc(["degraded"]), 3)
+
+    def test_an_error_still_wins(self):
+        self.assertEqual(self._rc(["refused", "error"]), 1)
+
+
+class TestRecallWritesNoFalseZero(unittest.TestCase):
+    def test_all_searches_failing_degrades_instead_of_recording_zero(self):
+        import tempfile, pathlib as _pl, json as _json
+        with tempfile.TemporaryDirectory() as td:
+            tmp = _pl.Path(td); (tmp / "inv").mkdir()
+            with open(tmp / "inv" / "findings.jsonl", "w") as fh:
+                fh.write(_json.dumps({"id": "a", "text": "finding text a",
+                                      "investigation_id": "inv"}) + "\n")
+
+            class _P:
+                id = "a"
+
+            client = mock.Mock()
+            client.scroll.return_value = ([_P()], None)
+            fake = mock.Mock()
+            fake._retention_days.return_value = 0
+            fake._get_qdrant.return_value = (client, "c")
+            gd = tmp / "_groom"
+            with mock.patch.dict(sys.modules, {"qdrant_ops": fake}):
+                r = groom.pass_recall(sample=1, paraphrase=False, memory_dir=tmp, groom_dir=gd,
+                                      search_fn=lambda q: {"ok": False, "results": []})
+        self.assertEqual(r["status"], "degraded")
+        self.assertEqual(r["identity"]["attempted"], 0, "report shape stays stable")
+        self.assertFalse((gd / "recall.jsonl").exists(),
+                         "a missing point is honest; a zero in the trend file is a lie")


### PR DESCRIPTION
From `dt-loci-open-tasks-2026-08-25` — 24 ideas, 24 persisted, 26 confirmed, 20
ranked. Each item below was verified against the live system before being fixed,
and one was deliberately **not** applied as proposed.

## 1. A refused groom pass reported success

```
$ LOCI_QDRANT_RETENTION_DAYS=30 loci_groom.py index --json
  status: refused
  exit code: 0
```

`return 0 if all(r.get("status") != "error" ...)` — so only an uncaught exception
was nonzero. Every failure this tool actually produces exits 0: `refused` (the
retention guard), and `degraded` from qdrant unreachable, scroll failed, no
generation tier, graph unreadable.

The refusal guard added in #199/#200 was built specifically so a destructive run
would fail **loudly**, and it was silent to the only consumer a cron job has. This
is the precondition for scheduling anything.

Now three-way: `0` all ok, `1` error, `3` anything refused or degraded. Verified:
the same command now exits **3**. Exceptions also keep `traceback.format_exc()`
rather than only `repr(exc)`.

## 2. `pass_recall` published a false zero

When every probe search fails — typically the cross-encoder failing to load on the
flaky GPU — `_score` returns `recall_at_1=0.0` for an empty sample and
`_append_recall` persisted it into **the one longitudinal retrieval metric the
system keeps**, with `status: ok` and exit 0. Unattended on a schedule, that
records a dead GPU as permanent total retrieval collapse in the file whose entire
purpose is its trend.

The report keeps its shape (`identity.attempted = 0`) so callers are unaffected;
nothing is written to the trend. A missing point is honest.

## 3. The MCP tool server was published on `0.0.0.0`, unauthenticated

Moved to `127.0.0.1` on the **publish** side, along with `hermes-a2a` and the dev
Qdrant/Ollama publishes.

Deliberately **not** setting `HERMES_MCP_HOST=127.0.0.1`, which is what #78's
filed remediation recommends: `mcp/server.py:7922` reads it into
`mcp.settings.host`, so that binds the server to the *container's own* loopback,
makes the published mapping unreachable, and leaves the in-container HEALTHCHECK
passing — a dead service reporting healthy. A comment in the compose file records
the distinction so the next reader doesn't "complete" the fix.

One line, no Python, no client change, reverts with `docker compose up -d`.

## One finding NOT applied as proposed

The audit recommended making `run_provenance` abstain when there are no audit
receipts. I implemented that, and it broke
`test_checks.py::test_observed_with_empty_audit_flagged` — which asserts exactly
the behaviour I'd removed. That contract is **deliberate and tested**, so I
reverted rather than overriding a designed semantic on the strength of an
argument, however good.

The harm is real but it is downstream. `_hallucination_candidates` does
`if other in unsupported_ids: continue` — and since only **1 of 140**
investigations has an `audit.jsonl`, essentially every observed finding is
"unsupported", so **every observed-vs-observed contradiction is discarded** and
the strongest hallucination signal available can never produce a candidate.

Fixed at the consumer: when *every* observed finding is unsupported, the verdict
is uninformative rather than damning, and no longer gates the contradiction pass.
The provenance check keeps its documented per-finding semantics.

## Tests

`test_groom_retention_guard.py` +5: all-ok exits 0, a refusal is not success, a
degraded pass is not success, an error still wins, and all-searches-failing
degrades **without writing to the trend file** — asserted on the file not
existing, not on the status string.

`scripts/`: 646 passed. `mcp/`: 597 passed. Ruff and vulture clean. The remaining
failures are the pre-existing host-specific ones that reproduce on unmodified
`main` here.