### PR TITLE
fix(qdrant): one definition of the quantized-search params, used by every path

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -474,6 +474,28 @@ def _qdrant_degraded_mode(enabled: bool, available: bool, errors, query_success:
 # but anything >= 1024 is defensible and the 1024-vs-2048 gap was noise.
 RERANK_MAX_CHARS = int(os.environ.get("LOCI_RERANK_MAX_CHARS", "1024"))
 
+# One definition of the quantized-search parameters, used by every query path.
+# rescore=True re-scores ANN candidates against the original full-precision
+# vectors, recovering the ~0.5-1% recall INT8 costs; oversampling=2.0 gives the
+# rescore twice the candidates to choose from.
+#
+# Built lazily because qdrant_client is an optional import at module scope.
+_QUANT_SEARCH_PARAMS = None
+
+
+def _quant_search_params():
+    """Shared SearchParams. Was hand-built at each call site, and the site that
+    forgot it (retrieval_selftest) was then diagnosing a different search path
+    from the one production runs."""
+    global _QUANT_SEARCH_PARAMS
+    if _QUANT_SEARCH_PARAMS is None:
+        from qdrant_client.models import SearchParams, QuantizationSearchParams
+        _QUANT_SEARCH_PARAMS = SearchParams(
+            quantization=QuantizationSearchParams(rescore=True, oversampling=2.0)
+        )
+    return _QUANT_SEARCH_PARAMS
+
+
 
 def _ce_rerank(query: str, rows: list[dict], top_k: int) -> tuple[list[dict], bool]:
     """Cross-encoder rerank of ``rows`` against ``query``, truncated to ``top_k``.
@@ -556,13 +578,7 @@ def _qdrant_similarity_search(
     output_k = min(rerank_top_k, limit) if rerank_top_k is not None else limit
     fetch_limit = output_k * 5 if rerank else limit * 4
 
-    from qdrant_client.models import SearchParams, QuantizationSearchParams
-    # rescore=True: after ANN candidate selection from quantized index, re-score
-    # with original full-precision vectors. Recovers ~0.5-1% recall lost to INT8.
-    # oversampling fetches 2x candidates to give rescore more to work with.
-    _search_params = SearchParams(
-        quantization=QuantizationSearchParams(rescore=True, oversampling=2.0)
-    )
+    _search_params = _quant_search_params()
 
     sparse_vec = _embed_sparse(query)
     if sparse_vec is not None:
@@ -725,7 +741,11 @@ def probe_collection(query_vec, client, name: str, limit: int = 3) -> dict:
         )
         return out
 
-    kwargs = {"collection_name": name, "query": query_vec, "limit": limit, "with_payload": False}
+    # search_params matters here: without it this probe queries a different path
+    # from the one production uses, so a green selftest would not mean the real
+    # search works.
+    kwargs = {"collection_name": name, "query": query_vec, "limit": limit,
+              "with_payload": False, "search_params": _quant_search_params()}
     try:
         dense_name = _dense_vector_name(client, name) if shape["named"] else None
         if dense_name:
@@ -766,7 +786,7 @@ def _qdrant_search_collection(
     fetch_limit = limit * 5
     sparse_vec = _embed_sparse(query)
 
-    from qdrant_client.models import Prefetch, FusionQuery, Fusion, SearchParams, QuantizationSearchParams
+    from qdrant_client.models import Prefetch, FusionQuery, Fusion
 
     # Detect whether this collection uses named vectors (dense/sparse) or a flat vector.
     try:
@@ -783,7 +803,7 @@ def _qdrant_search_collection(
     if has_named_vectors and dense_name is None:
         has_named_vectors = False        # nothing nameable to query; fall through to flat
 
-    _qsp = SearchParams(quantization=QuantizationSearchParams(rescore=True, oversampling=2.0))
+    _qsp = _quant_search_params()
 
     if has_named_vectors and has_sparse_index and sparse_vec is not None:
         result = client.query_points(

--- a/mcp/tests/test_quant_search_params.py
+++ b/mcp/tests/test_quant_search_params.py
@@ -1,0 +1,56 @@
+"""Every query path uses the same quantized-search parameters.
+
+The params were hand-built at two call sites and forgotten at a third —
+probe_collection, which backs retrieval_selftest. A diagnostic that queries
+without rescore/oversampling is measuring a different search path from the one
+production runs, so a green selftest would not mean the real search works.
+
+hermes_memory is INT8-quantized (quantile=0.99, always_ram=True); it is the only
+collection on the instance that is. rescore re-scores ANN candidates against the
+original full-precision vectors, so omitting it changes what comes back.
+"""
+import unittest
+from unittest import mock
+
+import qdrant_ops
+
+
+class SharedSearchParamsTest(unittest.TestCase):
+
+    def test_the_params_are_rescore_and_oversampled(self):
+        sp = qdrant_ops._quant_search_params()
+        self.assertTrue(sp.quantization.rescore)
+        self.assertEqual(sp.quantization.oversampling, 2.0)
+
+    def test_one_instance_is_reused(self):
+        self.assertIs(qdrant_ops._quant_search_params(),
+                      qdrant_ops._quant_search_params())
+
+    def test_probe_collection_passes_them_to_query_points(self):
+        """The site that forgot them. This is the regression."""
+        client = mock.MagicMock()
+        client.get_collection.return_value.config.params.vectors = {
+            "dense": mock.MagicMock(size=768)
+        }
+        client.count.return_value.count = 10
+        client.query_points.return_value.points = []
+        with mock.patch.object(qdrant_ops, "_collection_shape",
+                               return_value={"named": True, "dense_dims": [768],
+                                             "points": 10, "sparse": False}), \
+             mock.patch.object(qdrant_ops, "_dense_vector_name", return_value="dense"):
+            qdrant_ops.probe_collection([0.0] * 768, client, "hermes_memory", 3)
+        kw = client.query_points.call_args.kwargs
+        self.assertIn("search_params", kw,
+                      "probe_collection must query the same path production does")
+        self.assertTrue(kw["search_params"].quantization.rescore)
+
+    def test_no_call_site_builds_its_own_copy(self):
+        """Three hand-built copies is how one of them drifted. Keep it to one."""
+        src = open(qdrant_ops.__file__).read()
+        built = src.count("QuantizationSearchParams(")
+        self.assertEqual(built, 1,
+                         f"{built} construction sites; the shared helper should be the only one")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`probe_collection` — which backs `retrieval_selftest` — called `query_points`
**without** `search_params`.

`hermes_memory` is INT8-quantized (`quantile=0.99`, `always_ram=True`) and is the
**only** collection on the instance that is. `rescore=True` re-scores ANN
candidates against the original full-precision vectors, so omitting it changes
what comes back. The diagnostic was measuring a different search path from the
one production runs — **a green selftest did not mean the real search worked.**

## Fixed as a class, not a third patch

The params were hand-built at two call sites and forgotten at a third. Adding a
fourth copy would preserve exactly the condition that let one drift.

One `_quant_search_params()` helper now — lazy, because `qdrant_client` is an
optional import at module scope — used by all three sites.

`test_no_call_site_builds_its_own_copy` greps the module and asserts
`QuantizationSearchParams(` appears **exactly once**, so it cannot re-fragment.

## Verified on the wire

Not from reading the source:

```
captured kwargs: [collection_name, limit, query, search_params, using, with_payload]
search_params:   rescore=True  oversampling=2.0
probe status=ok  hits=5
```

Sabotage: dropping `search_params` from `probe_collection` fails with
`'search_params' not found in {...}` — the defect itself, not an incidental error.

## No memory win here, and worth saying so

`hermes_memory` is **2,706 points × 768d** — 8.3 MB float32, 2.1 MB quantized.
Measured median latency **3.1 ms** with rescore vs **3.6 ms** without.

Quantization on this collection is about the diagnostic being honest, not about
resources. (The instance's real headroom is `agent_core_chunks` at 6M points /
18.6 GB float32 — not a Loci collection, and not touched here.)

`mcp/` **710 passed** (only the pre-existing host-specific `test_graph_integration`
failure). ruff clean, vulture whitelist clean.