### PR TITLE
hooks: make the grounding and session hooks actually run

### DIFF
--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Install the Claude Code hooks from this repo into ~/.claude/hooks.
+#
+#   install.sh          copy repo -> ~/.claude/hooks (backing up what is there)
+#   install.sh --check  report drift and exit 1 if any; changes nothing
+#
+# Nothing kept the two copies in sync before this script existed, and they did
+# diverge: the deployed pre_tool_grounding.py had been hand-edited to accept the
+# Claude Code "PreToolUse" event while the repo copy still only accepted the
+# Hermes name, so a fresh install would have silently disabled the hook.
+
+set -uo pipefail
+
+HOOKS=(pre_llm_grounding.py pre_tool_grounding.py session_end_sync.py)
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST="${CLAUDE_HOOKS_DIR:-$HOME/.claude/hooks}"
+
+if [[ "${1:-}" == "--check" ]]; then
+  drift=0
+  for h in "${HOOKS[@]}"; do
+    if [[ ! -f "$DEST/$h" ]]; then
+      echo "MISSING  $DEST/$h"; drift=1
+    elif ! diff -q "$SRC/$h" "$DEST/$h" >/dev/null; then
+      echo "DRIFTED  $h"; diff -u "$SRC/$h" "$DEST/$h" | sed -n '3,$p' | head -20; drift=1
+    fi
+  done
+  [[ $drift -eq 0 ]] && echo "hooks in sync"
+  exit $drift
+fi
+
+mkdir -p "$DEST"
+backup="$DEST/backup-$(date +%Y%m%d-%H%M%S)"
+for h in "${HOOKS[@]}"; do
+  [[ -f "$SRC/$h" ]] || { echo "no such hook in repo: $h" >&2; exit 1; }
+  if [[ -f "$DEST/$h" ]] && ! diff -q "$SRC/$h" "$DEST/$h" >/dev/null; then
+    mkdir -p "$backup"; cp "$DEST/$h" "$backup/"
+  fi
+  cp "$SRC/$h" "$DEST/$h"; chmod +x "$DEST/$h"
+  echo "installed $h"
+done
+[[ -d "$backup" ]] && echo "previous copies backed up to $backup"
+exit 0

