### PR TITLE
eval: a fixed benchmark for the adversarial skeptic

### DIFF
--- a/eval/verify_skeptic_eval.py
+++ b/eval/verify_skeptic_eval.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Measure the adversarial skeptic's verdicts against a fixed, self-contained set.
+
+Run:  ./mcp/.venv/bin/python eval/verify_skeptic_eval.py [trials] [votes]
+
+WHY THESE CASES. An earlier probe of this same skeptic was invalidated because
+its labels asserted things about the loci corpus that the corpus then changed —
+past-tense-true labels against a present-tense codebase. Nothing here touches
+loci: every case carries its own context, so no commit can falsify a label.
+
+WHY THE SCORE IS ASYMMETRIC. Overall accuracy is the wrong objective. A verdict
+is an advisory note and never changes a finding's lifecycle, so "uncertain" is
+harmless — it leaves a finding unverified. "Refuted" on a claim that is actually
+true is the damage, because it is what a later reader acts on. FALSE REFUTATION
+is therefore the headline number; missed refutations are reported but mild.
+"""
+from __future__ import annotations
+
+import collections
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "mcp"))
+
+# (expected_verdict, claim, context)
+CASES = [
+    # CONFIRMED — the context positively supports the claim.
+    ("confirmed", "The function add returns the sum of its two arguments.",
+     "def add(a, b):\n    return a + b"),
+    ("confirmed", "TIMEOUT is set to 30.", "TIMEOUT = 30"),
+    ("confirmed", "48000 divided by 960 equals 50.", ""),
+    ("confirmed", "The loop body runs exactly 3 times.",
+     "for i in range(3):\n    print(i)"),
+    ("confirmed", "connect() raises ValueError when url is empty.",
+     'def connect(url):\n    if not url:\n        raise ValueError("url required")\n'
+     "    return open_socket(url)"),
+    # REFUTED — the context positively contradicts the claim.
+    ("refuted", "The function add multiplies its two arguments.",
+     "def add(a, b):\n    return a + b"),
+    ("refuted", "TIMEOUT is set to 60.", "TIMEOUT = 30"),
+    ("refuted", "48000 divided by 960 equals 60.", ""),
+    ("refuted", "The loop body runs 10 times.", "for i in range(3):\n    print(i)"),
+    ("refuted", "connect() returns None when url is empty.",
+     'def connect(url):\n    if not url:\n        raise ValueError("url required")\n'
+     "    return open_socket(url)"),
+    # UNCERTAIN — nothing here decides it either way.
+    ("uncertain", "The staging deployment completed at 14:02 UTC.", ""),
+    ("uncertain", "The retry_count setting defaults to 5.", ""),
+    ("uncertain", "The battery monitor is an INA226 at I2C address 0x40.", ""),
+    ("uncertain", "The nightly job takes about 20 minutes to finish.", ""),
+    ("uncertain", "The team decided to postpone the migration to Q3.", ""),
+]
+
+
+def run(trials: int, votes: int):
+    from verify import verify_finding
+    per = collections.defaultdict(collections.Counter)
+    rows = []
+    for want, claim, ctx in CASES:
+        got = []
+        for _ in range(trials):
+            # votes= is only passed when asked for, so this harness can also
+            # benchmark a build that predates consensus voting.
+            kw = {"votes": votes} if votes > 1 else {}
+            got.append(verify_finding(claim, context=ctx, **kw)
+                       .get("verdict", "uncertain"))
+            per[want][got[-1]] += 1
+        rows.append((want, claim, got))
+    return per, rows
+
+
+def main() -> int:
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+    votes = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+    t0 = time.time()
+    per, rows = run(trials, votes)
+    print(f"\n  {len(CASES)} cases x {trials} trials, votes={votes}, "
+          f"{time.time() - t0:.0f}s\n")
+    print(f"  {'expected':<11}{'confirmed':>10}{'refuted':>9}{'uncertain':>11}   accuracy")
+    total = correct = 0
+    for want in ("confirmed", "refuted", "uncertain"):
+        c = per[want]
+        n = sum(c.values())
+        total += n
+        correct += c[want]
+        print(f"  {want:<11}{c['confirmed']:>10}{c['refuted']:>9}"
+              f"{c['uncertain']:>11}   {c[want]}/{n}")
+
+    harmful = per["confirmed"]["refuted"] + per["uncertain"]["refuted"]
+    non_ref = sum(sum(per[w].values()) for w in ("confirmed", "uncertain"))
+    missed = sum(per["refuted"].values()) - per["refuted"]["refuted"]
+    print(f"\n  overall: {correct}/{total} = {correct * 100 // max(total, 1)}%")
+    print(f"  FALSE REFUTATION (the harm): {harmful}/{non_ref} = "
+          f"{harmful * 100 // max(non_ref, 1)}%")
+    print(f"  missed refutations (mild)  : {missed}/{sum(per['refuted'].values())}")
+    print("\n  --- per case ---")
+    for want, claim, got in rows:
+        flag = "  " if all(g == want for g in got) else "!!"
+        print(f"  {flag} want={want:<10} got={','.join(got):<30} {claim[:52]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -309,7 +309,7 @@ def _check_lazy_import():
 def _check_real_corpus():
     result = build_graph(rev="HEAD")
     store = result.store
-    assert result.meta.file_count == 118, result.meta.file_count
+    assert result.meta.file_count == 119, result.meta.file_count
     assert result.meta.error_count == 0, result.meta.errors
     bad = registered_but_dead(store)
     assert bad == [], [n.id for n in bad]

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,13 +1,13 @@
 from .conftest import needs_corpus_deps, needs_git_history  # noqa: F401
 """config.py against the REAL repo: acceptance criterion is an exact file
