### PR TITLE
fix: two defects the generation census measured

### DIFF
--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -523,10 +523,26 @@ def investigation_reflect(investigation_id: str) -> str:
                     "single sentence under 120 characters. Reply with ONLY a JSON array "
                     "of strings, no other text. Example: [\"First point.\", \"Second point.\"]"
                 )
-                l1_raw = _llm.call_llm(l1_prompt, json_mode=True, timeout=60.0)
+                # json_mode=False on purpose. Ollama's format=json coerces the
+                # reply to an OBJECT, but this prompt asks for a bare ARRAY and
+                # the parse below required a list — so the two were mutually
+                # exclusive and summary_l1 could never be populated. Measured on
+                # the same prompt, 5 trials each: json_mode=True -> 0/5 parsed as
+                # a list (all dicts); json_mode=False -> 5/5 parsed as an array.
+                # Corpus evidence: 0 of 142 manifests carried an LLM-authored
+                # summary; the 3 that had one were the deterministic fallback.
+                l1_raw = _llm.call_llm(l1_prompt, timeout=60.0)
                 if l1_raw:
                     try:
                         parsed = json.loads(l1_raw)
+                        # Accept a bare array, or one wrapped in a single-key
+                        # object — a model that answers {"bullets": [...]} is
+                        # being helpful, not wrong, and this used to discard it.
+                        if isinstance(parsed, dict):
+                            for _v in parsed.values():
+                                if isinstance(_v, list):
+                                    parsed = _v
+                                    break
                         if isinstance(parsed, list):
                             summary_l1 = [str(b) for b in parsed if str(b).strip()][:7]
                     except Exception as _l1_exc:

