### PR TITLE
fix(security): the A2A bridge defaulted its shared secret to "changeme" (#186)

### DIFF
--- a/scripts/a2a_context_bridge.py
+++ b/scripts/a2a_context_bridge.py
@@ -56,7 +56,16 @@ if os.path.exists(_ENV):
 
 # ── config ───────────────────────────────────────────────────────────────────────
 LOCAL_A2A_URL  = os.environ.get("HERMES_A2A_URL", "http://127.0.0.1:8201")
-LOCAL_A2A_TOKEN = os.environ.get("HERMES_A2A_TOKEN", "changeme")
+# Empty, not "changeme". The A2A server reads the same variable and defaults it
+# to '' precisely so an unset token fails closed; defaulting the client to a
+# guessable literal handed that back. A shared secret with a published value is
+# not a shared secret, and the failure was silent in the direction that matters —
+# authenticating rather than refusing.
+LOCAL_A2A_TOKEN = os.environ.get("HERMES_A2A_TOKEN", "")
+if not LOCAL_A2A_TOKEN:
+    print('WARNING: HERMES_A2A_TOKEN is not set. The bridge will be rejected by any '
+          'server that enforces bearer auth. Generate one with: '
+          'python3 -c "import secrets;print(secrets.token_hex(32))"', flush=True)
 LOOKBACK_MIN   = int(os.environ.get("BRIDGE_LOOKBACK_MIN", "30"))
 MIN_IMP        = float(os.environ.get("BRIDGE_MIN_IMP", "0.5"))
 MAX_ITEMS      = int(os.environ.get("BRIDGE_MAX_ITEMS", "20"))


### PR DESCRIPTION
## The defect

`a2a_server/server.py:210` defaults `HERMES_A2A_TOKEN` to `''` deliberately, so
an unset token fails closed and prints how to generate one.

`scripts/a2a_context_bridge.py:59` defaulted the **same variable** to the literal
`"changeme"`, and sent it as `Authorization: Bearer changeme`.

That hands the server's fail-closed design back: the bridge authenticates with a
published value rather than refusing. A shared secret with a known value is not a
shared secret, and this failed in the direction that matters — succeeding instead
of refusing.

## Fix

Default to `''` and warn at startup, matching the server it talks to.

## Scope note

`#186` listed four divergent names. Checked each on `main` rather than taking the
issue at its word:

- **`MAX_PER_RUN`** — already fixed in #187 (`f1ae93f`): each script has its own
  name with a fallback to the shared one. Nothing to do.
- **`HERMES_A2A_TOKEN`** — this PR.
- **`EMBED_MODEL`** — **not a divergence.** `mcp/embed_ops.py:28` defaults to `''`
  as a documented sentinel meaning "resolve from backends at call time", and
  `:50`/`:52` do exactly that. Leaving as-is.
- **`HERMES_AGENT_ID`** — four defaults, but the issue's own analysis holds: the
  `''` sites are the write path and no read path filters on the env value, so it
  is inconsistent stamping rather than a silent-empty read. Not addressed here.

`scripts/` suite: 117 passed. ruff clean.