### PR TITLE
summaries: an investigation with nothing to summarise is not an error

### DIFF
--- a/scripts/loci_groom.py
+++ b/scripts/loci_groom.py
@@ -1020,6 +1020,58 @@ def pass_reflect(limit: Optional[int] = None, seed_fn: Optional[Callable] = None
     return report
 
 
+def _summarisable(inv_dir: Path) -> bool:
+    """True if the investigation holds at least one record worth summarising.
+
+    findings.jsonl also carries text-less access rows, so a file that is not
+    empty is not the same as an investigation with findings.
+    """
+    fj = inv_dir / "findings.jsonl"
+    if not fj.exists():
+        return False
+    # A retracted finding is still in the log but is not something to summarise;
+    # investigation_reflect drops it, so counting it here would keep asking for a
+    # summary of nothing.
+    retracted = set()
+    rj = inv_dir / "retractions.jsonl"
+    if rj.exists():
+        try:
+            with rj.open() as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except ValueError:
+                        continue
+                    if isinstance(rec, dict) and rec.get("active") and rec.get("finding_id"):
+                        retracted.add(str(rec["finding_id"]))
+        except OSError:
+            pass
+    try:
+        with fj.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                if (rec.get("record_type") or rec.get("type") or "") == "access":
+                    continue
+                if str(rec.get("id", "")) in retracted:
+                    continue
+                if str(rec.get("text", "")).strip():
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 def _has_llm_summary(manifest: dict) -> bool:
     """True only for a MODEL-authored summary.
 
@@ -1083,7 +1135,7 @@ def pass_summaries(limit: Optional[int] = None, memory_dir: Optional[Path] = Non
             return report
 
     root = Path(memory_dir or MEMORY_DIR)
-    done = skipped = errors = 0
+    done = skipped = errors = empty = 0
     for man_path in sorted(root.glob("*/manifest.json")):
         if done >= budget:
             break
@@ -1094,6 +1146,13 @@ def pass_summaries(limit: Optional[int] = None, memory_dir: Optional[Path] = Non
             continue
         if _has_llm_summary(manifest):
             skipped += 1
+            continue
+        # An investigation with nothing to summarise is not a failure. Without
+        # this the empty ones error on every run, and once the backlog is clear
+        # that is every run — a pass permanently reporting degraded is a pass
+        # nobody reads when it finally means it.
+        if not _summarisable(man_path.parent):
+            empty += 1
             continue
         inv = manifest.get("investigation_id") or man_path.parent.name
         try:
@@ -1109,7 +1168,8 @@ def pass_summaries(limit: Optional[int] = None, memory_dir: Optional[Path] = Non
                 errors += 1
         except Exception:
             errors += 1
-    report.update(summarised=done, already_had=skipped, errors=errors, budget=budget)
+    report.update(summarised=done, already_had=skipped, nothing_to_say=empty,
+                  errors=errors, budget=budget)
     if errors and not done:
         report.update(status="degraded",
                       detail=f"{errors} investigations errored and none were summarised")

--- a/scripts/tests/test_groom_summaries.py
+++ b/scripts/tests/test_groom_summaries.py
@@ -59,10 +59,14 @@ class PassSummariesGateTest(unittest.TestCase):
 
 
 class PassSummariesWorkTest(unittest.TestCase):
-    def _inv(self, tmp, name, manifest):
+    def _inv(self, tmp, name, manifest, findings=None):
         d = tmp / name
         d.mkdir(parents=True)
         (d / "manifest.json").write_text(json.dumps(manifest))
+        recs = findings if findings is not None else [
+            {"record_type": "observed", "text": "a real finding to summarise"}]
+        (d / "findings.jsonl").write_text(
+            "".join(json.dumps(x) + "\n" for x in recs))
         return d
 
     def setUp(self):
@@ -132,3 +136,102 @@ class PassSummariesWorkTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class EmptyInvestigationTest(unittest.TestCase):
+    """Once the backlog is clear the only ones left are those with nothing to
+    summarise. Counting them as errors made the pass report degraded on every
+    single run, which is how a real failure goes unnoticed."""
+
+    def setUp(self):
+        import tempfile, pathlib
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _inv(self, name, lines):
+        d = self.root / name
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps({"investigation_id": name}))
+        (d / "findings.jsonl").write_text("".join(json.dumps(x) + "\n" for x in lines))
+        return d
+
+    def test_no_findings_file_is_not_an_error(self):
+        d = self.root / "bare"
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps({"investigation_id": "bare"}))
+        seen = []
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=lambda **kw: seen.append(kw))
+        self.assertEqual(seen, [], "must not reflect an investigation with no findings")
+        self.assertEqual(rep["nothing_to_say"], 1)
+        self.assertEqual(rep["errors"], 0)
+        self.assertEqual(rep["status"], "ok")
+
+    def test_access_rows_alone_are_not_summarisable(self):
+        self._inv("acc", [{"record_type": "access", "query": "q"}] * 5)
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=lambda **kw: None)
+        self.assertEqual(rep["nothing_to_say"], 1)
+        self.assertEqual(rep["errors"], 0)
+
+    def test_one_real_finding_is_summarisable(self):
+        d = self._inv("real", [{"record_type": "access"},
+                               {"record_type": "observed", "text": "a real one"}])
+
+        def reflect(investigation_id):
+            p = d / "manifest.json"
+            m = json.loads(p.read_text())
+            m["summary_l1"] = ["p"]
+            m["summary_l2"] = "Real."
+            p.write_text(json.dumps(m))
+
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=reflect)
+        self.assertEqual(rep["summarised"], 1)
+        self.assertEqual(rep["nothing_to_say"], 0)
+
+    def test_a_cleared_backlog_reports_ok_not_degraded(self):
+        self._inv("empty", [{"record_type": "access"}])
+        d = self.root / "done"
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps(
+            {"investigation_id": "done", "summary_l1": ["p"], "summary_l2": "Real."}))
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=lambda **kw: None)
+        self.assertEqual(rep["status"], "ok")
+        self.assertEqual(rep["summarised"], 0)
+
+    def test_a_retracted_only_investigation_has_nothing_to_say(self):
+        """investigation_reflect drops retracted findings, so an investigation
+        whose only finding is retracted reports 'Investigation with 0 findings'
+        forever. dtl-mnemo-probe is exactly this case."""
+        d = self._inv("retracted", [{"id": "f1", "record_type": "observed",
+                                     "text": "a finding that was retracted"}])
+        (d / "retractions.jsonl").write_text(
+            json.dumps({"finding_id": "f1", "active": True}) + "\n")
+        seen = []
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=lambda **kw: seen.append(kw))
+        self.assertEqual(seen, [])
+        self.assertEqual(rep["nothing_to_say"], 1)
+        self.assertEqual(rep["errors"], 0)
+        self.assertEqual(rep["status"], "ok")
+
+    def test_an_inactive_retraction_does_not_hide_a_finding(self):
+        d = self._inv("unretracted", [{"id": "f1", "record_type": "observed",
+                                       "text": "still a live finding"}])
+        (d / "retractions.jsonl").write_text(
+            json.dumps({"finding_id": "f1", "active": False}) + "\n")
+
+        def reflect(investigation_id):
+            p = d / "manifest.json"
+            m = json.loads(p.read_text())
+            m["summary_l1"] = ["p"]; m["summary_l2"] = "Real."
+            p.write_text(json.dumps(m))
+
+        rep = g.pass_summaries(memory_dir=self.root, gen_probe=lambda: True,
+                               reflect_fn=reflect)
+        self.assertEqual(rep["summarised"], 1)


### PR DESCRIPTION
Follow-up to #229. After the backfill cleared the backlog, the `summaries` pass reported **degraded on every run**:

```
summaries: degraded summarised=0 already_had=137 errors=5
```

The only investigations left were the ones it can never summarise, each counted as an error, and with no successes to offset them the pass tripped its own `errors and not done` guard. A lane that cries wolf nightly is a lane nobody reads when it finally means it — and this one would have been scheduled that way from day one.

### Two reasons to have nothing to say, neither a failure

- **No findings at all**, or only text-less access rows — four of the five.
- **Every finding retracted.** `investigation_reflect` drops retracted findings, so `dtl-mnemo-probe` (one finding, retracted in June) reports `Investigation with 0 findings` no matter how often it is asked. Its LLM call actually succeeds and returns valid bullets; there is simply nothing behind them.

`_summarisable` now checks both **before** spending a model call, and reports them as `nothing_to_say` rather than folding them into `errors`, so a genuine failure still surfaces.

### Steady state

```
summaries: ok summarised=0 already_had=137 nothing_to_say=5 errors=0
```

### Verification

- `scripts/tests` + `scripts/hooks/tests`: 703 passed.
- Sabotage-tested: removing the empty-investigation skip fails 3 of the new tests.
- Verified through the real cron entrypoint (`loci_groom_cron.sh summaries`), not just the pass function.
- ruff clean.