### PR TITLE
feat(memcheck): report the audit lane's state instead of an uninformative count (#193)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1616,6 +1616,7 @@ def _compute_self_check(investigation_id: str, llm_verify: bool = False) -> dict
         raw_findings = [f for f in raw_findings if str(f.get("id", "")) not in retracted]
     findings = _tag_finding_ids(raw_findings, investigation_id)
     audit_entries = _read_jsonl(_inv_dir(investigation_id) / "audit.jsonl")
+    audit_lane = _audit_lane_status(findings, audit_entries)
 
     try:
         unsupported = run_provenance(
@@ -1658,6 +1659,45 @@ def _compute_self_check(investigation_id: str, llm_verify: bool = False) -> dict
         "unsupported_observed": unsupported,
         "contradictions": contradictions,
         "hallucination_candidates": candidates,
+        "audit_lane": audit_lane,
+    }
+
+
+def _audit_lane_status(findings: list[dict], audit_entries: list[dict]) -> dict:
+    """Whether provenance verdicts on this investigation mean anything.
+
+    run_provenance flags every observed finding without a matching receipt, which
+    is the documented per-finding contract and is correct. But with NO receipts
+    at all it flags every observed finding it is given, and a verdict that fires
+    on 100% of its inputs carries no information.
+
+    Measured on the live corpus: 1 of 140 investigations has an audit.jsonl, and
+    nothing has written a receipt since 2026-06-20. The cause is structural —
+    audit_log is an MCP tool an agent has to remember to call after every
+    invocation, described as a "post-call hook" but not hooked to anything. When
+    whatever workflow was calling it stopped, the lane went silent and nothing
+    said so.
+
+    This does not change any verdict. It reports the lane's state so a caller can
+    say "no receipts exist" instead of "every observed finding is unsupported" —
+    two very different claims that were indistinguishable in the output.
+    """
+    observed = sum(1 for f in findings or []
+                   if (f.get("type") or f.get("record_type")) == "observed"
+                   and str(f.get("text", "") or "").strip())
+    receipts = sum(1 for e in audit_entries or [] if isinstance(e, dict))
+    if receipts:
+        return {"status": "present", "receipts": receipts, "observed_findings": observed}
+    return {
+        "status": "empty",
+        "receipts": 0,
+        "observed_findings": observed,
+        "verdicts_informative": False,
+        "detail": (
+            f"no audit receipts for this investigation, so all {observed} observed "
+            "finding(s) are reported unsupported by construction. This is the "
+            "absence of evidence about provenance, not evidence of bad provenance."
+        ),
     }
 
 
@@ -4242,7 +4282,7 @@ def memory_self_check(
             else []
         )
         all_candidates.extend(inv_candidates)