--- a/mcp/llm_local.py
+++ b/mcp/llm_local.py
@@ -143,6 +143,18 @@ def _try_vllm(prompt: str, *, fmt: Optional[str], max_tokens: int,
     actually registers (backends.vllm_model()), which is the part llm_local was
     getting wrong. Reusing it keeps one definition of both.
     """
+    # OPT-IN. This fallback was added when Ollama generation was broken; Ollama
+    # works now, and the endpoint backends resolves is NOT Loci's: 127.0.0.1:18000
+    # is /home/rjmendez/dama-vllm/vllm_tailscale_forward.py (pid 378), another
+    # project's service, serving Qwen2.5-3B-Instruct at max_model_len=4096.
+    # Grounded verify prompts exceed that, so firing into it 400s AND borrows
+    # capacity Loci does not own. Measured verify latencies (153s, >300s) also
+    # exceed _TIMEOUT=120s, so the failure path that reaches here is exactly the
+    # one that would hit it hardest.
+    #
+    # Set LOCI_VLLM_FALLBACK=1 when Loci has a vLLM of its own.
+    if os.environ.get("LOCI_VLLM_FALLBACK", "").strip() in ("", "0"):
+        return None
     try:
         import batched_gen
     except Exception:

--- a/mcp/memcheck/llm.py
+++ b/mcp/memcheck/llm.py
@@ -218,6 +218,8 @@ def call_llm(
     json_mode: bool = False,
     timeout: float = 60.0,
     max_tokens: int = 1024,
+    model: str | None = None,
+    options: dict | None = None,
 ) -> str | None:
     """Single-shot completion against the resolved provider. None on any failure.
 
@@ -252,7 +254,8 @@ def call_llm(
             elif provider == "openrouter":
                 out = _call_openrouter(prompt, json_mode, timeout, max_tokens)
             else:
-                out = _call_ollama(prompt, json_mode, timeout)
+                out = _call_ollama(prompt, json_mode, timeout, model=model,
+                                   options=options)
         except Exception as exc:  # noqa: BLE001 — fail-open, but say which one
             _log.warning("call_llm provider=%s raised, trying next: %r", provider, exc)
             continue
@@ -263,19 +266,66 @@ def call_llm(
     return None
 
 
-def _call_ollama(prompt: str, json_mode: bool, timeout: float) -> str | None:
-    payload: dict = {"model": _llm_model(), "prompt": prompt, "stream": False}
+def _call_ollama(prompt: str, json_mode: bool, timeout: float,
+                 model: str | None = None, options: dict | None = None) -> str | None:
+    model = model or _llm_model()
+    payload: dict = {"model": model, "prompt": prompt, "stream": False}
     if json_mode:
         payload["format"] = "json"
-    model = _llm_model()
     # qwen extended-thinking is noisy for a yes/no judge — disable when present.
     if "qwen" in model.lower():
         payload["think"] = False
+    if options:
+        payload["options"] = options
     data = _post_json(f"{_ollama_gen_base()}/api/generate", payload, {}, timeout)
     if not data:
         return None
+    _warn_if_truncated(prompt, data, model)
     text = (data.get("response") or "").strip()
     return text or None
+
+
+def _warn_if_truncated(prompt: str, data: dict, model: str) -> None:
+    """Say so when the server silently dropped part of the prompt.
+
+    Ollama truncates a prompt that exceeds the LOADED context window and returns
+    done_reason="stop" with no error — the model then answers from whatever
+    survived. Observed: prompt_eval_count=4095 against a 4096 window, and a
+    confidently wrong answer about content that had been cut.
+
+    The window is not ours to fix. It is set at load time by whoever loaded the
+    model, this endpoint is shared, and the same model has been seen loaded at
+    4096 and at 16384 while DECLARING 131072. Pinning num_ctx would force a
+    reload and evict another tenant's model, so this reports rather than imposes.
+
+    Detection is direct: compare the tokens the server says it evaluated against
+    a rough estimate of what we sent. ~4 chars per token is crude, so the margin
+    is generous — this must not cry wolf on ordinary prompts.
+    """
+    try:
+        evaluated = int(data.get("prompt_eval_count") or 0)
+    except (TypeError, ValueError):
+        return
+    if evaluated <= 0:
+        return
+
+    # Thresholding on a chars/4 token estimate does not work — it is off by ±25%
+    # on ordinary text, so any threshold either misses real truncation or fires
+    # on normal prompts. Truncation has a much sharper signature: the server
+    # stops exactly AT the window, and windows are powers of two. Observed
+    # 4095 against a 4096 window.
+    estimated = max(1, len(prompt) // 4)
+    for window in (2048, 4096, 8192, 16384, 32768, 65536):
+        if abs(evaluated - window) <= 2 and estimated > window:
+            _log.warning(
+                "prompt TRUNCATED by the context window: model=%s evaluated %d "
+                "tokens against an apparent %d-token window, for a ~%d-token "
+                "prompt. The answer was formed from a PARTIAL prompt and may be "
+                "confidently wrong. Load the model with a larger num_ctx, or "
+                "shorten the grounding.",
+                model, evaluated, window, estimated,
+            )
+            return
 
 
 def _call_anthropic(prompt: str, timeout: float, max_tokens: int) -> str | None:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -7021,6 +7021,7 @@ def _run_causal_inference(investigation_id: str, findings: list[dict]) -> int:
     if not findings:
         return 0
     edges: list[dict] = []
+    known_ids = {str(f.get("id")) for f in findings if f.get("id")}
     try:
         from memcheck import llm as _llm  # type: ignore
         if _llm.llm_available():
@@ -7069,6 +7070,16 @@ def _run_causal_inference(investigation_id: str, findings: list[dict]) -> int:
                     tgt = str(obj.get("target_id") or "")
                     etype = str(obj.get("edge_type") or "")
                     conf = float(obj.get("confidence") or 0.0)
+                    # src/tgt must name findings that EXIST. The prompt renders
+                    # the list as "{idx+1}. [{id}] ..." and the model sometimes
+                    # returns the ORDINAL instead — measured: edges written with
+                    # source_id "1"/"2"/"3". Checking only for a non-empty string
+                    # let those through, and causal_edges_list strips `method`,
+                    # so a consumer cannot tell a dangling edge from a real one.
+                    if src not in known_ids or tgt not in known_ids:
+                        logger.warning("causal LLM edge names unknown finding(s) "
+                                       "%r -> %r; dropping", src[:40], tgt[:40])
+                        continue
                     if src and tgt and etype in valid_types and conf >= 0.6:
                         edges.append({
                             "id": str(uuid.uuid4()),

--- a/mcp/tests/test_causal_id_validation.py
+++ b/mcp/tests/test_causal_id_validation.py
@@ -18,13 +18,23 @@ import server
 class CausalLlmIdValidationTest(unittest.TestCase):
 
     def _run(self, llm_reply, findings):
-        with mock.patch.dict("sys.modules", {"memcheck.llm": mock.MagicMock()}):
-            import memcheck.llm as fake
-            fake.llm_available.return_value = True
-            fake.call_llm.return_value = llm_reply
-            with mock.patch.object(server, "_append_jsonl") as appended, \
-                 mock.patch.object(server, "MEMORY_DIR"):
-                server._run_causal_inference("inv", findings)
+        """Patch the ATTRIBUTE on the memcheck package, not sys.modules.
+
+        _run_causal_inference does `from memcheck import llm`, which reads
+        memcheck.llm as an attribute. Patching sys.modules["memcheck.llm"] only
+        takes effect if the package has not been imported yet, so the first
+        version of this test passed alone and failed inside the full suite —
+        order-dependent, which is no test at all.
+        """
+        import memcheck
+        fake = mock.MagicMock()
+        fake.llm_available.return_value = True
+        fake.call_llm.return_value = llm_reply
+        with mock.patch.object(memcheck, "llm", fake, create=True), \
+             mock.patch.dict("sys.modules", {"memcheck.llm": fake}), \
+             mock.patch.object(server, "_append_jsonl") as appended, \
+             mock.patch.object(server, "MEMORY_DIR"):
+            server._run_causal_inference("inv", findings)
         return [c.args[1] for c in appended.call_args_list]
 
     def test_ordinal_ids_are_dropped(self):

--- a/mcp/tests/test_causal_id_validation.py
+++ b/mcp/tests/test_causal_id_validation.py
@@ -1,0 +1,55 @@
+"""Causal LLM edges must name findings that exist.
+
+The prompt numbers the finding list as "{idx+1}. [{id}] ...", and the model
+sometimes returns the ORDINAL instead of the id. Measured on a live run: three
+edges written with source_id "1", "2", "3". The guard checked only that the
+strings were non-empty, and causal_edges_list strips `method`, so a consumer
+could not tell a dangling edge from a real one.
+
+_declared_causal_edges already validates against the finding set; the LLM path
+did not.
+"""
+import unittest
+from unittest import mock
+
+import server
+
+
+class CausalLlmIdValidationTest(unittest.TestCase):
+
+    def _run(self, llm_reply, findings):
+        with mock.patch.dict("sys.modules", {"memcheck.llm": mock.MagicMock()}):
+            import memcheck.llm as fake
+            fake.llm_available.return_value = True
+            fake.call_llm.return_value = llm_reply
+            with mock.patch.object(server, "_append_jsonl") as appended, \
+                 mock.patch.object(server, "MEMORY_DIR"):
+                server._run_causal_inference("inv", findings)
+        return [c.args[1] for c in appended.call_args_list]
+
+    def test_ordinal_ids_are_dropped(self):
+        """The measured corruption: source_id '1' instead of a uuid."""
+        findings = [{"id": "aaa", "text": "one"}, {"id": "bbb", "text": "two"}]
+        reply = '{"source_id": "1", "target_id": "2", "edge_type": "caused_by", "confidence": 0.9}'
+        written = self._run(reply, findings)
+        llm_edges = [e for e in written if e.get("method") == "llm_slow_path"]
+        self.assertEqual(llm_edges, [], "an edge naming ordinals must not be written")
+
+    def test_real_ids_are_kept(self):
+        findings = [{"id": "aaa", "text": "one"}, {"id": "bbb", "text": "two"}]
+        reply = '{"source_id": "aaa", "target_id": "bbb", "edge_type": "caused_by", "confidence": 0.9}'
+        written = self._run(reply, findings)
+        llm_edges = [e for e in written if e.get("method") == "llm_slow_path"]
+        self.assertEqual(len(llm_edges), 1)
+        self.assertEqual((llm_edges[0]["source_id"], llm_edges[0]["target_id"]), ("aaa", "bbb"))
+
+    def test_a_half_valid_edge_is_dropped(self):
+        """One real id and one ordinal is still a dangling edge."""
+        findings = [{"id": "aaa", "text": "one"}, {"id": "bbb", "text": "two"}]
+        reply = '{"source_id": "aaa", "target_id": "2", "edge_type": "caused_by", "confidence": 0.9}'
+        written = self._run(reply, findings)
+        self.assertEqual([e for e in written if e.get("method") == "llm_slow_path"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_llm_local_fallback.py
+++ b/mcp/tests/test_llm_local_fallback.py
@@ -143,3 +143,47 @@ class GenerationEndpointResolutionTest(unittest.TestCase):
             r = llm_local.generate("hello")
         self.assertEqual(r["model"], "some-model:7b")
         self.assertEqual(post.call_args.kwargs["json"]["model"], "some-model:7b")
+
+
+class VllmFallbackIsOptInTest(unittest.TestCase):
+    """The fallback must not borrow a service Loci does not own.
+
+    backends resolves vLLM to 127.0.0.1:18000, which is
+    /home/rjmendez/dama-vllm/vllm_tailscale_forward.py — another project's
+    process, serving Qwen2.5-3B-Instruct at max_model_len=4096. Grounded verify
+    prompts exceed that, so firing into it both 400s and consumes capacity Loci
+    has no claim on. It was added when Ollama generation was broken; Ollama works
+    now, so the default is off.
+    """
+
+    def test_disabled_by_default(self):
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("LOCI_VLLM_FALLBACK", None)
+            self.assertIsNone(
+                llm_local._try_vllm("hi", fmt=None, max_tokens=8, temperature=0.0))
+
+    def test_zero_is_also_disabled(self):
+        with mock.patch.dict("os.environ", {"LOCI_VLLM_FALLBACK": "0"}):
+            self.assertIsNone(
+                llm_local._try_vllm("hi", fmt=None, max_tokens=8, temperature=0.0))
+
+    def test_opt_in_reaches_batched_gen(self):
+        fake = mock.MagicMock()
+        fake.generate_batch.return_value = [{"text": "OK", "ok": True}]
+        with mock.patch.dict("os.environ", {"LOCI_VLLM_FALLBACK": "1"}), \
+             mock.patch.dict("sys.modules", {"batched_gen": fake}):
+            out = llm_local._try_vllm("hi", fmt=None, max_tokens=8, temperature=0.0)
+        self.assertEqual(out["ok"], True)
+        fake.generate_batch.assert_called_once()
+
+    def test_an_ollama_failure_no_longer_silently_reaches_vllm(self):
+        """The whole point: a failed generate must report why, not reroute."""
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("LOCI_VLLM_FALLBACK", None)
+            with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+                 mock.patch("requests.post", side_effect=OSError("refused")):
+                r = llm_local.generate("hello")
+        self.assertFalse(r["ok"])
+        self.assertIn("ollama", r["why"])

--- a/mcp/tests/test_llm_truncation_and_routing.py
+++ b/mcp/tests/test_llm_truncation_and_routing.py
@@ -1,0 +1,114 @@
+"""Per-call model/options, and a truncated prompt that says so.
+
+Two defects an adversarial review of the tier census surfaced:
+
+1. call_llm had no model parameter. The model resolved from _llm_model(), a
+   process-global, so all four memcheck consumers shared one — making any
+   per-consumer routing unexpressible in the code it targeted. _call_ollama also
+   sent no options dict, so num_ctx and num_predict were unsettable.
+
+2. Ollama silently truncates a prompt that exceeds the LOADED context window and
+   returns done_reason="stop" with no error. Observed: prompt_eval_count=4095
+   against a 4096 window, and a confidently wrong answer about content that had
+   been cut. The same model has been seen loaded at 4096 and 16384 while
+   DECLARING 131072 — the window is set by whoever loaded it, on a shared
+   endpoint, so this reports rather than pinning num_ctx and forcing a reload
+   that would evict another tenant.
+"""
+import unittest
+from unittest import mock
+
+from memcheck import llm
+
+
+class PerCallModelAndOptionsTest(unittest.TestCase):
+
+    def _capture(self, **kw):
+        seen = {}
+
+        def fake_post(url, payload, headers, timeout):
+            seen.update(payload)
+            return {"response": "ok", "prompt_eval_count": 999999}
+
+        with mock.patch.object(llm, "_post_json", side_effect=fake_post), \
+             mock.patch.object(llm, "_provider_order", return_value=["ollama"]):
+            llm.call_llm("hello", **kw)
+        return seen
+
+    def test_model_defaults_to_the_configured_one(self):
+        with mock.patch.object(llm, "_llm_model", return_value="configured:7b"):
+            self.assertEqual(self._capture()["model"], "configured:7b")
+
+    def test_an_explicit_model_overrides_the_global(self):
+        """The whole point: two consumers in one process can differ."""
+        with mock.patch.object(llm, "_llm_model", return_value="configured:7b"):
+            self.assertEqual(self._capture(model="other:3b")["model"], "other:3b")
+
+    def test_options_reach_the_payload(self):
+        seen = self._capture(options={"num_ctx": 16384})
+        self.assertEqual(seen["options"], {"num_ctx": 16384})
+
+    def test_no_options_means_no_options_key(self):
+        """Sending an empty options dict would still force server-side defaults."""
+        self.assertNotIn("options", self._capture())
+
+    def test_qwen_thinking_is_disabled_for_an_explicit_qwen_model(self):
+        with mock.patch.object(llm, "_llm_model", return_value="llama:8b"):
+            self.assertIs(self._capture(model="qwen3:14b")["think"], False)
+
+
+class TruncationDetectionTest(unittest.TestCase):
+
+    def _warn(self, prompt, evaluated):
+        with mock.patch.object(llm, "_log") as log:
+            llm._warn_if_truncated(prompt, {"prompt_eval_count": evaluated}, "m")
+        return [c for c in log.warning.call_args_list]
+
+    def test_a_truncated_prompt_warns(self):
+        """The measured case: ~6000 tokens sent, 4095 evaluated."""
+        warns = self._warn("x" * 24000, 4095)
+        self.assertEqual(len(warns), 1)
+        self.assertIn("TRUNCATED", warns[0].args[0])
+
+    def test_a_normal_prompt_does_not_cry_wolf(self):
+        """~4 chars/token is crude; the margin must tolerate ordinary variance."""
+        self.assertEqual(self._warn("x" * 4000, 950), [])
+
+    def test_a_slightly_short_count_is_tolerated(self):
+        """Tokenisers legitimately beat 4 chars/token on repetitive text."""
+        self.assertEqual(self._warn("x" * 4000, 700), [])
+
+    def test_a_missing_count_is_not_a_warning(self):
+        with mock.patch.object(llm, "_log") as log:
+            llm._warn_if_truncated("x" * 24000, {}, "m")
+        log.warning.assert_not_called()
+
+    def test_a_garbage_count_does_not_raise(self):
+        with mock.patch.object(llm, "_log"):
+            llm._warn_if_truncated("x" * 100, {"prompt_eval_count": "many"}, "m")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TruncationSignatureEdgesTest(unittest.TestCase):
+    """The detector keys on 'stopped exactly at a power-of-two window'."""
+
+    def _warn(self, prompt_chars, evaluated):
+        with mock.patch.object(llm, "_log") as log:
+            llm._warn_if_truncated("x" * prompt_chars,
+                                   {"prompt_eval_count": evaluated}, "m")
+        return log.warning.call_args_list
+
+    def test_a_short_prompt_that_merely_lands_near_a_window_does_not_warn(self):
+        """4096 tokens evaluated from a 4096-token prompt is a full read, not a cut."""
+        self.assertEqual(self._warn(16000, 4096), [])
+
+    def test_every_common_window_is_recognised(self):
+        for w in (2048, 4096, 8192, 16384):
+            with self.subTest(window=w):
+                self.assertEqual(len(self._warn(w * 8, w - 1)), 1)
+
+    def test_a_count_far_from_any_window_does_not_warn(self):
+        self.assertEqual(self._warn(40000, 5000), [])


### PR DESCRIPTION
A workflow censused every LLM consumer in Loci against the live system. Two
findings fixed here; the third deliberately not.

## 1. The causal LLM path wrote dangling edges

The prompt renders findings as `{idx+1}. [{id}] ...` and the model sometimes
returns the **ordinal** rather than the id. Measured on a live run: three edges
written with `source_id` `"1"`, `"2"`, `"3"`.

The guard checked only that `src` and `tgt` were non-empty strings — and
`causal_edges_list` strips `method`, so a consumer **could not tell a dangling
edge from a real one**. Intermittent (a later run returned real uuids) and silent
either way.

Now validated against the finding set, which is what `_declared_causal_edges`
already did.

**This one is mine:** `causal_infer` (#218) made the path directly invocable, so
I widened exposure to it.

## 2. The summary ladder could never populate

`investigation_reflect` asks for *"ONLY a JSON array"* while passing
`json_mode=True`. Ollama's `format=json` coerces the reply to an **object**, and
the parse required a **list**. Mutually exclusive — so `summary_l1` was always
empty, and `summary_l2` is gated behind it.

| | |
|---|---:|
| `json_mode=True` → parsed as a list | **0/5** |
| `json_mode=False` → parsed as a list | **5/5** |
| manifests with an LLM-authored summary | **0 of 142** |

The 3 that had one were the deterministic fallback — every `summary_l2` began
`"Investigation with N findings"`, the literal fallback string.

**This was the lane with real demand.** 7 of 15 `investigation_load` calls in the
audit window requested `fidelity` summary/brief and were served empty — including
a 143-finding investigation, with no error and no degraded flag.

Verified live after the fix: **5 bullets, a 667-char `summary_l2`, `fallback=False`.**

## Not fixed, deliberately

`_call_ollama` ignores `call_llm`'s `max_tokens` — no `num_predict` is ever sent.
The census attributes an 8.4× throughput swing to it, but **its own measurement
shows capping made generation slower**:

```
uncapped        →  9.5s, 603 tokens, done_reason=stop
num_predict=256 → 34.3s, 256 tokens, done_reason=length
```

That is backwards. One sample on a contended shared endpoint is not enough to act
on, and this repo already has a scar from setting a threshold off a single
measurement. It needs its own experiment.

`mcp/` **737 passed**. Sabotage: removing the id check fails 2 of the 3 new tests.