### PR TITLE
fix: the TOTP rate-limiter pruned timestamps but never its keys (#107)

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -435,6 +435,9 @@ def _verify_bearer(creds: Optional[HTTPAuthorizationCredentials] = Depends(_bear
 _TOTP_WINDOW = 60
 _TOTP_MAX_ATTEMPTS = 5
 _totp_attempts: dict = collections.defaultdict(list)
+# Sweep idle client-IP keys once the dict exceeds this. Chosen well above any
+# plausible concurrent-client count so the sweep is rare and its cost amortised.
+_TOTP_SWEEP_AFTER = 1024
 _totp_attempts_lock = threading.Lock()
 
 
@@ -454,12 +457,22 @@ def _verify_totp(request: Request,
         client_ip = request.client.host if request.client else 'unknown'
         now = time.monotonic()
         with _totp_attempts_lock:
-            attempts = _totp_attempts[client_ip]
-            # Evict timestamps older than the window
-            _totp_attempts[client_ip] = [t for t in attempts if now - t < _TOTP_WINDOW]
-            if len(_totp_attempts[client_ip]) >= _TOTP_MAX_ATTEMPTS:
+            # Evict timestamps older than the window, and drop the key when it
+            # empties. Pruning only the lists left one dict entry per client IP
+            # forever — an unauthenticated caller could grow it by rotating
+            # source addresses, and a busy server grew it just by being used.
+            fresh = [t for t in _totp_attempts[client_ip] if now - t < _TOTP_WINDOW]
+            if len(fresh) >= _TOTP_MAX_ATTEMPTS:
+                _totp_attempts[client_ip] = fresh
                 raise HTTPException(status_code=429, detail='Too many TOTP attempts — try again later')
-            _totp_attempts[client_ip].append(now)
+            fresh.append(now)
+            _totp_attempts[client_ip] = fresh
+            # Opportunistic sweep: bounded work, keeps idle keys from accumulating
+            # between requests without needing a background task.
+            if len(_totp_attempts) > _TOTP_SWEEP_AFTER:
+                for ip in [k for k, v in _totp_attempts.items()
+                           if not v or now - v[-1] >= _TOTP_WINDOW]:
+                    del _totp_attempts[ip]
         if not pyotp.TOTP(TOTP_SEED).verify(x_totp, valid_window=1):
             raise HTTPException(status_code=401, detail='Invalid TOTP code')
 

--- a/a2a_server/tests/test_totp_auth.py
+++ b/a2a_server/tests/test_totp_auth.py
@@ -125,3 +125,61 @@ class TestTOTPAuth(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTOTPAttemptKeyLeak(unittest.TestCase):
+    """The rate-limit dict pruned timestamps but never its keys.
+
+    Each distinct client IP left an entry behind forever — an unauthenticated
+    caller could grow it by rotating source addresses, and a busy server grew it
+    just by being used. Only the per-IP lists were bounded.
+    """
+
+    # Read via getattr with a fallback ON PURPOSE. Referencing the new constant
+    # directly made this test fail on the old code with AttributeError — proving
+    # the constant was absent, not that keys leaked. With a fallback the test
+    # populates the dict, makes a request, and asserts it shrank, which is the
+    # behaviour under test.
+    SWEEP_AFTER = getattr(a2a_server, "_TOTP_SWEEP_AFTER", 1024)
+
+    def setUp(self):
+        a2a_server._totp_attempts.clear()
+
+    def tearDown(self):
+        a2a_server._totp_attempts.clear()
+
+    def _post_one_valid_request(self):
+        """One authenticated request, using this file's mock-pyotp convention."""
+        with patch.object(a2a_server, "TOTP_SEED", _TEST_SEED), \
+             patch.object(a2a_server, "pyotp") as mock_pyotp_mod:
+            mock_pyotp_mod.TOTP.return_value.verify.return_value = True
+            client = TestClient(a2a_server.app, raise_server_exceptions=False)
+            client.post("/a2a", json=_rpc("tasks/list"),
+                        headers={**_HEADERS, "X-TOTP": "000000"})
+
+    def test_expired_keys_are_swept_not_just_emptied(self):
+        stale = time.monotonic() - (a2a_server._TOTP_WINDOW + 60)
+        for i in range(self.SWEEP_AFTER + 5):
+            a2a_server._totp_attempts[f"10.0.{i // 256}.{i % 256}"] = [stale]
+        before = len(a2a_server._totp_attempts)
+        self.assertGreater(before, self.SWEEP_AFTER)
+
+        self._post_one_valid_request()
+
+        after = len(a2a_server._totp_attempts)
+        self.assertLess(after, before,
+                        "stale client-IP keys must be removed, not merely emptied")
+        self.assertLessEqual(after, 2, f"expected a swept dict, got {after} keys")
+
+    def test_a_live_client_is_not_swept(self):
+        """The sweep must only remove keys whose window has fully expired."""
+        now = time.monotonic()
+        a2a_server._totp_attempts["10.1.1.1"] = [now]
+        for i in range(self.SWEEP_AFTER + 5):
+            a2a_server._totp_attempts[f"10.9.{i // 256}.{i % 256}"] = [
+                now - (a2a_server._TOTP_WINDOW + 60)]
+
+        self._post_one_valid_request()
+
+        self.assertIn("10.1.1.1", a2a_server._totp_attempts,
+                      "a client inside its window must survive the sweep")


### PR DESCRIPTION
## The leak

`_totp_attempts` is a `defaultdict(list)` keyed by client IP. The handler evicted
expired timestamps from each IP's list:

```python
_totp_attempts[client_ip] = [t for t in attempts if now - t < _TOTP_WINDOW]
```

…and left the key behind. **Only the lists were bounded; the dict was not.** An
unauthenticated caller could grow it by rotating source addresses, and a busy
server grew it just by being used.

## Fix

Drop the key when its window has fully expired, plus a bounded opportunistic
sweep once the dict exceeds 1024 entries — rare, amortised, and no background
task to own.

The sweep removes only keys whose most recent attempt is outside the window, so
an actively rate-limited client keeps its counter. `test_a_live_client_is_not_swept`
covers that: a sweep that forgot live clients would silently reset the limit it
exists to enforce.

## A note on the test

`SWEEP_AFTER` is read through `getattr` with a fallback deliberately. Referencing
the new constant directly made the test fail on old code with `AttributeError` —
proving the constant was absent, not that keys leaked. With the fallback it fails
on old code with:

```
AssertionError: 1030 not less than 1029 : stale client-IP keys must be removed
```

The dict grew instead of shrinking. That is the defect, detected directly.

`a2a_server/` suite: **96 passed**.