### PR TITLE
fix: the EMBEDDING env var was capturing generation — regression from #222/#224

### DIFF
--- a/mcp/llm_local.py
+++ b/mcp/llm_local.py
@@ -27,7 +27,31 @@ from typing import Optional
 
 # [substrate] read the base URL from env, same convention as embed_ops.py. When unset, the
 # call-time _resolve_ollama() falls back to backends (local probe -> config) for portability.
-_OLLAMA = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_URL") or ""
+# GENERATION-specific vars ONLY. OLLAMA_BASE_URL is the EMBEDDING endpoint, and
+# reading it here re-created the exact conflation #222 set out to fix, one level
+# up: #222 taught the RESOLVER to separate generation from embeddings, then left
+# the embedding variable as the highest-precedence generation override.
+#
+# scripts/loci_groom.load_env() — which every groom pass calls — sets
+# OLLAMA_BASE_URL to backends.ollama_url(), the in-cluster host that serves only
+# nomic-embed-text. Measured in one process: bare import resolves to oxalis and
+# generates; after load_env() it resolves to 10.42.0.1 and 404s. So under cron,
+# 100% of generation went to a host with no generation model, and the vLLM
+# fallback was silently rescuing it — until #224 made that fallback opt-in, which
+# took the groom pass from 9/100 degraded to 100/100.
+#
+# A host with one capable Ollama still works: _resolve_ollama() falls through to
+# backends.ollama_gen_url(), which itself falls back to ollama_url(). This only
+# removes the env var's ability to OUTRANK that resolution.
+# Read at CALL time, not import time. qdrant_ops._retention_days() already
+# established this pattern here for the same reason: scripts/loci_groom.load_env()
+# runs AFTER this module is imported, so an import-time capture reflects the
+# environment before the process configured itself. That ordering is what let a
+# stale value win, and a module-level constant cannot be tested without reload()
+# — which made the test for it order-dependent in the suite.
+def _gen_env() -> str:
+    return (os.environ.get("LOCI_OLLAMA_GEN_URL")
+            or os.environ.get("OLLAMA_GEN_URL") or "")
 
 
 def _resolve_ollama() -> str:
