### PR TITLE
feat(groom): schedule investigation_verify_all and the reflection loop (closes #194)

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -46,8 +46,10 @@ _ = wiring_obligation_declare
 _ = wiring_obligation_list
 _ = wiring_obligation_resolve
 _ = rag_context_search
-_ = reflection_loop_seed
-_ = reflection_loop_tick
+# reflection_loop_seed / reflection_loop_tick / investigation_verify_all were
+# here as tool surface with no local caller. scripts/loci_groom.py now calls
+# all three (#194), so vulture sees real references and the entries would
+# suppress nothing.
 _ = reflection_loop_status
 _ = conflict_list
 _ = conflict_resolve
@@ -85,7 +87,6 @@ _ = get_task
 # is the authority, and mcp/tests asserts its count.
 _ = health
 _ = finding_resolve
-_ = investigation_verify_all
 _ = loci_health
 _ = retrieval_selftest
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6057,7 +6057,9 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
 
     Returns:
         JSON: {"investigation_id": ..., "verified": N,
-               "results": [{"finding_id", "verdict", "confidence"}, ...]}
+               "results": [{"finding_id", "verdict", "confidence", "degraded"}, ...]}
+               ``degraded`` is True when no model could be reached, so a caller
+               can tell "the skeptic was uncertain" from "the skeptic never ran".
         On error: {"error": "<message>"}
     """
     manifest = _load_manifest(investigation_id)
@@ -6106,6 +6108,13 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
         )
         verdict = res.get("verdict", "uncertain")
         confidence = res.get("confidence", 0.0)
+        # verify_finding sets degraded=True when it could not reach a model, and
+        # returns uncertain/0.0 in exactly the same shape as a real judgement.
+        # Without carrying the flag, finding_verifications.jsonl cannot tell a
+        # considered "uncertain" from "nothing ran" — the file fills up and says
+        # nothing. Recorded, not suppressed: the note is still evidence that the
+        # finding was reached.
+        degraded = bool(res.get("degraded"))
         # Record as an append-only verification note in a SEPARATE log so these
         # accumulating records never slow the resolution read path — does NOT
         # touch resolution. Guarded per-finding: a single write failure (disk
@@ -6118,6 +6127,7 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
                 "finding_id": fid,
                 "verdict": verdict,
                 "confidence": confidence,
+                "degraded": degraded,
                 "ts": _now(),
             })
         except Exception as exc:  # noqa: BLE001 — never abort the batch on one write
@@ -6127,6 +6137,7 @@ def investigation_verify_all(investigation_id: str, limit: int = 20) -> str:
             "finding_id": fid,
             "verdict": verdict,
             "confidence": confidence,
+            "degraded": degraded,
         })
 
     return json.dumps({

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -110,6 +110,10 @@ GROOM_DIR = MEMORY_DIR / "_groom"
 # tier resolve its own. Set LOCI_GROOM_MODEL only to pin one deliberately.
 GROOM_MODEL = os.environ.get("LOCI_GROOM_MODEL") or None
 GROOM_BATCH = int(os.environ.get("LOCI_GROOM_BATCH", "16"))
+# Per-run ceilings. These bound a nightly job, not a human sitting in front of it.
+VERIFY_MAX_PER_RUN = int(os.environ.get("LOCI_GROOM_VERIFY_INVESTIGATIONS", "5"))
+VERIFY_PER_INVESTIGATION = int(os.environ.get("LOCI_GROOM_VERIFY_FINDINGS", "10"))
+REFLECT_MAX_ITEMS = int(os.environ.get("LOCI_GROOM_REFLECT_ITEMS", "3"))
 
 
 # --- corpus access ----------------------------------------------------------
@@ -891,12 +895,138 @@ def pass_codelink(limit: Optional[int] = None, calibrate: bool = False,
     return report
 
 
+def pass_verify(limit: Optional[int] = None, memory_dir: Optional[Path] = None,
+                verify_fn: Optional[Callable] = None,
+                gen_probe: Optional[Callable] = None, **_) -> dict:
+    """Batch adversarial-verify open findings, one investigation at a time.
+
+    investigation_verify_all is a correct, exposed tool that had never been
+    invoked: finding_verifications.jsonl held 0 records across 131
+    investigations (#194). Nothing was broken — nothing had ever called it.
+
+    Safe unattended because it is append-only to a SEPARATE file and explicitly
+    not a lifecycle change: a verdict is recorded as a verification note and does
+    not overwrite a finding's resolution. Bounded per run so a nightly pass
+    cannot turn into an unbounded model spend.
+    """
+    report = {"pass": "verify", "status": "ok"}
+    budget = int(limit or VERIFY_MAX_PER_RUN)
+
+    # Probe generation BEFORE verifying anything. verify_finding is fail-open: an
+    # unreachable model yields verdict='uncertain', confidence=0.0 for every
+    # finding, and investigation_verify_all writes those to
+    # finding_verifications.jsonl. Unattended, that fills an empty lane with
+    # records carrying no information — a file that looks populated and says
+    # nothing, which is the exact failure this tier exists to catch. Measured
+    # here on the first run: 5 records, all uncertain/0.0, because llm_local
+    # returns ok=False with no reason given.
+    if gen_probe is None:
+        def gen_probe():
+            sys.path.insert(0, str(_REPO / "mcp"))
+            from llm_local import generate
+            return bool(generate("Reply with OK.", max_tokens=8).get("ok"))
+    try:
+        if not gen_probe():
+            report.update(status="degraded",
+                          detail="generation backend is not answering; skipping rather "
+                                 "than writing uncertain/0.0 verdicts for every finding")
+            return report
+    except Exception as exc:
+        report.update(status="degraded", detail=f"generation probe failed: {exc!r}")
+        return report
+
+    if verify_fn is None:
+        try:
+            sys.path.insert(0, str(_REPO / "mcp"))
+            import server as _server
+            verify_fn = _server.investigation_verify_all
+        except Exception as exc:
+            report.update(status="degraded",
+                          detail=f"cannot import the verifier: {exc!r}")
+            return report
+
+    root = memory_dir or MEMORY_DIR
+    checked = verified = 0
+    errors = 0
+    for inv_dir in sorted(root.glob("*/findings.jsonl")):
+        if checked >= budget:
+            break
+        inv = inv_dir.parent.name
+        # Skip investigations already carrying verdicts, so repeated runs move
+        # through the corpus instead of re-verifying the same head every night.
+        if (inv_dir.parent / "finding_verifications.jsonl").exists():
+            continue
+        try:
+            raw = verify_fn(investigation_id=inv, limit=VERIFY_PER_INVESTIGATION)
+            payload = json.loads(raw) if isinstance(raw, str) else (raw or {})
+            n = len(payload.get("results") or payload.get("verifications") or [])
+            verified += n
+            checked += 1
+        except Exception as exc:
+            errors += 1
+            logger.debug("verify: %s failed: %r", inv, exc)
+    report.update(investigations_checked=checked, findings_verified=verified,
+                  errors=errors, budget=budget)
+    if errors and not checked:
+        report.update(status="degraded", detail=f"every attempt failed ({errors})")
+    return report
+
+
+def pass_reflect(limit: Optional[int] = None, seed_fn: Optional[Callable] = None,
+                 tick_fn: Optional[Callable] = None, **_) -> dict:
+    """Seed and tick the bounded self-reflection queue.
+
+    The loop had never ticked (#194) and no state file existed, so its queue was
+    never seeded — not because it lacks input: this host carries 25 copilot
+    session-state files, 3 process logs and 15 Claude Code project logs.
+
+    Safe unattended for two reasons that are worth stating, because a cron job
+    that manufactures findings is otherwise exactly what this project spent a
+    session learning not to build. Findings land in ONE dedicated investigation
+    ("Copilot self-reflection loop"), not scattered through the corpus. And the
+    tick is deterministic parsing with no model call, bounded by max_items and
+    max_lines_per_file.
+    """
+    report = {"pass": "reflect", "status": "ok"}
+    if seed_fn is None or tick_fn is None:
+        try:
+            sys.path.insert(0, str(_REPO / "mcp"))
+            import server as _server
+            seed_fn = seed_fn or _server.reflection_loop_seed
+            tick_fn = tick_fn or _server.reflection_loop_tick
+        except Exception as exc:
+            report.update(status="degraded",
+                          detail=f"cannot import the reflection loop: {exc!r}")
+            return report
+    try:
+        seeded = json.loads(seed_fn())
+        report["queued"] = seeded.get("queued", seeded.get("queue_size"))
+    except Exception as exc:
+        report.update(status="degraded", detail=f"seed failed: {exc!r}")
+        return report
+    try:
+        ticked = json.loads(tick_fn(max_items=int(limit or REFLECT_MAX_ITEMS)))
+        report["processed_items"] = ticked.get("processed_items", 0)
+        report["findings_written"] = ticked.get("findings_written", 0)
+        # remaining_queue, NOT queue_size. tick only emits queue_size on the
+        # empty-queue early return, so .get("queue_size", 0) reported a backlog
+        # of 0 while 262 items were still queued — a false zero of exactly the
+        # kind this tier exists to catch.
+        if "remaining_queue" in ticked:
+            report["remaining_queue"] = ticked["remaining_queue"]
+    except Exception as exc:
+        report.update(status="degraded", detail=f"tick failed: {exc!r}")
+    return report
+
+
 PASSES = {
     "index": {"fn": pass_index, "applyable": True},
     "tags": {"fn": pass_tags, "applyable": False},
     "recall": {"fn": pass_recall, "applyable": False},
     "knn_tags": {"fn": pass_knn_tags, "applyable": False},
     "codelink": {"fn": pass_codelink, "applyable": False},
+    "verify": {"fn": pass_verify, "applyable": False},
+    "reflect": {"fn": pass_reflect, "applyable": False},
 }
 
 

--- a/scripts/loci_groom_cron.sh
+++ b/scripts/loci_groom_cron.sh
@@ -38,8 +38,11 @@ printf '{"ts":%d,"pass":"%s","rc":%d,"summary":%s}\n' \
     >> "$STATE/runs.jsonl"
 
 if [ "$rc" -eq 3 ]; then
-    echo "loci-groom: pass '$pass' REFUSED or DEGRADED — corpus not groomed." >&2
-    echo "loci-groom: check loci_health retention_days; a non-zero purge window" >&2
-    echo "loci-groom: makes grooming an index-then-delete loop." >&2
+    # Print the pass's OWN reason. This used to state the retention diagnosis
+    # unconditionally, which is right for `index` and wrong for every other
+    # pass — a fixed explanation for a variable failure is how you get told the
+    # wrong cause with total confidence.
+    echo "loci-groom: pass '$pass' REFUSED or DEGRADED — not groomed." >&2
+    printf '%s\n' "$out" | grep -iE 'refused|degraded|detail=' | tail -2 >&2
 fi
 exit "$rc"

--- a/scripts/tests/test_groom_verify_reflect.py
+++ b/scripts/tests/test_groom_verify_reflect.py
@@ -1,0 +1,104 @@
+"""The two passes that wire up #194's dormant features.
+
+Neither feature was broken — investigation_verify_all and the reflection loop
+were correct, exposed code that had never been invoked. Scheduling them is the
+fix, but only with the guards below: a fail-open verifier and a cron job are a
+bad combination without them.
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import loci_groom as g
+
+
+class PassVerifyGateTest(unittest.TestCase):
+    """verify_finding is fail-open: no model -> uncertain/0.0 for EVERY finding.
+
+    investigation_verify_all writes those to finding_verifications.jsonl, so an
+    unattended run against a dead backend fills an empty lane with records that
+    carry no information. Measured on the first real run: 5 records, all
+    uncertain/0.0. The pass must refuse instead.
+    """
+
+    def test_a_dead_generation_backend_degrades_and_writes_nothing(self):
+        called = []
+        rep = g.pass_verify(gen_probe=lambda: False,
+                            verify_fn=lambda **kw: called.append(kw) or "{}")
+        self.assertEqual(rep["status"], "degraded")
+        self.assertIn("generation backend", rep["detail"])
+        self.assertEqual(called, [], "must not verify anything with no model")
+
+    def test_a_raising_probe_also_degrades(self):
+        rep = g.pass_verify(gen_probe=lambda: (_ for _ in ()).throw(OSError("refused")))
+        self.assertEqual(rep["status"], "degraded")
+
+    def test_a_live_backend_proceeds(self):
+        seen = []
+
+        def fake_verify(investigation_id, limit):
+            seen.append(investigation_id)
+            return json.dumps({"results": [{"finding_id": "x", "verdict": "confirmed",
+                                            "confidence": 0.8, "degraded": False}]})
+
+        rep = g.pass_verify(gen_probe=lambda: True, verify_fn=fake_verify, limit=2)
+        self.assertEqual(rep["status"], "ok")
+        self.assertGreaterEqual(rep["investigations_checked"], 0)
+
+
+class PassReflectReportingTest(unittest.TestCase):
+    """The backlog number has to be true.
+
+    reflection_loop_tick emits `remaining_queue`; it only emits `queue_size` on
+    the empty-queue early return. Reading queue_size with a default of 0 reported
+    a backlog of 0 while 262 items were still queued.
+    """
+
+    def test_the_remaining_backlog_is_reported_not_defaulted_to_zero(self):
+        rep = g.pass_reflect(
+            seed_fn=lambda: json.dumps({"queued": 260}),
+            tick_fn=lambda **kw: json.dumps({"processed_items": 3,
+                                             "findings_written": 1,
+                                             "remaining_queue": 257}),
+        )
+        self.assertEqual(rep["status"], "ok")
+        self.assertEqual(rep["remaining_queue"], 257)
+        self.assertNotIn("queue_size", rep)
+
+    def test_an_absent_backlog_key_is_omitted_rather_than_reported_as_zero(self):
+        rep = g.pass_reflect(
+            seed_fn=lambda: json.dumps({"queued": 5}),
+            tick_fn=lambda **kw: json.dumps({"processed_items": 1, "findings_written": 0}),
+        )
+        self.assertNotIn("remaining_queue", rep,
+                         "a missing backlog must not be reported as an empty one")
+
+    def test_a_failing_seed_degrades_without_ticking(self):
+        ticked = []
+        rep = g.pass_reflect(
+            seed_fn=lambda: (_ for _ in ()).throw(RuntimeError("no sources")),
+            tick_fn=lambda **kw: ticked.append(kw) or "{}",
+        )
+        self.assertEqual(rep["status"], "degraded")
+        self.assertEqual(ticked, [])
+
+    def test_a_failing_tick_degrades(self):
+        rep = g.pass_reflect(
+            seed_fn=lambda: json.dumps({"queued": 5}),
+            tick_fn=lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        self.assertEqual(rep["status"], "degraded")
+
+
+class PassRegistryTest(unittest.TestCase):
+    def test_both_passes_are_registered_and_not_applyable(self):
+        for name in ("verify", "reflect"):
+            self.assertIn(name, g.PASSES)
+            self.assertFalse(g.PASSES[name]["applyable"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #194.

## The decision

Wire them. Neither was broken — `investigation_verify_all` and the reflection
loop were correct, exposed code that had **never been invoked**
(`finding_verifications.jsonl`: 0 records across 131 investigations; no
reflection state file at all). The blocker was that nothing ran them, and until
the cron work landed there was nowhere to run them from.

## Two guards, both found by running the passes rather than reasoning about them

**1. A fail-open verifier plus a cron job is a lie-feed generator.**

`verify_finding` returns `uncertain` / `0.0` when it cannot reach a model — in
exactly the shape of a real judgement — and `investigation_verify_all` writes
that to disk. My first real run produced **5 records, every one uncertain/0.0**,
because `llm_local` returns `ok=False` with no reason given. Unattended, that
fills an empty lane with records carrying no information.

`pass_verify` now probes generation first and degrades (**exit 3**) instead. The
5 records were deleted.

The verification record also now carries `degraded`, so the file cannot claim a
considered "uncertain" when nothing ran. Recorded rather than suppressed — the
note is still evidence the finding was reached.

**2. A false zero, in the tier built to catch false zeros.**

`reflection_loop_tick` emits `remaining_queue`. It only emits `queue_size` on the
empty-queue early return. My draft read `queue_size` with a default of `0` and
reported a backlog of **0 while 262 items were queued**. Now it reads the right
key and omits the field rather than defaulting when it is absent.

## Also fixed

The cron wrapper printed the retention diagnosis for **every** exit 3 — correct
for `index`, wrong for everything else. It now prints the pass's own reason. A
fixed explanation for a variable failure is how you get told the wrong cause with
total confidence.

```
loci-groom: pass 'verify' REFUSED or DEGRADED — not groomed.
[groom] verify: degraded detail=generation backend is not answering; skipping
        rather than writing uncertain/0.0 verdicts for every finding
```

## Safety of running reflection unattended

Findings land in **one dedicated investigation** ("Copilot self-reflection
loop"), not scattered through the corpus, and the tick is deterministic parsing
with no model call, bounded by `max_items` and `max_lines_per_file`. Verified
live: seeded 260, processed 3, wrote 1 finding, 257 remaining.

Bounded per run — 5 investigations × 10 findings, 3 reflection items, all
env-overridable.

## Not yet scheduled

`verify` degrades until the local model answers, so adding it to crontab now
would just mail an exit 3 every night. The pass is ready; the schedule waits on
the backend.

`scripts/` **125 passed**, `mcp/` **667 passed**. ruff clean.