### PR TITLE
fix(llm): resolve generation separately from embeddings, and say why on failure

### DIFF
--- a/mcp/backends.py
+++ b/mcp/backends.py
@@ -98,6 +98,39 @@ def ollama_url(probe_timeout: float = 1.0) -> str:
     return _cfg("ollama", "url", "") or ""
 
 
+def ollama_gen_url(probe_timeout: float = 1.0) -> str:
+    """Ollama base URL for GENERATION, which is not always the embedding one.
+
+    Reachability is not capability. An Ollama that answers /api/tags may carry no
+    generation model at all: on this host the in-cluster instance serves only
+    nomic-embed-text, so it satisfies _alive() and then fails every generate()
+    call. ollama_url() resolved to it and llm_local inherited the choice.
+
+    They also want opposite things. Measured here: embeddings 93 ms in-cluster vs
+    5,595 ms over the tailnet, while the generation model only exists over the
+    tailnet (35.7 s cold, 247 ms warm with keep_alive). One URL cannot serve both
+    well, so generation gets its own.
+
+    Resolution: LOCI_OLLAMA_GEN_URL / OLLAMA_GEN_URL -> [ollama].gen_url ->
+    ollama_url() as a last resort, so a host with a single capable Ollama needs no
+    extra config.
+    """
+    env = os.environ.get("LOCI_OLLAMA_GEN_URL") or os.environ.get("OLLAMA_GEN_URL")
+    if env:
+        return env
+    configured = _cfg("ollama", "gen_url", "") or ""
+    if configured:
+        return configured
+    return ollama_url(probe_timeout)
+
+
+def ollama_gen_model() -> str:
+    """Generation model tag. Env -> [ollama].gen_model -> the verified-good default."""
+    return (os.environ.get("LOCI_OLLAMA_GEN_MODEL")
+            or _cfg("ollama", "gen_model", "")
+            or "qwen2.5:3b")
+
+
 @functools.lru_cache(maxsize=8)
 def vllm_url(probe_timeout: float = 1.0) -> str:
     """vLLM/OpenAI base URL: env -> local probe -> config -> '' (batched_gen falls back to Ollama).

--- a/mcp/llm_local.py
+++ b/mcp/llm_local.py
@@ -31,9 +31,15 @@ _OLLAMA = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_URL") or "
 
 
 def _resolve_ollama() -> str:
+    """The GENERATION endpoint, which is not necessarily the embedding one.
+
+    This used to call backends.ollama_url() and inherit whichever Ollama answered
+    a reachability probe first. That instance serves only nomic-embed-text here,
+    so every generate() call failed against a server that was demonstrably up.
+    """
     try:
         import backends
-        return backends.ollama_url()
+        return backends.ollama_gen_url()
     except Exception:
         return ""
 
@@ -43,7 +49,7 @@ _TIMEOUT = float(os.environ.get("OLLAMA_GEN_TIMEOUT", "120"))
 
 
 def generate(prompt: str,
-             model: str = "qwen2.5:3b",
+             model: str = "",
              fmt: Optional[str] = None,
              max_tokens: int = 256,
              temperature: float = 0.2,
@@ -63,10 +69,30 @@ def generate(prompt: str,
     Returns:
         {'text': str, 'ok': bool, 'model': str}. On any failure text='' and ok=False.
     """
-    fail = {"text": "", "ok": False, "model": model}
+    if not model:
+        try:
+            import backends
+            model = backends.ollama_gen_model()
+        except Exception:
+            model = "qwen2.5:3b"
+
+    def fail(why: str) -> dict:
+        """Degraded, but never silent.
+
+        This used to be a bare `return fail` that discarded the exception, so a
+        misconfigured backend produced {'text':'','ok':False} with nothing to act
+        on. That cost a live diagnosis: the verify groom pass degraded for a day
+        and the reason -- a model name no server recognised -- was sitting in a
+        swallowed exception the whole time.
+        """
+        return {"text": "", "ok": False, "model": model, "why": why}
+
     base = _OLLAMA or _resolve_ollama()   # env wins; else backends (local probe -> config)
