### PR TITLE
Stop counting access rows as findings, and drive the summary ladder

### DIFF
--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -98,6 +98,22 @@ def investigation_start(
     return json.dumps({"status": "created", "manifest": manifest}, indent=2)
 
 
+# findings.jsonl is a mixed append log: alongside real findings it carries
+# access-tracking rows written on every read. They hold no text, and because one
+# is appended per access they are also the NEWEST rows, so any findings[-N:]
+# slice fills up with them. Measured across the corpus: 3,681 of 6,610 records
+# (55.7%) are access rows, all text-less — which is why the summary ladder was
+# handing the model twenty empty bullets and getting an invented summary back.
+_NON_FINDING_RECORD_TYPES = frozenset({"access"})
+
+
+def _only_findings(records: list) -> list:
+    """Drop the non-finding rows from a raw findings.jsonl read."""
+    return [r for r in records
+            if isinstance(r, dict)
+            and (r.get("record_type") or r.get("type") or "") not in _NON_FINDING_RECORD_TYPES]
+
+
 def investigation_load(
     investigation_id: str,
     last_n_findings: int = 20,
@@ -156,7 +172,7 @@ def investigation_load(
         }, indent=2)
 
     if fidelity == "summary":
-        findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
+        findings = _only_findings(_read_jsonl(_inv_dir(investigation_id) / "findings.jsonl"))
         all_retracted = _load_retracted_ids(investigation_id)
         total_retracted = len(all_retracted)
         retracted = set() if include_retracted else all_retracted
@@ -177,7 +193,7 @@ def investigation_load(
         }, indent=2)
 
     # Default: fidelity == "full"
-    findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
+    findings = _only_findings(_read_jsonl(_inv_dir(investigation_id) / "findings.jsonl"))
     all_retracted = _load_retracted_ids(investigation_id)
     total_retracted = len(all_retracted)
     retracted = set() if include_retracted else all_retracted
@@ -441,7 +457,7 @@ def investigation_reflect(investigation_id: str) -> str:
     if not manifest:
         return json.dumps({"error": f"Investigation '{investigation_id}' not found."})
 
-    findings = _read_jsonl(_inv_dir(investigation_id) / "findings.jsonl")
+    findings = _only_findings(_read_jsonl(_inv_dir(investigation_id) / "findings.jsonl"))
     retracted = _load_retracted_ids(investigation_id)
     excluded_retracted = 0
     if retracted:

