### PR TITLE
fix(rag): timeout, a shadowed expander, and a docstring that pointed at the wrong corpus

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -269,7 +269,14 @@ def _get_qdrant():
             )
 
             qdrant_api_key = os.environ.get("QDRANT_API_KEY", "") or None
-            client = QdrantClient(url=qdrant_url, api_key=qdrant_api_key, timeout=5)
+            # 5s was too short for any collection but this server's own. Measured
+            # against agent_core_chunks (6.06M points, unquantized): 1.31s filtered,
+            # 10.87s unfiltered, 9.01s on a doc_type filter — so every explicit query
+            # to it timed out and came back mode="rag_failed", result_count=0 at
+            # HTTP 200. Raised, and configurable, because the right value depends on
+            # which collections a deployment actually searches.
+            client = QdrantClient(url=qdrant_url, api_key=qdrant_api_key,
+                                  timeout=_QDRANT_TIMEOUT)
             col = QDRANT_COLLECTION_PREFIX
             existing = {c.name for c in client.get_collections().collections}
 
@@ -473,6 +480,9 @@ def _qdrant_degraded_mode(enabled: bool, available: bool, errors, query_success:
 # 1024 stays the default because it is never worse and it is one median finding,
 # but anything >= 1024 is defensible and the 1024-vs-2048 gap was noise.
 RERANK_MAX_CHARS = int(os.environ.get("LOCI_RERANK_MAX_CHARS", "1024"))
+# Client-wide Qdrant timeout, seconds. Not per-collection: one client serves them
+# all, so this is sized for the slowest collection a deployment searches.
+_QDRANT_TIMEOUT = float(os.environ.get("LOCI_QDRANT_TIMEOUT", "20"))
 
 # One definition of the quantized-search parameters, used by every query path.
 # rescore=True re-scores ANN candidates against the original full-precision

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6573,13 +6573,23 @@ def rag_context_search(
     Hybrid RAG search over Qdrant corpus. Returns prompt-ready context with cited sources.
     ALWAYS uses Qdrant — no keyword fallback. Raises rag_required error if Qdrant unavailable.
 
-    Searches hermes_memory (task findings) and agent_core_chunks (1.84M knowledge base)
-    by default, merges results, reranks with cross-encoder, assembles cited context.
+    Searches QDRANT_COLLECTION_PREFIX (default "hermes_memory", the findings) plus
+    CODE_CHUNKS_COLLECTION when that env var is set, merges, reranks with a
+    cross-encoder and assembles cited context.
+
+    This used to claim it searched "agent_core_chunks (1.84M knowledge base)" by
+    default. It does not, and never did — the defaults are built from those two env
+    vars at :6606. On this deployment the second is dama_gotchi_code, and
+    agent_core_chunks is a 6.06M-point DAMA telemetry lake that is 86% GPS
+    trajectory points and 0.18% code. Naming it here sent callers to override
+    `collections` with it, which is slow and returns telemetry.
 
     Args:
         query: Natural language search query.
         limit: Results per collection (default 10).
-        collections: Override collections list (default: ["hermes_memory", "agent_core_chunks"]).
+        collections: Override the collections list. The DEFAULT is
+                     [QDRANT_COLLECTION_PREFIX] + [CODE_CHUNKS_COLLECTION if set],
+                     NOT agent_core_chunks — see the note above before overriding.
         budget_chars: Max characters in assembled context (default 6000).
         exclude_types: Payload 'type' values to exclude from agent_core_chunks results.
                        Default None → ['gps_trajectory'] to suppress high-volume GPS pings.

--- a/mcp/tests/test_rag_defaults_and_timeout.py
+++ b/mcp/tests/test_rag_defaults_and_timeout.py
@@ -1,0 +1,72 @@
+"""Three defects a corpus audit measured against the live instance.
+
+1. The Qdrant client timeout was 5s. Measured on agent_core_chunks (6.06M points,
+   unquantized): 1.31s filtered, 10.87s unfiltered, 9.01s on a doc_type filter. So
+   every explicit query to it returned mode="rag_failed", result_count=0 at HTTP 200.
+
+2. rag_context_search's docstring claimed it searched agent_core_chunks by default.
+   It never did — defaults come from QDRANT_COLLECTION_PREFIX + CODE_CHUNKS_COLLECTION.
+   The docstring sent callers to override with a collection that is 86% GPS
+   trajectory points and 0.18% code.
+
+3. scripts/query_expand.py shares a module NAME with mcp/query_expand.py but defined
+   only main(). scripts/judge_eval.py puts scripts/ AHEAD of mcp/ on sys.path, so
+   `import query_expand` could resolve to the wrapper, leaving _rag_expand_queries to
+   fail open with "module 'query_expand' has no attribute 'expand'" — silently
+   disabling the expansion whose +4% nDCG@10 is the reason it exists.
+"""
+import importlib
+import os
+import unittest
+from unittest import mock
+
+
+class QdrantTimeoutTest(unittest.TestCase):
+
+    def test_default_timeout_exceeds_the_measured_slow_search(self):
+        import qdrant_ops
+        self.assertGreaterEqual(
+            qdrant_ops._QDRANT_TIMEOUT, 11.0,
+            "10.87s was measured on agent_core_chunks; a shorter timeout fails it")
+
+    def test_timeout_is_configurable(self):
+        with mock.patch.dict(os.environ, {"LOCI_QDRANT_TIMEOUT": "42"}):
+            import qdrant_ops
+            importlib.reload(qdrant_ops)
+            try:
+                self.assertEqual(qdrant_ops._QDRANT_TIMEOUT, 42.0)
+            finally:
+                importlib.reload(qdrant_ops)
+
+
+class QueryExpandShadowTest(unittest.TestCase):
+
+    def test_the_cli_wrapper_reexports_expand(self):
+        """Whichever module wins the name, expand() must exist."""
+        import importlib.util
+        import sys
+        path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                            "..", "scripts", "query_expand.py")
+        spec = importlib.util.spec_from_file_location("scripts_query_expand", path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["scripts_query_expand"] = mod
+        try:
+            spec.loader.exec_module(mod)
+            self.assertTrue(hasattr(mod, "expand"),
+                            "the CLI wrapper must re-export expand() or it shadows it away")
+            self.assertIsNotNone(mod.expand)
+        finally:
+            sys.modules.pop("scripts_query_expand", None)
+
+
+class RagDocstringTest(unittest.TestCase):
+
+    def test_docstring_does_not_claim_agent_core_chunks_is_a_default(self):
+        import server
+        doc = server.rag_context_search.__doc__ or ""
+        self.assertIn("CODE_CHUNKS_COLLECTION", doc)
+        self.assertNotIn('default: ["hermes_memory", "agent_core_chunks"]', doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/query_expand.py
+++ b/scripts/query_expand.py
@@ -13,6 +13,21 @@ import json
 import os
 import sys
 
+# Re-export the real implementation. This file is a CLI wrapper, but it shares a
+# module NAME with mcp/query_expand.py — and scripts/judge_eval.py puts scripts/
+# AHEAD of mcp/ on sys.path, so `import query_expand` can resolve here instead.
+# When it did, the module had no expand() and _rag_expand_queries failed open:
+# every response carried degraded:true with "module 'query_expand' has no
+# attribute 'expand'", so the measured +4% nDCG@10 from expansion was silently off.
+# Delegating means the name resolves to a working expand() either way.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+try:
+    from query_expand import expand  # noqa: F401  (re-export)
+except ImportError:  # pragma: no cover - only when mcp/ is genuinely absent
+    expand = None
+import os
+import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
 
 


### PR DESCRIPTION
Three defects a corpus audit measured against the live instance.

## 1. The Qdrant client timeout was 5s

Measured on `agent_core_chunks` (6.06M points, unquantized):

| query | time |
|---|---:|
| with the `gps_trajectory` exclusion | 1.31s |
| on a `doc_type` filter | 9.01s |
| unfiltered | **10.87s** |

So every explicit query to it timed out and came back `mode="rag_failed"`,
`result_count=0` — at **HTTP 200**. Now `LOCI_QDRANT_TIMEOUT`, default **20s**.

Client-wide rather than per-collection, because one client serves them all — so
it is sized for the slowest collection a deployment searches.

Worth noting the failure was **already reported honestly**: `mode`,
`collections_failed` and `collection_errors` are all set, and the comment there
describes the earlier bug where it wasn't. Only the timeout was wrong.

## 2. `query_expand` was shadowed, silently disabling expansion

`scripts/query_expand.py` shares a module **name** with `mcp/query_expand.py` but
defined only `main()`. And `scripts/judge_eval.py:21-22` inserts `mcp/` **then**
`scripts/`, leaving scripts first — so `import query_expand` could resolve to the
CLI wrapper, and `_rag_expand_queries` failed open with:

```
module 'query_expand' has no attribute 'expand'
```

Expansion exists for a measured **+4% nDCG@10**. It has been off in that path
without saying so.

The wrapper now re-exports `expand()` from the real module, so the name resolves
to something that works whichever wins. Renaming would also fix it, but every
caller of the CLI would have to change.

## 3. The docstring named a corpus it never searched

It claimed *"hermes_memory and agent_core_chunks (1.84M knowledge base)"* by
default. Defaults are built at `:6606` from `QDRANT_COLLECTION_PREFIX` +
`CODE_CHUNKS_COLLECTION` — measured live, that is
`["hermes_memory", "dama_gotchi_code"]`.

And `agent_core_chunks` is not a knowledge base. It is a **6.06M-point DAMA
telemetry lake: 86.3% GPS trajectory points, 0.18% code.** The docstring was
sending callers to override `collections` with something slow that returns
telemetry.

`mcp/` **765 passed**, `scripts/` **125 passed**. Sabotage: reverting the timeout
to 5 and removing the re-export each fail their test.