### PR TITLE
feat(security): bearer auth on the HTTP transports, and refuse a wide bind without it (closes #78)

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -108,7 +108,3 @@ _ = recall_decision
 # no root model that makes this resolvable, so it is suppressed by name.
 _ = row_factory
 
-# ── FastMCP settings written by main()
-# `mcp.settings.port` is read inside FastMCP.run() when it builds the uvicorn
-# config; there is no in-repo read, so vulture calls the write dead.
-_ = port

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -8,3 +8,7 @@ iocextract>=1.16.1
 ladybug>=0.18.0
 tree-sitter>=0.24
 tree-sitter-language-pack>=1.10
+
+# Serving the sse / streamable-http transports directly, so a bearer gate can
+# wrap the app (#78). Pulled in transitively by mcp before; now imported here.
+uvicorn>=0.30

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import asyncio  # noqa: F401  (kept on the module namespace; live users import it function-locally)
 import fcntl
 import hashlib
+import hmac
 import json
 import math
 import os
@@ -7980,6 +7981,54 @@ from investigation_tools import (  # noqa: E402,F401
 )
 
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "0:0:0:0:0:0:0:1"})
+
+
+def _is_loopback(host: str) -> bool:
+    return (host or "").strip().lower() in _LOOPBACK_HOSTS
+
+
+class _BearerAuthMiddleware:
+    """Shared-secret gate for the HTTP transports.
+
+    Deliberately not the SDK's token_verifier path: that requires AuthSettings
+    with an issuer_url, i.e. the full OAuth resource-server model, and would
+    publish /.well-known/oauth-* discovery describing an authorization server
+    that does not exist. A single secret shared between an operator and their own
+    server is not OAuth, and modelling it as OAuth advertises a fiction.
+
+    /health stays open so liveness probes work without the secret; it returns a
+    fixed {"status": "ok"} and discloses nothing.
+    """
+
+    __slots__ = ("_app", "_token", "_exempt")
+
+    def __init__(self, app, token: str, exempt_paths=frozenset({"/health"})):
+        self._app = app
+        self._token = token
+        self._exempt = exempt_paths
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or scope.get("path") in self._exempt:
+            await self._app(scope, receive, send)
+            return
+        raw = dict(scope.get("headers") or {}).get(b"authorization", b"")
+        value = raw.decode("latin-1") if isinstance(raw, bytes) else str(raw)
+        presented = value[7:] if value[:7].lower() == "bearer " else ""
+        # compare_digest on both branches: a plain == would leak the token length
+        # and prefix through timing, and an early return on empty would leak
+        # whether a token was presented at all.
+        if not (presented and hmac.compare_digest(presented, self._token)):
+            body = b'{"error":"unauthorized"}'
+            await send({"type": "http.response.start", "status": 401,
+                        "headers": [(b"content-type", b"application/json"),
+                                    (b"content-length", str(len(body)).encode()),
+                                    (b"www-authenticate", b"Bearer")]})
+            await send({"type": "http.response.body", "body": body})
+            return
+        await self._app(scope, receive, send)
+
+
 def main() -> None:
     # Fire-and-forget embed warm-ping so the FIRST real RAG/dedup call doesn't eat the
     # ~9s nomic cold-load. Non-blocking (daemon thread) and fail-open — never blocks or
@@ -8003,7 +8052,32 @@ def main() -> None:
         # silently exposing an unauthenticated tool server.
         mcp.settings.host = os.environ.get("HERMES_MCP_HOST", "127.0.0.1")
         mcp.settings.port = int(os.environ.get("HERMES_MCP_PORT", "8000"))
-        mcp.run(transport=transport)
+
+        # This server exposes the whole tool surface. #206 made the bind loopback
+        # by default; a token is what makes a NON-loopback bind defensible, so
+        # without one we refuse rather than serve. Loud beats exposed — the same
+        # trade as the bind default and the retention default.
+        token = os.environ.get("HERMES_MCP_TOKEN", "").strip()
+        if not token and not _is_loopback(mcp.settings.host):
+            raise SystemExit(
+                f"refusing to serve {transport} on {mcp.settings.host} without "
+                "HERMES_MCP_TOKEN: this would expose every tool unauthenticated. "
+                'Generate one with: python3 -c "import secrets;print(secrets.token_hex(32))" '
+                "— or bind 127.0.0.1."
+            )
+
+        app = (mcp.streamable_http_app() if transport == "streamable-http"
+               else mcp.sse_app())
+        if token:
+            app = _BearerAuthMiddleware(app, token)
+        else:
+            logger.warning("HERMES_MCP_TOKEN is not set — serving %s on %s with no "
+                           "authentication. Safe only because the bind is loopback.",
+                           transport, mcp.settings.host)
+
+        import uvicorn
+        uvicorn.run(app, host=mcp.settings.host, port=mcp.settings.port,
+                    log_level=str(mcp.settings.log_level).lower())
     else:
         mcp.run(transport="stdio")
 

