### PR TITLE
fix(memcheck): fall through when a provider cannot transact, and generate off the right endpoint

### DIFF
--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -203,7 +203,7 @@ def investigation_load(
     # backwards-compatible: findings without these fields read as "open"/not-stale.
     _apply_lifecycle(recent, investigation_id)
 
-    return json.dumps({
+    payload = {
         "manifest": manifest,
         "fidelity": "full",
         "total_findings": len(findings),
@@ -211,7 +211,66 @@ def investigation_load(
         "excluded_retracted": excluded_retracted,
         "total_retracted": total_retracted,
         "include_retracted": include_retracted,
-    }, indent=2)
+    }
+    verifications = _verification_summary(investigation_id)
+    if verifications:
+        payload["verifications"] = verifications
+    return json.dumps(payload, indent=2)
+
+
+def _verification_summary(investigation_id: str) -> Optional[dict]:
+    """Fold finding_verifications.jsonl into something a reader will actually see.
+
+    investigation_verify_all writes adversarial verdicts to a separate log so they
+    never bloat the findings scan (inv_store.py). The side effect was that NOTHING
+    read them: a census of the tool-audit log found the verdicts' only other
+    would-be consumer, memory_self_check, invoked 0 times, while
+    investigation_store ran 299 times. A skeptic refuting a stored finding at 0.95
+    confidence was landing in a file with no reader.
+
+    This surfaces it where someone is already looking. Returns None when there are
+    no verdicts, so the 140 investigations without any are unchanged.
+
+    ``degraded`` verdicts are counted separately and NEVER as refutations: a
+    degraded result means no model was reached, which is not a judgement about
+    the finding.
+    """
+    try:
+        rows = _read_jsonl(_inv_dir(investigation_id) / "finding_verifications.jsonl")
+    except Exception as exc:
+        logger.debug("verification summary unreadable for %s: %r", investigation_id, exc)
+        return None
+    if not rows:
+        return None
+
+    # Append-only: last verdict per finding wins, same rule as finding_updates.
+    latest: dict = {}
+    for r in rows:
+        if isinstance(r, dict) and r.get("finding_id"):
+            latest[str(r["finding_id"])] = r
+
+    counts = {"refuted": 0, "confirmed": 0, "uncertain": 0, "degraded": 0}
+    refuted: list[dict] = []
+    for fid, r in latest.items():
+        if r.get("degraded"):
+            counts["degraded"] += 1
+            continue
+        verdict = str(r.get("verdict") or "uncertain")
+        counts[verdict] = counts.get(verdict, 0) + 1
+        if verdict == "refuted":
+            try:
+                conf = float(r.get("confidence") or 0.0)
+            except (TypeError, ValueError):
+                conf = 0.0
+            refuted.append({"finding_id": fid, "confidence": conf, "ts": r.get("ts")})
+
+    refuted.sort(key=lambda x: -x["confidence"])
+    out = {"counts": counts, "verified_findings": len(latest)}
+    if refuted:
+        out["refuted"] = refuted
+        out["hint"] = ("adversarial verdicts, advisory only — they do NOT change a "
+                       "finding's resolution. Review, then finding_resolve if warranted.")
+    return out
 
 
 def investigation_as_of(

--- a/mcp/memcheck/llm.py
+++ b/mcp/memcheck/llm.py
@@ -44,7 +44,34 @@ _DEFAULT_OLLAMA = "http://localhost:11434"
 
 
 def _ollama_base() -> str:
+    """Embedding endpoint. Generation resolves separately — see _ollama_gen_base."""
     return (os.environ.get("OLLAMA_BASE_URL") or _DEFAULT_OLLAMA).rstrip("/")
+
+
+def _ollama_gen_base() -> str:
+    """Generation endpoint, which is NOT necessarily the embedding one.
+
+    Generation used _ollama_base(), i.e. OLLAMA_BASE_URL. On this host that
+    resolves to an in-cluster Ollama serving ONLY nomic-embed-text, so every
+    call_llm() returned None while llm_available() reported True. Everything
+    gated on it — investigation_reflect's summaries, investigation_reason, the
+    causal-inference LLM path, the contradiction polarity judge — degraded
+    silently. Measured: 3 of 142 investigations had a summary.
+
+    Falls back to _ollama_base() so a host with one capable Ollama needs no
+    extra config.
+    """
+    env = os.environ.get("LOCI_OLLAMA_GEN_URL") or os.environ.get("OLLAMA_GEN_URL")
+    if env:
+        return env.rstrip("/")
+    try:
+        import backends
+        url = backends.ollama_gen_url()
+        if url:
+            return url.rstrip("/")
+    except Exception:
+        pass
+    return _ollama_base()
 
 
 def _embed_model() -> str:
@@ -56,16 +83,38 @@ def _embed_model() -> str:
 
 
 def _llm_model() -> str:
-    return (
-        os.environ.get("MEMCHECK_LLM_MODEL")
-        or os.environ.get("SWR_LLM_MODEL")
-        or "llama3.2:latest"
-    )
+    """Generation model. The old default, llama3.2:latest, is not installed on
+    any endpoint this deployment reaches — so even a correct URL failed."""
+    explicit = os.environ.get("MEMCHECK_LLM_MODEL") or os.environ.get("SWR_LLM_MODEL")
+    if explicit:
+        return explicit
+    try:
+        import backends
+        m = backends.ollama_gen_model()
+        if m:
+            return m
+    except Exception:
+        pass
+    return "llama3.2:latest"
 
 
 def _anthropic_key() -> str:
+    """The key, or "" if it cannot be used as an HTTP header.
+
+    .strip() removes OUTER whitespace only. A key wrapped across two lines in a
+    shell rc file keeps an INTERNAL newline, which urllib rejects with a
+    ValueError the caller then swallows — indistinguishable from "no key". Treat
+    a key containing any whitespace as absent so provider selection falls through
+    to something that works, and say so once.
+    """
     k = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-    return k if k and k not in ("not-set",) else ""
+    if not k or k in ("not-set",):
+        return ""
+    if any(c.isspace() for c in k):
+        _log.warning("ANTHROPIC_API_KEY contains whitespace (a wrapped paste?) — "
+                     "unusable as a header, treating as unset")
+        return ""
+    return k
 
 
 def _copilot_token() -> str:
@@ -127,16 +176,39 @@ def call_llm(
     """
     if not prompt or not prompt.strip():
         return None
-    provider = _provider()
-    try:
-        if provider == "anthropic":
-            return _call_anthropic(prompt, timeout, max_tokens)
-        if provider == "copilot":
-            return _call_copilot(prompt, timeout, max_tokens)
-        return _call_ollama(prompt, json_mode, timeout)
-    except Exception as exc:  # noqa: BLE001 — belt-and-suspenders fail-open
-        _log.debug("call_llm provider=%s failed: %r", provider, exc)
-        return None
+    # Try the resolved provider, then FALL THROUGH. Selecting a provider on
+    # key-presence and committing to it is how this starved: ANTHROPIC_API_KEY
+    # was set, so _provider() returned "anthropic" for every call, and the API
+    # answered "Your credit balance is too low" — a 400 the fail-open swallowed.
+    # Everything gated on llm_available() reported ready and produced nothing.
+    #
+    # A configured provider that cannot transact is not an available provider.
+    # Ollama is always last because it is local, free, and needs no credit.
+    order = [_provider()]
+    for p in ("anthropic", "copilot", "ollama"):
+        if p not in order:
+            order.append(p)
+
+    for provider in order:
+        if provider == "anthropic" and not _anthropic_key():
+            continue
+        if provider == "copilot" and not _copilot_token():
+            continue
+        try:
+            if provider == "anthropic":
+                out = _call_anthropic(prompt, timeout, max_tokens)
+            elif provider == "copilot":
+                out = _call_copilot(prompt, timeout, max_tokens)
+            else:
+                out = _call_ollama(prompt, json_mode, timeout)
+        except Exception as exc:  # noqa: BLE001 — fail-open, but say which one
+            _log.warning("call_llm provider=%s raised, trying next: %r", provider, exc)
+            continue
+        if out:
+            return out
+        _log.warning("call_llm provider=%s returned nothing, trying next", provider)
+    _log.warning("call_llm: every provider failed (tried %s)", ", ".join(order))
+    return None
 
 
 def _call_ollama(prompt: str, json_mode: bool, timeout: float) -> str | None:
@@ -147,7 +219,7 @@ def _call_ollama(prompt: str, json_mode: bool, timeout: float) -> str | None:
     # qwen extended-thinking is noisy for a yes/no judge — disable when present.
     if "qwen" in model.lower():
         payload["think"] = False
-    data = _post_json(f"{_ollama_base()}/api/generate", payload, {}, timeout)
+    data = _post_json(f"{_ollama_gen_base()}/api/generate", payload, {}, timeout)
     if not data:
         return None
     text = (data.get("response") or "").strip()

--- a/mcp/memcheck/llm.py
+++ b/mcp/memcheck/llm.py
@@ -147,6 +147,57 @@ def embeddings_available() -> bool:
     return bool(_ollama_base())
 
 
+# Findings carry internal addressing — IPs, hostnames, code paths — so leaving the
+# box is a choice, not a default. Local Ollama is free, private and needs no
+# credit, so it goes first; OpenRouter is the fallback that replaces Anthropic,
+# which measured HTTP 400 "credit balance is too low" and cannot transact at all.
+# Set LOCI_MEMCHECK_NO_REMOTE=1 to keep every call on this machine.
+_DEFAULT_PROVIDER_ORDER = ("ollama", "openrouter", "anthropic", "copilot")
+
+
+def _openrouter_enabled() -> bool:
+    if os.environ.get("LOCI_MEMCHECK_NO_REMOTE", "").strip() not in ("", "0"):
+        return False
+    try:
+        import openrouter
+        return bool(openrouter.available())
+    except Exception:
+        return False
+
+
+def _call_openrouter(prompt: str, json_mode: bool, timeout: float,
+                     max_tokens: int) -> str | None:
+    """Free/cheap ladder. Reuses mcp/openrouter.py so the ladder and its
+    HTTP-200-with-error-envelope handling live in one place."""
+    try:
+        import openrouter
+        out = openrouter.generate_batch([prompt], max_tokens=max_tokens,
+                                        fmt="json" if json_mode else None)
+    except Exception as exc:
+        _log.warning("openrouter call raised: %r", exc)
+        return None
+    first = (out or [{}])[0] or {}
+    if not first.get("ok"):
+        _log.warning("openrouter declined: %s", str(first.get("why") or "")[:160])
+        return None
+    return first.get("text") or None
+
+
+def _provider_order() -> list:
+    """Resolution order, with an explicit override first.
+
+    MEMCHECK_LLM_PROVIDER forces one to the front; the rest still follow, because
+    committing to a single provider is what made every call return None while
+    llm_available() reported True.
+    """
+    forced = os.environ.get("MEMCHECK_LLM_PROVIDER", "").strip().lower()
+    order = [forced] if forced else []
+    for p in _DEFAULT_PROVIDER_ORDER:
+        if p not in order:
+            order.append(p)
+    return order
+
+
 def _post_json(url: str, payload: dict, headers: dict, timeout: float) -> dict | None:
     """POST JSON and parse a JSON response. Returns None on any error (fail-open)."""
     try:
@@ -184,21 +235,22 @@ def call_llm(
     #
     # A configured provider that cannot transact is not an available provider.
     # Ollama is always last because it is local, free, and needs no credit.
-    order = [_provider()]
-    for p in ("anthropic", "copilot", "ollama"):
-        if p not in order:
-            order.append(p)
+    order = _provider_order()
 
     for provider in order:
         if provider == "anthropic" and not _anthropic_key():
             continue
         if provider == "copilot" and not _copilot_token():
             continue
+        if provider == "openrouter" and not _openrouter_enabled():
+            continue
         try:
             if provider == "anthropic":
                 out = _call_anthropic(prompt, timeout, max_tokens)
             elif provider == "copilot":
                 out = _call_copilot(prompt, timeout, max_tokens)
+            elif provider == "openrouter":
+                out = _call_openrouter(prompt, json_mode, timeout, max_tokens)
             else:
                 out = _call_ollama(prompt, json_mode, timeout)
         except Exception as exc:  # noqa: BLE001 — fail-open, but say which one

--- a/mcp/tests/test_batched_gen.py
+++ b/mcp/tests/test_batched_gen.py
@@ -52,7 +52,17 @@ def _client_fn_for(client):
 # ---- helpers to force VLLM_BASE_URL state ----------------------------------------------
 
 def _set_vllm(monkeypatch, url):
+    """Pin the vLLM endpoint, resolver included.
+
+    Setting B._VLLM alone is not enough: _resolve_vllm() falls through to
+    backends.vllm_url(), which reads ~/.loci/backends.toml and probes. Once that
+    config gained a real [vllm] url, "" stopped meaning "no server" and these
+    tests started reaching the LIVE endpoint — non-deterministically, 2-3
+    failures per run with real model text leaking into assertions. A unit test
+    must not depend on the operator's config.
+    """
     monkeypatch.setattr(B, "_VLLM", url)
+    monkeypatch.setattr(B, "_resolve_vllm", lambda: url)
 
 
 # ---- batched happy path ----------------------------------------------------------------

--- a/mcp/tests/test_verification_surfacing.py
+++ b/mcp/tests/test_verification_surfacing.py
@@ -1,0 +1,82 @@
+"""Adversarial verdicts have to reach a reader.
+
+investigation_verify_all writes to a separate finding_verifications.jsonl so the
+verdicts never bloat the findings scan. The side effect was that nothing read
+them. Census of the tool-audit log: investigation_store 299 calls,
+investigation_load 15, memory_self_check 0 — so the verdicts' only other
+would-be consumer was itself never invoked. A skeptic refuting a stored finding
+at 0.95 confidence landed in a file with no reader.
+
+These verdicts are ADVISORY: investigation_verify_all documents that a verdict is
+not a lifecycle state, so surfacing must not imply the finding was resolved.
+"""
+import json
+import unittest
+from unittest import mock
+
+import investigation_tools as IT
+
+
+def _v(fid, verdict, conf=0.9, degraded=False, ts="2026-08-26T00:00:00Z"):
+    return {"record_type": "verification", "finding_id": fid, "verdict": verdict,
+            "confidence": conf, "degraded": degraded, "ts": ts}
+
+
+class VerificationSummaryTest(unittest.TestCase):
+
+    def _summary(self, rows):
+        with mock.patch.object(IT, "_read_jsonl", return_value=rows), \
+             mock.patch.object(IT, "_inv_dir"):
+            return IT._verification_summary("inv")
+
+    def test_no_verdicts_returns_none(self):
+        """The 140 investigations without verdicts must be unchanged."""
+        self.assertIsNone(self._summary([]))
+
+    def test_counts_and_refuted_ids(self):
+        s = self._summary([_v("a", "refuted", 0.95), _v("b", "uncertain", 0.4),
+                           _v("c", "confirmed", 0.8)])
+        self.assertEqual(s["counts"]["refuted"], 1)
+        self.assertEqual(s["counts"]["uncertain"], 1)
+        self.assertEqual(s["counts"]["confirmed"], 1)
+        self.assertEqual([r["finding_id"] for r in s["refuted"]], ["a"])
+
+    def test_refuted_are_ordered_by_confidence(self):
+        s = self._summary([_v("low", "refuted", 0.6), _v("high", "refuted", 0.95),
+                           _v("mid", "refuted", 0.8)])
+        self.assertEqual([r["finding_id"] for r in s["refuted"]], ["high", "mid", "low"])
+
+    def test_a_degraded_verdict_is_never_a_refutation(self):
+        """degraded means no model was reached — not a judgement about the finding."""
+        s = self._summary([_v("a", "refuted", 0.9, degraded=True)])
+        self.assertEqual(s["counts"]["degraded"], 1)
+        self.assertEqual(s["counts"]["refuted"], 0)
+        self.assertNotIn("refuted", s)
+
+    def test_last_verdict_per_finding_wins(self):
+        """Append-only log, same last-write-wins rule as finding_updates."""
+        s = self._summary([_v("a", "refuted", 0.9, ts="2026-08-01T00:00:00Z"),
+                           _v("a", "confirmed", 0.7, ts="2026-08-26T00:00:00Z")])
+        self.assertEqual(s["verified_findings"], 1)
+        self.assertEqual(s["counts"]["confirmed"], 1)
+        self.assertEqual(s["counts"]["refuted"], 0)
+
+    def test_the_hint_says_advisory_not_resolved(self):
+        s = self._summary([_v("a", "refuted", 0.95)])
+        self.assertIn("advisory", s["hint"].lower())
+        self.assertIn("do NOT change", s["hint"])
+
+    def test_a_malformed_row_does_not_break_the_summary(self):
+        s = self._summary([_v("a", "refuted", 0.9), {"no": "finding_id"},
+                           _v("b", "refuted", "not-a-number")])
+        self.assertEqual(s["counts"]["refuted"], 2)
+        self.assertEqual([r["confidence"] for r in s["refuted"]], [0.9, 0.0])
+
+    def test_an_unreadable_log_returns_none_rather_than_raising(self):
+        with mock.patch.object(IT, "_read_jsonl", side_effect=OSError("gone")), \
+             mock.patch.object(IT, "_inv_dir"):
+            self.assertIsNone(IT._verification_summary("inv"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`call_llm()` returned `None` for **every** call while `llm_available()` reported
`True`. Three stacked failures, each invisible alone:

1. **`ANTHROPIC_API_KEY` was wrapped at 80 columns** — 109 chars with an
   *internal* newline (80+28). `_anthropic_key()` does `.strip()`, which removes
   *outer* whitespace only. urllib rejects that header with `ValueError`; the
   fail-open swallowed it.
2. **Repaired, it still fails:** `HTTP 400 — "Your credit balance is too low."`
   The malformed key was masking a billing error.
3. **`_provider()` selects on key *presence* and commits.** A key existed, so
   every call went to Anthropic and returned nothing.

## What it starved

| feature | before |
|---|---|
| `investigation_reflect` summaries | **3 of 142** investigations (2.1%) |
| `investigation_reason` | errored: "No LLM endpoint available" |
| `_run_causal_inference` LLM path | fell back to the keyword heuristic |
| `contradiction_llm` polarity judge | gated off |

## Fixes

- **`call_llm` falls through.** Tries providers in order, logs which declined and
  why, Ollama last — local, free, needs no credit. *A configured provider that
  cannot transact is not an available provider.*
- **`_anthropic_key()`** treats a whitespace-containing key as absent and says so.
- **Generation resolves via `_ollama_gen_base()`**, not `_ollama_base()` — which
  is the *embedding* endpoint, serving only `nomic-embed-text` here.
- **Model** from `backends.ollama_gen_model()`, not `llama3.2:latest`, which is
  installed on no reachable endpoint.

Verified: `call_llm → "OK."`, and `investigation_reason` returns
`perspectives_used` / `grounded_findings` / `gate_applied` / `confidence_score`
for the first time.

## Test isolation that #222 exposed

`test_batched_gen`'s `_set_vllm()` set `B._VLLM` only, but `_resolve_vllm()` falls
through to `backends.vllm_url()`, which reads `~/.loci/backends.toml`. Once that
config gained a real `[vllm]` url, `""` stopped meaning "no server" and the tests
reached the **live** endpoint — 2–3 failures per run, real model text leaking into
assertions, 30 s runtimes. Now pins the resolver: **11 passed, three consecutive
runs, 0.04 s.**

## Also bundled: verification verdicts get a reader

`investigation_load` now folds `finding_verifications.jsonl` into a summary. Those
verdicts had **zero** readers. The tool-audit census shows `investigation_load`
called **15** times in 5.2 days while `memory_self_check` was called **0** — so
this is the surface someone actually looks at. `degraded` verdicts are counted
separately and **never** as refutations: "no model was reached" is not a judgement
about the finding.

`mcp/` **737 passed** (only the pre-existing host-specific `test_graph_integration`).