-    if not prompt or not base:
-        return fail
+    if not prompt:
+        return fail("empty prompt")
+    if not base:
+        return fail("no Ollama endpoint resolved (OLLAMA_BASE_URL unset and backends "
+                    "returned nothing)")
 
     body = {
         "model": model,
@@ -86,14 +112,61 @@ def generate(prompt: str,
         r = requests.post(f"{base}/api/generate", json=body, timeout=_TIMEOUT)
         r.raise_for_status()
         text = (r.json().get("response") or "")
-    except Exception:
-        return fail
+    except Exception as exc:
+        # Ollama could not serve this. Try the vLLM tier before giving up: on this
+        # host Ollama carries only nomic-embed-text (an EMBEDDING model, no
+        # generation model at all) while vLLM serves the generation model under a
+        # different name -- Qwen/Qwen2.5-3B-Instruct, not the Ollama-style
+        # qwen2.5:3b. Asking one server for the other's name fails on both.
+        fallback = _try_vllm(prompt, fmt=fmt, max_tokens=max_tokens,
+                             temperature=temperature)
+        if fallback is not None:
+            return fallback
+        return fail(f"ollama {type(exc).__name__}: {exc}"[:300])
 
     if fmt == "json":
         # ok=True only if the body actually parses as JSON.
         try:
             json.loads(text)
-        except Exception:
-            return {"text": text, "ok": False, "model": model}
+        except Exception as exc:
+            return {"text": text, "ok": False, "model": model,
+                    "why": f"response was not valid JSON: {exc}"[:200]}
 
     return {"text": text, "ok": True, "model": model}
+
+
+def _try_vllm(prompt: str, *, fmt: Optional[str], max_tokens: int,
+              temperature: float) -> Optional[dict]:
+    """Second tier. Returns a result dict, or None if vLLM is not usable either.
+
+    batched_gen already resolves the vLLM endpoint AND the model name the server
+    actually registers (backends.vllm_model()), which is the part llm_local was
+    getting wrong. Reusing it keeps one definition of both.
+    """
+    try:
+        import batched_gen
+    except Exception:
+        return None
+    try:
+        out = batched_gen.generate_batch([prompt], max_tokens=max_tokens, fmt=fmt,
+                                         temperature=temperature)
+    except TypeError:
+        # older signature without temperature
+        try:
+            out = batched_gen.generate_batch([prompt], max_tokens=max_tokens, fmt=fmt)
+        except Exception:
+            return None
+    except Exception:
+        return None
+    if not out:
+        return None
+    first = out[0] or {}
+    if not first.get("ok"):
+        return None
+    served = first.get("model")
+    if not served:
+        try:
+            served = batched_gen._resolve_vllm_model()
+        except Exception:
+            served = "vllm"
+    return {"text": first.get("text", ""), "ok": True, "model": served, "tier": "vllm"}

--- a/mcp/tests/test_llm_local.py
+++ b/mcp/tests/test_llm_local.py
@@ -4,6 +4,7 @@ No live Ollama: requests.post is monkeypatched with a fake response object. Cove
 happy path, HTTP-error fail-open, JSON-format validation, and that keep_alive + format
 are actually placed in the posted payload.
 """
+import pytest
 import json
 import os
 import sys
@@ -51,6 +52,25 @@ def _ensure_base(monkeypatch):
     monkeypatch.setattr(L, "_OLLAMA", "http://fake-ollama:11434")
 
 
+@pytest.fixture(autouse=True)
+def _no_vllm_fallback(monkeypatch):
+    """Keep these tests on the Ollama path and off the network.
+
+    generate() now falls through to the vLLM tier when Ollama fails, so every
+    fail-open test below would otherwise attempt a real request to whatever
+    backends resolves. The fallback has its own tests in
+    test_llm_local_fallback.py; here it is disabled so a failure means what the
+    test name says it means.
+    """
+    monkeypatch.setattr(L, "_try_vllm", lambda *a, **k: None)
+    # Pin the model too. generate() now resolves it via backends.ollama_gen_model(),
+    # which reads ~/.loci/backends.toml -- so without this these tests assert
+    # against whatever the OPERATOR has configured, passing locally and failing in
+    # CI (or vice versa). A unit test must not depend on a machine's config.
+    import backends
+    monkeypatch.setattr(backends, "ollama_gen_model", lambda: "qwen2.5:3b")
+
+
 def test_happy_path_ok_true(monkeypatch):
     _ensure_base(monkeypatch)
     _install_post(monkeypatch, resp=_FakeResp({"response": "hello world"}))
@@ -73,7 +93,13 @@ def test_exception_never_raises(monkeypatch):
     _ensure_base(monkeypatch)
     _install_post(monkeypatch, exc=TimeoutError("timed out"))
     r = L.generate("say hi")  # must not raise
-    assert r == {"text": "", "ok": False, "model": "qwen2.5:3b"}
+    assert r["ok"] is False
+    assert r["text"] == ""
+    assert r["model"] == "qwen2.5:3b"
+    # The failure must carry its reason. This asserted the exact dict, which is
+    # why adding `why` broke it -- and the absence of a reason here is exactly
+    # what made a misconfigured endpoint take a live diagnosis to find.
+    assert "timed out" in r["why"]
 
 
 def test_json_fmt_invalid_body_not_ok(monkeypatch):
@@ -116,6 +142,15 @@ def test_payload_omits_format_when_not_json(monkeypatch):
 
 
 def test_no_base_url_fails_open(monkeypatch):
+    """No endpoint at all -- which means stubbing the RESOLVER too.
+
+    This set only _OLLAMA and passed because _resolve_ollama() fell back to an
+    endpoint that happened to be incapable of generating. Once generation was
+    pointed at a host that works, the test failed -- correctly, because it had
+    been asserting "the resolved backend is broken", not "there is no backend".
+    """
     monkeypatch.setattr(L, "_OLLAMA", "")
+    monkeypatch.setattr(L, "_resolve_ollama", lambda: "")
     r = L.generate("say hi")
     assert r["ok"] is False and r["text"] == ""
+    assert "no Ollama endpoint" in r["why"]

--- a/mcp/tests/test_llm_local_fallback.py
+++ b/mcp/tests/test_llm_local_fallback.py
@@ -1,0 +1,145 @@
+"""llm_local: say why it failed, and try the tier that works.
+
+generate() targeted Ollama only, with a hardcoded model tag, and swallowed the
+exception on failure — returning {'text':'','ok':False} with nothing to act on.
+
+Measured on this host: Ollama serves ONLY nomic-embed-text (an embedding model,
+no generation model at all) while vLLM serves the generation model under a
+different name — Qwen/Qwen2.5-3B-Instruct, not the Ollama-style qwen2.5:3b.
+Asking either server for the other's name fails, and the reason was discarded.
+
+Consequence: verify_finding returned degraded=True with empty reasoning for every
+finding, and the verify groom pass refused to run (correctly) rather than write
+uncertain/0.0 records. The cause sat in a swallowed exception.
+"""
+import unittest
+from unittest import mock
+
+import llm_local
+
+
+class FailuresAreExplainedTest(unittest.TestCase):
+
+    def test_an_empty_prompt_says_so(self):
+        r = llm_local.generate("")
+        self.assertFalse(r["ok"])
+        self.assertIn("empty prompt", r["why"])
+
+    def test_no_endpoint_says_so(self):
+        with mock.patch.object(llm_local, "_OLLAMA", ""), \
+             mock.patch.object(llm_local, "_resolve_ollama", return_value=""):
+            r = llm_local.generate("hello")
+        self.assertFalse(r["ok"])
+        self.assertIn("no Ollama endpoint", r["why"])
+
+    def test_a_transport_failure_carries_the_exception(self):
+        """The regression: this used to return ok=False with no reason at all."""
+        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch.object(llm_local, "_try_vllm", return_value=None), \
+             mock.patch("requests.post", side_effect=OSError("connection refused")):
+            r = llm_local.generate("hello")
+        self.assertFalse(r["ok"])
+        self.assertIn("OSError", r["why"])
+        self.assertIn("connection refused", r["why"])
+
+    def test_unparseable_json_says_so_rather_than_just_failing(self):
+        resp = mock.MagicMock()
+        resp.json.return_value = {"response": "not json at all"}
+        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch("requests.post", return_value=resp):
+            r = llm_local.generate("hello", fmt="json")
+        self.assertFalse(r["ok"])
+        self.assertIn("not valid JSON", r["why"])
+
+
+class VllmFallbackTest(unittest.TestCase):
+
+    def test_ollama_failure_falls_through_to_vllm(self):
+        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch("requests.post", side_effect=OSError("refused")), \
+             mock.patch.object(llm_local, "_try_vllm",
+                               return_value={"text": "OK", "ok": True,
+                                             "model": "Qwen/Qwen2.5-3B-Instruct",
+                                             "tier": "vllm"}):
+            r = llm_local.generate("hello")
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["tier"], "vllm")
+
+    def test_a_successful_ollama_call_does_not_reach_vllm(self):
+        resp = mock.MagicMock()
+        resp.json.return_value = {"response": "hi"}
+        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch("requests.post", return_value=resp), \
+             mock.patch.object(llm_local, "_try_vllm") as vllm:
+            r = llm_local.generate("hello")
+        self.assertTrue(r["ok"])
+        vllm.assert_not_called()
+
+    def test_vllm_declining_leaves_the_ollama_reason_intact(self):
+        """Both tiers down must not hide WHICH failed or why."""
+        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch("requests.post", side_effect=OSError("refused")), \
+             mock.patch.object(llm_local, "_try_vllm", return_value=None):
+            r = llm_local.generate("hello")
+        self.assertFalse(r["ok"])
+        self.assertIn("ollama", r["why"])
+
+    def test_a_vllm_result_that_is_not_ok_is_not_returned_as_success(self):
+        with mock.patch.object(llm_local, "batched_gen", create=True):
+            with mock.patch.dict("sys.modules"):
+                fake = mock.MagicMock()
+                fake.generate_batch.return_value = [{"text": "", "ok": False}]
+                with mock.patch.dict("sys.modules", {"batched_gen": fake}):
+                    self.assertIsNone(
+                        llm_local._try_vllm("hi", fmt=None, max_tokens=8, temperature=0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class GenerationEndpointResolutionTest(unittest.TestCase):
+    """Reachability is not capability.
+
+    backends.ollama_url() resolves env -> reachability probe -> config, and the
+    probe only asks whether something ANSWERS. The in-cluster Ollama here serves
+    only nomic-embed-text, so it passed the probe and then failed every
+    generate() call. Measured: embeddings 93ms in-cluster vs 5595ms over the
+    tailnet; the generation model exists only over the tailnet. One URL cannot
+    serve both, so generation resolves separately.
+    """
+
+    def test_gen_url_prefers_its_own_env_var(self):
+        import backends
+        with mock.patch.dict("os.environ", {"LOCI_OLLAMA_GEN_URL": "http://gen:1"}):
+            self.assertEqual(backends.ollama_gen_url(), "http://gen:1")
+
+    def test_gen_url_prefers_config_over_the_embedding_url(self):
+        import backends
+        with mock.patch.dict("os.environ", {}, clear=False):
+            os_env = {k: v for k, v in __import__("os").environ.items()
+                      if k not in ("LOCI_OLLAMA_GEN_URL", "OLLAMA_GEN_URL")}
+            with mock.patch.dict("os.environ", os_env, clear=True), \
+                 mock.patch.object(backends, "_cfg", side_effect=lambda s, k, d="": {
+                     ("ollama", "gen_url"): "http://oxalis:11434"}.get((s, k), d)), \
+                 mock.patch.object(backends, "ollama_url", return_value="http://incluster:11434"):
+                self.assertEqual(backends.ollama_gen_url(), "http://oxalis:11434")
+
+    def test_gen_url_falls_back_to_the_embedding_url_when_unconfigured(self):
+        """A host with one capable Ollama must need no extra config."""
+        import backends
+        with mock.patch.dict("os.environ", {}, clear=True), \
+             mock.patch.object(backends, "_cfg", return_value=""), \
+             mock.patch.object(backends, "ollama_url", return_value="http://only:11434"):
+            self.assertEqual(backends.ollama_gen_url(), "http://only:11434")
+
+    def test_generate_uses_the_configured_model_not_a_hardcoded_tag(self):
+        import backends
+        resp = mock.MagicMock()
+        resp.json.return_value = {"response": "hi"}
+        with mock.patch.object(backends, "ollama_gen_model", return_value="some-model:7b"), \
+             mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch("requests.post", return_value=resp) as post:
+            r = llm_local.generate("hello")
+        self.assertEqual(r["model"], "some-model:7b")
+        self.assertEqual(post.call_args.kwargs["json"]["model"], "some-model:7b")


### PR DESCRIPTION
`llm_local.generate()` returned `{'text':'','ok':False}` for every call with **no
reason**. So `verify_finding` returned `degraded=True` with empty reasoning, and
the verify groom pass (#194) correctly refused to run rather than write
`uncertain`/`0.0` records for every finding.

Three defects, each hiding the next.

## 1. The silence

```python
except Exception:
    return fail          # the reason, discarded
```

A misconfigured backend was indistinguishable from a working one with nothing to
say. **Fixed first**, because it is what turned a config error into a live
diagnosis. Every failure path now carries `why`.

## 2. The endpoint

`backends.ollama_url()` resolves env → **reachability probe** → config. And
reachability is not capability: the in-cluster Ollama serves **only
`nomic-embed-text`**, so it answers `/api/tags` happily and then fails every
generate call. Generation had silently inherited the embedding endpoint.

## 3. The conflation

One URL cannot serve both. Measured:

| | in-cluster | over the tailnet |
|---|---:|---:|
| embeddings | **93 ms** | 5,595 ms |
| generation | impossible | **247 ms warm** (35.7 s cold) |

Generation now resolves via `ollama_gen_url()` / `ollama_gen_model()`, falling
back to `ollama_url()` so a host with one capable Ollama needs no extra config.
Embeddings keep the fast in-cluster path untouched.

A vLLM fallback stays as a backstop, reusing `batched_gen` — which already
resolves the model name the server actually registers, the part `llm_local` was
getting wrong.

## Result

| | before | after |
|---|---|---|
| `verify_finding` | `degraded=True`, empty reasoning | `degraded=False`, real reasoning |
| groom `verify` pass | `rc=3`, refused | `rc=0`, 14 verified, 0 errors |

## Three ways the tests went non-hermetic under this change

All introduced by this change, all fixed:

- the fallback would send **every fail-open test at the real network**
- the model now comes from `~/.loci/backends.toml`, so tests asserted against
  whatever the **operator** configured — passing locally, failing in CI
- `test_no_base_url_fails_open` stubbed only `_OLLAMA`, not the resolver, and had
  been **passing for the wrong reason** — because the resolved endpoint was
  incapable, not absent. Point generation at a host that works and it fails,
  correctly.

Verified hermetic by running the suite under a hostile `LOCI_OLLAMA_GEN_MODEL`
override while the real config stays on the chosen model.

`mcp/` **729 passed** (only the pre-existing host-specific `test_graph_integration`
failure). ruff clean, vulture whitelist clean.