@@ -87,7 +111,7 @@ def generate(prompt: str,
         """
         return {"text": "", "ok": False, "model": model, "why": why}
 
-    base = _OLLAMA or _resolve_ollama()   # env wins; else backends (local probe -> config)
+    base = _gen_env() or _resolve_ollama()   # gen env wins; else backends
     if not prompt:
         return fail("empty prompt")
     if not base:

--- a/mcp/tests/test_llm_local.py
+++ b/mcp/tests/test_llm_local.py
@@ -49,7 +49,7 @@ def _install_post(monkeypatch, resp=None, exc=None, capture=None):
 
 def _ensure_base(monkeypatch):
     # generate() short-circuits when no base URL is configured; give it one.
-    monkeypatch.setattr(L, "_OLLAMA", "http://fake-ollama:11434")
+    monkeypatch.setattr(L, "_gen_env", lambda _v="http://fake-ollama:11434": _v)
 
 
 @pytest.fixture(autouse=True)
@@ -149,7 +149,7 @@ def test_no_base_url_fails_open(monkeypatch):
     pointed at a host that works, the test failed -- correctly, because it had
     been asserting "the resolved backend is broken", not "there is no backend".
     """
-    monkeypatch.setattr(L, "_OLLAMA", "")
+    monkeypatch.setattr(L, "_gen_env", lambda: "")
     monkeypatch.setattr(L, "_resolve_ollama", lambda: "")
     r = L.generate("say hi")
     assert r["ok"] is False and r["text"] == ""

--- a/mcp/tests/test_llm_local_fallback.py
+++ b/mcp/tests/test_llm_local_fallback.py
@@ -12,6 +12,7 @@ Consequence: verify_finding returned degraded=True with empty reasoning for ever
 finding, and the verify groom pass refused to run (correctly) rather than write
 uncertain/0.0 records. The cause sat in a swallowed exception.
 """
+import os
 import unittest
 from unittest import mock
 
@@ -26,7 +27,7 @@ class FailuresAreExplainedTest(unittest.TestCase):
         self.assertIn("empty prompt", r["why"])
 
     def test_no_endpoint_says_so(self):
-        with mock.patch.object(llm_local, "_OLLAMA", ""), \
+        with mock.patch.object(llm_local, "_gen_env", lambda: ""), \
              mock.patch.object(llm_local, "_resolve_ollama", return_value=""):
             r = llm_local.generate("hello")
         self.assertFalse(r["ok"])
@@ -34,7 +35,7 @@ class FailuresAreExplainedTest(unittest.TestCase):
 
     def test_a_transport_failure_carries_the_exception(self):
         """The regression: this used to return ok=False with no reason at all."""
-        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+        with mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
              mock.patch.object(llm_local, "_try_vllm", return_value=None), \
              mock.patch("requests.post", side_effect=OSError("connection refused")):
             r = llm_local.generate("hello")
@@ -45,7 +46,7 @@ class FailuresAreExplainedTest(unittest.TestCase):
     def test_unparseable_json_says_so_rather_than_just_failing(self):
         resp = mock.MagicMock()
         resp.json.return_value = {"response": "not json at all"}
-        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+        with mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
              mock.patch("requests.post", return_value=resp):
             r = llm_local.generate("hello", fmt="json")
         self.assertFalse(r["ok"])
@@ -55,7 +56,7 @@ class FailuresAreExplainedTest(unittest.TestCase):
 class VllmFallbackTest(unittest.TestCase):
 
     def test_ollama_failure_falls_through_to_vllm(self):
-        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+        with mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
              mock.patch("requests.post", side_effect=OSError("refused")), \
              mock.patch.object(llm_local, "_try_vllm",
                                return_value={"text": "OK", "ok": True,
@@ -68,7 +69,7 @@ class VllmFallbackTest(unittest.TestCase):
     def test_a_successful_ollama_call_does_not_reach_vllm(self):
         resp = mock.MagicMock()
         resp.json.return_value = {"response": "hi"}
-        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+        with mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
              mock.patch("requests.post", return_value=resp), \
              mock.patch.object(llm_local, "_try_vllm") as vllm:
             r = llm_local.generate("hello")
@@ -77,7 +78,7 @@ class VllmFallbackTest(unittest.TestCase):
 
     def test_vllm_declining_leaves_the_ollama_reason_intact(self):
         """Both tiers down must not hide WHICH failed or why."""
-        with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+        with mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
              mock.patch("requests.post", side_effect=OSError("refused")), \
              mock.patch.object(llm_local, "_try_vllm", return_value=None):
             r = llm_local.generate("hello")
@@ -138,7 +139,7 @@ class GenerationEndpointResolutionTest(unittest.TestCase):
         resp = mock.MagicMock()
         resp.json.return_value = {"response": "hi"}
         with mock.patch.object(backends, "ollama_gen_model", return_value="some-model:7b"), \
-             mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+             mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
              mock.patch("requests.post", return_value=resp) as post:
             r = llm_local.generate("hello")
         self.assertEqual(r["model"], "some-model:7b")
@@ -182,8 +183,52 @@ class VllmFallbackIsOptInTest(unittest.TestCase):
         with mock.patch.dict("os.environ", {}, clear=False):
             import os
             os.environ.pop("LOCI_VLLM_FALLBACK", None)
-            with mock.patch.object(llm_local, "_OLLAMA", "http://x"), \
+            with mock.patch.object(llm_local, "_gen_env", lambda: "http://x"), \
                  mock.patch("requests.post", side_effect=OSError("refused")):
                 r = llm_local.generate("hello")
         self.assertFalse(r["ok"])
         self.assertIn("ollama", r["why"])
+
+
+class GenerationEnvPrecedenceTest(unittest.TestCase):
+    """OLLAMA_BASE_URL is the EMBEDDING endpoint and must not outrank generation.
+
+    #222 taught the RESOLVER to separate the two, then left the embedding variable
+    as the highest-precedence generation override. scripts/loci_groom.load_env(),
+    which every groom pass calls, sets OLLAMA_BASE_URL to the in-cluster host that
+    serves only nomic-embed-text — so under cron, 100% of generation went to a
+    host with no generation model. The vLLM fallback was silently rescuing it;
+    once #224 made that opt-in, the groom pass went from 9/100 to 100/100 degraded.
+
+    Read at CALL time so load_env() — which runs after import — is respected, and
+    so these tests need no importlib.reload (which made the first version of them
+    order-dependent inside the full suite).
+    """
+
+    def test_the_embedding_var_does_not_capture_generation(self):
+        with mock.patch.dict("os.environ", {"OLLAMA_BASE_URL": "http://embeddings-only:11434"}):
+            self.assertEqual(llm_local._gen_env(), "",
+                             "OLLAMA_BASE_URL must not become the generation endpoint")
+
+    def test_a_generation_specific_var_still_wins(self):
+        for var in ("LOCI_OLLAMA_GEN_URL", "OLLAMA_GEN_URL"):
+            with self.subTest(var=var):
+                env = {k: v for k, v in os.environ.items()
+                       if k not in ("LOCI_OLLAMA_GEN_URL", "OLLAMA_GEN_URL")}
+                env[var] = "http://gen:1"
+                with mock.patch.dict("os.environ", env, clear=True):
+                    self.assertEqual(llm_local._gen_env(), "http://gen:1")
+
+    def test_env_is_read_at_call_time_not_import_time(self):
+        """load_env() runs AFTER this module is imported; an import-time capture
+        would reflect the environment before the process configured itself."""
+        with mock.patch.dict("os.environ", {"LOCI_OLLAMA_GEN_URL": "http://late:2"}):
+            self.assertEqual(llm_local._gen_env(), "http://late:2")
+        self.assertNotEqual(llm_local._gen_env(), "http://late:2")
+
+    def test_a_single_capable_ollama_still_resolves_via_backends(self):
+        """No regression for a host that only sets OLLAMA_BASE_URL: the resolver
+        falls through ollama_gen_url() -> ollama_url()."""
+        import backends
+        with mock.patch.object(backends, "ollama_gen_url", return_value="http://only:11434"):
+            self.assertEqual(llm_local._resolve_ollama(), "http://only:11434")


### PR DESCRIPTION
**#224 made the groom pass worse, not better.** A workflow re-measuring verify
quality caught it: **9/100 degraded before, 100/100 after.**

## The 4096 ceiling was never the root cause

`scripts/loci_groom.load_env()` — which **every groom pass calls** — sets
`OLLAMA_BASE_URL` to `backends.ollama_url()`, the in-cluster host serving only
`nomic-embed-text`. `llm_local` read that variable for **generation**, silently
outranking the `ollama_gen_url()` resolution #222 added.

Measured in one process, two orders:

```
bare import       _OLLAMA=''                        -> oxalis, ok=True
after load_env()  _OLLAMA='http://10.42.0.1:11434'  -> 404, rerouted to vLLM
```

So under cron, **100% of generation went to a host with no generation model**, and
llm_local's vLLM fallback was accidentally rescuing it. #224 made that fallback
opt-in — correct on its own terms — and removed the only thing making the pass
work.

## Same conflation as #222, one level up

#222 separated the *resolver* and left the **embedding** variable as the
highest-precedence **generation** override. Generation now reads
`LOCI_OLLAMA_GEN_URL` / `OLLAMA_GEN_URL` only. A host with a single capable Ollama
is unaffected: `_resolve_ollama()` still falls through
`ollama_gen_url()` → `ollama_url()`.

## Read at call time

Matching `qdrant_ops._retention_days()`, which established this pattern here for
the same reason: `load_env()` runs **after** import, so an import-time capture
reflects the environment before the process configured itself.

It also removes the `importlib.reload()` the first version of these tests
needed — which had made them order-dependent in the full suite. That was my
**fourth** non-hermetic test today, all the same shape.

## Verified end to end

Generation resolves to oxalis **through** `load_env()`, and the verify groom pass
writes 5 verdicts with `degraded=False` on all of them — where the merged code
predicted 100/100 degraded.

`mcp/` **761 passed**.