--- a/mcp/tests/test_only_findings.py
+++ b/mcp/tests/test_only_findings.py
@@ -1,0 +1,57 @@
+"""findings.jsonl is a mixed append log.
+
+Alongside real findings it carries access-tracking rows, written once per read.
+They hold no text, and being the newest rows they crowd out any findings[-N:]
+slice: measured across the corpus, 3,681 of 6,610 records (55.7%) are access
+rows, all text-less. For one investigation all 20 of the last 20 records were
+access rows, so the summary ladder handed the model twenty empty bullets and got
+back a summary invented from the title.
+
+The same slice feeds recent_findings on every full-fidelity investigation_load,
+and total_findings counted them too.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from investigation_tools import _only_findings
+
+
+class OnlyFindingsTest(unittest.TestCase):
+    def test_drops_access_rows(self):
+        recs = [
+            {"record_type": "observed", "text": "a real finding"},
+            {"record_type": "access", "last_accessed": 1787766238, "query": "q"},
+            {"record_type": "inferred", "text": "another"},
+        ]
+        self.assertEqual([r["record_type"] for r in _only_findings(recs)],
+                         ["observed", "inferred"])
+
+    def test_keeps_every_real_finding_type(self):
+        # The corpus census: observed, inferred, gap, procedure, assumed.
+        kinds = ["observed", "inferred", "gap", "procedure", "assumed"]
+        recs = [{"record_type": k, "text": "t"} for k in kinds]
+        self.assertEqual(len(_only_findings(recs)), len(kinds))
+
+    def test_falls_back_to_the_type_key(self):
+        # Older records carry "type" rather than "record_type".
+        self.assertEqual(_only_findings([{"type": "access"}]), [])
+        self.assertEqual(len(_only_findings([{"type": "observed", "text": "t"}])), 1)
+
+    def test_keeps_records_with_no_type_at_all(self):
+        # Unknown is not the same as non-finding; dropping these would lose data.
+        self.assertEqual(len(_only_findings([{"text": "no type given"}])), 1)
+
+    def test_ignores_non_dict_rows(self):
+        self.assertEqual(_only_findings(["junk", None, 3]), [])
+
+    def test_an_all_access_tail_leaves_nothing(self):
+        # The exact shape that produced the invented summary.
+        recs = [{"record_type": "access"} for _ in range(20)]
+        self.assertEqual(_only_findings(recs), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -113,6 +113,7 @@ GROOM_BATCH = int(os.environ.get("LOCI_GROOM_BATCH", "16"))
 # Per-run ceilings. These bound a nightly job, not a human sitting in front of it.
 VERIFY_MAX_PER_RUN = int(os.environ.get("LOCI_GROOM_VERIFY_INVESTIGATIONS", "5"))
 VERIFY_PER_INVESTIGATION = int(os.environ.get("LOCI_GROOM_VERIFY_FINDINGS", "10"))
+SUMMARY_MAX_PER_RUN = int(os.environ.get("LOCI_GROOM_SUMMARY_INVESTIGATIONS", "12"))
 REFLECT_MAX_ITEMS = int(os.environ.get("LOCI_GROOM_REFLECT_ITEMS", "3"))
 
 
@@ -1019,6 +1020,102 @@ def pass_reflect(limit: Optional[int] = None, seed_fn: Optional[Callable] = None
     return report
 
 
+def _has_llm_summary(manifest: dict) -> bool:
+    """True only for a MODEL-authored summary.
+
+    investigation_reflect always persists something: when the model is
+    unavailable it falls back to a deterministic stub built from the last few
+    findings. Treating that stub as "done" would let one run with the backend
+    down permanently mark every investigation as summarised, which is the shape
+    of failure this tier exists to catch. The stub's paragraph is recognisable.
+    """
+    if not manifest.get("summary_l1"):
+        return False
+    l2 = str(manifest.get("summary_l2") or "").strip()
+    if not l2 or re.match(r"^Investigation with \d+ finding", l2):
+        return False
+    return True
+
+
+def pass_summaries(limit: Optional[int] = None, memory_dir: Optional[Path] = None,
+                   reflect_fn: Optional[Callable] = None,
+                   gen_probe: Optional[Callable] = None, **_) -> dict:
+    """Fill in the per-investigation summaries that investigation_load asks for.
+
+    The summary ladder lives inside investigation_reflect, and that tool had
+    never been called: 6 of 142 manifests carried a summary while 7 of 15 real
+    investigation_load calls asked for fidelity=summary or brief. The generator
+    exists and works; nothing drove it.
+
+    Safe unattended: it writes only summary_l1/summary_l2 on the manifest, never
+    findings, and it is bounded per run. Investigations that already carry a
+    model-authored summary are skipped, so repeated runs advance the backlog
+    instead of re-spending on the same ones.
+    """
+    report = {"pass": "summaries", "status": "ok"}
+    budget = int(limit or SUMMARY_MAX_PER_RUN)
+
+    # Same guard as pass_verify, for the same reason: with the backend down the
+    # ladder silently writes its deterministic stub for every investigation.
+    if gen_probe is None:
+        def gen_probe():
+            sys.path.insert(0, str(_REPO / "mcp"))
+            from llm_local import generate
+            return bool(generate("Reply with OK.", max_tokens=8).get("ok"))
+    try:
+        if not gen_probe():
+            report.update(status="degraded",
+                          detail="generation backend is not answering; skipping rather "
+                                 "than stamping a deterministic stub on every manifest")
+            return report
+    except Exception as exc:
+        report.update(status="degraded", detail=f"generation probe failed: {exc!r}")
+        return report
+
+    if reflect_fn is None:
+        try:
+            sys.path.insert(0, str(_REPO / "mcp"))
+            import server as _server
+            reflect_fn = _server.investigation_reflect
+        except Exception as exc:
+            report.update(status="degraded",
+                          detail=f"cannot import investigation_reflect: {exc!r}")
+            return report
+
+    root = Path(memory_dir or MEMORY_DIR)
+    done = skipped = errors = 0
+    for man_path in sorted(root.glob("*/manifest.json")):
+        if done >= budget:
+            break
+        try:
+            manifest = json.loads(man_path.read_text())
+        except Exception:
+            errors += 1
+            continue
+        if _has_llm_summary(manifest):
+            skipped += 1
+            continue
+        inv = manifest.get("investigation_id") or man_path.parent.name
+        try:
+            reflect_fn(investigation_id=inv)
+        except Exception:
+            errors += 1
+            continue
+        # Confirm the model actually authored one; a stub means it did not.
+        try:
+            if _has_llm_summary(json.loads(man_path.read_text())):
+                done += 1
+            else:
+                errors += 1
+        except Exception:
+            errors += 1
+    report.update(summarised=done, already_had=skipped, errors=errors, budget=budget)
+    if errors and not done:
+        report.update(status="degraded",
+                      detail=f"{errors} investigations errored and none were summarised")
+    return report
+
+
 PASSES = {
     "index": {"fn": pass_index, "applyable": True},
     "tags": {"fn": pass_tags, "applyable": False},
@@ -1027,6 +1124,7 @@ PASSES = {
     "codelink": {"fn": pass_codelink, "applyable": False},
     "verify": {"fn": pass_verify, "applyable": False},
     "reflect": {"fn": pass_reflect, "applyable": False},
+    "summaries": {"fn": pass_summaries, "applyable": False},
 }
 
 

--- a/scripts/tests/test_groom_summaries.py
+++ b/scripts/tests/test_groom_summaries.py
@@ -1,0 +1,134 @@
+"""The summaries pass, and the access-record filter it depends on.
+
+The summary ladder inside investigation_reflect was correct code that nothing
+called: 6 of 142 manifests carried a summary while 7 of 15 real
+investigation_load calls asked for fidelity=summary or brief.
+
+It also could not have produced a good one. findings.jsonl is a mixed append log
+and 3,681 of its 6,610 records (55.7%) are text-less access rows written on every
+read. Being the newest rows, they filled findings[-20:] completely for some
+investigations, so the model was handed twenty empty bullets plus a title and
+invented a plausible topic from the title alone.
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import loci_groom as g
+
+
+class HasLlmSummaryTest(unittest.TestCase):
+    """The deterministic stub must not count as done, or one run with the backend
+    down would permanently mark every investigation as summarised."""
+
+    def test_model_authored_summary_counts(self):
+        self.assertTrue(g._has_llm_summary(
+            {"summary_l1": ["a point"], "summary_l2": "A real paragraph about it."}))
+
+    def test_deterministic_stub_does_not_count(self):
+        self.assertFalse(g._has_llm_summary(
+            {"summary_l1": ["raw finding text"],
+             "summary_l2": "Investigation with 12 findings. Latest: something."}))
+
+    def test_singular_stub_does_not_count(self):
+        self.assertFalse(g._has_llm_summary(
+            {"summary_l1": ["x"], "summary_l2": "Investigation with 1 finding."}))
+
+    def test_missing_pieces_do_not_count(self):
+        self.assertFalse(g._has_llm_summary({}))
+        self.assertFalse(g._has_llm_summary({"summary_l1": [], "summary_l2": "text"}))
+        self.assertFalse(g._has_llm_summary({"summary_l1": ["x"], "summary_l2": "   "}))
+
+
+class PassSummariesGateTest(unittest.TestCase):
+    def test_a_dead_backend_degrades_and_reflects_nothing(self):
+        called = []
+        rep = g.pass_summaries(gen_probe=lambda: False,
+                               reflect_fn=lambda **kw: called.append(kw))
+        self.assertEqual(rep["status"], "degraded")
+        self.assertIn("generation backend", rep["detail"])
+        self.assertEqual(called, [], "must not stamp a stub with no model")
+
+    def test_a_raising_probe_also_degrades(self):
+        rep = g.pass_summaries(
+            gen_probe=lambda: (_ for _ in ()).throw(OSError("refused")))
+        self.assertEqual(rep["status"], "degraded")
+
+
+class PassSummariesWorkTest(unittest.TestCase):
+    def _inv(self, tmp, name, manifest):
+        d = tmp / name
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps(manifest))
+        return d
+
+    def setUp(self):
+        import tempfile, pathlib
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_skips_investigations_that_already_have_one(self):
+        self._inv(self.root, "done", {"investigation_id": "done",
+                                      "summary_l1": ["p"], "summary_l2": "Real summary."})
+        seen = []
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=lambda **kw: seen.append(kw))
+        self.assertEqual(seen, [])
+        self.assertEqual(rep["already_had"], 1)
+        self.assertEqual(rep["summarised"], 0)
+
+    def test_summarises_one_that_lacks_it(self):
+        d = self._inv(self.root, "todo", {"investigation_id": "todo"})
+
+        def reflect(investigation_id):
+            m = json.loads((d / "manifest.json").read_text())
+            m["summary_l1"] = ["a point"]
+            m["summary_l2"] = "A real paragraph."
+            (d / "manifest.json").write_text(json.dumps(m))
+
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=reflect)
+        self.assertEqual(rep["summarised"], 1)
+        self.assertEqual(rep["errors"], 0)
+
+    def test_a_stub_written_by_reflect_counts_as_an_error_not_a_success(self):
+        """Otherwise a transient model failure would be recorded as done and the
+        investigation would never be retried."""
+        d = self._inv(self.root, "todo", {"investigation_id": "todo"})
+
+        def reflect(investigation_id):
+            m = json.loads((d / "manifest.json").read_text())
+            m["summary_l1"] = ["raw text"]
+            m["summary_l2"] = "Investigation with 3 findings."
+            (d / "manifest.json").write_text(json.dumps(m))
+
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=reflect)
+        self.assertEqual(rep["summarised"], 0)
+        self.assertEqual(rep["errors"], 1)
+        self.assertEqual(rep["status"], "degraded")
+
+    def test_budget_bounds_the_run(self):
+        for i in range(5):
+            self._inv(self.root, f"inv{i}", {"investigation_id": f"inv{i}"})
+
+        def reflect(investigation_id):
+            p = self.root / investigation_id / "manifest.json"
+            m = json.loads(p.read_text())
+            m["summary_l1"] = ["p"]
+            m["summary_l2"] = "Real."
+            p.write_text(json.dumps(m))
+
+        rep = g.pass_summaries(memory_dir=self.root, limit=2,
+                               gen_probe=lambda: True, reflect_fn=reflect)
+        self.assertEqual(rep["summarised"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two defects, one visible symptom: `investigation_load(fidelity="summary")` was serving summaries that were either absent or invented.

### The summaries barely existed

The ladder lives inside `investigation_reflect`, and that tool had **never been called**. Result: **6 of 142** manifests carried a summary, while **7 of 15** real `investigation_load` calls asked for `fidelity=summary` or `brief`. Working code, no caller.

### The ones that existed were invented

`findings.jsonl` is a mixed append log. Alongside real findings it carries access-tracking rows written once per read — no text, and being the newest rows they crowd out any `findings[-N:]` slice.

Census over the corpus:

| record_type | count | text-less |
|---|---:|---:|
| **access** | **3,681** | **3,681** |
| observed | 1,772 | 0 |
| inferred | 746 | 0 |
| gap | 355 | 0 |
| procedure | 55 | 0 |
| assumed | 1 | 0 |

**55.7% of the "findings" corpus is access telemetry.**

For `acoustic-system-deep-dive-2026-08-17`, all 20 of the last 20 records were access rows. The ladder's prompt was **139 characters of `- [?]` placeholders** plus the title, so the model invented from the title alone — generic prose about *"researchers exploring device fingerprinting"* for an investigation into this operator's own fleet.

The same unfiltered slice feeds `recent_findings` on **every** full-fidelity `investigation_load`, and `total_findings` counted them: 57 reported where 12 exist.

### The fix

`_only_findings` drops access rows at the three sites in `investigation_tools` that treat records as findings. Records with no type at all are kept — unknown is not the same as non-finding.

Same investigation, after, in 5.1s:

> • Ggwave-based TWR ranging is entirely absent from the codebase.
> • The BeepBeep formula is a genuine mathematically-verified implementation.
> • Three subsystems are parallel and independently triggered, not staged.

`pass_summaries` then drives the ladder: bounded per run, skips investigations that already have a summary, and gated on the generation backend answering. That gate matters — with the backend down the ladder writes a deterministic stub, and stamping that across the corpus would mark everything as summarised forever. A stub written despite the gate counts as an **error, not a success**, so the investigation is retried rather than left stubbed.

### Measured

- 25 investigations summarised in **1m45s** (~4s each), 2 errors that retry next run.
- Model-authored summaries went **6 → 29** during validation.
- Spot-checked against independently-known facts; they corroborate.

### Verification

- `scripts/tests` + `scripts/hooks/tests`: 697 passed. `mcp/`: 771 passed.
- `mcp/tests/test_graph_integration.py::test_code_graph_ingest_and_query` fails, and fails identically on clean `main` with these changes stashed — pre-existing and unrelated.
- Sabotage-tested: reverting the access filter fails 3 of its 6 tests; reverting the stub detection fails 3 of the pass tests.
- ruff clean on the touched files.