--- a/mcp/tests/test_main_transport.py
+++ b/mcp/tests/test_main_transport.py
@@ -5,17 +5,38 @@ TypeError, so every non-stdio transport died at startup. The bind address has to
 go on mcp.settings instead.
 """
 import os
+import unittest
 from unittest import mock
 
 import server
 
 
 def _run_main(env):
+    """stdio path: FastMCP.run() is still the entry point."""
     with mock.patch.dict(os.environ, env, clear=True), \
          mock.patch.object(server.mcp, "run") as run, \
          mock.patch.object(server, "logger"):
         server.main()
     return run
+
+
+def _run_http(env):
+    """HTTP path: served through uvicorn so a bearer gate can wrap the app.
+
+    FastMCP.run() builds its own app internally with no injection point for
+    middleware, and the SDK's token_verifier hook requires AuthSettings with an
+    issuer_url — the full OAuth resource-server model. Serving the app directly
+    is what makes a shared-secret gate possible without pretending to be OAuth.
+    """
+    with mock.patch.dict(os.environ, env, clear=True), \
+         mock.patch.object(server.mcp, "streamable_http_app") as sapp, \
+         mock.patch.object(server.mcp, "sse_app") as eapp, \
+         mock.patch.object(server, "logger"), \
+         mock.patch("uvicorn.run") as urun:
+        sapp.return_value = mock.sentinel.http_app
+        eapp.return_value = mock.sentinel.sse_app
+        server.main()
+    return urun
 
 
 def test_stdio_is_the_default():
@@ -24,14 +45,15 @@ def test_stdio_is_the_default():
 
 
 def test_sse_binds_via_settings():
-    run = _run_main({
+    urun = _run_http({
         "HERMES_MCP_TRANSPORT": "sse",
         "HERMES_MCP_HOST": "127.0.0.1",
         "HERMES_MCP_PORT": "9001",
     })
-    run.assert_called_once_with(transport="sse")
     assert server.mcp.settings.host == "127.0.0.1"
     assert server.mcp.settings.port == 9001
+    assert urun.call_args.kwargs["host"] == "127.0.0.1"
+    assert urun.call_args.kwargs["port"] == 9001
 
 
 def test_streamable_http_defaults_to_loopback():
@@ -42,19 +64,93 @@ def test_streamable_http_defaults_to_loopback():
     outcome. docker-compose sets HERMES_MCP_HOST=0.0.0.0 explicitly and publishes
     on 127.0.0.1, so the containerised path is unaffected.
     """
-    run = _run_main({"HERMES_MCP_TRANSPORT": "streamable-http"})
-    run.assert_called_once_with(transport="streamable-http")
+    urun = _run_http({"HERMES_MCP_TRANSPORT": "streamable-http"})
     assert server.mcp.settings.host == "127.0.0.1"
     assert server.mcp.settings.port == 8000
+    assert urun.call_args.kwargs["host"] == "127.0.0.1"
 
 
 def test_a_wide_bind_is_still_available_explicitly():
-    run = _run_main({"HERMES_MCP_TRANSPORT": "streamable-http",
-                     "HERMES_MCP_HOST": "0.0.0.0"})
-    run.assert_called_once_with(transport="streamable-http")
+    """…but only with a token. See TestHttpTokenAuth for the refusal."""
+    urun = _run_http({"HERMES_MCP_TRANSPORT": "streamable-http",
+                      "HERMES_MCP_HOST": "0.0.0.0",
+                      "HERMES_MCP_TOKEN": "s3cret"})
     assert server.mcp.settings.host == "0.0.0.0"
+    assert urun.call_args.kwargs["host"] == "0.0.0.0"
 
 
 def test_unknown_transport_falls_back_to_stdio():
     run = _run_main({"HERMES_MCP_TRANSPORT": "carrier-pigeon"})
     run.assert_called_once_with(transport="stdio")