--- a/scripts/hooks/pre_llm_grounding.py
+++ b/scripts/hooks/pre_llm_grounding.py
@@ -106,6 +106,8 @@ RULES_DIR    = os.environ.get("HOOK_RULES_DIR",
 RECALL_TOP_K      = int(os.environ.get("HOOK_RECALL_TOP_K",          "3"))
 MIN_IMPORTANCE    = float(os.environ.get("HOOK_RECALL_MIN_IMPORTANCE", "0.2"))
 MIN_SCORE         = float(os.environ.get("HOOK_RECALL_MIN_SCORE",      "0.55"))
+# Every named collection on this instance uses "dense"; overridable if that changes.
+VECTOR_NAME       = os.environ.get("HOOK_RECALL_VECTOR_NAME",    "dense")
 MAX_CONTENT_CHARS = int(os.environ.get("HOOK_RECALL_MAX_CHARS",        "200"))
 RULES_MAX_CHARS   = int(os.environ.get("HOOK_RULES_MAX_CHARS",         "1200"))
 EMBED_TIMEOUT     = float(os.environ.get("HOOK_EMBED_TIMEOUT",         "3.0"))
@@ -211,6 +213,13 @@ def _embed(text: str) -> Optional[list[float]]:
 
 # ── Qdrant search ─────────────────────────────────────────────────────────────
 
+class _SearchFailed(Exception):
+    """One collection's search did not complete. Raised so the fan-out can tell
+    'nothing matched' apart from 'every request failed' — the wrong named-vector
+    request shape returned an empty list from all three base collections for
+    months, and an empty list is what a genuinely unmatched query looks like."""
+
+
 def _search_collection(
     collection: str,
     vector: list[float],
@@ -221,7 +230,7 @@ def _search_collection(
 ) -> list[dict]:
     """Search one Qdrant collection, return normalised hit dicts."""
     url = f"{QDRANT_URL}/collections/{collection}/points/search"
-    vec_payload = {"dense": vector} if named_vec else vector
+    vec_payload = {"name": VECTOR_NAME, "vector": vector} if named_vec else vector
     body = json.dumps({
         "vector": vec_payload,
         "limit": top_k,
@@ -240,7 +249,7 @@ def _search_collection(
         with urllib.request.urlopen(req, timeout=QDRANT_TIMEOUT) as resp:
             d = json.loads(resp.read())
     except Exception:
-        return []
+        raise _SearchFailed(collection)
 
     hits = []
     for pt in d.get("result", []):
@@ -569,10 +578,13 @@ def main() -> None:
         if QDRANT_URL:
             sub_vec = _embed(intent)
             if sub_vec is not None:
-                sub_hits = _search_collection(
-                    "hermes_memory", sub_vec, "text", "confidence", True,
-                    top_k=min(RECALL_TOP_K, 2),
-                )
+                try:
+                    sub_hits = _search_collection(
+                        "hermes_memory", sub_vec, "text", "confidence", True,
+                        top_k=min(RECALL_TOP_K, 2),
+                    )
+                except _SearchFailed:
+                    sub_hits = _beam_fallback(intent)
                 sub_hits = [h for h in sub_hits if h["importance"] >= MIN_IMPORTANCE]
                 _sub_ts = time.time()
                 for h in sub_hits:
@@ -627,11 +639,18 @@ def main() -> None:
                 ): col
                 for col, cf, impf, named in COLLECTIONS
             }
+            searched = failed = 0
             for f in as_completed(futures):
+                searched += 1
                 try:
                     all_hits.extend(f.result())
+                except _SearchFailed:
+                    failed += 1
                 except Exception:
-                    pass
+                    failed += 1
+        if searched and failed == searched:
+            used_fallback = True
+            all_hits = _beam_fallback(intent)
 
         # Keyword rerank adds overlap bonus to fused before multi-signal scoring.
         hits = _keyword_rerank(all_hits, intent)

--- a/scripts/hooks/pre_llm_grounding.py
+++ b/scripts/hooks/pre_llm_grounding.py
@@ -84,8 +84,18 @@ if os.path.exists(_ENV_FILE):
 # ── constants ─────────────────────────────────────────────────────────────────
 QDRANT_URL   = os.environ.get("QDRANT_URL")
 QDRANT_KEY   = os.environ.get("QDRANT_API_KEY", "")
-_OLLAMA_BASE = os.environ.get("OLLAMA_BASE_URL")
-OLLAMA_URL   = f"{_OLLAMA_BASE}/v1" if _OLLAMA_BASE else None
+def _embed_base_url() -> Optional[str]:
+    """OpenAI-compatible embeddings base. OLLAMA_BASE_URL is a bare host and needs
+    /v1; MNEMOSYNE_EMBEDDING_API_URL (what the Hermes profile actually sets) is
+    already a full /v1 endpoint."""
+    base = os.environ.get("OLLAMA_BASE_URL")
+    if base:
+        return f"{base.rstrip('/')}/v1"
+    api = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL")
+    return api.rstrip("/") if api else None
+
+
+OLLAMA_URL   = _embed_base_url()
 EMBED_MODEL  = os.environ.get("MNEMOSYNE_EMBEDDING_MODEL",   "nomic-embed-text")
 _EMBED_API_KEY        = os.environ.get("EMBED_API_KEY", "")
 _EMBED_API_KEY_HEADER = os.environ.get("EMBED_API_KEY_HEADER", "Authorization")
@@ -527,7 +537,9 @@ def main() -> None:
     task_id = extra.get("task_id") or payload.get("session_id") or ""
     is_subagent = "subagent" in task_id.lower() or bool(os.environ.get("HERMES_SUBAGENT"))
 
-    user_message = extra.get("user_message") or ""
+    # Claude Code (UserPromptSubmit/SubagentStart) puts the text at the top level;
+    # Hermes (pre_llm_call) nested it under extra.user_message.
+    user_message = payload.get("prompt") or extra.get("user_message") or ""
     if not isinstance(user_message, str):
         user_message = ""
     msg_stripped = user_message.strip()

--- a/scripts/hooks/pre_tool_grounding.py
+++ b/scripts/hooks/pre_tool_grounding.py
@@ -377,7 +377,7 @@ def main() -> None:
         sys.exit(0)
 
     event = payload.get("hook_event_name", "")
-    if event != "pre_tool_call":
+    if event not in ("pre_tool_call", "PreToolUse"):
         sys.exit(0)
 
     tool_name: str = payload.get("tool_name") or ""

--- a/scripts/hooks/session_end_sync.py
+++ b/scripts/hooks/session_end_sync.py
@@ -96,16 +96,21 @@ def ensure_collection():
 def stable_id(s: str) -> int:
     return int(hashlib.sha256(s.encode()).hexdigest()[:15], 16)
 
-def read_stdin_session_id() -> str:
+def read_stdin_payload() -> dict:
     try:
         raw = sys.stdin.read()
         if not raw.strip():
-            return ""
+            return {}
         data = json.loads(raw)
-        # session_id is top-level in the Hermes hook payload
-        return data.get("session_id") or ""
+        return data if isinstance(data, dict) else {}
     except Exception:
-        return ""
+        return {}
+
+
+def read_stdin_session_id() -> str:
+    # session_id is top-level in both the Hermes and Claude Code payloads.
+    sid = read_stdin_payload().get("session_id")
+    return sid if isinstance(sid, str) else ""
 
 def get_session_content(session_id: str):
     """Return (title, started_at, source, model, content_text, msg_count)."""
@@ -163,6 +168,96 @@ def get_session_content(session_id: str):
         }
     except Exception:
         return None
+
+
+def _transcript_text(message) -> str:
+    """A user message carries a plain string; an assistant message carries a
+    list of content blocks. Only the text blocks are of interest."""
+    content = (message or {}).get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = [b.get("text", "") for b in content
+                 if isinstance(b, dict) and b.get("type") == "text"]
+        return "\n".join(x for x in parts if x).strip()
+    return ""
+
+
+def transcript_session_content(transcript_path: str, session_id: str):
+    """Same shape as get_session_content, built from a Claude Code transcript.
+
+    STATE_DB is Hermes' session store and holds Hermes-format ids only, so a
+    Claude Code session id never resolves there and the sync did nothing at all.
+    The Stop payload carries transcript_path, which is the record that exists.
+
+    Streams the file: transcripts reach tens of megabytes and only the last
+    MAX_CHARS of text is ever embedded.
+    """
+    if not transcript_path or not os.path.exists(transcript_path):
+        return None
+    title = model = ""
+    started_at = ""
+    msg_count = 0
+    tail: list[str] = []
+    tail_chars = 0
+    try:
+        with open(transcript_path, "r", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                kind = rec.get("type")
+                if kind == "ai-title" and not title:
+                    title = str(rec.get("aiTitle") or "")
+                    continue
+                if kind not in ("user", "assistant"):
+                    continue
+                msg = rec.get("message")
+                if not isinstance(msg, dict):
+                    continue
+                if kind == "assistant" and not model:
+                    model = str(msg.get("model") or "")
+                if not started_at and rec.get("timestamp"):
+                    started_at = str(rec["timestamp"])
+                text = _transcript_text(msg)
+                if len(text) <= 20:
+                    continue
+                msg_count += 1
+                entry = f"{kind.upper()}: {text}"
+                tail.append(entry)
+                tail_chars += len(entry)
+                # Keep a bounded tail so recent context drives the embedding.
+                while tail_chars > MAX_CHARS * 2 and len(tail) > 1:
+                    tail_chars -= len(tail.pop(0))
+    except OSError:
+        return None
+
+    if not msg_count:
+        return None
+
+    buf: list[str] = []
+    total = 0
+    for entry in reversed(tail):
+        if total + len(entry) > MAX_CHARS:
+            buf.append(entry[:MAX_CHARS - total])
+            break
+        buf.append(entry)
+        total += len(entry)
+
+    return {
+        "title":      title,
+        "started_at": started_at,
+        "source":     "claude-code",
+        "model":      model,
+        "content":    "\n\n".join(reversed(buf)),
+        "msg_count":  msg_count,
+    }
 
 # One file per session id, forever. A session that will never be seen again keeps
 # its counter indefinitely, so the directory grows with every session the machine
@@ -298,8 +393,9 @@ def _check_wiring_obligations(investigation_id: str, payload: dict) -> str:
 
 def main():
     t0 = time.monotonic()
-    session_id = read_stdin_session_id()
-    if not session_id:
+    payload = read_stdin_payload()
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
         sys.exit(0)
 
     # Prune before doing work. This hook is the only thing that writes the cache,
@@ -314,7 +410,8 @@ def main():
     except Exception as e:
         print(f"[session_end_sync] cache prune skipped: {e}", file=sys.stderr)
 
-    sess = get_session_content(session_id)
+    sess = get_session_content(session_id) or transcript_session_content(
+        payload.get("transcript_path") or "", session_id)
     if not sess:
         sys.exit(0)
 

--- a/scripts/hooks/session_end_sync.py
+++ b/scripts/hooks/session_end_sync.py
@@ -18,8 +18,17 @@ import urllib.request, urllib.error
 STATE_DB    = os.path.expanduser(os.environ.get("HERMES_STATE_DB", "~/.hermes/state.db"))
 QDRANT      = os.environ.get("QDRANT_URL")
 QDRANT_KEY  = os.environ.get("QDRANT_API_KEY", "")
-_OLLAMA_BASE = os.environ.get("OLLAMA_BASE_URL")
-OLLAMA      = f"{_OLLAMA_BASE}/v1/embeddings" if _OLLAMA_BASE else None
+def _embeddings_url() -> "str | None":
+    """OLLAMA_BASE_URL is a bare host; MNEMOSYNE_EMBEDDING_API_URL (what the
+    Hermes profile sets) is already a full /v1 endpoint."""
+    base = os.environ.get("OLLAMA_BASE_URL")
+    if base:
+        return f"{base.rstrip('/')}/v1/embeddings"
+    api = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL")
+    return f"{api.rstrip('/')}/embeddings" if api else None
+
+
+OLLAMA      = _embeddings_url()
 EMBED_MODEL           = os.environ.get("MNEMOSYNE_EMBEDDING_MODEL", "nomic-embed-text")
 _EMBED_API_KEY        = os.environ.get("EMBED_API_KEY", "")
 _EMBED_API_KEY_HEADER = os.environ.get("EMBED_API_KEY_HEADER", "Authorization")

--- a/scripts/hooks/tests/test_pre_llm_grounding.py
+++ b/scripts/hooks/tests/test_pre_llm_grounding.py
@@ -25,6 +25,7 @@ import json
 import math
 import os
 import pathlib
+import builtins
 import sys
 import time
 import types
@@ -407,10 +408,20 @@ def test_search_collection_missing_result_key_is_empty(hook):
 # ---------------------------------------------------------------------------
 
 def test_beam_fallback_returns_empty_when_mnemosyne_missing(hook):
+    # Clearing sys.modules is not enough: the import re-succeeds from disk on any
+    # host that has mnemosyne installed. Fail the import itself instead.
     saved = list(sys.path)
+    real_import = builtins.__import__
+
+    def no_mnemosyne(name, *a, **kw):
+        if name.startswith("mnemosyne"):
+            raise ImportError(f"no module named {name}")
+        return real_import(name, *a, **kw)
+
     blocked = {m: None for m in list(sys.modules) if m.startswith("mnemosyne")}
     try:
-        with mock.patch.dict(sys.modules, blocked):
+        with mock.patch.dict(sys.modules, blocked), \
+                mock.patch.object(builtins, "__import__", no_mnemosyne):
             for m in blocked:
                 del sys.modules[m]
             assert hook._beam_fallback("some query") == []
@@ -1380,3 +1391,75 @@ def test_output_is_a_single_json_line_on_stdout(hook):
     assert out.endswith("\n") and out.count("\n") == 1
     assert list(json.loads(out)) == ["context"]
     assert isinstance(json.loads(out)["context"], str)
+
+
+# ---------------------------------------------------------------------------
+# Claude Code payload shape
+#
+# The hook was ported from Hermes by adding the Claude Code event names but not
+# its payload shape. Claude Code sends the text as a top-level "prompt";
+# Hermes nested it under extra.user_message. Reading only the latter made the
+# hook emit nothing on every real UserPromptSubmit and SubagentStart.
+# ---------------------------------------------------------------------------
+
+def _dark_hook(hook):
+    hook._embed = lambda t: None
+    hook._beam_fallback = lambda q: []
+    hook._load_rules_summary = lambda: ""
+
+
+@pytest.mark.parametrize("event", ["UserPromptSubmit", "SubagentStart"])
+def test_main_grounds_claude_code_top_level_prompt(hook, event):
+    _dark_hook(hook)
+    code, out = run_main(hook, {"hook_event_name": event,
+                                "session_id": "s1",
+                                "prompt": "why did retention delete the index"})
+    assert code is None, "hook exited without emitting on a real Claude Code payload"
+    assert "WARNING: memory grounding UNAVAILABLE" in context_of(out)
+
+
+def test_main_still_grounds_legacy_hermes_shape(hook):
+    _dark_hook(hook)
+    code, out = run_main(hook, {"hook_event_name": "pre_llm_call",
+                                "extra": {"user_message": "a real question"}})
+    assert code is None
+    assert "WARNING: memory grounding UNAVAILABLE" in context_of(out)
+
+
+def test_main_prefers_top_level_prompt_over_extra(hook):
+    seen = []
+    hook._embed = lambda t: seen.append(t) or None
+    hook._beam_fallback = lambda q: []
+    hook._load_rules_summary = lambda: ""
+    run_main(hook, {"hook_event_name": "UserPromptSubmit",
+                    "prompt": "the real prompt",
+                    "extra": {"user_message": "stale hermes text"}})
+    assert seen and "the real prompt" in seen[0]
+
+
+def test_main_still_exits_when_no_text_anywhere(hook):
+    _dark_hook(hook)
+    code, out = run_main(hook, {"hook_event_name": "UserPromptSubmit"})
+    assert code == 0 and out == ""
+
+
+# ---------------------------------------------------------------------------
+# _embed_base_url
+# ---------------------------------------------------------------------------
+
+def test_embed_base_url_appends_v1_to_bare_ollama_host(hook):
+    with mock.patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://h:11434"}, clear=True):
+        assert hook._embed_base_url() == "http://h:11434/v1"
+
+
+def test_embed_base_url_falls_back_to_mnemosyne_var(hook):
+    # What the Hermes profile actually sets — already a full /v1 endpoint.
+    with mock.patch.dict(os.environ,
+                         {"MNEMOSYNE_EMBEDDING_API_URL": "http://h:11434/v1"},
+                         clear=True):
+        assert hook._embed_base_url() == "http://h:11434/v1"
+
+
+def test_embed_base_url_none_when_unset(hook):
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert hook._embed_base_url() is None

--- a/scripts/hooks/tests/test_pre_llm_grounding.py
+++ b/scripts/hooks/tests/test_pre_llm_grounding.py
@@ -27,6 +27,7 @@ import os
 import pathlib
 import builtins
 import sys
+import urllib.error
 import time
 import types
 from unittest import mock
@@ -286,7 +287,10 @@ def test_search_collection_named_vector_request_shape(hook):
         calls.stop()
     c = calls[0]
     assert c["url"] == "http://qdrant.invalid:6333/collections/mnemosyne/points/search"
-    assert c["body"] == {"vector": {"dense": [1.0, 2.0]}, "limit": 4,
+    # Qdrant's REST contract for a named vector is {"name": ..., "vector": ...}.
+    # This test previously asserted {"dense": [...]}, which the server rejects
+    # with HTTP 400, so it pinned the defect rather than catching it.
+    assert c["body"] == {"vector": {"name": "dense", "vector": [1.0, 2.0]}, "limit": 4,
                          "with_payload": True, "with_vector": False}
     assert c["headers"]["Api-key"] == "test-key"
     assert c["timeout"] == 2.0
@@ -375,10 +379,23 @@ def test_search_collection_non_numeric_importance_raises(hook):
         calls.stop()
 
 
-def test_search_collection_returns_empty_on_transport_error(hook):
+def test_search_collection_raises_on_transport_error(hook):
+    # An empty list is what an unmatched query looks like, so returning [] here
+    # made a failing search indistinguishable from a successful empty one.
     calls = fake_urlopen(hook, OSError("down"))
     try:
-        assert hook._search_collection("c1", [1.0], "text", None, True) == []
+        with pytest.raises(hook._SearchFailed):
+            hook._search_collection("c1", [1.0], "text", None, True)
+    finally:
+        calls.stop()
+
+
+def test_search_collection_raises_on_http_error(hook):
+    calls = fake_urlopen(hook, urllib.error.HTTPError(
+        "u", 400, "Bad Request", {}, io.BytesIO(b'{"status":{"error":"x"}}')))
+    try:
+        with pytest.raises(hook._SearchFailed):
+            hook._search_collection("c1", [1.0], "text", None, True)
     finally:
         calls.stop()
 
@@ -1463,3 +1480,53 @@ def test_embed_base_url_falls_back_to_mnemosyne_var(hook):
 def test_embed_base_url_none_when_unset(hook):
     with mock.patch.dict(os.environ, {}, clear=True):
         assert hook._embed_base_url() is None
+
+
+# ---------------------------------------------------------------------------
+# fan-out degradation
+#
+# With the wrong named-vector shape every base collection returned HTTP 400 and
+# _search_collection swallowed it into []. The fan-out then reported a clean
+# "no matches" turn after turn. A total failure now degrades to BeamMemory.
+# ---------------------------------------------------------------------------
+
+def test_fanout_falls_back_to_beam_when_every_collection_fails(hook):
+    hook._embed = lambda t: [0.1]
+    hook._load_rules_summary = lambda: ""
+    hook._beam_fallback = lambda q: [{"collection": "mnemosyne_beam", "score": 0.9,
+                                      "importance": 0.9, "fused": 0.81,
+                                      "content": "beam recalled this"}]
+    calls = fake_urlopen(hook, OSError("qdrant down"))
+    try:
+        code, out = run_main(hook, {"hook_event_name": "UserPromptSubmit",
+                                    "prompt": "a real question about the index"})
+    finally:
+        calls.stop()
+    assert code is None
+    assert "beam recalled this" in context_of(out)
+
+
+def test_fanout_keeps_hits_when_only_some_collections_fail(hook):
+    hook._embed = lambda t: [0.1]
+    hook._load_rules_summary = lambda: ""
+    hook._beam_fallback = lambda q: [{"collection": "mnemosyne_beam", "score": 0.9,
+                                      "importance": 0.9, "fused": 0.81,
+                                      "content": "beam should NOT be used"}]
+    good = {"collection": "hermes_memory", "point_id": None, "score": 0.9,
+            "importance": 0.9, "fused": 0.81, "content": "qdrant recalled this",
+            "payload": {}}
+    real = hook._search_collection
+    hook._search_collection = (
+        lambda col, *a, **k: [good] if col == "hermes_memory" else _raise(hook, col))
+    try:
+        code, out = run_main(hook, {"hook_event_name": "UserPromptSubmit",
+                                    "prompt": "a real question about the index"})
+    finally:
+        hook._search_collection = real
+    ctx = context_of(out)
+    assert "qdrant recalled this" in ctx
+    assert "beam should NOT be used" not in ctx
+
+
+def _raise(hook, col):
+    raise hook._SearchFailed(col)

--- a/scripts/hooks/tests/test_pre_tool_grounding.py
+++ b/scripts/hooks/tests/test_pre_tool_grounding.py
@@ -1230,3 +1230,35 @@ def test_dangerous_command_via_unknown_tool_is_not_scanned(tmp_path):
     rc, out, _ = run_hook(call("shell", {"command": "rm -rf /"}), home, block=True)
     assert (rc, out) == (0, "")
     assert decisions(home) == ["ALLOW"]
+
+
+# =============================================================================
+# Claude Code event name
+#
+# Every other test in this file drives the hook with the Hermes event name
+# "pre_tool_call". Claude Code emits "PreToolUse", so a suite that only used the
+# legacy name passed in full while the hook was inert against the real client.
+# =============================================================================
+
+def test_hook_accepts_claude_code_event_name(tmp_path):
+    home = tmp_path / "h"
+    home.mkdir()
+    run_hook({"hook_event_name": "PreToolUse", "tool_name": "Whatever",
+              "tool_input": {}, "session_id": "s"}, home)
+    assert decisions(home), "no audit entry — hook ignored the Claude Code event"
+
+
+def test_hook_still_accepts_hermes_event_name(tmp_path):
+    home = tmp_path / "h"
+    home.mkdir()
+    run_hook(call("Whatever"), home)
+    assert decisions(home)
+
+
+def test_hook_ignores_unknown_event_names(tmp_path):
+    home = tmp_path / "h"
+    home.mkdir()
+    rc, out, _ = run_hook({"hook_event_name": "SomethingElse", "tool_name": "Whatever",
+                           "tool_input": {}, "session_id": "s"}, home)
+    assert rc == 0 and not out
+    assert not decisions(home)

--- a/scripts/hooks/tests/test_session_end_sync.py
+++ b/scripts/hooks/tests/test_session_end_sync.py
@@ -243,11 +243,24 @@ def test_read_stdin_session_id(hook, raw, expected):
         assert hook.read_stdin_session_id() == expected
 
 
-def test_read_stdin_session_id_does_not_coerce_non_strings(hook):
-    """BUG-ish: a numeric session_id is returned as an int, not a str."""
+def test_read_stdin_session_id_rejects_non_strings(hook):
+    """A numeric session_id used to be passed through as an int and then used in
+    a SQL lookup and a path join."""
     with mock.patch.object(hook.sys, "stdin", io.StringIO('{"session_id": 123}')):
-        got = hook.read_stdin_session_id()
-    assert got == 123 and isinstance(got, int)
+        assert hook.read_stdin_session_id() == ""
+
+
+def test_read_stdin_payload_returns_whole_object(hook):
+    raw = '{"session_id": "s1", "transcript_path": "/tmp/t.jsonl"}'
+    with mock.patch.object(hook.sys, "stdin", io.StringIO(raw)):
+        got = hook.read_stdin_payload()
+    assert got == {"session_id": "s1", "transcript_path": "/tmp/t.jsonl"}
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "not json", "[1,2]", '"a string"'])
+def test_read_stdin_payload_returns_empty_dict_on_junk(hook, raw):
+    with mock.patch.object(hook.sys, "stdin", io.StringIO(raw)):
+        assert hook.read_stdin_payload() == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1193,3 +1206,84 @@ def test_embeddings_url_prefers_ollama_base_url():
 def test_embeddings_url_none_when_neither_set():
     mod = load_hook({"OLLAMA_BASE_URL": None})
     assert mod.OLLAMA is None
+
+
+# ---------------------------------------------------------------------------
+# transcript_session_content
+#
+# STATE_DB is Hermes' session store: 765 rows, all Hermes-format ids, none
+# written since 2026-06-19. A Claude Code session id never resolves there, so
+# get_session_content returned None and the Stop hook exited 0 without ever
+# syncing a single Claude Code session. The Stop payload carries
+# transcript_path, which is the record that actually exists.
+# ---------------------------------------------------------------------------
+
+def _write_transcript(tmp_path, records):
+    p = tmp_path / "t.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return str(p)
+
+
+def _msg(kind, text, ts="2026-08-26T12:00:00Z", model=None):
+    if kind == "user":
+        body = {"role": "user", "content": text}
+    else:
+        body = {"role": "assistant", "content": [{"type": "text", "text": text}]}
+        if model:
+            body["model"] = model
+    return {"type": kind, "timestamp": ts, "message": body}
+
+
+def test_transcript_content_builds_a_session(hook, tmp_path):
+    path = _write_transcript(tmp_path, [
+        {"type": "ai-title", "aiTitle": "Public Loci code"},
+        _msg("user", "a" * 40, ts="2026-08-24T17:40:37.466Z"),
+        _msg("assistant", "b" * 40, model="claude-opus-5"),
+    ])
+    got = hook.transcript_session_content(path, "sess-uuid")
+    assert got["title"] == "Public Loci code"
+    assert got["model"] == "claude-opus-5"
+    assert got["source"] == "claude-code"
+    assert got["started_at"] == "2026-08-24T17:40:37.466Z"
+    assert got["msg_count"] == 2
+    assert "USER: " + "a" * 40 in got["content"]
+    assert "ASSISTANT: " + "b" * 40 in got["content"]
+
+
+def test_transcript_content_extracts_only_text_blocks(hook, tmp_path):
+    rec = {"type": "assistant", "timestamp": "t", "message": {
+        "role": "assistant", "model": "m", "content": [
+            {"type": "thinking", "thinking": "hidden reasoning here padded out"},
+            {"type": "text", "text": "visible answer padded out to pass length"},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+        ]}}
+    got = hook.transcript_session_content(_write_transcript(tmp_path, [rec]), "s")
+    assert "visible answer" in got["content"]
+    assert "hidden reasoning" not in got["content"]
+    assert "tool_use" not in got["content"]
+
+
+def test_transcript_content_skips_unparseable_lines(hook, tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text("{not json\n" + json.dumps(_msg("user", "c" * 40)) + "\n\n")
+    got = hook.transcript_session_content(str(p), "s")
+    assert got["msg_count"] == 1
+
+
+def test_transcript_content_caps_at_max_chars(hook, tmp_path):
+    hook.MAX_CHARS = 200
+    records = [_msg("user", str(i) * 120) for i in range(40)]
+    got = hook.transcript_session_content(_write_transcript(tmp_path, records), "s")
+    assert got["msg_count"] == 40
+    assert len(got["content"]) <= 200
+    # The tail is what gets embedded, so the newest message must be present.
+    assert "39" in got["content"]
+
+
+def test_transcript_content_none_for_missing_or_empty(hook, tmp_path):
+    assert hook.transcript_session_content("", "s") is None
+    assert hook.transcript_session_content(str(tmp_path / "nope.jsonl"), "s") is None
+    assert hook.transcript_session_content(_write_transcript(tmp_path, []), "s") is None
+    # Records with no usable text are not a session.
+    short = _write_transcript(tmp_path, [_msg("user", "hi")])
+    assert hook.transcript_session_content(short, "s") is None

--- a/scripts/hooks/tests/test_session_end_sync.py
+++ b/scripts/hooks/tests/test_session_end_sync.py
@@ -1163,3 +1163,33 @@ def test_main_survives_a_missing_state_db_entirely(wired, capsys):
 def test_main_ignores_extra_stdin_keys_and_bad_json(wired):
     assert run_main(wired, "garbage not json") == 0
     assert run_main(wired, {"sessionId": "s1"}) == 0     # camelCase is not read
+
+
+# ---------------------------------------------------------------------------
+# _embeddings_url
+#
+# The module read only OLLAMA_BASE_URL. The Hermes profile sets
+# MNEMOSYNE_EMBEDDING_API_URL (already a full /v1 endpoint), so the sync had no
+# embeddings endpoint at all under the profile's own environment.
+# ---------------------------------------------------------------------------
+
+def test_embeddings_url_from_bare_ollama_host():
+    mod = load_hook({"OLLAMA_BASE_URL": "http://h:11434"})
+    assert mod.OLLAMA == "http://h:11434/v1/embeddings"
+
+
+def test_embeddings_url_falls_back_to_mnemosyne_var():
+    mod = load_hook({"OLLAMA_BASE_URL": None,
+                     "MNEMOSYNE_EMBEDDING_API_URL": "http://h:11434/v1"})
+    assert mod.OLLAMA == "http://h:11434/v1/embeddings"
+
+
+def test_embeddings_url_prefers_ollama_base_url():
+    mod = load_hook({"OLLAMA_BASE_URL": "http://a:1",
+                     "MNEMOSYNE_EMBEDDING_API_URL": "http://b:2/v1"})
+    assert mod.OLLAMA == "http://a:1/v1/embeddings"
+
+
+def test_embeddings_url_none_when_neither_set():
+    mod = load_hook({"OLLAMA_BASE_URL": None})
+    assert mod.OLLAMA is None

--- a/scripts/swr_replay.py
+++ b/scripts/swr_replay.py
@@ -98,7 +98,9 @@ def _qdrant_search_consolidated(collection: str, embedding: list[float], k: int)
     """Fetch existing consolidated points for interleaving."""
     url = f"{QDRANT_URL}/collections/{collection}/points/search"
     body = json.dumps({
-        "vector": {"dense": embedding},
+        # /points/search wants {"name": ..., "vector": ...}; the bare {"dense": v}
+        # form is for upsert and is rejected here with HTTP 400.
+        "vector": {"name": "dense", "vector": embedding},
         "limit": k,
         "with_payload": True,
         "with_vector": False,

--- a/scripts/tests/test_swr_replay_search_shape.py
+++ b/scripts/tests/test_swr_replay_search_shape.py
@@ -1,0 +1,67 @@
+"""swr_replay's consolidated-point search sent Qdrant the upsert form of a named
+vector, {"dense": vec}, which /points/search rejects with HTTP 400. The call
+swallowed the error and returned [], which is indistinguishable from a query
+that legitimately matched nothing, so the interleave step silently never ran."""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import pathlib
+from unittest import mock
+
+import pytest
+
+MODULE = pathlib.Path(__file__).resolve().parent.parent / "swr_replay.py"
+
+
+def load(env=None):
+    e = {"QDRANT_URL": "http://qdrant.invalid:6333", "QDRANT_API_KEY": "k",
+         **(env or {})}
+    with mock.patch.dict(os.environ, e, clear=True):
+        spec = importlib.util.spec_from_file_location("_swr_uut", MODULE)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def swr():
+    return load()
+
+
+def _capture(mod, bodies, result=None):
+    def fake(req, timeout=None):
+        bodies.append(json.loads(req.data.decode()))
+        payload = json.dumps({"result": result if result is not None else []})
+        r = io.BytesIO(payload.encode())
+        r.__enter__ = lambda s=r: s
+        r.__exit__ = lambda s, *a: False
+        return r
+    return mock.patch.object(mod.urllib.request, "urlopen", fake)
+
+
+def test_search_uses_named_vector_search_shape(swr):
+    bodies = []
+    with _capture(swr, bodies):
+        swr._qdrant_search_consolidated("hermes_memory", [1.0, 2.0], 3)
+    assert bodies, "no request issued"
+    assert bodies[0]["vector"] == {"name": "dense", "vector": [1.0, 2.0]}, (
+        "sent the upsert form; Qdrant answers 400 and the result is swallowed"
+    )
+
+
+def test_search_keeps_its_consolidated_filter(swr):
+    bodies = []
+    with _capture(swr, bodies):
+        swr._qdrant_search_consolidated("hermes_memory", [1.0], 3)
+    assert bodies[0]["filter"]["must"][0]["match"]["value"] == "consolidated"
+
+
+def test_upsert_still_uses_the_bare_named_vector_form(swr):
+    # Upsert genuinely takes {"dense": vec}; fixing search must not touch it.
+    bodies = []
+    with _capture(swr, bodies):
+        swr._qdrant_upsert("hermes_memory", "p1", [1.0], {"a": 1})
+    assert bodies[0]["points"][0]["vector"] == {"dense": [1.0]}

--- a/scripts/tests/test_swr_replay_search_shape.py
+++ b/scripts/tests/test_swr_replay_search_shape.py
@@ -31,14 +31,21 @@ def swr():
     return load()
 
 
+class _Resp(io.BytesIO):
+    """urlopen is used as a context manager, which BytesIO does not support."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
 def _capture(mod, bodies, result=None):
     def fake(req, timeout=None):
         bodies.append(json.loads(req.data.decode()))
-        payload = json.dumps({"result": result if result is not None else []})
-        r = io.BytesIO(payload.encode())
-        r.__enter__ = lambda s=r: s
-        r.__exit__ = lambda s, *a: False
-        return r
+        return _Resp(json.dumps(
+            {"result": result if result is not None else []}).encode())
     return mock.patch.object(mod.urllib.request, "urlopen", fake)
 
 


### PR DESCRIPTION
The hooks were installed, ran on every turn, exited 0, and did nothing. Several independent defects stacked; each alone was enough to make its hook inert. They share one cause: the hooks were ported from Hermes by updating the **event names** and not the **payload shapes** or the **endpoints**.

### Measured, end to end

| | before | after |
|---|---|---|
| `pre_llm_grounding` output on a real `UserPromptSubmit` | **0 bytes** | 1962 bytes |
| recalled memories in that output | **0** | 3 results from 3 collections |
| `pre_tool_grounding` (repo copy) on `PreToolUse` | ignored | audits |
| Claude Code sessions ever synced by the Stop hook | **0** | 932 messages in 0.42s |
| embeddings path | BeamMemory fallback | vector search |

---

### 1. The prompt hook never saw the prompt

`pre_llm_grounding` read `extra.user_message`. Claude Code sends the text as a top-level `prompt`, so every `UserPromptSubmit` and `SubagentStart` hit the empty-message guard and exited silently. Both shapes are accepted now.

### 2. Every Qdrant search returned 400

Qdrant's REST contract for a named vector is `{"name": ..., "vector": ...}`. The hook sent `{"dense": [...]}`:

```
400 Format error in JSON body: data did not match any variant of
untagged enum NamedVectorStruct
```

All three base collections (`mnemosyne`, `hermes_sessions`, `hermes_memory`) use the `dense` named vector, so all three 400'd every turn. `_search_collection` swallowed the error into `[]` — precisely what a query with no matches looks like — so the hook emitted the static directive plus rule headings and nothing else. That output is 1451 bytes and looks healthy.

`test_search_collection_named_vector_request_shape` **asserted** the `{"dense": [...]}` body, so the suite pinned the defect rather than catching it.

A failed search now raises `_SearchFailed`. The fan-out counts failures and degrades to BeamMemory only when *every* collection failed; partial failures still return the hits that succeeded. Without that distinction this bug class is invisible by construction.

A sweep of every `/points/search` and `/points/query` call site found one more — `swr_replay._qdrant_search_consolidated`, same shape, same silent swallow — and no others. `memgas_hierarchy.py` already had it right. Upserts genuinely take `{"dense": vec}` and are unchanged.

### 3. `pre_tool_grounding`'s repo copy was dark

It only accepted the event name `pre_tool_call`. The **deployed** copy had been hand-edited to also accept `PreToolUse`, and that edit was never backported — so a fresh install would have silently disabled the hook. Every test in its suite drives it with the Hermes name, which is why a fully green suite said nothing.

### 4. The Stop hook had never synced a Claude Code session

`get_session_content` looks the id up in `STATE_DB`, which is Hermes' session store: 765 rows, all of the form `20260619_014851_d15f74`, nothing written since 2026-06-19. A Claude Code session id is a UUID and never resolves there, so the hook returned `None` and exited 0 every time.

The Stop payload carries `transcript_path`, which is the record that does exist. `transcript_session_content` builds the same structure from it — `ai-title` for the title, first message timestamp, model off an assistant message, and the text blocks of user and assistant messages. Assistant content is a block list, so `thinking` and `tool_use` blocks are skipped. The file is streamed and the tail bounded: transcripts reach tens of megabytes and only the last `MAX_CHARS` is embedded.

Measured on a 15 MB, 10,586-line transcript: **932 messages, 0.42s**, `hermes_sessions` 315 to 316. A second session has since synced on its own.

`read_stdin_payload` parses the payload once so `main` can reach `transcript_path`. `read_stdin_session_id` is kept and delegates to it, but no longer returns a non-string id — `test_read_stdin_session_id_does_not_coerce_non_strings` asserted that an integer `session_id` was passed straight into a SQL lookup and a path join.

### 5. Embeddings endpoint

Both `pre_llm_grounding` and `session_end_sync` built their embeddings URL only from `OLLAMA_BASE_URL`. The Hermes profile sets `MNEMOSYNE_EMBEDDING_API_URL`. Recall ran on the fallback path; the sync had no endpoint at all. Both accept either now, via a function so it is testable without `importlib.reload`.

### 6. Drift

Nothing kept the repo and `~/.claude/hooks` in sync — which is how the `PreToolUse` edit went missing. `scripts/hooks/install.sh` installs with backup; `--check` reports drift. Its first run found a third divergence: the deployed `session_end_sync.py` predated the repo's `prune_cache`.

### Test fix

`test_beam_fallback_returns_empty_when_mnemosyne_missing` failed on clean `main` here. It cleared `sys.modules`, but the import re-succeeds from disk wherever mnemosyne is installed. It now fails the import itself — the layer `_beam_fallback` actually reads.

### Verification

- `scripts/hooks/tests` + `scripts/tests`: **687 passed** (baseline on `main`: 529 passed, 1 failed).
- Sabotage-tested — reverting each fix individually fails only its own tests: payload shape 3, event gate 1, embed URL 1, named-vector shape 1, error visibility 3, swr search shape 1, sync embed URL 1.
- Installed copies verified live: grounding hook returns `MEMORY MATCH (3 results from 3 Qdrant collections)`, tool hook still writes `tool-audit.log`, Stop hook synced a real session and the point is retrievable.
- CI 11/11.

### Host configuration, outside this repo

`~/.claude/hooks/session_end_sync.sh` had `QDRANT_URL` hardcoded to `an internal host`, which does not answer (10s timeout, confirmed twice), while the profile's `an internal host` replies in under a millisecond. It now reads endpoints from the profile `.env` rather than duplicating them, which is what let them drift. That file holds credentials and stays out of this public repo.

