### PR TITLE
fix(security): bind loopback by default on the HTTP transports (#78)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -7960,7 +7960,15 @@ def main() -> None:
     if transport in ("sse", "streamable-http"):
         # FastMCP.run() takes only transport and mount_path; the bind address
         # lives on settings.
-        mcp.settings.host = os.environ.get("HERMES_MCP_HOST", "0.0.0.0")
+        # Loopback by default. This server has no authentication, so a wide bind
+        # is a decision, not something you should get by not making one — the
+        # same reasoning that fixed the retention default in #204. Every
+        # legitimate wide bind already sets this explicitly: docker-compose.yml
+        # passes HERMES_MCP_HOST=0.0.0.0 because a container must bind all
+        # interfaces to receive published traffic, and publishes on 127.0.0.1.
+        # Getting this wrong now fails loudly (cannot connect) instead of
+        # silently exposing an unauthenticated tool server.
+        mcp.settings.host = os.environ.get("HERMES_MCP_HOST", "127.0.0.1")
         mcp.settings.port = int(os.environ.get("HERMES_MCP_PORT", "8000"))
         mcp.run(transport=transport)
     else:

--- a/mcp/tests/test_main_transport.py
+++ b/mcp/tests/test_main_transport.py
@@ -34,11 +34,25 @@ def test_sse_binds_via_settings():
     assert server.mcp.settings.port == 9001
 
 
-def test_streamable_http_defaults_the_bind():
+def test_streamable_http_defaults_to_loopback():
+    """An unauthenticated server must not reach the network by default.
+
+    This asserted 0.0.0.0 and was describing the behaviour rather than defending
+    it. A wide bind is a decision; not making one should not produce the exposed
+    outcome. docker-compose sets HERMES_MCP_HOST=0.0.0.0 explicitly and publishes
+    on 127.0.0.1, so the containerised path is unaffected.
+    """
     run = _run_main({"HERMES_MCP_TRANSPORT": "streamable-http"})
     run.assert_called_once_with(transport="streamable-http")
-    assert server.mcp.settings.host == "0.0.0.0"
+    assert server.mcp.settings.host == "127.0.0.1"
     assert server.mcp.settings.port == 8000
+
+
+def test_a_wide_bind_is_still_available_explicitly():
+    run = _run_main({"HERMES_MCP_TRANSPORT": "streamable-http",
+                     "HERMES_MCP_HOST": "0.0.0.0"})
+    run.assert_called_once_with(transport="streamable-http")
+    assert server.mcp.settings.host == "0.0.0.0"
 
 
 def test_unknown_transport_falls_back_to_stdio():


### PR DESCRIPTION
## The defect

`mcp/server.py` defaulted `HERMES_MCP_HOST` to `0.0.0.0`, and this server has no
authentication. Starting it on `sse` or `streamable-http` without setting that
variable puts an unauthenticated tool server on every interface.

Same class as #204's retention default: **the unsafe value is what you get by
not making a decision.**

## Why the trade is favourable

The failure modes are asymmetric.

| | before | after |
|---|---|---|
| forgot the variable | unauthenticated server on all interfaces, silently | cannot connect — set one env var |

Loud and fixable beats silent and exposed.

## Nothing legitimate loses a wide bind

`docker-compose.yml` already sets `HERMES_MCP_HOST=0.0.0.0` explicitly, which is
correct — a container must bind all interfaces to receive published traffic —
and since #203 it publishes on `127.0.0.1`. Every real wide-bind case is already
explicit.

`a2a_server/server.py` **keeps** its `0.0.0.0` default on purpose: it has bearer
+ TOTP auth and fails closed when `HERMES_A2A_TOKEN` is unset. A wide bind there
is defended. That contrast is what identifies the MCP one as the actual defect.

## Measured context

No Loci process is currently listening on any port — `ss -tlnp` shows the live
MCP servers are all on stdio, spawned per client. This exposure was latent, not
active. Fixing it now is cheap precisely because nothing depends on it yet.

## Tests

`test_streamable_http_defaults_the_bind` asserted `0.0.0.0`. That test was
describing the behaviour rather than defending a contract, so it is renamed and
inverted, with a docstring saying why. Added
`test_a_wide_bind_is_still_available_explicitly`.

`mcp/tests/test_main_transport.py`: 5 passed.

**Does not close #78.** Authentication on the HTTP transports remains an open
owner decision; this only removes the exposure you get by accident.