+
+
+class TestHttpTokenAuth(unittest.TestCase):
+    """#78: the HTTP transports expose every tool. A wide bind needs a secret."""
+
+    def test_wide_bind_without_a_token_refuses_to_start(self):
+        """The property that matters: it must not serve, not merely warn."""
+        with self.assertRaises(SystemExit) as ctx:
+            _run_http({"HERMES_MCP_TRANSPORT": "streamable-http",
+                       "HERMES_MCP_HOST": "0.0.0.0"})
+        msg = str(ctx.exception)
+        self.assertIn("HERMES_MCP_TOKEN", msg)
+        self.assertIn("0.0.0.0", msg)
+
+    def test_loopback_without_a_token_still_serves(self):
+        """Local development must not need a secret."""
+        urun = _run_http({"HERMES_MCP_TRANSPORT": "streamable-http"})
+        self.assertEqual(urun.call_args.kwargs["host"], "127.0.0.1")
+
+    def test_a_token_wraps_the_app_in_the_auth_gate(self):
+        urun = _run_http({"HERMES_MCP_TRANSPORT": "streamable-http",
+                          "HERMES_MCP_TOKEN": "s3cret"})
+        self.assertIsInstance(urun.call_args.args[0], server._BearerAuthMiddleware)
+
+    def test_no_token_leaves_the_app_unwrapped(self):
+        urun = _run_http({"HERMES_MCP_TRANSPORT": "streamable-http"})
+        self.assertIs(urun.call_args.args[0], mock.sentinel.http_app)
+
+    def test_ipv6_loopback_is_recognised(self):
+        urun = _run_http({"HERMES_MCP_TRANSPORT": "sse", "HERMES_MCP_HOST": "::1"})
+        self.assertEqual(urun.call_args.kwargs["host"], "::1")
+
+
+class TestBearerMiddleware(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.inner = mock.AsyncMock()
+        self.mw = server._BearerAuthMiddleware(self.inner, "s3cret")
+
+    async def _call(self, headers, path="/mcp"):
+        sent = []
+        scope = {"type": "http", "path": path, "headers": headers}
+        await self.mw(scope, mock.AsyncMock(), lambda m: sent.append(m) or _noop())
+        return sent
+
+    async def test_correct_token_passes_through(self):
+        sent = await self._call({b"authorization": b"Bearer s3cret"})
+        self.inner.assert_awaited_once()
+        self.assertEqual(sent, [])
+
+    async def test_wrong_token_is_401(self):
+        sent = await self._call({b"authorization": b"Bearer wrong"})
+        self.inner.assert_not_awaited()
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_missing_header_is_401(self):
+        sent = await self._call({})
+        self.inner.assert_not_awaited()
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_health_is_exempt(self):
+        """Liveness probes must work without the secret; /health discloses nothing."""
+        await self._call({}, path="/health")
+        self.inner.assert_awaited_once()
+
+    async def test_non_http_scope_passes_through(self):
+        await self.mw({"type": "lifespan"}, mock.AsyncMock(), mock.AsyncMock())
+        self.inner.assert_awaited_once()
+
+
+async def _noop():
+    return None


### PR DESCRIPTION
Closes #78.

#206 made the bind loopback by default. This is the other half — the token is
what makes a **non**-loopback bind defensible.

## Behaviour

| `HERMES_MCP_TOKEN` | bind | result |
|---|---|---|
| set | any | `Bearer` required on every request except `/health` |
| unset | loopback | serves, with a warning — local dev needs no secret |
| unset | non-loopback | **`SystemExit`**, with the command to generate a token |

The last row is the property that matters: it must not serve, not merely warn.

## Why not the SDK's `token_verifier`

It requires `AuthSettings` with an `issuer_url` — the full OAuth resource-server
model — and publishes `/.well-known/oauth-*` discovery describing an
authorization server that does not exist. A single secret shared between an
operator and their own server is not OAuth, and modelling it as OAuth advertises
a fiction.

## Why the startup path changed

`FastMCP.run()` builds its app internally with no injection point for middleware.
The HTTP transports are now served through `uvicorn` on `streamable_http_app()` /
`sse_app()`, which is what makes a gate possible. **stdio is untouched** and still
goes through `mcp.run()`.

## Details worth flagging

- `hmac.compare_digest` on **both** branches. A plain `==` leaks token length and
  prefix through timing; returning early on an absent header leaks whether a
  token was presented at all.
- `/health` is exempt so liveness probes work without the secret. It returns a
  fixed `{"status": "ok"}` and discloses nothing.
- IPv6 loopback (`::1`) is recognised, so it does not trip the refusal.

## Verified by sabotage, not just by passing

- gate always-allows → `test_wrong_token_is_401`, `test_missing_header_is_401` fail
- wide-bind refusal removed → `test_wide_bind_without_a_token_refuses_to_start` fails

`mcp/` suite: **677 passed** (only the pre-existing host-specific
`test_graph_integration` failure, identical on clean `main`). ruff clean.

`uvicorn` added to `mcp/requirements.txt` — transitive before, imported directly now.