-count (118), not a vibe. If this drifts, either the repo changed shape or
+count (119), not a vibe. If this drifts, either the repo changed shape or
 the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
 def test_corpus_is_exactly_118_files():
     files = config.iter_corpus_files_worktree()
-    assert len(files) == 118, sorted(files)
+    assert len(files) == 119, sorted(files)
 
 
 def test_corpus_excludes_test_directories():

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -5,7 +5,7 @@ the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
-def test_corpus_is_exactly_118_files():
+def test_corpus_is_exactly_119_files():
     files = config.iter_corpus_files_worktree()
     assert len(files) == 119, sorted(files)
 

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -4,7 +4,7 @@ from .. import ingest
 from ..tests.helpers import source_file
 
 
-def test_load_corpus_worktree_parses_118_files_with_no_errors():
+def test_load_corpus_worktree_parses_119_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
     assert len(sources) == 119

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -7,7 +7,7 @@ from ..tests.helpers import source_file
 def test_load_corpus_worktree_parses_118_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
-    assert len(sources) == 118
+    assert len(sources) == 119
     errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
     assert errors == []
     assert all(sf.tree is not None for sf in sources)
@@ -16,7 +16,7 @@ def test_load_corpus_worktree_parses_118_files_with_no_errors():
 def test_load_corpus_rev_head_reads_git_blobs():
     sources, origin = ingest.load_corpus(rev="HEAD")
     assert origin.startswith("rev ")
-    assert len(sources) == 118
+    assert len(sources) == 119
     assert all(sf.error is None for sf in sources)
     server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
     assert "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -15,7 +15,7 @@ from ..pipeline import build_graph
 
 
 def test_build_is_clean_and_fast(head_build):
-    assert head_build.meta.file_count == 118
+    assert head_build.meta.file_count == 119
     assert head_build.meta.error_count == 0
     # The 2s figure in ingest.py's own docstring is about ast.parse'ing the
     # corpus (steps 1-3's budget). Steps 4-6 (CALLSITE/CALLS resolution over

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -78,6 +78,6 @@ def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, 
     finally:
         monkeypatch.setattr(Path, "read_text", original_read_text)
     assert origin.startswith("rev ")
-    assert len(sources) == 118
+    assert len(sources) == 119
     server = _source_for(sources, "mcp/server.py")
     assert server.error is None and "loci-mcp" in server.source[:200]


### PR DESCRIPTION
**I could not fix the verifier's over-refutation.** This PR ships the harness that proved it, and no behaviour change — every variant I built measured neutral or worse than `main`.

### The number that matters

Overall accuracy is the wrong objective. A verdict is an advisory note that never changes a finding's lifecycle, so `uncertain` is harmless — it leaves a finding unverified. **`refuted` on a claim that is actually true is the damage**, because that is what a later reader acts on. So the headline metric is false refutation, not accuracy.

### Measured, n=150 per arm, `heretic-llama31-8b-instruct`

| arm | overall | false refutation |
|---|---|---|
| **`main`** | **73%** | **22%** |
| evidence-based prompt + verdict derived from evidence | 72% | 22% |
| `main` prompt + output guard | 73% | 22% (guard never fires) |
| NONE escape hatch + output guard | 72% | **34%** |
| `main` prompt minus "prefer refuted" | 68% | **31%** |

None of them shipped.

### Two results worth recording

**Run-to-run variance nearly fooled me.** On 30 harm samples the rate spans 16–26%. At that resolution I measured a "26% → 20% improvement" and was about to claim it. At n=150 both arms are 22% — the improvement does not exist. The intermediate arm was not better, it was a different roll.

**An output guard cannot help against the current prompt.** Refusing a refutation that cites no contradicting evidence sounds right, and is inert here: the prompt asks for `"your strongest attack OR WHY IT SURVIVES"`, so the field is never empty and there is nothing to disarm. Giving it a `NONE` escape hatch does make the guard fire — and made the harm *worse* (34%), because the reworded prompt also made empty-context claims refutable, which `main`'s prompt never does (50/50 on that row).

### Why it is not fixable this way

The residue is not label bias, it is the model reasoning wrongly. Two reproducible examples:

- `for i in range(3)` — it invents `i < 3` semantics and concludes *"the loop body will run at least 4 times"*.
- It confirms that 48000/960 = 60.

`mistralai/mistral-nemo` via OpenRouter scored **53%**, worse, so this is not specific to the 8B. `qwen/qwen3.7-flash` returned no parseable JSON at all.

### The harness

`eval/verify_skeptic_eval.py [trials] [votes]`. Cases are self-contained: an earlier probe of this same skeptic was invalidated because its labels asserted things about the loci corpus that the corpus then changed. Nothing here touches loci, so no commit can falsify a label. It also runs against builds predating the `votes` parameter, so it can benchmark across revisions.

### What would actually move it

Giving the skeptic real source. The production call in `investigation_verify_all` does not pass the finding's stamped `code_refs`, and `_safe_resolve` rejects them anyway — measured 59/59 rejected, 0/100 verifications with any source fetched. **#227** is open and fixes exactly that. The confirmed-row failures are cases where the model lacks or misreads evidence, so that is the lever to try next — not more prompt wording.