### PR TITLE
feat(causal): derive edges from declared derived_from lineage (#192)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6705,6 +6705,63 @@ def _find_most_recent_investigation() -> tuple[str, list[dict]] | tuple[None, No
         return None, None
 
 
+def _declared_causal_edges(findings: list[dict]) -> list[dict]:
+    """Causal edges from author-declared lineage — the derived_from links.
+
+    investigation_store records derived_from so a retraction can follow what was
+    built on a false fact. That is the same relation causal inference tries to
+    guess from text, except stated by whoever wrote the finding rather than
+    inferred from keywords, so it is strictly better evidence and does not need
+    to be re-derived.
+
+    Measured on the live corpus, 136 investigations:
+
+        heuristic         62 edges
+        declared lineage 524 edges   (234 findings carrying 565 links)
+
+    causal_edges.jsonl nevertheless held zero records everywhere, because the
+    producer is only reached from memory_consolidate behind `not dry_run` and
+    `len(findings) >= 3`. The census reading of "zero output" was a statement
+    about invocation, not about either producer — the heuristic is not inert, it
+    had simply never run.
+
+    524 < 565 because derived_from also accepts free-text claim strings, and ids
+    pointing outside the investigation have no node to attach to.
+
+    Direction matches the heuristic's convention: source is the antecedent (the
+    finding depended on), target is the finding that declared the dependency.
+    """
+    known = {str(f.get("id")) for f in findings if f.get("id")}
+    edges: list[dict] = []
+    for f in findings:
+        target = str(f.get("id") or "")
+        if not target:
+            continue
+        raw = f.get("derived_from")
+        if not raw:
+            continue
+        parents = raw if isinstance(raw, (list, tuple)) else [raw]
+        for parent in parents:
+            source = str(parent or "").strip()
+            # derived_from also accepts free-text claim strings, not just ids.
+            # Only ids resolvable within this investigation become edges; a
+            # claim string has no node to point at.
+            if not source or source == target or source not in known:
+                continue
+            edges.append({
+                "id": str(uuid.uuid4()),
+                "source_id": source,
+                "target_id": target,
+                "edge_type": "caused_by",
+                # Declared, not inferred. Higher than the heuristic's 0.5 because
+                # an author saying "this builds on that" is testimony, not a guess.
+                "confidence": 0.9,
+                "inferred_at": _now(),
+                "method": "declared_lineage",
+            })
+    return edges
+
+
 def _heuristic_causal_edges(findings: list[dict]) -> list[dict]:
     """Infer causal edges heuristically from finding texts.
 
@@ -6746,6 +6803,22 @@ def _heuristic_causal_edges(findings: list[dict]) -> list[dict]:
                     "method": "heuristic",
                 })
     return edges
+
+
+def _merge_causal_edges(inferred: list[dict], declared: list[dict]) -> list[dict]:
+    """Union two edge sets; declared lineage wins any (source, target) collision.
+
+    An author's derived_from is testimony about their own reasoning. Anything the
+    text heuristic or the LLM pass concluded about the same pair is a guess at
+    the same fact, so it is replaced rather than kept alongside — two edges for
+    one relation would double-count it downstream.
+    """
+    by_pair: dict[tuple, dict] = {}
+    for edge in inferred:
+        by_pair[(edge.get("source_id"), edge.get("target_id"))] = edge
+    for edge in declared:
+        by_pair[(edge.get("source_id"), edge.get("target_id"))] = edge
+    return list(by_pair.values())
 
 
 def _run_causal_inference(investigation_id: str, findings: list[dict]) -> int:
@@ -6825,6 +6898,11 @@ def _run_causal_inference(investigation_id: str, findings: list[dict]) -> int:
             edges = _heuristic_causal_edges(findings)
         except Exception:
             edges = []
+
+    try:
+        edges = _merge_causal_edges(edges, _declared_causal_edges(findings))
+    except Exception as exc:
+        logger.debug("_run_causal_inference: declared-lineage pass failed (fail-open): %r", exc)
 
     if not edges:
         return 0

--- a/mcp/tests/test_causal_declared_lineage.py
+++ b/mcp/tests/test_causal_declared_lineage.py
@@ -1,0 +1,98 @@
+"""Causal edges from author-declared derived_from links.
+
+The shipped producer inferred causality from text: it required B to contain A's
+UUID literally, or A's first 60 characters as a substring plus a causal keyword.
+Meanwhile investigation_store was already recording derived_from — the same
+relation, stated by the author instead of guessed.
+
+Measured over 136 live investigations: heuristic 62 edges, declared 524.
+"""
+import unittest
+
+import server
+
+
+def _f(fid, text="some finding text", **kw):
+    return {"id": fid, "text": text, **kw}
+
+
+class DeclaredCausalEdgesTest(unittest.TestCase):
+
+    def test_a_declared_link_becomes_an_edge(self):
+        edges = server._declared_causal_edges([
+            _f("a", "the purge deleted the index"),
+            _f("b", "coverage collapsed", derived_from=["a"]),
+        ])
+        self.assertEqual(len(edges), 1)
+        e = edges[0]
+        self.assertEqual((e["source_id"], e["target_id"]), ("a", "b"))
+        self.assertEqual(e["method"], "declared_lineage")
+        self.assertEqual(e["edge_type"], "caused_by")
+        self.assertGreater(e["confidence"], 0.5,
+                           "declared lineage must outrank the heuristic's 0.5")
+
+    def test_a_bare_string_is_accepted_not_only_a_list(self):
+        edges = server._declared_causal_edges([_f("a"), _f("b", derived_from="a")])
+        self.assertEqual([(e["source_id"], e["target_id"]) for e in edges], [("a", "b")])
+
+    def test_multiple_parents_each_produce_an_edge(self):
+        edges = server._declared_causal_edges([
+            _f("a"), _f("b"), _f("c", derived_from=["a", "b"]),
+        ])
+        self.assertEqual(sorted(e["source_id"] for e in edges), ["a", "b"])
+
+    def test_a_claim_string_with_no_matching_finding_is_skipped(self):
+        """derived_from also accepts free text; that has no node to point at."""
+        edges = server._declared_causal_edges([
+            _f("b", derived_from=["the relay was already known to be down"]),
+        ])
+        self.assertEqual(edges, [])
+
+    def test_a_parent_outside_the_investigation_is_skipped(self):
+        edges = server._declared_causal_edges([_f("b", derived_from=["not-here"])])
+        self.assertEqual(edges, [])
+
+    def test_self_reference_is_skipped(self):
+        edges = server._declared_causal_edges([_f("a", derived_from=["a"])])
+        self.assertEqual(edges, [])
+
+    def test_findings_without_lineage_produce_nothing(self):
+        self.assertEqual(server._declared_causal_edges([_f("a"), _f("b")]), [])
+
+
+class MergeCausalEdgesTest(unittest.TestCase):
+    """Both lanes are kept; declared wins a collision.
+
+    The heuristic is not inert — it produces 62 edges on the live corpus — so
+    this is a union, not a replacement.
+    """
+
+    def _e(self, src, tgt, method, conf):
+        return {"source_id": src, "target_id": tgt, "method": method,
+                "confidence": conf, "edge_type": "caused_by"}
+
+    def test_non_colliding_edges_are_both_kept(self):
+        merged = server._merge_causal_edges(
+            [self._e("a", "b", "heuristic", 0.5)],
+            [self._e("c", "d", "declared_lineage", 0.9)],
+        )
+        self.assertEqual(
+            sorted((e["source_id"], e["target_id"]) for e in merged),
+            [("a", "b"), ("c", "d")],
+        )
+
+    def test_declared_replaces_an_inferred_edge_for_the_same_pair(self):
+        merged = server._merge_causal_edges(
+            [self._e("a", "b", "heuristic", 0.5)],
+            [self._e("a", "b", "declared_lineage", 0.9)],
+        )
+        self.assertEqual(len(merged), 1, "one relation must not yield two edges")
+        self.assertEqual(merged[0]["method"], "declared_lineage")
+
+    def test_an_empty_declared_set_leaves_inferred_edges_alone(self):
+        merged = server._merge_causal_edges([self._e("a", "b", "heuristic", 0.5)], [])
+        self.assertEqual([e["method"] for e in merged], ["heuristic"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was sitting unused

`investigation_store` records `derived_from` so a retraction can follow what was
built on a false fact. That is **the same relation** causal inference tries to
guess from text — except stated by the author rather than inferred from keywords.

Measured across 136 live investigations:

| producer | edges |
|---|---:|
| heuristic (text/keyword) | 62 |
| **declared lineage** | **524** |

234 findings carry 565 `derived_from` links. None of them were being read.

## Both lanes are kept

`_merge_causal_edges` unions them and lets declared win a `(source, target)`
collision — testimony outranks a guess at the same fact, and two edges for one
relation would double-count it downstream.

`524 < 565` because `derived_from` also accepts free-text claim strings, and ids
pointing outside the investigation have no node to attach to. Both are skipped
rather than emitted as dangling edges.

## Correcting my own issue

I filed #192 claiming the producer "can only ever return empty", and wrote that
into the first draft of this docstring before measuring. **It is not inert — it
produces 62 edges.**

`causal_edges.jsonl` was empty because `_run_causal_inference` is only reached
from `memory_consolidate` behind `not dry_run` and `len(findings) >= 3`, so
neither producer had ever run. The census's "zero output" was a fact about
invocation, not about the heuristic. The issue and the docstring both now say so.

## Tests

`mcp/tests/test_causal_declared_lineage.py`: 10 passed — bare-string and list
forms, multiple parents, claim strings, out-of-investigation ids, self-reference,
and the merge/collision behaviour.

Full `mcp/` suite: **677 passed** (only the pre-existing host-specific
`test_graph_integration` failure). ruff clean.