-        per_investigation.append({
+        entry = {
             "investigation_id": inv_id,
             "counts": {
                 "unsupported_observed": sum(
@@ -4255,7 +4295,15 @@ def memory_self_check(
             },
             "verdicts": [_verdict_view(v) for v in inv_verdicts],
             "hallucination_candidates": inv_candidates,
-        })
+        }
+        # Carry the lane's state next to the count it explains. An
+        # unsupported_observed count computed against zero receipts is the
+        # investigation's observed-finding count wearing a different name, and
+        # reporting it bare invites reading absence of evidence as evidence.
+        lane = computed.get("audit_lane") or {}
+        if "provenance" in requested and lane.get("status") == "empty":
+            entry["audit_lane"] = lane
+        per_investigation.append(entry)
 
     recorded = False
     if record and qdrant_available:

--- a/mcp/tests/test_audit_lane_status.py
+++ b/mcp/tests/test_audit_lane_status.py
@@ -1,0 +1,73 @@
+"""Reporting the audit lane's state, so verdicts about it can be read correctly.
+
+run_provenance flags every observed finding without a matching receipt. That is
+its documented contract and test_checks.py::test_observed_with_empty_audit_flagged
+pins it deliberately. But with NO receipts it flags every observed finding it is
+given, and a verdict firing on 100% of inputs carries no information.
+
+Measured: 1 of 140 live investigations has an audit.jsonl, and nothing has
+written a receipt since 2026-06-20. This reports that condition rather than
+changing any verdict.
+"""
+import unittest
+
+import server
+
+
+def _obs(text="the relay dropped at 03:39"):
+    return {"id": "f1", "type": "observed", "text": text, "source": "netscan"}
+
+
+class AuditLaneStatusTest(unittest.TestCase):
+
+    def test_empty_lane_is_reported_as_uninformative(self):
+        lane = server._audit_lane_status([_obs()], [])
+        self.assertEqual(lane["status"], "empty")
+        self.assertEqual(lane["receipts"], 0)
+        self.assertIs(lane["verdicts_informative"], False)
+        self.assertIn("absence of evidence", lane["detail"])
+
+    def test_the_detail_names_the_count_it_explains(self):
+        lane = server._audit_lane_status([_obs(), dict(_obs(), id="f2")], [])
+        self.assertEqual(lane["observed_findings"], 2)
+        self.assertIn("2 observed", lane["detail"])
+
+    def test_a_populated_lane_reports_present(self):
+        lane = server._audit_lane_status([_obs()], [{"tool": "netscan", "text": "x"}])
+        self.assertEqual(lane["status"], "present")
+        self.assertEqual(lane["receipts"], 1)
+        self.assertNotIn("verdicts_informative", lane)
+
+    def test_non_observed_findings_are_not_counted(self):
+        lane = server._audit_lane_status(
+            [{"id": "a", "type": "inferred", "text": "probably the relay"}], [])
+        self.assertEqual(lane["observed_findings"], 0)
+
+    def test_textless_observed_findings_are_not_counted(self):
+        """run_provenance skips them, so counting them would overstate the lane."""
+        lane = server._audit_lane_status([{"id": "a", "type": "observed", "text": "  "}], [])
+        self.assertEqual(lane["observed_findings"], 0)
+
+    def test_record_type_is_accepted_as_well_as_type(self):
+        lane = server._audit_lane_status(
+            [{"id": "a", "record_type": "observed", "text": "the relay dropped"}], [])
+        self.assertEqual(lane["observed_findings"], 1)
+
+    def test_malformed_audit_entries_do_not_count_as_receipts(self):
+        lane = server._audit_lane_status([_obs()], ["not a dict", None])
+        self.assertEqual(lane["status"], "empty")
+
+
+class ProvenanceContractUnchangedTest(unittest.TestCase):
+    """The per-finding contract must be untouched by the lane reporting."""
+
+    def test_an_observed_finding_with_no_receipt_is_still_flagged(self):
+        from memcheck.checks.provenance import run_provenance
+        results = run_provenance([_obs()], [])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].verdict_type, "unsupported_observed")
+        self.assertEqual(results[0].decision, "warn")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`run_provenance` flags every observed finding without a matching receipt. That is
its documented contract, and `test_checks.py::test_observed_with_empty_audit_flagged`
pins it deliberately — **so it is unchanged here.**

But with **no** receipts it flags every observed finding it is given, and a
verdict that fires on 100% of its inputs carries no information.

Measured on the live corpus, 141 investigations:

| | |
|---|---:|
| with receipts | **1** |
| without receipts | **140** |
| "unsupported" verdicts in those | **1682** |

Those 1,682 are the observed-finding count wearing a different name. Reporting it
bare invites reading absence of evidence as evidence of bad provenance.

## What changes

`_audit_lane_status` reports the lane's state; `memory_self_check` carries it
next to the count it explains:

```
no audit receipts for this investigation, so all 4 observed finding(s) are
reported unsupported by construction. This is the absence of evidence about
provenance, not evidence of bad provenance.
```

**No verdict changes.** This is reporting, not re-judging — the same reasoning
that led me to fix the consumer in #203 rather than override the tested
`run_provenance` contract.

## Root cause, which this does not fix

`audit_log` is an MCP tool an agent has to **remember to call** after every
invocation. It is documented as a "post-call hook" but nothing hooks it, so when
whatever workflow was calling it stopped on 2026-06-20, the lane went silent and
nothing said so.

Making receipts automatic is a real architectural change — every tool call
writing its full untruncated output — and deserves its own decision rather than
being smuggled in here. Until then, the honest move is to stop reporting a number
that only measures the lane's absence.

`mcp/` suite: **675 passed**. ruff clean.