### PR TITLE
fix: bound the accumulating structures from the memory-leak audit (#107)

### DIFF
--- a/mcp/memcheck/backend.py
+++ b/mcp/memcheck/backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import os
 import math
 from dataclasses import dataclass
 
@@ -103,10 +104,30 @@ class InMemoryBackend(VerdictBackend):
     must mirror.
     """
 
-    def __init__(self) -> None:
+    #: Bound on retained verdicts. The reference backend is documented as the
+    #: canonical semantics for the persistent ones, and those evict; a list that
+    #: only ever grows is not the same semantics. Also stops a long-lived
+    #: in-memory engine from retaining every verdict for the process lifetime.
+    MAX_VERDICTS = int(os.environ.get("LOCI_INMEMORY_MAX_VERDICTS", "10000"))
+
+    def __init__(self, max_verdicts: int | None = None) -> None:
         self._verdicts: list[Verdict] = []
         self._embeddings: dict[str, list[float]] = {}  # verdict.id -> embedding
+        self._max = int(max_verdicts if max_verdicts is not None else self.MAX_VERDICTS)
         self._lock = asyncio.Lock()
+
+    def _evict(self) -> None:
+        """Drop oldest verdicts past the bound, and their orphaned embeddings.
+
+        Called with the lock held. Evicting the list without the embedding dict
+        would swap one unbounded structure for another.
+        """
+        if self._max <= 0 or len(self._verdicts) <= self._max:
+            return
+        drop = self._verdicts[:-self._max]
+        self._verdicts = self._verdicts[-self._max:]
+        for v in drop:
+            self._embeddings.pop(v.id, None)
 
     async def record(self, verdict: Verdict) -> None:
         # The embedding must be supplied for coalescing; pull it from the caller
@@ -141,6 +162,7 @@ class InMemoryBackend(VerdictBackend):
             self._verdicts.append(verdict)
             if embedding:
                 self._embeddings[verdict.id] = embedding
+            self._evict()
 
     async def recall(
         self,

--- a/mcp/memcheck/daemon.py
+++ b/mcp/memcheck/daemon.py
@@ -29,6 +29,7 @@ import logging
 import json
 import os
 import signal
+import socket
 import socketserver
 import stat
 import sys
@@ -53,6 +54,9 @@ DEFAULT_SOCKET = "~/.hermes/memcheck.sock"
 # A request is at most a single PreToolUse payload; bound how much we will read
 # so a runaway/hostile client cannot exhaust memory.
 _MAX_REQUEST_BYTES = 4 * 1024 * 1024
+# Hooks are latency-sensitive and local; a real client sends its payload and
+# half-closes immediately. Anything slower than this is stalled, not slow.
+_REQUEST_TIMEOUT_S = float(os.environ.get("LOCI_MEMCHECK_READ_TIMEOUT_S", "5"))
 
 
 def _resolve(override: Optional[str]) -> Path:
@@ -170,11 +174,32 @@ class _Handler(socketserver.BaseRequestHandler):
             except Exception as exc:  # noqa: BLE001
                 logger.debug("handle: fail-open swallow: %r", exc)
 
+    def setup(self) -> None:
+        # A client that connects, sends nothing and never half-closes would block
+        # this worker in recv() forever. daemon_threads lets the PROCESS exit, but
+        # the thread is still gone for good and request_queue_size is 64 — enough
+        # stalled clients and the daemon stops answering while looking healthy.
+        super().setup()
+        try:
+            self.request.settimeout(_REQUEST_TIMEOUT_S)
+        except OSError as exc:
+            logger.debug("_Handler.setup: settimeout failed: %r", exc)
+
     def _read_all(self) -> bytes:
         chunks: list[bytes] = []
         total = 0
         while True:
-            chunk = self.request.recv(65536)
+            try:
+                chunk = self.request.recv(65536)
+            except socket.timeout:
+                # Return what arrived. Incomplete JSON falls through to the
+                # existing malformed-payload path rather than hanging the worker.
+                logger.debug("_Handler: read timed out after %ss with %d byte(s)",
+                             _REQUEST_TIMEOUT_S, total)
+                break
+            except OSError as exc:
+                logger.debug("_Handler: read failed: %r", exc)
+                break
             if not chunk:
                 break
             chunks.append(chunk)

--- a/mcp/tests/test_bounded_caches.py
+++ b/mcp/tests/test_bounded_caches.py
@@ -1,0 +1,125 @@
+"""Bounds on the accumulating structures from #107.
+
+The audit listed seven items. Three of the target artifacts do not exist on this
+host yet (`.emb_cache.npz`, the mlops loop state, and the *default* sync-cache
+dir), so those bounds are preventive. Two are live: the session-sync cache the
+Stop hook actually writes (`HERMES_SYNC_CACHE`, 7 files), and the daemon's
+unbounded recv().
+"""
+import asyncio
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import unittest.mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hooks"))
+
+from memcheck.backend import InMemoryBackend  # noqa: E402
+from memcheck.verdict import new_verdict  # noqa: E402
+
+
+def _emb(i, n=64):
+    """One-hot: distinct verdicts must be mutually DISSIMILAR or the backend
+    coalesces them by cosine similarity and nothing accumulates to evict.
+    [i,i,i,i]-style vectors are all parallel — cosine 1.0 — which is how the
+    first draft of this test measured coalescing instead of eviction."""
+    v = [0.0] * n
+    v[i % n] = 1.0
+    return v
+
+
+def _v(i):
+    return new_verdict(subject_kind="memory", subject_signature=f"s{i}",
+                       subject_excerpt="", verdict_type="unsupported_observed",
+                       decision="warn", confidence=0.5, rationale="", source="rule")
+
+
+class InMemoryBackendBoundTest(unittest.TestCase):
+    """The reference backend documents the semantics the persistent ones mirror.
+    Those evict; a list that only grows is not the same semantics."""
+
+    def test_verdicts_are_capped(self):
+        b = InMemoryBackend(max_verdicts=10)
+        async def run():
+            for i in range(25):
+                await b.record_with_embedding(_v(i), _emb(i))
+        asyncio.run(run())
+        self.assertEqual(len(b._verdicts), 10)
+
+    def test_eviction_drops_the_oldest(self):
+        b = InMemoryBackend(max_verdicts=5)
+        async def run():
+            for i in range(12):
+                await b.record_with_embedding(_v(i), _emb(i))
+        asyncio.run(run())
+        kept = [v.subject_signature for v in b._verdicts]
+        self.assertEqual(kept, [f"s{i}" for i in range(7, 12)])
+
+    def test_embeddings_are_evicted_with_their_verdicts(self):
+        """Capping the list alone would swap one unbounded structure for another."""
+        b = InMemoryBackend(max_verdicts=5)
+        async def run():
+            for i in range(20):
+                await b.record_with_embedding(_v(i), _emb(i))
+        asyncio.run(run())
+        self.assertLessEqual(len(b._embeddings), 5)
+        self.assertEqual(set(b._embeddings), {v.id for v in b._verdicts})
+
+    def test_zero_disables_the_bound(self):
+        b = InMemoryBackend(max_verdicts=0)
+        async def run():
+            for i in range(30):
+                await b.record_with_embedding(_v(i), _emb(i))
+        asyncio.run(run())
+        self.assertEqual(len(b._verdicts), 30)
+
+
+class DaemonReadTimeoutTest(unittest.TestCase):
+    """A client that connects and never speaks must not own a worker forever."""
+
+    def test_a_silent_client_does_not_hang_the_worker(self):
+        from memcheck import daemon
+        sock_dir = tempfile.mkdtemp()
+        path = os.path.join(sock_dir, "s.sock")
+        ready = threading.Event()
+        srv = {}
+
+        def run():
+            s = daemon.MemcheckDaemon(  # type: ignore[call-arg]
+                __import__("pathlib").Path(path),
+                engine_factory=lambda: None,
+            )
+            srv["s"] = s
+            ready.set()
+            s.serve_forever(poll_interval=0.05)
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        self.assertTrue(ready.wait(5), "daemon did not start")
+        try:
+            with unittest.mock.patch.object(daemon, "_REQUEST_TIMEOUT_S", 0.3):
+                c = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                c.settimeout(5)
+                c.connect(path)
+                # connect, then say nothing and never half-close
+                t0 = time.monotonic()
+                try:
+                    c.recv(4096)          # server should close after its timeout
+                except (socket.timeout, OSError):
+                    pass
+                elapsed = time.monotonic() - t0
+                c.close()
+            self.assertLess(elapsed, 4.0,
+                            "worker stayed blocked on a silent client")
+        finally:
+            srv["s"].shutdown()
+            srv["s"].server_close()
+
+
+if __name__ == "__main__":
+    import unittest.mock  # noqa: F401
+    unittest.main()

--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -30,7 +30,18 @@ def _load_cache() -> dict:
     return {}
 
 
+# Cap the on-disk embedding cache. Every unseen text adds a 768-float entry and
+# nothing ever removed one, so the file grew for the life of the checkout.
+# Bounded rather than rotated: the cache is a pure speedup — a miss costs one
+# re-embed, never a wrong answer — so dropping the oldest entries is free.
+EMB_CACHE_MAX = int(os.environ.get("LOCI_EMB_CACHE_MAX", "50000"))
+
+
 def _save_cache(cache: dict) -> None:
+    if len(cache) > EMB_CACHE_MAX:
+        # dict preserves insertion order, so this keeps the most recent entries
+        keep = list(cache)[-EMB_CACHE_MAX:]
+        cache = {k: cache[k] for k in keep}
     np.savez_compressed(CACHE_PATH, **cache)
 
 

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -344,6 +344,9 @@ def _emit_embedding_trigger() -> None:
 
 # ── Main loop ─────────────────────────────────────────────────────────────────
 
+RUNS_SEEN_MAX = int(os.environ.get("LOCI_RUNS_SEEN_MAX", "1000"))
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Loci MLOps self-closing loop")
     ap.add_argument("--findings", default=DEFAULT_FINDINGS,
@@ -425,7 +428,11 @@ def main() -> None:
                     print("[loop] canary held back or drift detected — keeping current model")
 
         state["last_dataset_size"] = new_size
-        state["runs_seen"] = state["runs_seen"] + new_runs
+        # Truncate: runs_seen only exists to skip runs already ingested, so the
+        # tail is what matters. It appended forever and was rewritten in full on
+        # every tick, so the state file grew without bound and got slower to
+        # write as it went.
+        state["runs_seen"] = (state["runs_seen"] + new_runs)[-RUNS_SEEN_MAX:]
 
     # ── 7a. Weibull memory decay (runs every loop tick) ──────────────────────
     loop_count = state.get("total_loop_runs", 0) + 1

--- a/scripts/hooks/session_end_sync.py
+++ b/scripts/hooks/session_end_sync.py
@@ -155,6 +155,38 @@ def get_session_content(session_id: str):
     except Exception:
         return None
 
+# One file per session id, forever. A session that will never be seen again keeps
+# its counter indefinitely, so the directory grows with every session the machine
+# ever runs. The cache only answers "how many messages had this session synced
+# last time", which is meaningless once the session is over.
+CACHE_TTL_DAYS = int(os.environ.get("HERMES_SYNC_CACHE_TTL_DAYS", "7"))
+
+
+def prune_cache(now: float | None = None) -> int:
+    """Delete cache entries older than CACHE_TTL_DAYS. Returns how many went.
+
+    Fail-open per file: an unreadable or already-deleted entry is skipped rather
+    than aborting a hook that runs at the end of every session.
+    """
+    if CACHE_TTL_DAYS <= 0:
+        return 0
+    cutoff = (now if now is not None else time.time()) - CACHE_TTL_DAYS * 86400
+    removed = 0
+    try:
+        entries = os.listdir(CACHE_DIR)
+    except OSError:
+        return 0
+    for name in entries:
+        fp = os.path.join(CACHE_DIR, name)
+        try:
+            if os.path.isfile(fp) and os.path.getmtime(fp) < cutoff:
+                os.unlink(fp)
+                removed += 1
+        except OSError:
+            continue
+    return removed
+
+
 def cache_path(session_id: str) -> str:
     os.makedirs(CACHE_DIR, exist_ok=True)
     return os.path.join(CACHE_DIR, hashlib.md5(session_id.encode()).hexdigest()[:12])
@@ -260,6 +292,18 @@ def main():
     session_id = read_stdin_session_id()
     if not session_id:
         sys.exit(0)
+
+    # Prune before doing work. This hook is the only thing that writes the cache,
+    # so it is the only place that can retire it, and end-of-session is when the
+    # entries that will never be read again are created.
+    try:
+        gone = prune_cache()
+        if gone:
+            print(f"[session_end_sync] pruned {gone} cache entr"
+                  f"{'y' if gone == 1 else 'ies'} older than {CACHE_TTL_DAYS}d",
+                  file=sys.stderr)
+    except Exception as e:
+        print(f"[session_end_sync] cache prune skipped: {e}", file=sys.stderr)
 
     sess = get_session_content(session_id)
     if not sess:


### PR DESCRIPTION
Five of the six items left open on #107.

## Measured before fixing

Three target artifacts do not exist on this host, so those bounds are
**preventive** — worth saying plainly rather than implying a live leak was fixed.

| item | state | fix |
|---|---|---|
| session-sync cache | **LIVE** — 7 files | prune entries older than 7d at hook start |
| daemon `recv()` | **LIVE** — no timeout at all | 5s socket timeout |
| `.emb_cache.npz` | absent (training never ran) | cap at 50k, oldest dropped |
| `runs_seen` | no state file yet | truncate to last 1000 |
| `InMemoryBackend` | in-process only | cap at 10k, evicting embeddings too |

The sync-cache item first read as inactive because the audit named the **default**
dir. The live Stop hook overrides `HERMES_SYNC_CACHE` to a profile path — that one
has files in it.

## `goroutine_leak-1` is not included

It asks for *"join in finally block or set `daemon=True`"*. The stopper thread is
**already** `daemon=True` (`daemon.py:255`). Nothing to do, and I am not claiming
it as fixed.

## `goroutine_leak-0` was real

`_read_all` looped on `recv()` with no timeout. A client that connects, sends
nothing, and never half-closes owned a worker thread **forever**.
`daemon_threads` lets the *process* exit, but the thread is gone and
`request_queue_size` is 64 — enough stalled clients and the daemon stops
answering while still looking healthy.

A timed-out read now returns what arrived and falls through to the existing
malformed-payload path, rather than hanging.

## Verified by sabotage

- remove `_evict()` → `25 != 10`, oldest retained
- remove `settimeout` → worker blocked **5.02s** (the client's own timeout)
  instead of the server closing

## Two mistakes worth recording

Both caught by *running* the code, not compiling it:

1. My prune code called `log()`. **That function does not exist** in
   `session_end_sync.py` — it uses `print(..., file=sys.stderr)`. The call inside
   the `except` block would have raised `NameError` uncaught and crashed the Stop
   hook on **every session end**. `py_compile` passes it happily.
2. The first eviction test used `[i,i,i,i]` embeddings — all parallel, cosine
   1.0 — so the backend coalesced them and the test measured *coalescing*, not
   eviction. One-hot vectors now, with a comment saying why.

`mcp/` **700 passed**, `scripts/` **125 passed** (only the pre-existing
host-specific `test_graph_integration` failure). ruff and vulture clean.