### PR TITLE
fix(grounding): stop counting function words as evidence (#183)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1330,11 +1330,38 @@ def _normalize_derived_from(derived_from: str | list[str] | None) -> list[str]:
 
 _NEGATION_RE = re.compile(r"\b(?:no|not|never|none|without|cannot|can't|didn't|isn't|aren't|won't)\b", re.I)
 _TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9._:/-]{2,}", re.I)
+# Words that carry no evidentiary weight in a lexical match. Two groups, kept
+# separate because they are dropped for different reasons.
+#
+# Domain-generic: true of almost every finding in this corpus, so sharing one
+# says nothing.
 _GENERIC_MATCH_TOKENS = {
     "host", "user", "device", "query", "result", "results", "output", "input", "tool",
     "found", "seen", "shows", "reported", "detected", "contacted", "event", "events",
     "record", "records", "row", "rows",
 }
+
+# Function words. These were NOT dropped, and _lexical_match_score normalises by
+# the claim side only, so a short claim could clear the 0.45 gate on stopword
+# overlap alone. Measured on 400 real findings before this change: 68.8% of
+# generic short claims were reported as supported, e.g. "the server is down"
+# declared supported by a document on cultural-noise characterisation, on the
+# overlap {"down", "the"}. investigation_pre_answer_check is the tool an agent
+# calls BEFORE asserting a claim, so this was a rubber stamp on the one gate
+# meant to catch unsupported assertions.
+_STOPWORD_MATCH_TOKENS = {
+    "a", "an", "and", "are", "as", "at", "be", "been", "but", "by", "can", "could",
+    "did", "do", "does", "for", "from", "had", "has", "have", "he", "her", "his",
+    "how", "i", "if", "in", "into", "is", "it", "its", "may", "might", "must", "no",
+    "not", "of", "on", "or", "our", "out", "over", "own", "she", "should", "so",
+    "some", "such", "than", "that", "the", "their", "them", "then", "there", "these",
+    "they", "this", "those", "to", "too", "under", "up", "was", "we", "were", "what",
+    "when", "where", "which", "while", "who", "why", "will", "with", "would", "you",
+    "your", "am", "being", "both", "each", "few", "more", "most", "only", "other",
+    "same", "very", "just", "also", "any", "all", "about", "after", "before",
+}
+
+_NON_EVIDENCE_TOKENS = _GENERIC_MATCH_TOKENS | _STOPWORD_MATCH_TOKENS
 _QDRANT_SUPPORT_MIN_SCORE = 0.55
 _QDRANT_PRECHECK_MIN_SCORE = 0.5
 
@@ -1369,9 +1396,15 @@ def _confidence_allowed(confidence: str, min_confidence: str) -> bool:
 
 
 def tokenize(text: str) -> set[str]:
+    """Content tokens only — the units a lexical match is allowed to count.
+
+    Shared by every lexical lane (pre-answer check, recall scoring, target match,
+    provenance). None of them want a function word to count as evidence, so the
+    drop set lives here rather than at one call site.
+    """
     return {
         token for token in (m.group(0).lower() for m in _TOKEN_RE.finditer(text or ""))
-        if token not in _GENERIC_MATCH_TOKENS
+        if token not in _NON_EVIDENCE_TOKENS
     }
 
 

