### PR TITLE
fix: the retention default was deleting the index on every server start

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -152,15 +152,45 @@ def _create_payload_indexes(client, col: str) -> None:
 
 
 def _retention_days() -> int:
-    """Startup purge window, in days. 0 disables the purge entirely.
+    """Startup purge window, in days. 0 (the default) disables the purge entirely.
+
+    The default is 0 because this window DELETES FINDINGS and the deletion is
+    silent. It used to default to 30, which meant a process that simply forgot to
+    export LOCI_QDRANT_RETENTION_DAYS destroyed every indexed finding older than a
+    month on its next start. Measured on the live store before this change: the
+    index held 912 findings and the corpus held 2,831, and the split was exact —
+    all 912 findings younger than 30 days were indexed, and zero of the 1,919
+    older ones were. The index boundary WAS the retention window. Re-indexing
+    restored coverage and the next server start removed it again.
+
+    Purging is a real option, but it has to be one somebody chose. Nothing in this
+    repo opts in.
+
+    Resolution order: environment, then ~/.loci/backends.toml, then 0. The
+    backends floor exists because the env var only reaches a process whose
+    launcher remembers to set it — and the four live MCP servers did not. A
+    setting that protects the corpus must not depend on being remembered.
 
     Read at call time, not import time, so a test or a caller can set it."""
-    raw = os.environ.get("LOCI_QDRANT_RETENTION_DAYS", "30").strip()
+    raw = os.environ.get("LOCI_QDRANT_RETENTION_DAYS", "").strip()
+    if not raw:
+        try:
+            import backends
+            days = backends._cfg("qdrant", "retention_days", None)
+            if days is not None:
+                raw = str(days).strip()
+        except Exception as exc:
+            logger.debug("retention: backends.toml unreadable (%r); using the safe default", exc)
+    if not raw:
+        return 0
     try:
         days = int(raw)
     except ValueError:
-        logger.warning("LOCI_QDRANT_RETENTION_DAYS=%r is not an integer; using 30", raw)
-        return 30
+        # Falls back to DISABLED, not to a window. Guessing a number here is
+        # guessing how much of the corpus to delete.
+        logger.warning("LOCI_QDRANT_RETENTION_DAYS=%r is not an integer; "
+                       "disabling the purge rather than guessing a window", raw)
+        return 0
     return max(0, days)
 
 
@@ -174,7 +204,7 @@ def _purge_old_records(client, col: str, retention_days: Optional[int] = None) -
     if retention_days is None:
         retention_days = _retention_days()
     if retention_days <= 0:
-        logger.debug("Qdrant TTL purge disabled (LOCI_QDRANT_RETENTION_DAYS=0)")
+        logger.info("Qdrant TTL purge disabled for %r (retention=0) — no findings deleted", col)
         return
 
     from qdrant_client.models import Filter, FieldCondition, Range, FilterSelector

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6187,6 +6187,24 @@ def loci_health() -> str:
     except Exception as exc:
         logger.debug("loci_health: embed warm-state probe failed: %r", exc)
         pass
+
+    # Corpus durability. A 30-day default purge window silently deleted every
+    # indexed finding older than a month on each process start, and nothing
+    # reported it: coverage looked fine right after a re-index and collapsed at
+    # the next restart. These two fields make that condition answerable from the
+    # tool people already call, instead of from a set-difference against disk.
+    try:
+        import qdrant_ops
+        days = qdrant_ops._retention_days()
+        out["retention_days"] = days
+        out["purge_active"] = days > 0
+        if days > 0:
+            out["purge_warning"] = (
+                f"findings older than {days} days are deleted on every server start"
+            )
+    except Exception as exc:
+        logger.debug("loci_health: retention probe failed: %r", exc)
+        pass
     return json.dumps(out, indent=2)
 
 

--- a/mcp/tests/test_health_retention.py
+++ b/mcp/tests/test_health_retention.py
@@ -1,0 +1,43 @@
+"""loci_health reports whether the corpus is being deleted.
+
+The 30-day purge default removed every indexed finding older than a month on
+each process start. Nothing surfaced it: coverage looked correct immediately
+after a re-index and collapsed at the next restart, so the condition was only
+visible as a set-difference between Qdrant and disk. These fields make it
+answerable from the tool that is already called to diagnose the server.
+"""
+import json
+import unittest
+from unittest import mock
+
+import server
+
+
+class HealthRetentionTest(unittest.TestCase):
+
+    def _health(self, days):
+        with mock.patch("qdrant_ops._retention_days", return_value=days):
+            return json.loads(server.loci_health())
+
+    def test_disabled_purge_reports_safe(self):
+        h = self._health(0)
+        self.assertEqual(h["retention_days"], 0)
+        self.assertFalse(h["purge_active"])
+        self.assertNotIn("purge_warning", h)
+
+    def test_active_purge_is_reported_with_a_warning(self):
+        h = self._health(30)
+        self.assertEqual(h["retention_days"], 30)
+        self.assertTrue(h["purge_active"])
+        self.assertIn("30 days", h["purge_warning"])
+
+    def test_a_failing_retention_probe_does_not_break_health(self):
+        """Every loci_health probe is fail-open; this one is no exception."""
+        with mock.patch("qdrant_ops._retention_days", side_effect=RuntimeError("boom")):
+            h = json.loads(server.loci_health())
+        self.assertIn("code_version", h)
+        self.assertNotIn("retention_days", h)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_qdrant_retention.py
+++ b/mcp/tests/test_qdrant_retention.py
@@ -39,10 +39,21 @@ def _purge(env, count=5):
 
 
 class TestRetentionWindow(unittest.TestCase):
-    def test_default_is_thirty_days(self):
+    def test_default_is_disabled_not_a_window(self):
+        """An unset variable must not delete anything.
+
+        This defaulted to 30 and the four live MCP servers all ran with the
+        variable unset. Measured consequence: the index held exactly the 912
+        findings younger than 30 days and zero of the 1,919 older ones — the
+        index boundary was the purge window. Re-indexing fixed it until the next
+        process start.
+        """
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("LOCI_QDRANT_RETENTION_DAYS", None)
-            self.assertEqual(qdrant_ops._retention_days(), 30)
+            with mock.patch.object(qdrant_ops, "logger"):
+                # no backends.toml value in the test env -> the floor is 0
+                with mock.patch.dict("sys.modules", {"backends": None}):
+                    self.assertEqual(qdrant_ops._retention_days(), 0)
 
     def test_zero_disables_the_purge(self):
         client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "0"})
@@ -53,9 +64,10 @@ class TestRetentionWindow(unittest.TestCase):
         client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "-1"})
         self.assertEqual(client.deletes, [])
 
-    def test_garbage_falls_back_to_the_default_rather_than_deleting_everything(self):
+    def test_garbage_disables_rather_than_guessing_a_window(self):
+        """Guessing a number here is guessing how much of the corpus to delete."""
         with mock.patch.dict(os.environ, {"LOCI_QDRANT_RETENTION_DAYS": "banana"}):
-            self.assertEqual(qdrant_ops._retention_days(), 30)
+            self.assertEqual(qdrant_ops._retention_days(), 0)
 
     def test_a_custom_window_is_honoured(self):
         client = _purge({"LOCI_QDRANT_RETENTION_DAYS": "90"})
@@ -84,3 +96,35 @@ class TestCallSiteDoesNotPinTheWindow(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRetentionResolutionOrder(unittest.TestCase):
+    """The env var only reaches a process whose launcher sets it.
+
+    All four live MCP servers ran with it unset, which is how the destructive
+    default went unnoticed. backends.toml is the durable floor: stdlib tomllib,
+    no third-party import, readable by anything that can read the file.
+    """
+
+    def test_backends_toml_supplies_the_window_when_env_is_unset(self):
+        fake = mock.Mock()
+        fake._cfg.return_value = 45
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOCI_QDRANT_RETENTION_DAYS", None)
+            with mock.patch.dict("sys.modules", {"backends": fake}):
+                self.assertEqual(qdrant_ops._retention_days(), 45)
+
+    def test_env_wins_over_backends_toml(self):
+        fake = mock.Mock()
+        fake._cfg.return_value = 45
+        with mock.patch.dict(os.environ, {"LOCI_QDRANT_RETENTION_DAYS": "7"}):
+            with mock.patch.dict("sys.modules", {"backends": fake}):
+                self.assertEqual(qdrant_ops._retention_days(), 7)
+
+    def test_an_unreadable_backends_file_disables_rather_than_purges(self):
+        fake = mock.Mock()
+        fake._cfg.side_effect = OSError("no such file")
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOCI_QDRANT_RETENTION_DAYS", None)
+            with mock.patch.dict("sys.modules", {"backends": fake}):
+                self.assertEqual(qdrant_ops._retention_days(), 0)

--- a/scripts/loci_groom_cron.sh
+++ b/scripts/loci_groom_cron.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Cron entrypoint for the passive grooming tier.
+#
+# Not scheduled into cron/jobs.json: that file lists five jobs marked
+# "enabled": true, every one with last_run_at: None, and nothing on this host
+# reads it (see issue #205). The live substrate is the user crontab.
+#
+# Exit codes come from loci_groom.py and are the point of this wrapper:
+#   0  ok
+#   1  a pass errored
+#   3  a pass refused or degraded — most importantly, refused because the
+#      retention window is non-zero and connecting would delete findings
+#
+# A 3 is not a warning to bury in a log. Grooming re-indexes findings; if the
+# server is configured to purge them, an unattended groomer becomes an infinite
+# index-then-delete loop that burns embedding compute and reports success.
+set -uo pipefail
+
+REPO="${LOCI_REPO:-/home/rjmendez/development/loci}"
+PY="$REPO/mcp/.venv/bin/python"
+STATE="${LOCI_GROOM_STATE:-$HOME/.loci/groom}"
+mkdir -p "$STATE"
+
+[ -x "$PY" ] || { echo "loci-groom: no interpreter at $PY" >&2; exit 1; }
+
+pass="${1:?usage: loci_groom_cron.sh <pass> [args...]}"
+shift || true
+
+out="$("$PY" "$REPO/scripts/loci_groom.py" "$pass" "$@" 2>&1)"
+rc=$?
+
+printf '%s\n' "$out"
+# One line per run, so "has this ever actually run, and what did it say" is a
+# question with an answer. The absence of a recent entry is itself the signal.
+printf '{"ts":%d,"pass":"%s","rc":%d,"summary":%s}\n' \
+    "$(date +%s)" "$pass" "$rc" \
+    "$(printf '%s' "$out" | tail -1 | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))')" \
+    >> "$STATE/runs.jsonl"
+
+if [ "$rc" -eq 3 ]; then
+    echo "loci-groom: pass '$pass' REFUSED or DEGRADED — corpus not groomed." >&2
+    echo "loci-groom: check loci_health retention_days; a non-zero purge window" >&2
+    echo "loci-groom: makes grooming an index-then-delete loop." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
## What happens

`_retention_days()` defaults to **30**, and the only way to change it is an
environment variable. The four live MCP servers all run with it unset, so each
one purges findings older than 30 days on startup — silently, because the
disabled path logged at `debug` and the delete runs `wait=False`.

## The measurement

Set-exact against the live store, not a count coincidence:

| | |
|---|---:|
| young (≤30d) on disk | 912 |
| old (>30d) on disk | 1919 |
| present in Qdrant | 912 |
| young **and** indexed | 912 |
| young **missing** | 0 |
| old **but still indexed** | 0 |

The index contained exactly the complement of the purge window.

This is also why it read as an indexing problem for so long. Re-indexing moved
coverage 24% → 94.5%; the next server start moved it back to 32%. Measuring
immediately after a write measures the write, not its survival.

## The fix

**Default 0 (disabled).** A destructive default is only safe if every launcher
remembers to override it. Nothing in this repo opts into purging, so the default
was doing all of the damage on its own. Unparseable values now disable rather
than falling back to 30 — guessing a number there is guessing how much of the
corpus to delete.

**A durable resolution floor.** When the env var is absent, read
`~/.loci/backends.toml` — the same channel `scripts/loci_groom.py` already uses.
stdlib `tomllib`, no third-party import, so a setting that protects the corpus
does not depend on `python-dotenv` importing or on a launcher passing env
through.

Purging stays available; it just has to be something someone chose.

## Verification

A/B in an identical bare environment (`env -i`, no `.env`):

```
OLD resolved retention = 30
NEW resolved retention = 0
```

`mcp/tests/test_qdrant_retention.py`: 11 passed. The two tests that pinned the
old default were changed deliberately and say why. Three new tests cover the
resolution order, including that an unreadable `backends.toml` disables rather
than purges.

Full `mcp/` suite: 656 passed. `test_graph_integration.py::test_code_graph_ingest_and_query`
fails identically on clean `main` (host-specific), unrelated to this change.