--- a/mcp/tests/test_lexical_gate_stopwords.py
+++ b/mcp/tests/test_lexical_gate_stopwords.py
@@ -1,0 +1,69 @@
+"""The lexical lane must not count function words as evidence.
+
+investigation_pre_answer_check is the tool an agent calls BEFORE asserting a
+memory-derived claim. Its lexical lane scored overlap normalised by the claim
+side only, and tokenize() dropped 21 domain words but no stopwords — so a short
+claim could clear the 0.45 gate on shared function words alone.
+
+Measured on 400 real findings before the fix: 68.8% of generic short claims were
+reported as supported. After: 1.2%. True-positive control over 300 claims drawn
+from the findings they should match: unchanged at 96.7%.
+"""
+import unittest
+
+import server
+
+
+class TokenizeDropsNonEvidenceTest(unittest.TestCase):
+
+    def test_stopwords_are_not_evidence(self):
+        self.assertEqual(server.tokenize("the and of is was it this"), set())
+
+    def test_domain_generic_words_are_still_dropped(self):
+        self.assertEqual(server.tokenize("the host reported a result"), set())
+
+    def test_content_words_survive(self):
+        self.assertEqual(
+            server.tokenize("the qdrant retention purge deleted findings"),
+            {"qdrant", "retention", "purge", "deleted", "findings"},
+        )
+
+
+class LexicalGateTest(unittest.TestCase):
+    """0.45 is the gate in _pre_answer_lexical_refs."""
+
+    GATE = 0.45
+
+    def _score(self, claim, evidence):
+        return server._lexical_match_score(server.tokenize(claim),
+                                           server.tokenize(evidence))
+
+    def test_unrelated_evidence_no_longer_clears_the_gate(self):
+        """The measured regression: shared stopwords declared support.
+
+        'the server is down' scored 0.67 against a document about cultural-noise
+        characterisation, on the overlap {'down', 'the'}.
+        """
+        score = self._score(
+            "the server is down",
+            "LITERATURE: how a continuous cultural-noise background is characterised",
+        )
+        self.assertLess(score, self.GATE)
+
+    def test_a_claim_of_only_stopwords_cannot_be_supported(self):
+        """It should be unassessable lexically, not trivially supported."""
+        self.assertEqual(server.tokenize("it was the result"), set())
+        self.assertEqual(self._score("it was the result", "anything at all here"), 0.0)
+
+    def test_genuinely_matching_evidence_still_clears_the_gate(self):
+        """The false-negative control: the fix must not break real matches."""
+        score = self._score(
+            "the retention purge deleted indexed findings",
+            "The Qdrant retention purge deleted every indexed finding older than "
+            "thirty days on each server start.",
+        )
+        self.assertGreaterEqual(score, self.GATE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`tokenize()` dropped 21 domain-generic words and **no stopwords**, and
`_lexical_match_score` normalises by the claim side only:

```python
return len(overlap) / max(1, len(claim_tokens))
```

So a short claim clears the `0.45` gate in `_pre_answer_lexical_refs` on shared
function words alone.

`investigation_pre_answer_check` is the tool an agent calls **before** asserting
a memory-derived claim. This was a rubber stamp on the one gate meant to catch
unsupported assertions.

## Measured, both directions

On 400 real findings from the live corpus:

| | before | after |
|---|---:|---:|
| generic short claims reported **supported** | **68.8%** | **1.2%** |
| legitimate claims still matching their own finding (n=300) | 96.7% | **96.7%** |

The true-positive control is the point. Reporting only the first row would be
the same error as tightening a filter and checking only that it filtered.

Example of what used to pass:

```
claim:     "the server is down"
evidence:  "LITERATURE: how a continuous cultural-noise background is characterised"
overlap:   {"down", "the"}          score: 0.67   -> SUPPORTED
```

## Fixed in the shared tokenizer, not at the call site

Four lexical lanes share `tokenize()` — pre-answer check (`:3518`), recall
scoring (`:3904`), target match (`:5212`), and provenance via injection
(`:1592`). None of them want `"the"` to count as evidence, so the drop set
belongs there. Fixing only the pre-answer caller would have left three lanes
scoring on stopwords.

The two drop sets are kept separate and commented, because they are dropped for
different reasons: domain-generic words are true of nearly every finding here,
function words carry no evidentiary weight anywhere.

A claim that reduces to zero content tokens now scores `0.0` — unassessable
lexically rather than trivially supported. The semantic lane still runs on it.

## Tests

`mcp/tests/test_lexical_gate_stopwords.py`: 6 passed, including the exact
false-positive case above and the false-negative control.

Full `mcp/` suite: **666 passed**. Only
`test_graph_integration.py::test_code_graph_ingest_and_query` fails, identically
on clean `main` (host-specific), unrelated.