### PR TITLE
Audit the "hermes" name, and fix the six occurrences that are actually stale

### DIFF
--- a/.claude/workflows/audit-remediate.js
+++ b/.claude/workflows/audit-remediate.js
@@ -1,0 +1,76 @@
+export const meta = {
+  name: 'audit-remediate',
+  description: 'Grounded, local-GPU-offloaded remediation planning over confirmed audit findings',
+  whenToUse: 'After a security/quality audit has recorded findings in a Loci investigation. Grounds once, fans out one remediation-planner per finding (grounded on the code graph + bge/expand RAG), offloads the mechanical tier (batch risk-statements via vLLM generate_batch, dedup via semantic_dedup) to the local GPUs through Loci, then synthesizes a ranked fix plan back into the investigation. args = {investigation_id, repo, findings:[{id,title,file,severity}]}.',
+  phases: [
+    { title: 'Ground', detail: 'assemble one grounding block from the investigation + code graph' },
+    { title: 'Plan', detail: 'one grounded remediation-planner agent per finding' },
+    { title: 'Offload', detail: 'vLLM generate_batch risk-statements + semantic_dedup merge — through Loci' },
+    { title: 'Synthesize', detail: 'rank + write the remediation plan back to the investigation' },
+  ],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const INV = A.investigation_id
+const REPO = A.repo || ''
+const FINDINGS = Array.isArray(A.findings) ? A.findings : []
+if (!INV || !FINDINGS.length) { log('need investigation_id + findings[]'); return { error: 'missing args' } }
+
+// ---- Phase 1: ground ONCE (injected into every planner). Exercises grounding + bge/expand RAG. ----
+phase('Ground')
+const grounding = await agent(
+  'Assemble grounding for a remediation pass on investigation "' + INV + '" (repo ' + REPO + '). '
+  + 'Call mcp__loci__ground with a focus of "security + robustness remediation" and case_ids including "' + INV + '". '
+  + 'Return the grounding block VERBATIM as your final text (it is injected into every downstream agent).',
+  { label: 'ground', phase: 'Ground' })
+
+// ---- Phase 2 (Plan) + Phase 3 (Offload) pipelined per finding, no barrier. ----
+// Each finding: a grounded planner drafts a concrete fix, THEN an offload step routes the
+// mechanical write-up through the local GPUs via Loci (vLLM batched gen + local-embed dedup).
+const planned = await pipeline(
+  FINDINGS,
+  (f) => agent(
+    'GROUNDING (shared, do not re-derive):\n' + String(grounding).slice(0, 6000) + '\n\n'
+    + 'You are a senior engineer writing a CONCRETE remediation for one audit finding in ' + REPO + '.\n'
+    + 'Finding [' + (f.severity || '?') + '] ' + f.title + (f.file ? ' (' + f.file + ')' : '') + '.\n'
+    + 'Use mcp__loci__rag_context_search (bge rerank + query_expand) and, if available, '
+    + 'mcp__loci__code_graph_query to pull the EXACT current code + its callers. Then write: (1) root cause in '
+    + 'one sentence, (2) the concrete fix as a minimal patch sketch tied to file:line, (3) any blast-radius/callers '
+    + 'to update, (4) a one-line test that would catch a regression. Be specific to the real code, not generic.',
+    { label: 'plan:' + String(f.id || f.title).slice(0, 8), phase: 'Plan',
+      schema: { type: 'object', required: ['id', 'severity', 'fix'],
+        properties: { id: { type: 'string' }, severity: { type: 'string' },
+          fix: { type: 'string' }, patch_sketch: { type: 'string' },
+          callers_to_update: { type: 'array', items: { type: 'string' } },
+          regression_test: { type: 'string' } } } })
+    .then((p) => p ? { ...p, id: p.id || f.id, title: f.title, file: f.file || '' } : null),
+)
+const plans = planned.filter(Boolean)
+
+// ---- Offload the mechanical tier to the local GPUs THROUGH Loci (the point of this run). ----
+phase('Offload')
+const offload = await agent(
+  'You coordinate LOCAL-GPU offload through Loci — do NOT reason about the fixes yourself; delegate.\n'
+  + 'Here are the drafted remediation plans as JSON:\n' + JSON.stringify(plans.map(p => ({ id: p.id, severity: p.severity, title: p.title, fix: String(p.fix).slice(0, 400) }))).slice(0, 8000) + '\n\n'
+  + '1) Call mcp__loci__generate_batch (this routes to vLLM batched-gen via backends, else Ollama) with one prompt '
+  + 'PER plan, each: "In one sentence, state the concrete production RISK if this is left unfixed: <title> — <fix>". '
+  + 'This is the continuous-batching win: submit all prompts in a single generate_batch call.\n'
+  + '2) Call mcp__loci__semantic_dedup on the array of plan titles (threshold ~0.85) to find remediations that '
+  + 'collapse into one fix.\n'
+  + 'Return {risk_by_id: {id: risk_sentence}, dedup_clusters: [[ids]], backend_used: "<vllm|ollama, from the tool output>"}.',
+  { label: 'offload:local-gpu', phase: 'Offload',
+    schema: { type: 'object', properties: {
+      risk_by_id: { type: 'object' }, dedup_clusters: { type: 'array' }, backend_used: { type: 'string' } } } })
+
+// ---- Phase 4: synthesize a ranked plan and persist it to the investigation. ----
+phase('Synthesize')
+const synthesis = await agent(
+  'Synthesize a RANKED remediation plan from these drafted fixes + local-GPU offload outputs.\n'
+  + 'PLANS:\n' + JSON.stringify(plans).slice(0, 12000) + '\n\nOFFLOAD (risk statements + dedup clusters):\n' + JSON.stringify(offload).slice(0, 4000) + '\n\n'
+  + 'Order by severity then blast radius. Merge any dedup_clusters into a single entry. For each: severity, '
+  + 'file:line, the fix, the regression test. Then call mcp__loci__investigation_store with investigation_id="' + INV + '", '
+  + 'finding_type="observed", source="workflow:audit-remediate", tags="remediation,plan", and text = the full ranked plan. '
+  + 'Return a concise markdown summary of the ranked plan for the operator.',
+  { label: 'synthesize', phase: 'Synthesize' })
+
+return { findings_planned: plans.length, backend_used: offload && offload.backend_used, synthesis }

--- a/.claude/workflows/defcon-audit2.js
+++ b/.claude/workflows/defcon-audit2.js
@@ -1,0 +1,102 @@
+export const meta = {
+  name: 'defcon-audit2',
+  description: 'Whole-codebase audit: fan out one grounded reviewer per subsystem, adversarially verify each candidate against live code, dedup + write confirmed findings. Read-only.',
+  whenToUse: 'A precise second-look audit of a well-defended codebase against current origin/main. Each subsystem reviewer is grounded with a known-fixed/intentional/in-flight exclusion set (no re-reporting). Every candidate is refuted before keeping. args = {tree, investigation_id, known_state, units:[{id,title,scope}]}.',
+  phases: [
+    { title: 'Ground', detail: 'assemble shared grounding from prior cases' },
+    { title: 'Review', detail: 'one grounded reviewer per subsystem (candidates)' },
+    { title: 'Verify', detail: 'adversarial refute of each unit candidates against live code' },
+    { title: 'Synthesize', detail: 'dedup (local GPU) + write confirmed findings to the investigation' },
+  ],
+}
+
+const CAND_ITEM = {
+  type: 'object', required: ['title', 'location', 'severity'],
+  properties: {
+    title: { type: 'string' }, location: { type: 'string' }, severity: { type: 'string' },
+    dimension: { type: 'string' }, evidence: { type: 'string' }, impact: { type: 'string' },
+  },
+}
+const REVIEW_SCHEMA = {
+  type: 'object', required: ['candidates'],
+  properties: { candidates: { type: 'array', items: CAND_ITEM } },
+}
+const CONF_ITEM = {
+  type: 'object', required: ['title', 'location', 'severity'],
+  properties: {
+    title: { type: 'string' }, location: { type: 'string' }, severity: { type: 'string' },
+    dimension: { type: 'string' }, impact: { type: 'string' }, how_confirmed: { type: 'string' },
+  },
+}
+const VERIFY_SCHEMA = {
+  type: 'object', required: ['confirmed'],
+  properties: { confirmed: { type: 'array', items: CONF_ITEM } },
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const TREE = A.tree
+const INV = A.investigation_id
+const KNOWN = A.known_state || ''
+const UNITS = Array.isArray(A.units) ? A.units : []
+if (!TREE || !INV || !UNITS.length) { log('need tree + investigation_id + units[]'); return { error: 'missing args' } }
+
+phase('Ground')
+const grounding = await agent(
+  'Assemble grounding for a whole-codebase audit. Call mcp__loci__ground with focus "security + correctness + data-integrity + robustness audit" and case_ids ["' + INV + '","defcon-defacement-audit-2026-06-24"]. Return the block VERBATIM as your final text.',
+  { label: 'ground', phase: 'Ground' })
+const GBLOCK = String(grounding).slice(0, 3500)
+
+function reviewPrompt(u) {
+  return 'GROUNDING (shared reference, do not re-derive):\n' + GBLOCK + '\n\n'
+    + 'KNOWN STATE — do NOT report any of these (already fixed / intentional / not-built / in-flight):\n' + KNOWN + '\n\n'
+    + 'You are a senior reviewer auditing ONE subsystem of a WELL-DEFENDED Next.js 16 app at ' + TREE + ' (this is current '
+    + 'origin/main — authoritative; read files directly, use ripgrep for cross-refs; treat any code_graph result as possibly '
+    + 'stale). SUBSYSTEM [' + u.id + '] ' + u.title + '.\nFILES: ' + u.scope + '\n\n'
+    + 'Hunt HARD across dimensions: correctness bugs, security (authz/IDOR/injection/SSRF/XSS/secret-exposure), data '
+    + 'integrity (round-trips, transactions, race conditions), robustness (error handling, fail-open/closed, unhandled '
+    + 'rejections), concurrency. Read the real code. For EACH candidate give file:line, the deciding code, and a CONCRETE '
+    + 'impact/exploit. Be strict — this codebase is well-defended, so only surface issues tied to a specific line; do NOT '
+    + 'pad. Exclude everything in KNOWN STATE. Return candidates (may be empty).'
+}
+
+function verifyPrompt(u, candidates) {
+  return 'You are an ADVERSARIAL verifier. For each candidate below, try to REFUTE it by reading the ACTUAL code at '
+    + TREE + ' (' + u.title + '). CONFIRMED only if the defect is real, reachable, NOT mitigated elsewhere (guards, callers, '
+    + 'validation, framework behaviour), and NOT in the known-fixed/intentional set. Default to refuted when uncertain. '
+    + 'This app is well-defended — expect some candidates to be wrong.\n\n'
+    + 'KNOWN STATE (auto-refute if it matches):\n' + KNOWN + '\n\nCANDIDATES:\n' + JSON.stringify(candidates).slice(0, 6000) + '\n\n'
+    + 'Return only CONFIRMED ones: title, location (file:line), severity (H/M/L), dimension, a one-line verified impact, '
+    + 'and how_confirmed (the mitigation you checked for and did NOT find).'
+}
+
+const perUnit = await pipeline(
+  UNITS,
+  (u) => agent(reviewPrompt(u), { label: 'review:' + u.id, phase: 'Review', schema: REVIEW_SCHEMA })
+    .then((r) => ({ unit: u.id, title: u.title, candidates: (r && r.candidates) || [] }))
+    .catch(() => ({ unit: u.id, title: u.title, candidates: [] })),
+  (rev, u) => {
+    const cands = (rev && rev.candidates) || []
+    if (!cands.length) return { unit: u.id, confirmed: [] }
+    return agent(verifyPrompt(u, cands), { label: 'verify:' + u.id, phase: 'Verify', schema: VERIFY_SCHEMA })
+      .then((v) => ({ unit: u.id, confirmed: (v && v.confirmed) || [] }))
+      .catch(() => ({ unit: u.id, confirmed: [] }))
+  },
+)
+
+const confirmed = perUnit.filter(Boolean).flatMap((r) => (r.confirmed || []).map((c) => ({ ...c, unit: r.unit })))
+log('confirmed findings across ' + UNITS.length + ' units: ' + confirmed.length)
+if (!confirmed.length) return { confirmed: 0, note: 'no confirmed findings survived verification' }
+
+phase('Synthesize')
+const synth = await agent(
+  'Here are ' + confirmed.length + ' adversarially-CONFIRMED audit findings across a whole-codebase pass:\n'
+  + JSON.stringify(confirmed).slice(0, 12000) + '\n\n'
+  + '1. Call mcp__loci__semantic_dedup on the finding titles (threshold 0.85) to collapse duplicates across subsystems; keep one representative each.\n'
+  + '2. For each deduped finding, call mcp__loci__investigation_store with investigation_id="' + INV + '", '
+  + 'finding_type="observed", source="workflow:defcon-audit2", confidence from severity (H=high/M=medium/L=low), '
+  + 'tags=the dimension, and text = "[SEV] title — file:line — impact (confirmed: how)".\n'
+  + '3. Return a RANKED markdown summary (severity, then subsystem) of the confirmed findings, noting how many candidates '
+  + 'were dropped as duplicates.',
+  { label: 'synthesize', phase: 'Synthesize' })
+
+return { confirmed: confirmed.length, by_unit: perUnit.map((r) => ({ unit: r.unit, n: (r.confirmed || []).length })), synthesis: synth }

--- a/.claude/workflows/defcon-fix-branches.js
+++ b/.claude/workflows/defcon-fix-branches.js
@@ -1,0 +1,60 @@
+export const meta = {
+  name: 'defcon-fix-branches',
+  description: 'Fan out one worktree-isolated fix agent per finding: implement + validate + reviewer subagents + commit to a local branch. NEVER pushes (repo rule: human-only push).',
+  whenToUse: 'For SamG0ld/defcon-defacement, whose CLAUDE.md forbids pushing from agents and forbids AI-attribution trailers. Each batch: worktree off origin/main, implement the scoped fix + test, validate (eslint + vitest + typecheck), get code-reviewer + security-reviewer passes on the diff, commit to a local branch with a clean Conventional-Commits message (NO trailers), and STOP. Josh reviews + pushes. args = {repo, batches:[{id,title,branch,scope,fix,test}]}.',
+  phases: [{ title: 'FixBranch', detail: 'per batch: worktree -> fix -> validate -> review -> commit to local branch (no push)' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const REPO = A.repo
+const BATCHES = Array.isArray(A.batches) ? A.batches : []
+if (!REPO || !BATCHES.length) { log('need repo + batches[]'); return { error: 'missing args' } }
+
+phase('FixBranch')
+const results = await parallel(BATCHES.map((b) => () =>
+  agent(
+    'You are shipping ONE focused fix to a LOCAL branch of the repo at ' + REPO + '. This repo FORBIDS agents pushing '
+    + '(human-only push) and FORBIDS AI-attribution trailers in commits — obey both. Do EXACTLY this, in order, and '
+    + 'report honestly (say so if you skip/adjust a step):\n\n'
+    + '1. Worktree + branch off origin/main (unique /tmp dir):\n'
+    + '   WT=/tmp/claude-1000/-home-rjmendez/2c90c7f0-8dc3-4c5b-a56d-b4cb6cdf34ce/scratchpad/wt-' + b.branch.replace(/[^a-zA-Z0-9]/g, '-') + '\n'
+    + '   git -C ' + REPO + ' fetch origin main -q; rm -rf "$WT"\n'
+    + '   git -C ' + REPO + ' worktree add -b ' + b.branch + ' "$WT" origin/main\n'
+    + '   ln -s ' + REPO + '/node_modules "$WT/node_modules"; [ -d ' + REPO + '/app/generated ] && ln -s ' + REPO + '/app/generated "$WT/app/generated"\n'
+    + '2. FIRST verify the finding still exists on origin/main (it may already be fixed — the audit set was partly '
+    + 'stale). If already fixed: report FIXED, open NO branch content, clean up, and stop. Otherwise implement the '
+    + 'MINIMAL correct fix. SCOPE (only these files): ' + b.scope + '\n   FIX: ' + b.fix + '\n'
+    + '3. Add/update a focused test: ' + (b.test || 'a unit test that fails before and passes after.') + '\n'
+    + '4. Validate from "$WT": `npx eslint <changed files>` (clean), `npx vitest run <relevant test(s)>` (pass), and '
+    + '`npx tsc --noEmit` if it completes within a few minutes (else note it is deferred to CI). Fix any failure; if you '
+    + 'cannot, report it and do NOT commit.\n'
+    + '5. Commit ONLY the intended files with an explicit `git add <files>` (NEVER `git add -A` — the app/generated symlink '
+    + 'is not gitignored and must not be committed). Use a Conventional-Commits message. DO NOT add any Co-Authored-By, '
+    + 'Claude-Session, "Generated with", or other AI-attribution trailer — the repo forbids them.\n'
+    + '6. Do NOT push and do NOT open a PR. Leave the branch local in ' + REPO + ' for the human to review + push.\n'
+    + '7. Clean up the worktree: `git -C ' + REPO + ' worktree remove --force "$WT"` (the branch persists in the repo).\n\n'
+    + 'Batch: [' + b.id + '] ' + b.title,
+    { label: 'fix:' + b.id, phase: 'FixBranch',
+      schema: { type: 'object', required: ['id', 'status'],
+        properties: {
+          id: { type: 'string' },
+          status: { type: 'string', description: 'committed_local_branch | already_fixed | failed' },
+          branch: { type: 'string' }, files_changed: { type: 'array', items: { type: 'string' } },
+          validation: { type: 'string' }, summary: { type: 'string' }, problems: { type: 'string' } } } })
+    .then((r) => r ? { ...r, id: r.id || b.id } : { id: b.id, status: 'failed', problems: 'agent returned null' })
+    .catch((e) => ({ id: b.id, status: 'failed', problems: String(e) })),
+))
+
+// Independent reviewer pass on each committed branch (repo "done" bar: fresh-context reviewers).
+const committed = results.filter((r) => r && r.status === 'committed_local_branch')
+const reviewed = await parallel(committed.map((r) => () =>
+  agent(
+    'Review the diff on local branch ' + r.branch + ' of ' + REPO + ' (git -C ' + REPO + ' diff origin/main..' + r.branch + '). '
+    + 'You are a fresh-context reviewer — the author did NOT grade themselves. Check correctness, security, scope creep, '
+    + 'test adequacy, and that NO AI-attribution trailer is present. Return {branch, verdict: approve|changes-requested, notes}.',
+    { label: 'review:' + r.id, phase: 'FixBranch',
+      schema: { type: 'object', required: ['verdict'],
+        properties: { branch: { type: 'string' }, verdict: { type: 'string' }, notes: { type: 'string' } } } })
+    .then((v) => ({ id: r.id, ...v })).catch(() => ({ id: r.id, verdict: 'review-error' }))))
+
+return { total: BATCHES.length, committed: committed.length, results, reviews: reviewed }

--- a/.claude/workflows/defcon-fix-prs.js
+++ b/.claude/workflows/defcon-fix-prs.js
@@ -1,0 +1,62 @@
+export const meta = {
+  name: 'defcon-fix-prs',
+  description: 'Fan out one worktree-isolated fix agent per audit finding-batch: implement + validate + push + open PR + request Copilot review',
+  whenToUse: 'After consolidating audit findings into PR-sized batches. Each batch runs in its OWN git worktree of the target repo off origin/main (parallel-safe), implements the scoped fix + a test, validates with eslint + targeted vitest, commits, pushes, opens a PR against main, and requests a Copilot review. args = {repo, batches:[{id,title,branch,scope,fix,test}]}.',
+  phases: [{ title: 'FixPR', detail: 'per batch: worktree -> fix -> validate -> push -> PR -> request Copilot' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const REPO = A.repo
+const BATCHES = Array.isArray(A.batches) ? A.batches : []
+if (!REPO || !BATCHES.length) { log('need repo + batches[]'); return { error: 'missing args' } }
+
+phase('FixPR')
+const results = await parallel(BATCHES.map((b) => () =>
+  agent(
+    'You are a senior engineer shipping ONE focused fix PR to the repo at ' + REPO + ' (base branch: main). '
+    + 'Work ENTIRELY inside a dedicated git worktree so parallel agents do not collide. Do EXACTLY this, in order, '
+    + 'and stop + report if any step fails:\n\n'
+    + '1. Create the worktree + branch off origin/main (use a unique dir under /tmp):\n'
+    + '   WT=/tmp/claude-1000/-home-rjmendez/2c90c7f0-8dc3-4c5b-a56d-b4cb6cdf34ce/scratchpad/wt-' + b.branch.replace(/[^a-zA-Z0-9]/g, '-') + '\n'
+    + '   git -C ' + REPO + ' fetch origin main -q; rm -rf "$WT"\n'
+    + '   git -C ' + REPO + ' worktree add -b ' + b.branch + ' "$WT" origin/main\n'
+    + '   ln -s ' + REPO + '/node_modules "$WT/node_modules"; [ -d ' + REPO + '/app/generated ] && ln -s ' + REPO + '/app/generated "$WT/app/generated"\n'
+    + '2. cd "$WT". Implement the fix. SCOPE (only touch these files): ' + b.scope + '\n'
+    + '   FIX: ' + b.fix + '\n'
+    + '   Read the real current code first; make the MINIMAL correct change. Keep the existing code style.\n'
+    + '3. Add or update a focused test proving the fix: ' + (b.test || 'add a unit test under tests/unit/ that fails before and passes after your change.') + '\n'
+    + '4. Validate (from "$WT"): `npx eslint <the files you changed>` (must be clean) and '
+    + '`npx vitest run --project unit <relevant test file(s)>` (must pass). Do NOT run the full tsc/build (slow; CI covers it). '
+    + 'If validation fails, FIX it; if you cannot, report the failure and do NOT push.\n'
+    + '5. Commit: `git -C "$WT" add -A && git -C "$WT" commit` with a Conventional-Commits message. '
+    + 'End the commit body with these two trailer lines EXACTLY:\n'
+    + '   Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\n'
+    + '   Claude-Session: https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45\n'
+    + '6. Push: `git -C "$WT" push -u origin ' + b.branch + '`\n'
+    + '7. Open the PR: `gh pr create --repo SamG0ld/defcon-defacement --base main --head ' + b.branch + ' --title "..." --body "..."`. '
+    + 'The body must: summarize the fix, cite the finding, note the test, and END with exactly these two lines:\n'
+    + '   🤖 Generated with [Claude Code](https://claude.com/claude-code)\n'
+    + '   https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45\n'
+    + '8. Request a Copilot review (best-effort; capture whether it worked): try '
+    + '`gh pr edit <PR#> --repo SamG0ld/defcon-defacement --add-reviewer @copilot` and, if that errors, '
+    + '`gh api -X POST repos/SamG0ld/defcon-defacement/pulls/<PR#>/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"`. '
+    + 'Record the exact outcome (success or the error text).\n'
+    + '9. Clean up: `git -C ' + REPO + ' worktree remove --force "$WT"` (the branch is safely on origin now).\n\n'
+    + 'Report honestly. If you skipped or faked any step, say so. Title/body prefix for this batch: [' + b.id + '] ' + b.title,
+    { label: 'fix:' + b.id, phase: 'FixPR',
+      schema: { type: 'object', required: ['id', 'status'],
+        properties: {
+          id: { type: 'string' },
+          status: { type: 'string', description: 'pushed_pr_opened | validated_not_pushed | failed' },
+          branch: { type: 'string' }, pr_number: { type: 'string' }, pr_url: { type: 'string' },
+          files_changed: { type: 'array', items: { type: 'string' } },
+          validation: { type: 'string', description: 'eslint + vitest results' },
+          copilot_review: { type: 'string', description: 'requested-ok | error text | not-attempted' },
+          summary: { type: 'string' }, problems: { type: 'string' } } } })
+    .then((r) => r ? { ...r, id: r.id || b.id } : { id: b.id, status: 'failed', problems: 'agent returned null' })
+    .catch((e) => ({ id: b.id, status: 'failed', problems: String(e) })),
+))
+
+const ok = results.filter((r) => r && r.status === 'pushed_pr_opened')
+log('opened ' + ok.length + '/' + BATCHES.length + ' PRs')
+return { total: BATCHES.length, opened: ok.length, results }

--- a/.claude/workflows/defcon-gate-branches.js
+++ b/.claude/workflows/defcon-gate-branches.js
@@ -1,0 +1,48 @@
+export const meta = {
+  name: 'defcon-gate-branches',
+  description: 'Bring existing local fix branches to the repo done-bar: run typecheck (or Python gate) + a fresh-context reviewer per branch. Read-only, no push.',
+  whenToUse: 'For local fix branches that only got a partial gate. Per branch: worktree at the branch, run tsc --noEmit + eslint (TS) or ruff + pytest (Python), then a fresh-context reviewer on the diff vs origin/main. args = {repo, branches:[{id,branch,lang}]}.',
+  phases: [{ title: 'Gate', detail: 'per branch: typecheck/lint + fresh reviewer' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const REPO = A.repo
+const BRANCHES = Array.isArray(A.branches) ? A.branches : []
+if (!REPO || !BRANCHES.length) { log('need repo + branches[]'); return { error: 'missing args' } }
+
+phase('Gate')
+const results = await parallel(BRANCHES.map((b) => () =>
+  agent(
+    'Bring the EXISTING local branch ' + b.branch + ' of ' + REPO + ' to the repo done-bar. READ-ONLY: do not edit, '
+    + 'commit, or push. This branch is language: ' + (b.lang || 'typescript') + '.\n\n'
+    + '1. Check it out in a worktree:\n'
+    + '   WT=/tmp/claude-1000/-home-rjmendez/2c90c7f0-8dc3-4c5b-a56d-b4cb6cdf34ce/scratchpad/gate-' + b.id + '\n'
+    + '   rm -rf "$WT"; git -C ' + REPO + ' worktree add "$WT" ' + b.branch + '\n'
+    + '   ln -s ' + REPO + '/node_modules "$WT/node_modules"; [ -d ' + REPO + '/app/generated ] && ln -s ' + REPO + '/app/generated "$WT/app/generated"\n'
+    + '2. From "$WT", run the gate:\n'
+    + (b.lang === 'python'
+        ? '   - `ruff check <changed .py files>` (or `python -m py_compile`), and `python -m pytest <the branch\'s test file>`. '
+          + 'tsc/eslint do NOT apply to Python.\n'
+        : '   - `npx tsc --noEmit` (WHOLE-PROJECT typecheck — this is the bar the earlier pass skipped; give it a few minutes), '
+          + '`npx eslint <changed files>`, and `npx vitest run <the branch\'s test file(s)>`.\n')
+    + '   Report each result exactly (pass/fail + any errors). Do NOT try to fix failures — just report them.\n'
+    + '3. Then REVIEW the diff as a fresh-context reviewer (you did not write it): '
+    + '`git -C ' + REPO + ' diff origin/main..' + b.branch + '`. Check correctness, security, scope creep, test adequacy, '
+    + 'and that NO AI-attribution trailer is present in the commit.\n'
+    + '4. Clean up: `git -C ' + REPO + ' worktree remove --force "$WT"`.\n\n'
+    + 'Return the gate results + your review verdict.',
+    { label: 'gate:' + b.id, phase: 'Gate',
+      schema: { type: 'object', required: ['id', 'typecheck', 'verdict'],
+        properties: {
+          id: { type: 'string' }, branch: { type: 'string' },
+          typecheck: { type: 'string', description: 'tsc/ruff+pytest result: pass | fail: <detail> | n/a' },
+          lint_test: { type: 'string', description: 'eslint + vitest (or py) result' },
+          verdict: { type: 'string', description: 'approve | changes-requested' },
+          notes: { type: 'string' } } } })
+    .then((r) => r ? { ...r, id: r.id || b.id, branch: r.branch || b.branch } : { id: b.id, branch: b.branch, verdict: 'error' })
+    .catch((e) => ({ id: b.id, branch: b.branch, verdict: 'error', notes: String(e) })),
+))
+
+const approved = results.filter((r) => r && r.verdict === 'approve')
+log('gate: ' + approved.length + '/' + BRANCHES.length + ' approve')
+return { results }

--- a/.claude/workflows/defcon-reverify.js
+++ b/.claude/workflows/defcon-reverify.js
@@ -1,0 +1,43 @@
+export const meta = {
+  name: 'defcon-reverify',
+  description: 'Re-verify each audit finding against a current-code worktree — pure read-only status check, no writes/PRs',
+  whenToUse: 'When an audit finding set may be stale (generated against an out-of-date checkout). Fans out one agent per finding to read the CURRENT code and return FIXED / OPEN / CHANGED / INTENTIONAL with the corrected file:line. args = {tree, findings:[{id,claim,hint,kind}]}.',
+  phases: [{ title: 'Reverify', detail: 'one read-only agent per finding against current code' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const TREE = A.tree
+const FINDINGS = Array.isArray(A.findings) ? A.findings : []
+if (!TREE || !FINDINGS.length) { log('need tree + findings[]'); return { error: 'missing args' } }
+
+phase('Reverify')
+const results = await parallel(FINDINGS.map((f) => () =>
+  agent(
+    'You are re-verifying ONE prior audit finding against the CURRENT code at ' + TREE + ' (this is the up-to-date '
+    + 'origin/main; an earlier audit read a stale checkout, so some findings are already fixed). READ-ONLY: do not edit, '
+    + 'commit, or push anything. Just read the real current code.\n\n'
+    + 'FINDING [' + f.id + ']: ' + f.claim + '\n'
+    + (f.hint ? 'Where to look (verify, do not trust): ' + f.hint + '\n' : '')
+    + '\nDetermine the CURRENT status by reading the code:\n'
+    + '- OPEN: the defect still exists on origin/main. Give the exact current file:line and the one line of code that proves it.\n'
+    + '- FIXED: it has been resolved upstream. Cite the current code that fixes it (file:line).\n'
+    + '- CHANGED: the code moved/differs enough that the finding must be re-stated. Give the new statement + location.\n'
+    + '- INTENTIONAL: it is a documented, deliberate design choice (cite the doc/comment).\n'
+    + 'Be strict and specific. If OPEN, also give a one-line severity (H/M/L) and a one-line fix direction.',
+    { label: 'reverify:' + f.id, phase: 'Reverify',
+      schema: { type: 'object', required: ['id', 'status'],
+        properties: {
+          id: { type: 'string' },
+          status: { type: 'string', description: 'OPEN | FIXED | CHANGED | INTENTIONAL' },
+          location: { type: 'string', description: 'current file:line' },
+          evidence: { type: 'string', description: 'the deciding line(s) of current code' },
+          severity: { type: 'string' },
+          fix_direction: { type: 'string' },
+          restated: { type: 'string', description: 'if CHANGED, the corrected finding' } } } })
+    .then((r) => r ? { ...r, id: r.id || f.id, claim: f.claim } : { id: f.id, status: 'ERROR', claim: f.claim })
+    .catch((e) => ({ id: f.id, status: 'ERROR', evidence: String(e), claim: f.claim })),
+))
+
+const by = (s) => results.filter((r) => r && r.status === s).map((r) => r.id)
+log('OPEN=' + by('OPEN').length + ' FIXED=' + by('FIXED').length + ' CHANGED=' + by('CHANGED').length + ' INTENTIONAL=' + by('INTENTIONAL').length)
+return { open: by('OPEN'), fixed: by('FIXED'), changed: by('CHANGED'), intentional: by('INTENTIONAL'), results }

--- a/.claude/workflows/loci-address-copilot.js
+++ b/.claude/workflows/loci-address-copilot.js
@@ -1,0 +1,50 @@
+export const meta = {
+  name: 'loci-address-copilot',
+  description: 'Address Copilot review comments on existing loci PR branches: fix each comment, re-gate (pytest+ruff), push, re-request Copilot. One agent per PR.',
+  whenToUse: 'After Copilot reviews a batch of loci PRs. Each agent checks out the PR branch, addresses its listed comments minimally, re-runs the full mcp suite + ruff, commits (trailers on), pushes to update the PR, and re-requests a Copilot review. args = {repo, prs:[{number,branch,comments}]}.',
+  phases: [{ title: 'Address', detail: 'per PR: fix Copilot comments -> gate -> push -> re-request Copilot' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const REPO = A.repo
+const PRS = Array.isArray(A.prs) ? A.prs : []
+if (!REPO || !PRS.length) { log('need repo + prs[]'); return { error: 'missing args' } }
+
+const TRAILERS = 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45'
+
+const results = await parallel(PRS.map((p) => () =>
+  agent(
+    'Address the Copilot review comments on PR #' + p.number + ' (branch ' + p.branch + ') of the loci repo at ' + REPO + '. '
+    + 'Backward-compatible, minimal, fail-open — do not over-refactor. Steps:\n\n'
+    + '1. Check out the existing branch in a worktree + share the venv:\n'
+    + '   WT=/tmp/claude-1000/-home-rjmendez/2c90c7f0-8dc3-4c5b-a56d-b4cb6cdf34ce/scratchpad/cop-' + p.branch.replace(/[^a-zA-Z0-9]/g, '-') + '\n'
+    + '   git -C ' + REPO + ' fetch origin ' + p.branch + ' -q; rm -rf "$WT"\n'
+    + '   git -C ' + REPO + ' worktree add "$WT" ' + p.branch + '\n'
+    + '   ln -s ' + REPO + '/mcp/.venv "$WT/mcp/.venv"\n'
+    + '2. Read the current code, then address EACH comment below. Fix the substance, not just the symptom. For SECURITY '
+    + 'comments (path traversal / arbitrary file read): restrict any file path derived from user-controlled text to paths '
+    + 'UNDER the repo root, reject absolute paths and ".." traversal, and add a sane size cap; fail-open (skip a rejected ref, '
+    + 'never raise). COMMENTS:\n' + p.comments + '\n'
+    + '3. Validate from "$WT/mcp": `. .venv/bin/activate; python -m pytest -q` (FULL suite green) + '
+    + '`ruff check <changed files> --select E9,F401,F811,F821,F841 --ignore E402`. Add/adjust tests where a comment asks for '
+    + 'coverage. Fix any failure before committing.\n'
+    + '4. Commit the intended files (explicit `git add`). Conventional-Commits message referencing the Copilot feedback; '
+    + 'END the body with EXACTLY these two lines:\n' + TRAILERS + '\n'
+    + '5. Push to update the PR: `git -C "$WT" push origin ' + p.branch + '`\n'
+    + '6. Re-request Copilot: `gh api --method POST repos/rjmendez/loci/pulls/' + p.number + '/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"` (capture outcome).\n'
+    + '7. Clean up: `git -C ' + REPO + ' worktree remove --force "$WT"`.\n\n'
+    + 'Report which comments you addressed and how, honestly (flag any you deliberately did NOT change + why).',
+    { label: 'address:' + p.number, phase: 'Address',
+      schema: { type: 'object', required: ['number', 'status'],
+        properties: {
+          number: { type: 'string' }, status: { type: 'string', description: 'pushed | failed' },
+          addressed: { type: 'array', items: { type: 'string' } },
+          not_changed: { type: 'string' }, suite: { type: 'string' },
+          copilot_rerequested: { type: 'string' }, problems: { type: 'string' } } } })
+    .then((r) => r ? { ...r, number: r.number || String(p.number) } : { number: String(p.number), status: 'failed', problems: 'null' })
+    .catch((e) => ({ number: String(p.number), status: 'failed', problems: String(e) })),
+))
+
+const pushed = results.filter((r) => r && r.status === 'pushed')
+log('addressed + re-requested Copilot on ' + pushed.length + '/' + PRS.length + ' PRs')
+return { total: PRS.length, pushed: pushed.length, results }

--- a/.claude/workflows/loci-code-corpus-coverage.js
+++ b/.claude/workflows/loci-code-corpus-coverage.js
@@ -1,0 +1,250 @@
+export const meta = {
+  name: 'loci-code-corpus-coverage',
+  description: 'Make Loci retrieval actually cover the repos its findings cite: audit the code corpus, index the missing repos, and stop payload filters failing open',
+  whenToUse: 'The measured demand is for the operator OWN SOURCE (31/91), not documentation (2/91). agent_core_chunks indexes agent-mesh, not the repos the corpus talks about.',
+  phases: [
+    { title: 'Audit',  detail: 'What is really in the code corpus, who maintains it, and does anything filter on the missing index' },
+    { title: 'Build',  detail: 'Close the coverage gap; isolated worktrees' },
+    { title: 'Refute', detail: 'Adversarial pass before anything is proposed' },
+  ],
+}
+
+const GROUND = (typeof args === 'object' && args && args.ground) || ''
+const REPO = (typeof args === 'object' && args && args.repo) || '.'
+
+const RULES = `
+DISCIPLINE — each of these cost this project real time today:
+
+1. ASSERT ON THE PAYLOAD, NOT THE COUNT. A Qdrant count with a filter on an
+   UNINDEXED field fails OPEN and returns the whole collection. Four probes today
+   returned an identical 3,030,551 and looked like four confirmations; they were
+   one filter being ignored. Scroll and inspect actual values.
+2. MEASURE, do not assert. Lead with the number and how you got it.
+3. RUN it. py_compile and ruff pass code that raises NameError at runtime.
+4. TEST ON THE RIGHT TREE. Twice today a fix was called broken because it was
+   tested on a branch missing its dependency.
+5. HERMETIC TESTS — no network, no ~/.loci/backends.toml, and patch the layer the
+   code actually reads (a sys.modules patch does not affect 'from pkg import mod').
+6. A LANE WITH NO READER IS NOT WORTH FEEDING. Establish the consumer first.
+7. A NEGATIVE RESULT IS A RESULT. Two builds were correctly declined today.
+8. Comment economy: rationale in the commit message, not the source.
+`
+
+const AUDIT_SCHEMA = {
+  type: 'object',
+  properties: {
+    topic: { type: 'string' },
+    findings: { type: 'string' },
+    numbers: { type: 'string' },
+    blockers: { type: 'array', items: { type: 'string' } },
+    recommend: { type: 'string' },
+  },
+  required: ['topic', 'findings', 'numbers', 'blockers', 'recommend'],
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  properties: {
+    item: { type: 'string' },
+    diff: { type: 'string' },
+    tests_added: { type: 'array', items: { type: 'string' } },
+    sabotage_result: { type: 'string' },
+    suite_result: { type: 'string' },
+    measured_effect: { type: 'string' },
+    complete: { type: 'boolean' },
+    abandoned: { type: 'boolean' },
+    blocked_reason: { type: 'string' },
+  },
+  required: ['item', 'diff', 'tests_added', 'sabotage_result', 'complete'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    item: { type: 'string' },
+    refuted: { type: 'boolean' },
+    strongest_objection: { type: 'string' },
+    safe_to_propose: { type: 'boolean' },
+  },
+  required: ['item', 'refuted', 'strongest_objection', 'safe_to_propose'],
+}
+
+phase('Audit')
+
+const AUDITS = [
+  {
+    id: 'corpus-truth',
+    prompt: `Establish what agent_core_chunks actually IS, and whether it is maintained.
+
+Measured already, re-verify: 12,000 sampled points, only 298 carried a file_path
+(2.5%), zero contained "hugbot", and the top path roots were a2a, deployment,
+scouts, dispatch, mas-research — i.e. agent-mesh, not the repos Loci findings
+cite. The collection holds ~6M points and is NOT quantized (hermes_memory is the
+only quantized collection on the instance).
+
+Answer, with evidence:
+  - What are the 97.5% of points that have no file_path? Sample their payloads.
+    If most of the collection is not code, "agent_core_chunks is Loci's code
+    index" is false and the whole framing changes.
+  - WHO WRITES IT? Find the producer. Is it in this repo, another repo, or a
+    process nobody owns? When did it last write — check a timestamp field.
+  - Does anything in Loci FILTER it by file_path or repo? If yes, those filters
+    are failing open right now (no payload index) and that is a correctness bug,
+    not a performance one. If nothing filters it, the missing index is latent.
+  - What does rag_context_search actually retrieve from it in practice? Run a
+    real query about a hugbot subsystem and report what comes back.`,
+  },
+  {
+    id: 'ingest-path',
+    prompt: `Find the cheapest correct way to get the cited repos into retrieval.
+
+Loci findings cite /home/rjmendez/hugbot5000 and /home/rjmendez/hb-mountfix-v2.
+Neither is in agent_core_chunks.
+
+Two candidate mechanisms already exist — evaluate BOTH before recommending:
+  a) .claude/workflows/loci-codebase-ingest.js — recovered today, takes args.repo,
+     reads source and stores structured module docs into a Loci investigation via
+     investigation_store. Verified working: 8 modules, idempotent (supersedes the
+     prior doc per module). But it writes FINDINGS, which land in hermes_memory —
+     consider whether flooding the findings corpus with generated module docs is
+     acceptable, and what it does to retrieval for real findings.
+  b) whatever populates agent_core_chunks (find it in the audit) — if it is a
+     reusable indexer, pointing it at another repo may be a config change.
+
+Also establish the SCALE: how many source files are in hugbot5000, and what would
+indexing cost in embedding calls at 93ms each against 10.42.0.1. A number, not a
+guess. If it is tens of thousands of files, a naive full index is not viable and
+the recommendation must be scoped (changed files? cited files only? one subsystem?).
+
+The host has MANY hugbot5000-wt-* worktrees. Indexing several revisions of the
+same file would poison retrieval with near-duplicates. Say how to avoid that.`,
+  },
+]
+
+log(`Auditing ${AUDITS.length} questions before building anything`)
+const audit = (await parallel(AUDITS.map(a => () =>
+  agent(`${GROUND}\n${RULES}\nRepo: ${REPO}\n\nTOPIC: ${a.id}\n\n${a.prompt}`,
+    { label: `audit:${a.id}`, phase: 'Audit', schema: AUDIT_SCHEMA,
+      model: 'opus', effort: 'high' })
+))).filter(Boolean)
+
+log(`${audit.length}/${AUDITS.length} audits returned`)
+for (const a of audit) log(`  ${a.topic}: ${(a.blockers || []).length} blocker(s)`)
+
+// ── Build ────────────────────────────────────────────────────────────────────
+const ITEMS = [
+  {
+    id: 'payload-index-file-path',
+    brief: `Stop payload filters on the code corpus failing open.
+
+A Qdrant filter on an UNINDEXED payload field does not error — it returns the
+whole collection. Measured today: four different MatchText probes on file_path
+each returned an identical 3,030,551, which reads as four confirmations and is
+one filter being ignored. Anything that filters agent_core_chunks by file_path or
+repo is silently unfiltered right now.
+
+Loci already has _create_payload_indexes in mcp/qdrant_ops.py and applies it to
+its own collection. Establish from the audit whether Loci actually filters this
+collection. If it does, add the index and a test that a filtered count differs
+from an unfiltered one — that is the assertion that catches a filter failing
+open, and it must FAIL without the index.
+
+If nothing in Loci filters it, say so and set abandoned=true: adding an index to
+a 6M-point collection Loci does not own, for a filter nobody issues, is not an
+improvement. The audit answers this — do not guess.`,
+  },
+  {
+    id: 'index-cited-repos',
+    brief: `Close the coverage gap for the repos Loci findings actually cite, using
+whichever mechanism the ingest-path audit recommends.
+
+Constraints that decide the shape:
+  - SCOPE IT. Do not full-index a repo of unknown size on a first pass. The audit
+    reports the file count and the embedding cost; use it. Cited-files-first is a
+    defensible scope: 33 unique paths are referenced by real findings, and those
+    are the ones with measured demand.
+  - NO NEAR-DUPLICATES. The host carries many hugbot5000-wt-* worktrees of the
+    same files. Index one canonical revision, not several.
+  - DO NOT POLLUTE hermes_memory with generated content unless the audit shows
+    that is genuinely fine. Retrieval quality for real findings is the thing being
+    protected here.
+  - The result must have a READER. Establish which retrieval path will actually
+    surface it before writing anything — rag_context_search's collections list is
+    hardcoded to ["hermes_memory","agent_core_chunks"], so a new collection that
+    nothing queries is another dead lane.
+
+Report a BEFORE and AFTER: run a grounded query about a hugbot subsystem and show
+what retrieval returns in each case. If you cannot demonstrate an improvement,
+set abandoned=true — that is a real result and this project has accepted it twice
+today.`,
+  },
+]
+
+phase('Build')
+const results = await pipeline(
+  ITEMS,
+  it => agent(
+    `${GROUND}\n${RULES}\nRepo: ${REPO}
+
+AUDIT FINDINGS:
+${JSON.stringify(audit, null, 2).slice(0, 16000)}
+
+WORK ITEM: ${it.id}
+
+${it.brief}
+
+You are in your OWN git worktree. Do not commit, push, or open a PR.
+Tests must FAIL without the change — reintroduce the absence, watch them fail,
+restore, and report the exact failure text. Run the relevant suite and report
+counts; test_graph_integration::test_code_graph_ingest_and_query fails on clean
+main for host-specific reasons and is NOT yours. ruff clean with
+--select E9,F401,F811,F821,F841 --ignore E402. Return the full diff.`,
+    { label: `build:${it.id}`, phase: 'Build', schema: IMPL_SCHEMA,
+      model: 'opus', effort: 'high', isolation: 'worktree' }
+  ),
+  (impl, orig) => {
+    if (!impl || !impl.complete || impl.abandoned) return { impl, verdict: null, item: orig.id }
+    return agent(
+      `${RULES}\n
+Adversarially review this. REFUTE it. Default refuted=true when unsure.
+
+ITEM: ${orig.id}
+SABOTAGE CLAIMED: ${impl.sabotage_result}
+SUITE CLAIMED: ${impl.suite_result || 'not reported'}
+EFFECT CLAIMED: ${impl.measured_effect || 'not reported'}
+
+DIFF:
+${(impl.diff || '').slice(0, 30000)}
+
+Attack specifically:
+  - Is the measured effect real, or an artefact? A retrieval improvement measured
+    without QDRANT_URL set is measuring nothing. A count taken with a filter on an
+    unindexed field is measuring nothing.
+  - Does it write generated content into hermes_memory, and what does that do to
+    retrieval for REAL findings? Dilution is the risk nobody notices until later.
+  - Could it index several worktree revisions of the same file?
+  - Does the new content have a reader, or is rag_context_search's hardcoded
+    collections list still excluding it?
+  - Is any test non-hermetic?
+  - Does the sabotage failure match the defect, or is it incidental?
+
+safe_to_propose=false unless you would defend it yourself.`,
+      { label: `refute:${orig.id}`, phase: 'Refute', schema: VERDICT_SCHEMA,
+        model: 'opus', effort: 'xhigh' }
+    ).then(v => ({ impl, verdict: v, item: orig.id }))
+  }
+)
+
+const all = (results || []).filter(Boolean)
+const ready = all.filter(r => r.verdict && r.verdict.safe_to_propose && !r.verdict.refuted)
+const abandoned = all.filter(r => r.impl && r.impl.abandoned)
+const rejected = all.filter(r => r.verdict && (r.verdict.refuted || !r.verdict.safe_to_propose))
+log(`${ready.length} ready, ${rejected.length} rejected, ${abandoned.length} abandoned`)
+
+return {
+  audit,
+  ready: ready.map(r => ({ item: r.item, diff: r.impl.diff, tests: r.impl.tests_added,
+                           sabotage: r.impl.sabotage_result, effect: r.impl.measured_effect })),
+  rejected: rejected.map(r => ({ item: r.item, objection: r.verdict.strongest_objection })),
+  abandoned: abandoned.map(r => ({ item: r.item, reason: r.impl.blocked_reason })),
+}

--- a/.claude/workflows/loci-docs-and-comments.js
+++ b/.claude/workflows/loci-docs-and-comments.js
@@ -1,0 +1,340 @@
+export const meta = {
+  name: 'loci-docs-and-comments',
+  description: 'Bring the docs back in line with 60 commits of drift, and cut narration comments without losing measured rationale',
+  whenToUse: 'Docs last written 2026-08-10; HEAD is 2026-08-27 with 60 commits and +35,645 lines since. 94 files carry 1,522 lines of multi-line comment prose.',
+  phases: [
+    { title: 'Docs',    detail: 'One agent per document; correct what is now FALSE first' },
+    { title: 'Comments', detail: 'One agent per file cluster; narration out, measured rationale kept' },
+    { title: 'Refute',  detail: 'Adversarial pass — did anything load-bearing get deleted, is any doc claim wrong' },
+  ],
+}
+
+const GROUND = (typeof args === 'object' && args && args.ground) || ''
+
+const RULES = `
+DISCIPLINE — each of these cost this project real time:
+
+1. MEASURE, do not assert. Lead with the number and how you got it.
+2. VERIFY AGAINST LIVE CODE. A doc sentence is a claim; check it before you keep
+   it. grep the symbol, read the function, run the thing.
+3. A NEGATIVE RESULT IS A RESULT. "This section is already correct" is a fine
+   answer. Do not manufacture churn to look productive.
+4. NEVER invent behaviour. If you cannot establish what something does, say so
+   in blockers rather than describing what it probably does.
+5. Do not commit, push, or open a PR. Return a diff.
+`
+
+const COMMENT_POLICY = `
+THE RULE — this is the operator's standing directive of 2026-08-17, recovered
+from Loci, and it is stricter than a general style preference:
+
+  Comments must be short and sparse — ONE LINE MAX — and only for a genuinely
+  non-obvious WHY: a hidden constraint, a subtle invariant, a workaround for a
+  specific bug. NEVER multi-paragraph blocks. NEVER narrative or historical
+  explanation ("this used to be", "the operator corrected", dated commentary).
+  NEVER restating what the code already says. Rationale, history and design
+  justification belong in commit messages and PR descriptions — which are
+  already the durable record — not living permanently in source files.
+
+So the default for a multi-line block is DELETE. There is no "keep the good
+long ones" exception. A block survives only by being compressed to one line.
+
+BUT NOTHING MEASURED MAY BE LOST. Some blocks carry real work: a table of
+results across seeds, a swept constant, a note on what did NOT replicate. The
+canonical case is the 28-line block above the reranker passage-chars constant in
+mcp/qdrant_ops.py — three seeds, the value it replaces, and an explicit
+non-replication. Under the directive that does NOT belong in source. Under this
+project's discipline it must not be destroyed either.
+
+So RELOCATE, do not discard:
+  - Put the full original text of any block carrying measurements, tables, or a
+    non-obvious design justification into 'relocated' — verbatim, with the file
+    and the symbol it sat above. It goes into this change's PR description,
+    which is the durable record the directive points at.
+  - Then delete it from source, leaving at most ONE line: e.g.
+      # 1024 chars: swept against identity recall; 512 scored worse than no CE.
+  - If a block is pure narration, just delete it. Nothing to relocate.
+
+ALWAYS DELETE:
+  - Comments restating the next line, or the docstring above them.
+  - Changelog in source: "added in #217", "previously X", any dated note.
+  - Hedging: "note that", "it is worth mentioning", "this is a bit tricky".
+  - Comments explaining Python itself or an obvious idiom.
+
+KEEP AS ONE LINE (compress, do not expand):
+  - A fail-open or silent-failure trap someone will otherwise reintroduce.
+  - An ordering, concurrency or security property ("compare_digest on both
+    branches: == leaks length").
+  - Why the non-obvious option was chosen.
+  - In tests: the defect the test guards, in one line. It is read at the moment
+    the test fails. Compress the paragraph; do not delete the fact.
+
+OUT OF SCOPE — do not touch:
+  - Docstrings. Any of them, however long.
+  - Section banners (# ---- Foo ----). Structural, not prose.
+  - Any executable line. This change moves comments only.
+
+WHEN IN DOUBT: compress to one line rather than delete outright, and list it in
+kept_but_borderline. A deleted measurement not captured in 'relocated' is
+unrecoverable; that is the only unforgivable outcome here.
+`
+
+const DOC_SCHEMA = {
+  type: 'object',
+  properties: {
+    doc: { type: 'string' },
+    diff: { type: 'string' },
+    false_claims_found: { type: 'array', items: { type: 'string' } },
+    gaps_filled: { type: 'array', items: { type: 'string' } },
+    verified_against: { type: 'array', items: { type: 'string' } },
+    blockers: { type: 'array', items: { type: 'string' } },
+    complete: { type: 'boolean' },
+  },
+  required: ['doc', 'diff', 'false_claims_found', 'verified_against', 'complete'],
+}
+
+const COMMENT_SCHEMA = {
+  type: 'object',
+  properties: {
+    cluster: { type: 'string' },
+    diff: { type: 'string' },
+    lines_removed: { type: 'number' },
+    kept_but_borderline: { type: 'array', items: { type: 'string' } },
+    relocated: { type: 'array', items: { type: 'string' } },
+    suite_result: { type: 'string' },
+    complete: { type: 'boolean' },
+  },
+  required: ['cluster', 'diff', 'lines_removed', 'relocated', 'suite_result', 'complete'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    item: { type: 'string' },
+    refuted: { type: 'boolean' },
+    strongest_objection: { type: 'string' },
+    load_bearing_deletions: { type: 'array', items: { type: 'string' } },
+    safe_to_propose: { type: 'boolean' },
+  },
+  required: ['item', 'refuted', 'strongest_objection', 'safe_to_propose'],
+}
+
+// ── what actually changed, so the doc agents are not guessing ────────────────
+const RECENT = `
+Landed since the docs were last written (2026-08-10), most recent first:
+  #231 eval/verify_skeptic_eval.py — fixed benchmark for the adversarial skeptic.
+       Measured 22% false-refutation on main; five prompt/guard variants all
+       neutral or worse, so NO behaviour changed. Verify is NOT fit to schedule.
+  #230 groom "summaries": empty / fully-retracted investigations are
+       nothing_to_say, not errors.
+  #229 findings.jsonl is a MIXED log — 3,681 of 6,610 records (55.7%) are
+       text-less access rows. _only_findings() drops them. New pass_summaries
+       drives the summary ladder; corpus went 6 -> 137 of 142 summaries.
+  #228 the grounding hooks were inert: pre_llm_grounding read extra.user_message
+       while Claude Code sends a top-level "prompt"; every named-vector Qdrant
+       search sent {"dense": v} instead of {"name":..,"vector":..} and 400'd;
+       session_end_sync looked Claude Code UUIDs up in a Hermes state.db and had
+       never synced a session. scripts/hooks/install.sh --check reports drift.
+  #226 rag: timeout, a shadowed expander, a docstring naming the wrong corpus.
+  #222/#224/#225 generation resolves separately from embeddings; the vLLM
+       fallback is opt-in (LOCI_VLLM_FALLBACK) and default OFF.
+  #221 grounding gate corroborates the semantic lane instead of trusting 0.55.
+  #220 one definition of the quantized-search params.
+  #218/#212 causal_infer and derived_from lineage edges.
+  #214 groom schedules investigation_verify_all and the reflection loop.
+  #213 memcheck reports the audit lane's state instead of a bare count.
+  #211/#206 bearer auth on the HTTP transports; loopback bind by default.
+  #204 the retention default was deleting the index on every server start
+       (30 days -> 0). This one changes what OPERATIONS should say about startup.
+
+Live scheduled work (crontab), all verified through their real entrypoint:
+  index every 6h (coverage 0.9476), knn_tags 03:20, codelink 03:40,
+  summaries 04:50. verify is NOT scheduled and should not be described as if it is.
+`
+
+phase('Docs')
+
+const DOCS = [
+  { id: 'README',
+    files: 'README.md',
+    brief: `The front door. It is 300 lines and was last touched 2026-08-10.
+
+Establish first what it CLAIMS and whether each claim is still true — a wrong
+README is worse than a thin one. Check the install/run instructions actually
+work as written, the tool list against the real @mcp.tool registrations in
+mcp/server.py, and any configuration it names against what the code reads.` },
+
+  { id: 'ARCHITECTURE+CONCEPTS',
+    files: 'docs/ARCHITECTURE.md, docs/CONCEPTS.md',
+    brief: `ARCHITECTURE (340 lines, 2026-08-09) and CONCEPTS (225 lines, 2026-08-07).
+
+The storage story moved: the code graph is now graph.ladybug (LadybugStore, not
+Kuzu naming), findings.jsonl is a mixed append log whose access rows are not
+findings, and hermes_memory/mnemosyne/hermes_sessions all use a NAMED "dense"
+vector while agent_core_chunks is unnamed. Check every diagram and every claim
+about what is stored where against mcp/qdrant_ops.py, mcp/inv_store.py and
+mcp/graph/ladybug_store.py.` },
+
+  { id: 'COMPONENTS',
+    files: 'docs/COMPONENTS.md',
+    brief: `348 lines, last touched 2026-08-07 — the most stale document here.
+
+It enumerates components, so the failure mode is components that no longer exist,
+have been renamed, or have gained/lost responsibilities. Reconcile the list
+against the actual modules under mcp/ and scripts/. Anything you cannot find in
+the tree is either renamed (say what to) or gone (remove it).` },
+
+  { id: 'OPERATIONS+DEPLOYMENT',
+    files: 'docs/OPERATIONS.md, docs/DEPLOYMENT.md',
+    brief: `OPERATIONS (193 lines) and DEPLOYMENT (246 lines), both 2026-08-10.
+
+Highest risk of being actively WRONG, because they tell an operator what to run.
+Reconcile against scripts/loci_groom.py PASSES and the real crontab shape
+described above. Specifically: the retention default is now 0 (#204) and the
+startup no longer purges; four groom passes are scheduled and "verify" is NOT
+one of them; the hooks are installed via scripts/hooks/install.sh with a --check
+mode that reports drift; bearer auth and loopback binding changed how the HTTP
+transports come up (#206/#211).` },
+]
+
+log(`${DOCS.length} documents, ${DOCS.length + 5} agents planned`)
+
+const docResults = await parallel(DOCS.map(d => () =>
+  agent(`${GROUND}\n${RULES}\n${RECENT}
+
+DOCUMENT: ${d.id}   (${d.files})
+
+${d.brief}
+
+Method, in this order:
+  1. Read the document.
+  2. For every factual claim it makes, verify it against the live tree. List the
+     ones that are now FALSE in false_claims_found — that is the primary output.
+  3. Correct those first. Then fill genuine gaps from RECENT above.
+  4. Cite what you verified against in verified_against (file:line or command).
+
+Write like the rest of this repo: direct, concrete, no marketing. Prefer a
+measured number to an adjective. Do not pad, do not add a "Recent changes"
+section — fold the truth into where it belongs. If a section is already correct,
+leave it and say so.
+
+Return the full unified diff.`,
+    { label: `docs:${d.id}`, phase: 'Docs', schema: DOC_SCHEMA,
+      model: 'opus', effort: 'high', isolation: 'worktree' })
+)).then(r => r.filter(Boolean))
+
+log(`${docResults.length}/${DOCS.length} documents returned`)
+for (const d of docResults) {
+  log(`  ${d.doc}: ${(d.false_claims_found || []).length} false claim(s) corrected`)
+}
+
+// ── Comments ────────────────────────────────────────────────────────────────
+phase('Comments')
+
+const CLUSTERS = [
+  { id: 'server',
+    files: 'mcp/server.py',
+    note: '301 prose lines across 59 blocks — the single largest target. It also holds real security rationale (the compare_digest note) and fail-open warnings. Read every block; this is judgment, not a sweep.' },
+  { id: 'graph',
+    files: 'mcp/graph/ladybug_store.py, mcp/graph/code_parse.py, mcp/graph/linker.py',
+    note: '131 prose lines. ladybug_store carries the leasing and checkpoint semantics — a mid-checkpoint death leaves a corrupt WAL that blocks BOTH read and write opens, and the lease PID is diagnostics only while fcntl.flock is the real lock. Those are keepers.' },
+  { id: 'qdrant+inv',
+    files: 'mcp/qdrant_ops.py, mcp/investigation_tools.py, mcp/llm_local.py',
+    note: '177 prose lines. CONTAINS THE CANONICAL RELOCATE: the 28-line reranker passage-chars table in qdrant_ops.py — capture it verbatim in relocated, then cut it to one line. llm_local.py is 20.7% comments, the densest file in the repo, and much of it is narration.' },
+  { id: 'scripts',
+    files: 'scripts/loci_groom.py, scripts/hooks/pre_llm_grounding.py, scripts/hooks/session_end_sync.py, scripts/a2a_context_bridge.py, scripts/generate_memory_md.py, scripts/callgraph/resolve.py, scripts/amem_consolidation.py',
+    note: '~180 prose lines. loci_groom carries why each pass refuses rather than writing junk — keep those, they are the difference between a pass that fails closed and one that fills a lane with noise.' },
+  { id: 'tests',
+    files: 'scripts/callgraph/tests/, scripts/hooks/tests/, mcp/tests/, eval/tests/',
+    note: '327 prose lines, 21% of the total. A comment naming the defect a test guards is read at the moment it fails — COMPRESS those to one line, do not delete the fact. Delete narration outright ("# arrange", "# now call the function", restating the assert).' },
+]
+
+const commentResults = await pipeline(
+  CLUSTERS,
+  c => agent(`${GROUND}\n${RULES}\n${COMMENT_POLICY}
+
+CLUSTER: ${c.id}
+FILES: ${c.files}
+
+${c.note}
+
+Method:
+  - Read each comment block and decide: narration (delete) or rationale (keep).
+  - Delete whole blocks where they are narration. Where a block is half and half,
+    keep the load-bearing sentences and drop the rest — but do not reword what
+    survives.
+  - Docstrings are NOT in scope. Leave every docstring alone.
+  - Section banners are NOT in scope. Leave them.
+  - After editing, run the relevant suite and report counts:
+      ./mcp/.venv/bin/python -m pytest mcp/ -q          (for mcp/)
+      python3 -m pytest scripts/tests scripts/hooks/tests -q
+      python3 -m pytest scripts/callgraph/tests -q
+    NOTE: mcp/tests/test_graph_integration.py::test_code_graph_ingest_and_query
+    fails on clean main for host reasons — it is NOT yours.
+  - ruff check --select E9,F401,F811,F821,F841 --ignore E402 must be clean.
+  - Report lines_removed, and list anything you nearly deleted in
+    kept_but_borderline.
+
+Return the full unified diff.`,
+    { label: `cut:${c.id}`, phase: 'Comments', schema: COMMENT_SCHEMA,
+      model: 'opus', effort: 'high', isolation: 'worktree' }),
+
+  (impl, orig) => {
+    if (!impl || !impl.complete) return { impl, verdict: null, item: orig.id }
+    return agent(`${RULES}\n${COMMENT_POLICY}
+
+Adversarially review this comment purge. REFUTE it. Default refuted=true when unsure.
+
+CLUSTER: ${orig.id}
+LINES REMOVED: ${impl.lines_removed}
+SUITE: ${impl.suite_result || 'not reported'}
+BORDERLINE KEPT: ${JSON.stringify(impl.kept_but_borderline || [])}
+RELOCATED (must cover every measured block the diff deletes):
+${(impl.relocated || []).join('\n---\n').slice(0, 8000)}
+
+DIFF:
+${(impl.diff || '').slice(0, 30000)}
+
+Attack specifically:
+  - Did it delete a MEASURED rationale — numbers, a table, a seed count, a
+    "what did not replicate" — WITHOUT capturing it verbatim in 'relocated'?
+    That is the one unforgivable outcome: unrecoverable without redoing the
+    work. Cross-check every such deletion in the diff against the relocated
+    list and report misses in load_bearing_deletions.
+  - Conversely: did it KEEP a multi-paragraph block? The directive is one line
+    max. A surviving paragraph is a failure to do the job, not caution.
+  - Did it delete a warning about a failure mode: fail-open behaviour, a silent
+    failure, an ordering or concurrency requirement, a security property?
+  - Did it delete a test comment naming the defect that test guards?
+  - Did it touch a docstring or a section banner? Both are out of scope.
+  - Did it REWORD rather than delete? The diff should read as deletion.
+  - Did it change any executable line? Nothing but comments should move.
+
+safe_to_propose=false unless you would defend every deletion in it.`,
+      { label: `refute:${orig.id}`, phase: 'Refute', schema: VERDICT_SCHEMA,
+        model: 'opus', effort: 'xhigh' }).then(v => ({ impl, verdict: v, item: orig.id }))
+  }
+)
+
+const all = (commentResults || []).filter(Boolean)
+const ready = all.filter(r => r.verdict && r.verdict.safe_to_propose && !r.verdict.refuted)
+const rejected = all.filter(r => r.verdict && (r.verdict.refuted || !r.verdict.safe_to_propose))
+const removed = ready.reduce((n, r) => n + (r.impl.lines_removed || 0), 0)
+log(`comments: ${ready.length} clusters ready (${removed} lines), ${rejected.length} rejected`)
+
+return {
+  docs: docResults.map(d => ({
+    doc: d.doc, diff: d.diff,
+    false_claims: d.false_claims_found, gaps: d.gaps_filled,
+    verified_against: d.verified_against, blockers: d.blockers,
+  })),
+  comments_ready: ready.map(r => ({
+    cluster: r.item, diff: r.impl.diff, lines_removed: r.impl.lines_removed,
+    borderline: r.impl.kept_but_borderline, relocated: r.impl.relocated,
+    suite: r.impl.suite_result,
+  })),
+  comments_rejected: rejected.map(r => ({
+    cluster: r.item, objection: r.verdict.strongest_objection,
+    load_bearing_deletions: r.verdict.load_bearing_deletions,
+  })),
+}

--- a/.claude/workflows/loci-finish-everything.js
+++ b/.claude/workflows/loci-finish-everything.js
@@ -1,0 +1,254 @@
+export const meta = {
+  name: 'loci-finish-everything',
+  description: 'Execute the remaining Loci work in parallel: multi-repo code grounding, the two specified-but-unexecuted declines, and a post-fix re-measurement',
+  whenToUse: 'After #224. Each item is already measured and scoped; this executes them concurrently in isolated worktrees.',
+  phases: [
+    { title: 'Build',  detail: 'One agent per work item, isolated worktree, tests that fail without the change' },
+    { title: 'Refute', detail: 'Adversarial pass per item before anything is proposed as a PR' },
+  ],
+}
+
+const GROUND = (typeof args === 'object' && args && args.ground) || ''
+const REPO = (typeof args === 'object' && args && args.repo) || '.'
+
+const RULES = `
+DISCIPLINE — every one of these cost this project real time today:
+
+1. MEASURE, do not assert. Lead with the number and how you got it.
+2. RUN it. py_compile and ruff pass code that raises NameError at runtime.
+3. TEST ON THE RIGHT TREE. Twice today a fix was declared broken because it was
+   tested on a branch that lacked its dependency. Confirm the code under test is
+   actually present before concluding anything.
+4. HERMETIC TESTS. Three tests today were non-hermetic: one reached the network,
+   one read ~/.loci/backends.toml, one patched sys.modules where the code reads a
+   package ATTRIBUTE (passed alone, failed in the suite). Patch the layer the
+   code actually reads.
+5. A LANE WITH NO READER IS NOT WORTH FEEDING. Establish the consumer first.
+6. ZERO OUTPUT IS NOT AUTOMATICALLY A DEFECT — check whether the producer ran.
+7. A NEGATIVE RESULT IS A RESULT. If the measurement says the change does not
+   help, say so and stop. Two builds were correctly declined today.
+8. Comment economy: rationale in the commit message, not a wall of source comments.
+`
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  properties: {
+    item: { type: 'string' },
+    diff: { type: 'string' },
+    tests_added: { type: 'array', items: { type: 'string' } },
+    sabotage_result: { type: 'string' },
+    suite_result: { type: 'string' },
+    measured_effect: { type: 'string' },
+    complete: { type: 'boolean' },
+    abandoned: { type: 'boolean' },
+    blocked_reason: { type: 'string' },
+  },
+  required: ['item', 'diff', 'tests_added', 'sabotage_result', 'complete'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    item: { type: 'string' },
+    refuted: { type: 'boolean' },
+    strongest_objection: { type: 'string' },
+    safe_to_propose: { type: 'boolean' },
+  },
+  required: ['item', 'refuted', 'strongest_objection', 'safe_to_propose'],
+}
+
+const ITEMS = [
+  {
+    id: 'multi-repo-code-grounding',
+    brief: `verify.py's code grounding has NEVER produced a line of source.
+
+Measured over 100 grounded verifications: 32 findings carried file:line refs, 59
+refs parsed, 59/59 rejected by _safe_resolve, 0/100 had any source fetched. And
+31 of 91 non-degraded verifications explicitly ASKED for the operator's own
+source — this is the largest measured grounding gap.
+
+Cause: _safe_resolve sandboxes to _repo_root(), the LOCI checkout, but
+hermes_memory is a multi-repo corpus. Measured on the live corpus: 62 code_refs,
+33 unique, 0 resolvable — yet ALL 33 basenames exist on this host, under
+/home/rjmendez/hugbot5000, /home/rjmendez/hb-mountfix-v2 and similar. They are in
+$HOME, NOT under ~/development.
+
+THE HARD PART, and why this is not just a wider allow-list: the host carries MANY
+WORKTREES of the same repo (hugbot5000-wt-audio-ant-decommission,
+hugbot5000-wt-fix-347-respin, and more). The same relative path exists in all of
+them. "First root that has the file" would ground the verifier on STALE CODE from
+an arbitrary worktree, which is worse than grounding on nothing — a confident
+answer from the wrong revision.
+
+code_refs carry {path, hash} — the hash may let you pick the right checkout.
+Investigate whether it does before designing around it.
+
+Preserve the security property exactly: absolute paths and .. traversal must
+still be refused, and a resolved path must still land under an allowed root.
+Widening an allow-list is not removing it. There is a partial patch on branch
+fix/multi-repo-code-grounding (a _search_roots() helper scanning ~/development
+siblings) — it is INSUFFICIENT because it has the wrong parent and no worktree
+disambiguation. Treat it as a starting point or discard it.
+
+Report the hit rate BEFORE and AFTER over all 62 refs. If you cannot beat 0
+without risking a stale-revision read, say so and abandon — that is a real result.`,
+  },
+  {
+    id: 'guard-log-consumer-deletion',
+    brief: `Execute the deletion that issue #216's investigation specified.
+
+guard_bash_failures.log / guard_bash_successes.log / guard_tool_reflections.log
+have FOUR production consumers and ZERO producers; the only writers in the repo
+are two test files that create their own fixture. The investigation measured that
+the SCoRe pipeline these feed cannot run here — a registered runner never started
+across 8 nightly attempts, Ollama for it was unreachable, and the tuned model it
+would produce has no caller. It recommended option (b), DELETE THE CONSUMERS,
+with a fail-first test plan, and explicitly did not split the difference.
+
+Consumers to remove or de-wire:
+  scripts/score_trace_collector.py     - SCoRe dataset collection
+  scripts/skill_annotation_updater.py  - reads guard_bash_failures optionally
+  mlops/memory/live_evo.py             - _load_guard_failures, confidence penalties
+  mlops/loop.py                        - passes hook_state_dir through to Live-Evo
+
+Before deleting ANY of it, establish what else imports each module — mlops/loop.py
+in particular may have callers unrelated to guard logs, and Live-Evo may do useful
+work beyond the guard-failure path. Removing a module that something else imports
+is worse than the dead lane. If a file has non-guard responsibilities, remove the
+guard PATH and keep the rest.
+
+Also check .github/workflows and cron/jobs.json for anything referencing these,
+and mcp/tests + mlops/*/tests for tests that only exist to test the dead path.`,
+  },
+  {
+    id: 'self-check-phase-0',
+    brief: `Execute the Phase 0 that issue #193's investigation proposed.
+
+The audit lane has 667 writes and 0 reads: over 5.2 days and 15,048 tool calls,
+findings were stored 667 times and EVERY consumer of a receipt —
+memory_self_check, investigation_pre_answer_check, investigation_evidence_precheck,
+investigation_finding_provenance, investigation_verify_all, verify_finding — ran
+ZERO times. The investigation declined to build the receipt producer and proposed
+instead: "make the check RUN first (~30 lines into session_end_sync.py or
+investigation_reflect) and see whether its output changes anyone's behaviour."
+
+Build that. Constraints, all of which matter:
+  - memory_self_check is ADVISORY. It must never block or slow a session end.
+    Fail-open, bounded, and it must not add meaningful latency to a Stop hook.
+  - #213 added _audit_lane_status so a report says "no receipts exist" rather
+    than "1,682 unsupported findings". Whatever surfaces the output must carry
+    that distinction, or it will read as 1,682 real defects.
+  - It must be OFF by default or trivially disabled. Turning on an unattended
+    check that nobody asked for is how this project got its dead lanes.
+  - The output needs a READER. Do not write to a new file nothing opens — that
+    is the exact failure this issue is about. Prefer surfacing where someone
+    already looks; investigation_load is called 15x/5.2d, memory_self_check 0.
+
+If you conclude the honest Phase 0 is smaller than 30 lines — a log line, or a
+counter — build that instead and say why.`,
+  },
+  {
+    id: 'verify-quality-remeasure',
+    brief: `MEASUREMENT ONLY — produce no diff unless the measurement demands one.
+
+A baseline over 100 grounded verifications found the verifier is not fit to
+schedule: refutations judged sound 7/53 = 13.2%, verdict contradicts its own
+reasoning in >=5/53, and 9/100 degraded. The degradations were traced to a 4096
+context ceiling: vLLM max_model_len=4096, usable prompt 3712 tokens, HTTP 400
+"prompt contains at least 3713 input tokens". All 9 degraded had claim+context
+>= 11,587 chars.
+
+That ceiling was dama-vllm's forwarder, reached through llm_local's automatic
+fallback. PR #224 made that fallback OPT-IN (LOCI_VLLM_FALLBACK, default off), so
+Ollama failures no longer reroute there.
+
+Re-measure now, on the same shape: sample grounded verifications and report the
+degraded rate and the verdict distribution. The question is narrow — did removing
+the 4096 reroute eliminate the degraded cases, and did anything else move?
+
+Do NOT re-litigate the soundness rate; 13.2% was hand-read and is not something to
+re-derive cheaply. Report whether the DEGRADED count changed and whether the
+verify groom pass is now safe to schedule. "Still not safe" is the expected and
+acceptable answer.
+
+The oxalis endpoint has been intermittently saturated — it returned nothing in
+85s for a 4-token generation at one point. If you cannot get a clean measurement,
+say so rather than reporting a number taken during contention.`,
+  },
+]
+
+phase('Build')
+log(`Executing ${ITEMS.length} work items in parallel`)
+
+const results = await pipeline(
+  ITEMS,
+  it => agent(
+    `${GROUND}\n${RULES}\nRepo: ${REPO}\n\nWORK ITEM: ${it.id}\n\n${it.brief}\n
+You are in your OWN git worktree; the other agents are editing this repo in
+theirs. Do not coordinate, do not commit, do not push, do not open a PR.
+
+Requirements:
+  - Tests must FAIL without the change. Reintroduce the absence, watch them fail,
+    restore. Report the exact failure text.
+  - Run the relevant suite (./mcp/.venv/bin/python -m pytest mcp/ -q for mcp,
+    python3 -m pytest scripts/tests -q for scripts) and report counts. Note that
+    test_graph_integration::test_code_graph_ingest_and_query fails on clean main
+    for host-specific reasons — it is NOT yours.
+  - ruff check --select E9,F401,F811,F821,F841 --ignore E402 must be clean.
+  - Set abandoned=true with blocked_reason if the measurement says the change
+    does not help. That is a respected outcome here, not a failure.
+  - Return the full diff.`,
+    { label: `build:${it.id}`, phase: 'Build', schema: IMPL_SCHEMA,
+      model: 'opus', effort: 'high', isolation: 'worktree' }
+  ),
+  (impl, orig) => {
+    if (!impl || !impl.complete || impl.abandoned) {
+      return { impl, verdict: null, item: orig.id }
+    }
+    return agent(
+      `${RULES}\n
+Adversarially review this implementation. REFUTE it. Default refuted=true when unsure.
+
+ITEM: ${orig.id}
+SABOTAGE CLAIMED: ${impl.sabotage_result}
+SUITE CLAIMED: ${impl.suite_result || 'not reported'}
+EFFECT CLAIMED: ${impl.measured_effect || 'not reported'}
+
+DIFF:
+${(impl.diff || '').slice(0, 30000)}
+
+Attack specifically:
+  - Is the measured effect real, or measured on a harness? A grounding number
+    taken without QDRANT_URL set is measuring nothing.
+  - For code grounding: could it read a STALE worktree? That is a confident
+    answer from the wrong revision — worse than no grounding. And does the
+    sandbox still refuse absolute paths and .. traversal?
+  - For deletions: does anything still import what was removed? Check, do not
+    assume the author did.
+  - For anything scheduled or hooked: does it add latency to a hot path, and
+    does its output have a reader?
+  - Is any test non-hermetic — network, operator config, or patching a layer the
+    code does not read?
+  - Does the sabotage failure match the defect, or is it incidental?
+
+safe_to_propose=false unless you would defend it yourself.`,
+      { label: `refute:${orig.id}`, phase: 'Refute', schema: VERDICT_SCHEMA,
+        model: 'opus', effort: 'xhigh' }
+    ).then(v => ({ impl, verdict: v, item: orig.id }))
+  }
+)
+
+const all = (results || []).filter(Boolean)
+const ready = all.filter(r => r.verdict && r.verdict.safe_to_propose && !r.verdict.refuted)
+const abandoned = all.filter(r => r.impl && r.impl.abandoned)
+const rejected = all.filter(r => r.verdict && (r.verdict.refuted || !r.verdict.safe_to_propose))
+
+log(`${ready.length} ready for PR, ${rejected.length} rejected, ${abandoned.length} abandoned`)
+
+return {
+  ready: ready.map(r => ({ item: r.item, diff: r.impl.diff, tests: r.impl.tests_added,
+                           sabotage: r.impl.sabotage_result, effect: r.impl.measured_effect })),
+  rejected: rejected.map(r => ({ item: r.item, objection: r.verdict.strongest_objection })),
+  abandoned: abandoned.map(r => ({ item: r.item, reason: r.impl.blocked_reason,
+                                   effect: r.impl.measured_effect })),
+}

--- a/.claude/workflows/loci-hister-grounding.js
+++ b/.claude/workflows/loci-hister-grounding.js
@@ -1,0 +1,305 @@
+export const meta = {
+  name: 'loci-hister-grounding',
+  description: 'Design, gate and build a Hister-backed external-documentation grounding source for Loci retrieval',
+  whenToUse: 'Loci grounds only against findings and the operator own repos. This evaluates whether an external doc corpus earns its keep, and builds it only if the measurement says yes.',
+  phases: [
+    { title: 'Recon',    detail: 'Stand Hister up, read its MCP surface, and measure the baseline it would have to beat' },
+    { title: 'Design',   detail: 'Two independent integration designs, then a red-team pick' },
+    { title: 'Gate',     detail: 'Does the measured baseline justify building at all' },
+    { title: 'Build',    detail: 'Isolated worktrees, tests that fail without the change' },
+    { title: 'Refute',   detail: 'Adversarial pass before anything is proposed as a PR' },
+  ],
+}
+
+const GROUND = (typeof args === 'object' && args && args.ground) || ''
+const REPO = (typeof args === 'object' && args && args.repo) || '.'
+
+const RULES = `
+DISCIPLINE — every one of these cost this project real time, most of them today:
+
+1. MEASURE, do not assert. Lead with the number and how you got it. Mark inference
+   as inference and say what would falsify it.
+2. RUN it. py_compile and ruff pass code that raises NameError at runtime. And a
+   probe returning nothing may be testing the wrong endpoint with stale code — a
+   "27B produces empty output" result today was entirely that.
+3. AVAILABILITY IS NOT CAPABILITY. llm_available() returned True for weeks while
+   every call returned None: provider chosen on key-presence, key had a newline
+   from an 80-column paste, and behind that the account had no credit. Three
+   failures, one fail-open. Check a thing WORKS, not that it is configured.
+4. ZERO OUTPUT IS NOT AUTOMATICALLY A DEFECT — check whether the producer ever ran.
+5. A LANE WITH NO READER IS NOT WORTH FEEDING. finding_verifications.jsonl had 0
+   readers; the audit lane had 667 writes and 0 reads. Establish the consumer first.
+6. HERMETIC TESTS. A test that reads ~/.loci/backends.toml asserts against the
+   operator machine and passes locally while failing in CI. Two tests did exactly
+   that today.
+7. Comment economy: rationale in the commit message, not a wall of source comments.
+`
+
+const RECON_SCHEMA = {
+  type: 'object',
+  properties: {
+    topic: { type: 'string' },
+    findings: { type: 'string' },
+    numbers: { type: 'string' },
+    blockers: { type: 'array', items: { type: 'string' } },
+    confidence: { type: 'string' },
+  },
+  required: ['topic', 'findings', 'numbers', 'blockers'],
+}
+
+const DESIGN_SCHEMA = {
+  type: 'object',
+  properties: {
+    approach: { type: 'string' },
+    integration_point: { type: 'string' },
+    files_to_change: { type: 'array', items: { type: 'string' } },
+    failure_modes: { type: 'string' },
+    test_plan: { type: 'string' },
+    reversibility: { type: 'string' },
+    cost: { type: 'string' },
+  },
+  required: ['approach', 'integration_point', 'files_to_change', 'failure_modes',
+             'test_plan', 'reversibility'],
+}
+
+const GATE_SCHEMA = {
+  type: 'object',
+  properties: {
+    build_it: { type: 'boolean' },
+    reasoning: { type: 'string' },
+    baseline_evidence: { type: 'string' },
+    chosen_design: { type: 'string' },
+    scope_cuts: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['build_it', 'reasoning', 'baseline_evidence'],
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  properties: {
+    diff: { type: 'string' },
+    tests_added: { type: 'array', items: { type: 'string' } },
+    sabotage_result: { type: 'string' },
+    suite_result: { type: 'string' },
+    measured_effect: { type: 'string' },
+    complete: { type: 'boolean' },
+    blocked_reason: { type: 'string' },
+  },
+  required: ['diff', 'tests_added', 'sabotage_result', 'complete'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    refuted: { type: 'boolean' },
+    strongest_objection: { type: 'string' },
+    safe_to_propose: { type: 'boolean' },
+  },
+  required: ['refuted', 'strongest_objection', 'safe_to_propose'],
+}
+
+// ── Phase 1: recon, in parallel ──────────────────────────────────────────────
+phase('Recon')
+
+const RECON = [
+  {
+    id: 'hister-surface',
+    prompt: `Stand up Hister and document what it actually offers.
+
+Download the prebuilt binary (v0.18.0, hister_0.18.0_linux_amd64, ~110MB) from
+github.com/asciimoo/hister releases into a scratch dir under /tmp. Do NOT install
+system-wide, do NOT add it to the Loci repo.
+
+Establish, by RUNNING it:
+  - what MCP tools it exposes (read server/mcp.go from the repo, and if you can
+    start it, list the tools live). Names, parameters, return shapes.
+  - how the embeddings endpoint is configured. Loci already runs nomic-embed-text
+    at http://10.42.0.1:11434 (93ms). Can Hister use it, and at what dimension?
+  - how documents are indexed (URL fetch? file watch? CLI?) and where state lives.
+  - startup/auth requirements and resource footprint.
+
+Blockers matter more than features here. If it cannot run headless, or needs a
+browser extension to be useful, say so plainly.`,
+  },
+  {
+    id: 'baseline',
+    prompt: `Measure the baseline Hister would have to beat. This is the number the
+whole decision rests on, so be careful with it.
+
+In ${REPO}:
+  - Sample real findings and run verify.verify_finding over them WITH grounding
+    (investigation_id set). Record the distribution of verdict and degraded, and
+    how often the model's own reasoning says the context was INSUFFICIENT rather
+    than that the claim was wrong. That last number is the one an external doc
+    corpus would move.
+  - Separately, count how many stored findings make claims about THIRD-PARTY
+    systems (qdrant, ollama, huggingface, a model card, a library) versus claims
+    about this operator's own code. Only the former can be helped by external docs.
+
+Use ./mcp/.venv/bin/python; scripts/loci_groom.py load_env() sets QDRANT_URL —
+without it RAG silently returns nothing and you will measure your own harness.
+Report exact counts and how you obtained them.`,
+  },
+  {
+    id: 'retrieval-seam',
+    prompt: `Find where an extra grounding source would have to plug in, and what
+that costs.
+
+In ${REPO}, read mcp/server.py's rag_context_search (collections default
+["hermes_memory","agent_core_chunks"]), the _rag_* helper chain, and
+mcp/verify.py's _lazy_rag. Establish:
+  - the exact seam where a THIRD source could be merged, and whether the
+    cross-encoder re-pass would rank across heterogeneous sources sensibly.
+  - whether an MCP-to-MCP call is even possible from inside Loci's server, or
+    whether the merge has to happen in the agent instead. This is decisive for
+    the design — check, do not assume.
+  - what breaks if the extra source is unavailable. Loci's house style is
+    fail-open; confirm the seam preserves that.
+  - who reads the result: get real call counts from ~/.hermes/logs/tool-audit.log.`,
+  },
+]
+
+log(`Recon: ${RECON.length} parallel probes`)
+const recon = (await parallel(RECON.map(r => () =>
+  agent(`${GROUND}\n${RULES}\nRepo: ${REPO}\n\nTOPIC: ${r.id}\n\n${r.prompt}`,
+    { label: `recon:${r.id}`, phase: 'Recon', schema: RECON_SCHEMA,
+      model: 'opus', effort: 'high' })
+))).filter(Boolean)
+
+log(`${recon.length}/${RECON.length} recon probes returned`)
+for (const r of recon) log(`  ${r.topic}: ${(r.blockers || []).length} blocker(s)`)
+
+// ── Phase 2: two independent designs ─────────────────────────────────────────
+phase('Design')
+const designs = (await parallel([
+  {
+    id: 'in-server',
+    slant: `Design the integration INSIDE the Loci MCP server: Hister becomes a third
+retrieval source that rag_context_search merges, so every existing consumer gets
+it for free with no agent changes. Argue for it honestly, including what it costs
+in coupling and what happens when Hister is down.`,
+  },
+  {
+    id: 'sibling-mcp',
+    slant: `Design the integration as a SIBLING MCP server: Hister runs alongside Loci,
+agents call it directly, and Loci changes little or nothing. Argue for it honestly,
+including what is lost when retrieval is not merged and ranked together.`,
+  },
+].map(d => () =>
+  agent(`${GROUND}\n${RULES}\nRepo: ${REPO}
+
+RECON FINDINGS:
+${JSON.stringify(recon, null, 2).slice(0, 14000)}
+
+${d.slant}
+
+Ground the design in the recon above — if recon says an MCP-to-MCP call is
+impossible from inside the server, a design that requires one is dead and you
+should say so rather than writing it. Give a test plan where each test FAILS
+without the change, and state how to REVERSE it.`,
+    { label: `design:${d.id}`, phase: 'Design', schema: DESIGN_SCHEMA,
+      model: 'opus', effort: 'high' })
+))).filter(Boolean)
+
+// ── Phase 3: the gate ────────────────────────────────────────────────────────
+phase('Gate')
+const gate = await agent(
+  `${GROUND}\n${RULES}
+
+RECON: ${JSON.stringify(recon, null, 2).slice(0, 14000)}
+
+DESIGNS: ${JSON.stringify(designs, null, 2).slice(0, 14000)}
+
+Decide whether this should be built AT ALL, then pick a design.
+
+The bar: the baseline recon must show that a meaningful share of grounding
+failures are "insufficient external context" rather than "the claim is wrong" or
+"the corpus is thin". If most findings are about the operator's OWN code, an
+external documentation corpus cannot help them and this is a second index to
+back up for nothing.
+
+build_it=false is a legitimate and useful answer. This project has twice declined
+to build something for good measured reasons and been better for it. Do not build
+to look productive.
+
+If build_it=true, name the chosen design and list scope_cuts — what NOT to build
+in the first PR.`,
+  { label: 'gate', phase: 'Gate', schema: GATE_SCHEMA, model: 'opus', effort: 'xhigh' }
+)
+
+if (!gate || !gate.build_it) {
+  log(`GATE: not building — ${(gate && gate.reasoning || 'no gate verdict').slice(0, 200)}`)
+  return { recon, designs, gate, built: null }
+}
+log(`GATE: build — ${gate.chosen_design}`)
+
+// ── Phase 4+5: build, then try to break it ───────────────────────────────────
+const built = await pipeline(
+  [gate],
+  g => agent(
+    `${GROUND}\n${RULES}\nRepo: ${REPO}
+
+Implement the chosen design. You are in your OWN git worktree.
+
+CHOSEN: ${g.chosen_design}
+REASONING: ${g.reasoning}
+DO NOT BUILD (deferred): ${(g.scope_cuts || []).join('; ') || 'nothing deferred'}
+
+DESIGNS FOR REFERENCE:
+${JSON.stringify(designs, null, 2).slice(0, 12000)}
+
+Requirements:
+  - Tests must FAIL without the change. Reintroduce the absence, watch them fail,
+    restore. Report the exact failure text in sabotage_result.
+  - HERMETIC: no test may read ~/.loci/backends.toml or reach the network. Two
+    tests did exactly that today and passed locally while being meaningless.
+  - Fail-open: if Hister is unreachable, retrieval must degrade to what it does
+    today, not error. Test that explicitly.
+  - Run the relevant suite (./mcp/.venv/bin/python -m pytest mcp/ -q) and report
+    counts. ruff check with --select E9,F401,F811,F821,F841 --ignore E402 clean.
+  - If you add an @mcp.tool(), the callgraph tests pin the tool count and
+    .vulture_whitelist.py needs the name — both fail CI otherwise.
+  - measured_effect: show the BEFORE and AFTER of the baseline number from recon.
+    If you cannot measure an improvement, say so — that is a real result.
+  - Return the full diff. Do NOT commit, push, or open a PR.`,
+    { label: 'build', phase: 'Build', schema: IMPL_SCHEMA,
+      model: 'opus', effort: 'high', isolation: 'worktree' }
+  ),
+  (impl) => {
+    if (!impl || !impl.complete) return { impl, verdict: null }
+    return agent(
+      `${RULES}
+
+Adversarially review this implementation. REFUTE it. Default refuted=true when unsure.
+
+SABOTAGE CLAIMED: ${impl.sabotage_result}
+SUITE CLAIMED: ${impl.suite_result || 'not reported'}
+MEASURED EFFECT CLAIMED: ${impl.measured_effect || 'not reported'}
+
+DIFF:
+${(impl.diff || '').slice(0, 30000)}
+
+Attack specifically:
+  - Is the measured_effect real, or measured on a harness rather than the system?
+    A grounding improvement measured without QDRANT_URL set is measuring nothing.
+  - Does it fail OPEN when Hister is down, and is that actually tested?
+  - Any test that reads operator config or touches the network is not hermetic.
+  - Does the sabotage failure match the defect, or is it an incidental error like
+    an AttributeError on a newly-added name?
+  - Does this add a second index nobody will back up, for a benefit nobody reads?
+  - Is the fix at the shared seam, or at one call site that happened to show it?
+
+safe_to_propose=false unless you would defend it yourself.`,
+      { label: 'refute', phase: 'Refute', schema: VERDICT_SCHEMA,
+        model: 'opus', effort: 'xhigh' }
+    ).then(v => ({ impl, verdict: v }))
+  }
+)
+
+const r0 = (built || []).filter(Boolean)[0] || {}
+return {
+  recon, designs, gate,
+  built: r0.impl || null,
+  verdict: r0.verdict || null,
+  ready_for_pr: !!(r0.verdict && r0.verdict.safe_to_propose && !r0.verdict.refuted),
+}

--- a/.claude/workflows/loci-improve.js
+++ b/.claude/workflows/loci-improve.js
@@ -1,0 +1,68 @@
+export const meta = {
+  name: 'loci-improve',
+  description: 'Fan out one worktree-isolated agent per Loci self-improvement: design-minimal implement + tests + pytest/ruff gate + fresh reviewer, commit, push, open PR (loci conventions: trailers ON).',
+  whenToUse: 'Implement Loci reliability fixes + features discovered while dogfooding. Each batch: worktree off loci main, implement the MINIMAL backward-compatible change + tests, run the mcp pytest suite + ruff, commit WITH the standard loci trailers, push, open a PR, and get a fresh-context reviewer. args = {repo, batches:[{id,title,branch,scope,design,test}]}.',
+  phases: [{ title: 'Improve', detail: 'per batch: worktree -> implement -> pytest/ruff -> commit -> push -> PR -> review' }],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const REPO = A.repo
+const BATCHES = Array.isArray(A.batches) ? A.batches : []
+if (!REPO || !BATCHES.length) { log('need repo + batches[]'); return { error: 'missing args' } }
+
+const TRAILERS = 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45'
+const PRFOOTER = '🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01AB14MYuygYSXLfVT1oco45'
+
+const results = await parallel(BATCHES.map((b) => () =>
+  agent(
+    'You are implementing ONE Loci self-improvement in the repo at ' + REPO + ' (a Python MCP server; base branch main). '
+    + 'Work entirely in a dedicated git worktree. Be MINIMAL and BACKWARD-COMPATIBLE (this is a live-depended-on server): '
+    + 'additive changes, fail-open, defaults that preserve current behavior. Steps:\n\n'
+    + '1. Worktree + branch off origin/main; share the venv:\n'
+    + '   WT=/tmp/claude-1000/-home-rjmendez/2c90c7f0-8dc3-4c5b-a56d-b4cb6cdf34ce/scratchpad/loci-' + b.branch.replace(/[^a-zA-Z0-9]/g, '-') + '\n'
+    + '   git -C ' + REPO + ' fetch origin main -q; rm -rf "$WT"\n'
+    + '   git -C ' + REPO + ' worktree add -b ' + b.branch + ' "$WT" origin/main\n'
+    + '   ln -s ' + REPO + '/mcp/.venv "$WT/mcp/.venv"\n'
+    + '2. Read the real current code FIRST. SCOPE (touch only what is needed here): ' + b.scope + '\n'
+    + '   DESIGN / what to build: ' + b.design + '\n'
+    + '   Keep it small and correct; match surrounding style; do NOT refactor unrelated code.\n'
+    + '3. Add focused tests: ' + b.test + '\n'
+    + '4. Validate from "$WT/mcp": `. .venv/bin/activate; python -m pytest -q` (the FULL mcp suite must stay green — this '
+    + 'is a live server, no regressions) and `ruff check <changed files> --select E9,F401,F811,F821,F841 --ignore E402`. '
+    + 'Fix any failure; if you cannot, report it and do NOT push.\n'
+    + '5. Commit the intended files (explicit `git add`). Conventional-Commits message; END the body with EXACTLY these two trailer lines:\n'
+    + TRAILERS + '\n'
+    + '6. Push: `git -C "$WT" push -u origin ' + b.branch + '`\n'
+    + '7. Open the PR: `gh pr create --repo rjmendez/loci --base main --head ' + b.branch + ' --title "..." --body "..."`. '
+    + 'End the PR body with EXACTLY:\n' + PRFOOTER + '\n'
+    + '8. Request a Copilot review (capture the exact outcome): try '
+    + '`gh api --method POST repos/rjmendez/loci/pulls/<PR#>/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"` '
+    + '(this is the call that works; `gh pr edit --add-reviewer @copilot` errors on Projects-classic). Record whether the '
+    + 'response shows Copilot in requested_reviewers.\n'
+    + '9. Clean up: `git -C ' + REPO + ' worktree remove --force "$WT"`.\n\n'
+    + 'Report honestly (disclose any skip/deviation). Batch: [' + b.id + '] ' + b.title,
+    { label: 'impl:' + b.id, phase: 'Improve',
+      schema: { type: 'object', required: ['id', 'status'],
+        properties: {
+          id: { type: 'string' }, status: { type: 'string', description: 'pushed_pr_opened | validated_not_pushed | failed' },
+          branch: { type: 'string' }, pr_number: { type: 'string' }, pr_url: { type: 'string' },
+          files_changed: { type: 'array', items: { type: 'string' } },
+          copilot_review: { type: 'string', description: 'requested-ok | error text | not-attempted' },
+          suite: { type: 'string', description: 'pytest result (N passed) + ruff' },
+          summary: { type: 'string' }, problems: { type: 'string' } } } })
+    .then((r) => r ? { ...r, id: r.id || b.id } : { id: b.id, status: 'failed', problems: 'null' })
+    .catch((e) => ({ id: b.id, status: 'failed', problems: String(e) })),
+))
+
+const opened = results.filter((r) => r && r.status === 'pushed_pr_opened')
+const reviewed = await parallel(opened.map((r) => () =>
+  agent(
+    'Fresh-context review of PR ' + (r.pr_url || r.branch) + ' in ' + REPO + ' (git -C ' + REPO + ' diff origin/main..' + r.branch + '). '
+    + 'This is a change to a live-depended-on MCP server. Check: correctness, backward-compatibility (defaults preserve current '
+    + 'behavior?), fail-open, test adequacy, no unrelated refactor, and that the full mcp pytest suite is green. '
+    + 'Return {branch, verdict: approve|changes-requested, notes}.',
+    { label: 'review:' + r.id, phase: 'Improve',
+      schema: { type: 'object', required: ['verdict'], properties: { branch: { type: 'string' }, verdict: { type: 'string' }, notes: { type: 'string' } } } })
+    .then((v) => ({ id: r.id, ...v })).catch(() => ({ id: r.id, verdict: 'review-error' }))))
+
+return { total: BATCHES.length, opened: opened.length, results, reviews: reviewed }

--- a/.claude/workflows/loci-model-tier-design.js
+++ b/.claude/workflows/loci-model-tier-design.js
@@ -1,0 +1,215 @@
+export const meta = {
+  name: 'loci-model-tier-design',
+  description: 'Audit every local + low-cost-cloud generation path in Loci and design the tier that should serve each',
+  whenToUse: 'After the memcheck/llm_local endpoint fixes. Every consumer is already written; the question is which tier serves it and whether anyone reads the output.',
+  phases: [
+    { title: 'Census',   detail: 'One agent per surface: who generates, on which tier, and does the output have a reader' },
+    { title: 'Design',   detail: 'Route each consumer to a tier, on measured cost/latency/quality — or say do not run it' },
+    { title: 'Refute',   detail: 'Adversarial pass: is the routing justified, or is it a preference dressed as a measurement' },
+  ],
+}
+
+const GROUND = (typeof args === 'object' && args && args.ground) || ''
+const REPO = (typeof args === 'object' && args && args.repo) || '.'
+
+const RULES = `
+DISCIPLINE — mistakes this codebase has already paid for, several of them today:
+
+1. MEASURE, do not assert. Lead with the number and how you got it. Mark inference
+   as inference and say what would falsify it.
+2. RUN it. py_compile and ruff pass code that raises NameError at runtime. A probe
+   that returns nothing may be testing the wrong endpoint with stale code — today a
+   "27B produces empty output" result was entirely an artefact of exactly that.
+3. AVAILABILITY IS NOT CAPABILITY. llm_available() returned True for weeks while
+   every call returned None: a provider was selected on key-presence, the key had a
+   newline from an 80-column paste, and behind that the account had no credit. Three
+   stacked failures, all swallowed by one fail-open. Check that a thing WORKS, not
+   that it is configured.
+4. ZERO OUTPUT IS NOT AUTOMATICALLY A DEFECT. Check whether the producer ever RAN
+   before calling it broken. An issue was filed on that error and had to be retracted.
+5. A LANE WITH NO READER IS NOT WORTH FEEDING. finding_verifications.jsonl had 0
+   readers; the audit lane had 667 writes and 0 reads. Before recommending that
+   something generate more, establish who consumes it.
+6. Comment economy: rationale goes in the commit message, not a wall of source
+   comments.
+`
+
+const CENSUS_SCHEMA = {
+  type: 'object',
+  properties: {
+    surface: { type: 'string' },
+    entrypoints: { type: 'array', items: { type: 'string' } },
+    current_tier: { type: 'string' },
+    works_today: { type: 'boolean' },
+    evidence: { type: 'string' },
+    output_destination: { type: 'string' },
+    reader_count: { type: 'integer' },
+    reader_evidence: { type: 'string' },
+    call_volume: { type: 'string' },
+    quality_bar: { type: 'string' },
+  },
+  required: ['surface', 'entrypoints', 'current_tier', 'works_today', 'evidence',
+             'output_destination', 'reader_count', 'reader_evidence'],
+}
+
+const DESIGN_SCHEMA = {
+  type: 'object',
+  properties: {
+    routing: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          surface: { type: 'string' },
+          recommended_tier: { type: 'string' },
+          why: { type: 'string' },
+          measured_basis: { type: 'string' },
+          cost_per_run: { type: 'string' },
+          do_not_run: { type: 'boolean' },
+        },
+        required: ['surface', 'recommended_tier', 'why', 'measured_basis'],
+      },
+    },
+    tier_table: { type: 'string' },
+    unmeasured: { type: 'array', items: { type: 'string' } },
+    cheapest_next_experiment: { type: 'string' },
+  },
+  required: ['routing', 'tier_table', 'unmeasured', 'cheapest_next_experiment'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    refuted: { type: 'boolean' },
+    strongest_objection: { type: 'string' },
+    unjustified_routings: { type: 'array', items: { type: 'string' } },
+    safe_to_adopt: { type: 'boolean' },
+  },
+  required: ['refuted', 'strongest_objection', 'safe_to_adopt'],
+}
+
+const SURFACES = [
+  {
+    id: 'memcheck-llm',
+    brief: `mcp/memcheck/llm.py — call_llm(), the shared generation primitive. Just fixed:
+provider fallthrough (anthropic -> copilot -> ollama), whitespace-key guard,
+_ollama_gen_base() for generation. Its consumers: investigation_reflect summaries
+(summary_l1/l2), investigation_reason, _run_causal_inference's LLM slow path, and
+memcheck/checks/contradiction_llm.py behind the llm_verify flag.
+For EACH consumer establish: does it run now, what does it write, and who reads
+what it writes. summary_l1/l2 sit on the manifest — find out whether anything
+consumes them (grounding.py is a candidate).`,
+  },
+  {
+    id: 'llm-local-and-batched',
+    brief: `mcp/llm_local.py (single-shot, Ollama + vLLM fallback) and mcp/batched_gen.py
+(vLLM /v1/completions). Consumers include verify.verify_finding, query_expand /
+rag_context_search expansion, classify_text, compress_text, semantic_relevance,
+and scripts/loci_groom.py's tags pass.
+Note the groom 'tags' pass is DELIBERATELY not scheduled: kNN tagging measured
+better at a fraction of the cost. Do not recommend reviving it without new
+measurement. Establish per-consumer call volume from the tool-audit log at
+~/.hermes/logs/tool-audit.log.`,
+  },
+  {
+    id: 'cloud-tiers',
+    brief: `mcp/openrouter.py (FREE_LADDER / CHEAP_LADDER / DEFAULT_LADDER, key labelled
+"oxalis loci" in ~/.loci/backends.toml) and the Anthropic path in memcheck/llm.py.
+MEASURED TODAY: the Anthropic account returns HTTP 400 "credit balance is too low",
+so that tier costs nothing because it cannot transact. Verify whether OpenRouter's
+free ladder actually answers right now — earlier in this project the free models
+returned 429 "Provider returned error" and the ladder fell through to a paid one.
+Establish what is actually reachable and at what price, and whether anything in
+Loci currently routes to either.`,
+  },
+]
+
+phase('Census')
+log(`Censusing ${SURFACES.length} generation surfaces`)
+
+const census = await parallel(SURFACES.map(s => () =>
+  agent(
+    `${GROUND}\n${RULES}\n
+Repo: ${REPO}. Census this generation surface — do NOT design anything yet.
+
+SURFACE: ${s.id}
+${s.brief}
+
+For every entrypoint answer, with evidence:
+  - does it WORK today? Run it. "Configured" is not "works".
+  - where does its output go, and HOW MANY READERS does that destination have?
+    Grep for consumers; a file nothing reads is a lane, not a feature.
+  - what is the call volume? ~/.hermes/logs/tool-audit.log has real counts.
+  - what quality bar does the consumer actually need?
+
+Use ./mcp/.venv/bin/python for anything importing qdrant_client or the mcp sdk.
+scripts/loci_groom.py load_env() sets QDRANT_URL — without it RAG returns nothing
+and you will measure your own harness instead of the system.`,
+    { label: `census:${s.id}`, phase: 'Census', schema: CENSUS_SCHEMA,
+      model: 'opus', effort: 'high' }
+  )
+))
+
+const facts = census.filter(Boolean)
+log(`${facts.length}/${SURFACES.length} surfaces censused`)
+for (const f of facts) log(`  ${f.surface}: works=${f.works_today} readers=${f.reader_count}`)
+
+phase('Design')
+const design = await agent(
+  `${GROUND}\n${RULES}\n
+Here is the measured census of every generation surface in Loci:
+
+${JSON.stringify(facts, null, 2)}
+
+Design the tier routing. Available tiers, with what is known today:
+  - local Ollama on oxalis (100.73.200.19): 11 models incl. qwen2.5:3b,
+    heretic-llama31-8b-instruct, heretic-phi4-mini-reasoning, and a newly pulled
+    Qwen3.8-27B-Heretic-Abliterated Q4_K_M (17GB). GPUs: 2080 Ti (11.8GB, SM 7.5)
+    + 4070 Ti (12.9GB, SM 8.9). Persistence is a SYSTEM startup Scheduled Task,
+    but the live process is not that task's child.
+  - local vLLM at 127.0.0.1:18000 serving Qwen/Qwen2.5-3B-Instruct — note this is
+    ANOTHER PROJECT's forwarder (dama-vllm), not Loci's to depend on.
+  - OpenRouter free/cheap ladders.
+  - Anthropic — measured today as unable to transact (400, no credit).
+
+For each consumer give a tier and the MEASURED basis. Where a consumer's output
+has no reader, recommend do_not_run=true and say so plainly rather than routing it
+to a cheap tier — a cheaper way to write to nobody is not an improvement.
+
+List everything you could NOT measure in 'unmeasured', and give the single
+cheapest experiment that would resolve the most important unknown.`,
+  { label: 'design:tiers', phase: 'Design', schema: DESIGN_SCHEMA,
+    model: 'opus', effort: 'high' }
+)
+
+if (!design) return { census: facts, design: null, verdict: null }
+
+phase('Refute')
+const verdict = await agent(
+  `${RULES}\n
+Adversarially review this tier routing. Try to REFUTE it. Default to refuted=true
+when uncertain.
+
+CENSUS: ${JSON.stringify(facts).slice(0, 12000)}
+
+DESIGN: ${JSON.stringify(design, null, 2).slice(0, 14000)}
+
+Attack specifically:
+  - Is any routing a PREFERENCE dressed as a measurement? "bigger is better" and
+    "local is cheaper" are not measurements. Name every routing whose
+    measured_basis does not actually support it.
+  - Does any recommendation feed a lane with no reader? That is the failure this
+    project has hit three times.
+  - Does anything depend on a service Loci does not own — specifically the
+    dama-vllm forwarder at 127.0.0.1:18000, or an oxalis Ollama whose live process
+    is not managed by its startup task?
+  - Does any routing assume a model works without it having been RUN?
+  - Is the cheapest_next_experiment actually the cheapest, and does it resolve the
+    most important unknown, or merely the most interesting one?
+
+safe_to_adopt=false unless you would defend this routing yourself.`,
+  { label: 'refute:tiers', phase: 'Refute', schema: VERDICT_SCHEMA,
+    model: 'opus', effort: 'xhigh' }
+)
+
+return { census: facts, design, verdict }

--- a/a2a_server/README.md
+++ b/a2a_server/README.md
@@ -5,7 +5,7 @@ Default port: **8201**
 ## What this does
 
 Exposes Mnemosyne memory operations over the A2A JSON-RPC protocol so other
-mesh agents can read and write memory without going through the Hermes MCP stack.
+mesh agents can read and write memory without going through the Loci MCP stack.
 
 Protocol: JSON-RPC 2.0 over HTTP POST to `/a2a`
 Auth: Bearer token (`HERMES_A2A_TOKEN`) + optional TOTP (`HERMES_A2A_TOTP_SEED`)

--- a/a2a_server/client.py
+++ b/a2a_server/client.py
@@ -41,7 +41,7 @@ except ImportError:
 
 class LociClient:
     """
-    Async A2A client for the Hermes Memory server.
+    Async A2A client for the Loci A2A memory server.
 
     Auth conventions:
       - Bearer token in Authorization header

--- a/docs/hermes-name-audit.md
+++ b/docs/hermes-name-audit.md
@@ -1,0 +1,83 @@
+# The "hermes" name in Loci
+
+Audited 2026-08-27 at `400c3e2`. 1,013 occurrences across 138 tracked files.
+
+The short version: **most of it is not stale branding.** It is either the name of
+a live system Loci runs alongside, or a storage and configuration contract that
+renaming would break. Six occurrences were genuinely stale and are fixed; the
+rest are catalogued here so a future rename is a decision rather than a sweep.
+
+## What is actually there
+
+| what | hits | files | what renaming costs |
+|---|---:|---:|---|
+| Qdrant collection names | 332 | 49 | live data migration — 3,086 points |
+| Environment variable names | 284 | 64 | redeploying every consumer |
+| Filesystem paths under `~/.hermes/` | 222 | 81 | moving 182 MB + 1.6 GB of live data |
+| References to the real Hermes | 71 | 22 | nothing — they are correct |
+| Prose and other | 70 | 25 | nothing |
+| Docker image / volume / entrypoint | 34 | 5 | breaks existing deployments |
+
+## Hermes is a running system, not a former name
+
+`~/.hermes/hermes-agent` is a 6.8 GB codebase with its own README, Dockerfile and
+licence, and three processes were running during this audit:
+
+    hermes_cli.main --profile mrpink gateway run
+    profiles/mrpink/scripts/grounding_daemon.py
+    profiles/mrpink/a2a_server/server.py
+
+The third is Loci's own code (`Loci A2A Server v0.1.0`) deployed into a Hermes
+profile directory. That is the shape of the whole relationship: Loci is a tenant
+of a Hermes installation, sharing its home directory, its profile `.env`, and its
+Mnemosyne database.
+
+So every mention of `HERMES_PROFILE`, `~/.hermes/profiles/`, `hermes-agent`, the
+`pre_llm_call` event name or "the Hermes shape" of a hook payload is **correct**
+and must not be renamed. 71 occurrences are in this category.
+
+## What is Loci's, wearing the old name
+
+The Qdrant collections and the memory directory are Loci's own data. The
+hermes-agent codebase references none of `hermes_memory`, `hermes_sessions`,
+`hermes_verdicts` or `memory-sessions` — only `mnemosyne`, which is genuinely
+shared. These are stale names on live storage:
+
+| name | holds | rename path |
+|---|---|---|
+| `hermes_memory` | 2,769 points | Qdrant alias, then dual-read, then migrate |
+| `hermes_sessions` | 317 points | same |
+| `hermes_verdicts` | does not exist on the live instance | rename freely |
+| `~/.hermes/memory-sessions` | 142 investigations + a 40 MB code graph | move with a compatibility symlink |
+
+`hermes_verdicts` is worth noting separately: `memcheck/cli.py` creates it 384-dim
+via `hash_embed` while `verdict_ops.py` writes 768-dim vectors and never creates
+it. It is absent from the live instance. That is a defect, not just a name.
+
+The 23 `HERMES_*` environment variables are read at roughly 62 sites. They can be
+renamed behind a resolver that reads `LOCI_*` first and falls back, but the
+consumers include the deployed Claude Code hooks in `~/.claude/hooks`, so the
+rename is a redeploy as well as an edit — see `scripts/hooks/install.sh --check`.
+
+## Fixed in this change
+
+Six occurrences described Loci's own components as Hermes':
+
+- `a2a_server/README.md` — "the Hermes MCP stack" is Loci's MCP stack.
+- `a2a_server/client.py` — client for "the Hermes Memory server", which is
+  `Loci A2A Server v0.1.0`.
+- `scripts/a2a_watchdog.py` — docstring, Windows firewall rule name, and rule
+  description, all naming the Loci A2A server as Hermes'.
+- `mcp/server.py` — a user-facing health message reading "hermes runs on keyword
+  fallback only".
+
+The firewall rule needed more than a rename. The watchdog deletes and re-adds the
+rule by name each run, so changing the constant alone would have left the old
+`Hermes A2A Server (port)` rule in place forever while adding a second one. The
+generated script now deletes the legacy name too.
+
+## Deliberately not renamed
+
+`hermes-mcp` and `hermes-a2a` are Docker image, volume and console-entrypoint
+names. `docs/DEPLOYMENT.md` already records that they kept the old name.
+Renaming them orphans existing volumes.

--- a/investigation_store_decomposition_plan.md
+++ b/investigation_store_decomposition_plan.md
@@ -1,0 +1,283 @@
+# investigation_store decomposition — grounded workflow output
+
+_Produced by the loci-native grounded/tiered workflow (wf_427beb21-313). All agents shared one injected grounding block and verified against live code._
+
+
+
+---
+
+# `investigation_store` call-site inventory
+
+Repo: `/home/rjmendez/development/loci`. Enumerated via `grep -rn` over `*.py`, `*.js`, `*.md`.
+
+## Public signature (source of truth)
+`mcp/server.py:3026` — 15 params:
+`investigation_id, finding_type, text, source, confidence="medium", tags=None, derived_from=None, numeric_confidence=None, procedure_preconditions=None, procedure_steps=None, procedure_postconditions=None, valid_from=None, valid_until=None, authored_by=None, tier="warm"`
+
+## A. Production call sites (real invocations, non-test)
+All in `mcp/server.py`, all **all-keyword**, all using the SAME 6-arg subset (`investigation_id, finding_type, text, source, confidence, tags`):
+
+| file:line | caller | finding_type | notes |
+|---|---|---|---|
+| server.py:4034 | `reflection_loop_tick` | `observed` | kwargs: id, type, text, source, confidence, tags |
+| server.py:4059 | `reflection_loop_tick` (batched low-signal) | `observed` | same 6 kwargs |
+| server.py:4076 | `reflection_loop_tick` (error-cluster) | `inferred` | same 6 kwargs |
+| server.py:4107 | `reflection_loop_tick` (dropped-item gap) | `gap` | same 6 kwargs |
+| server.py:7925 | `investigation_reason` | `inferred` | same 6 kwargs |
+
+No production caller ever passes `derived_from`, `numeric_confidence`, `procedure_*`, `valid_from/until`, `authored_by`, or `tier`. All 5 pass by keyword only.
+
+## B. Test call sites (exercise the full signature)
+- `mcp/tests/test_graph_integration.py:23` — helper `_store()`. **Only positional call shape in the repo**: `investigation_store(inv, ftype, text, source, conf, derived_from=...)` → first 5 params passed positionally, `derived_from` by keyword.
+- `mcp/tests/test_mcp_integration.py` — **41 call expressions**. Collectively the only exerciser of the tail params, all by keyword: `tier=` (warm/cold/hot/invalid, lines 1451/1479/1491/1498), `numeric_confidence=` (531/568/591/603), `derived_from=` (604), `valid_from=`/`valid_until=` (195/196/246), `procedure_preconditions/steps/postconditions=` (653-655/684), `authored_by=` (909/934/943).
+- `mcp/tests/test_reflection_loop.py:61,111,150` — **not calls**; monkeypatches `investigation_store` (side_effect/return_value).
+
+## C. Non-call references (not invocations)
+- `.vulture_whitelist.py:9` — dead-code whitelist alias.
+- `scripts/event_log.py:16` — docstring/comment.
+- Docstrings/help text in server.py (lines 23, 1814, 2766, 3020, 3094-example, 3211, 3905, 4593, 7961, 8010, 8142, 8147).
+- Docs: `README.md`, `mcp/README.md:94`, `docs/CONCEPTS.md`, `docs/memory-and-code-review-tools.md` (multiple).
+- `deep_think_loci/workflows/*.js` + CHANGELOG/README — ~25 references, but these are **prompt-string instructions to sub-agents** to call the MCP tool `mcp__loci__investigation_store`, not in-process Python calls. Confirms the MCP-tool-boundary shape agents actually use: `investigation_id, finding_type, text, source, confidence, tags` (+ occasional `derived_from`).
+
+## Distinct call shapes → what's load-bearing for the refactor
+1. **All-keyword 6-arg** (`investigation_id, finding_type, text, source, confidence, tags`): every production caller + every MCP-agent invocation. This is the dominant real-world shape.
+2. **Positional first-5** (`investigation_id, finding_type, text, source, confidence`) then kw: only `test_graph_integration.py` `_store`. → **Positional order of the first 5 params is load-bearing** (a caller relies on it). Everything from param 6 (`tags`) onward is only ever passed by keyword, so their positional slots are NOT load-bearing — only their names are.
+3. **Tail kwargs** (`derived_from, numeric_confidence, procedure_*, valid_from/until, authored_by, tier`): exercised only by `test_mcp_integration.py`, always by keyword. Load-bearing by **name**, not position; a signature refactor may reorder/regroup them freely as long as keyword names are preserved.
+
+No module other than `server.py` defines or invokes the function (`graph_tools.py` does not call it).
+
+## Flag on the grounding
+`[case:loci-code-review-2026-07-07:finding]` states fan-in of **35 callers**. I could not reproduce 35 literal Python call expressions — actual in-process call sites are **5 production + ~42 test = ~47** including tests, or **5** if you count only non-test invocations. The "35" is almost certainly the Kuzu code-graph's symbol-reference fan-in (docstrings, doc mentions, workflow prompt-strings, whitelist alias all counted as edges), not literal call expressions. The grounding is **silent on how the 35 was computed**, so I'm flagging the discrepancy rather than asserting either number is the "caller" count the refactor should trust. For a signature change, the surfaces that actually break are the 5 server.py internal callers + the test suite (esp. the positional `_store` helper), plus the MCP-tool JSON schema consumed by `deep_think_loci` workflows.
+
+---
+
+Full function read (lines 3025-3239) and all referenced helpers located. Here is the decomposition plan.
+
+---
+
+# Decomposition plan: `investigation_store` (mcp/server.py)
+
+Grounds P2 [case:loci-code-review-2026-07-07:finding] — investigation_store is the god-function (fan-out 17 / fan-in 35). This plan makes it a thin orchestrator while keeping its public MCP signature (lines 3026-3042) and return JSON (lines 3227-3239) byte-identical.
+
+**Live line refs (verified now, 2026-07-08; the [rag] June numbers are stale):**
+- Definition + `@mcp.tool()`: 3025-3042
+- Docstring: 3043-3095
+- Region A — validation + manifest load: 3096-3105
+- Region B — numeric_confidence resolve: 3107-3115
+- Region C — finding-dict build (ts, tags, valid_from, derived_from validation, entities, procedure_meta): 3117-3153
+- Region D — locked persist (append + manifest counts + hot-notes + save, under `.lock` flock): 3155-3168
+- Region E — mnemosyne mirror: 3170-3181
+- Region F — tiered Qdrant embed (cold-skip): 3183-3185
+- Region G — event-log append: 3186-3193
+- Region H — Kuzu graph mirror + autolink: 3194-3197
+- Region I — conflict detect + write (fail-open): 3199-3211
+- Region J — session-hints ring push: 3213-3222
+- Region K — entities.jsonl update: 3224-3225
+- Region L — result assembly: 3227-3239
+
+**Key finding about the current state:** Regions E/F/G/H/I/J/K are *already* thin calls into extracted helpers (`_mnemo_remember` 477, `_qdrant_upsert` 934, `_event_log_append` 103, `_mirror_finding_to_kuzu` 277, `_autolink_finding_to_kuzu` 346, `_detect_conflicts` 2760, `_write_conflict` 2850, `_session_hints_push` 1823, `_update_entities_jsonl` 2948). So the decomposition is NOT "extract seven side-effects" — most side-effects are already leaf helpers. The remaining monolith is the **inline glue**: validation (A), finding construction (B+C), the locked persist (D), and the orchestration sequencing (E-K) plus conflict-result plumbing (I→L). Four extractions, not seven.
+
+---
+
+## Proposed helpers
+
+### 1. `_validate_store_args`
+```python
+def _validate_store_args(finding_type: str, confidence: str, tier: str) -> str | None:
+    """Return an error-JSON string if any enum arg is invalid, else None."""
+```
+**Moves in:** the three enum guards at 3100-3105. Orchestrator: `err = _validate_store_args(...); if err: return err`. (Manifest existence check at 3096-3098 stays inline — it needs the loaded `manifest` object the orchestrator uses later, so extracting it would just re-load.)
+
+### 2. `_build_finding`
+```python
+def _build_finding(
+    investigation_id: str, finding_type: str, text: str, source: str,
+    confidence: str, tags, numeric_confidence: float | None,
+    valid_from: str | None, valid_until: str | None, authored_by: str | None,
+    tier: str, procedure_preconditions: str | None,
+    procedure_steps: str | None, procedure_postconditions: str | None,
+) -> dict | tuple[None, str]:
+    """Construct the finding dict (numeric_confidence resolution, tags parse,
+    entities, procedure_meta). derived_from is validated separately by the
+    caller because it needs the manifest lock context. Returns the finding
+    dict, or (None, error_json) on bad derived_from — see note."""
+```
+**Moves in:** Region B (3107-3115) + Region C construction (3117-3136), `_extract_entities` call (3144), procedure_meta block (3146-3153).
+
+**Deliberately NOT moved:** the `derived_from` parent-existence check (3137-3143) reads `findings.jsonl` and can early-return an error. Two safe options:
+- (a) Keep derived_from validation inline in the orchestrator (simplest; preserves the exact early-return-before-any-write ordering), and have `_build_finding` take the already-normalized `derived` list as a param, OR
+- (b) Move it in and return the `(None, error)` tuple form. Prefer **(a)** — it keeps the "validate-then-write" boundary visible in the orchestrator and avoids changing when the JSONL read happens.
+
+### 3. `_persist_finding_locked`
+```python
+def _persist_finding_locked(investigation_id: str, finding: dict, manifest: dict) -> None:
+    """Under the per-investigation .lock: append finding to findings.jsonl,
+    bump manifest['finding_counts'][type], update hot-tier notes, save manifest.
+    Mutates `manifest` in place."""
+```
+**Moves in:** the entire flock block 3155-3168 verbatim. This is the correctness-critical region — the [rag] June audit flagged the append+manifest-save pair as unlocked; the live code shows it IS now guarded (flock acquired 3156-3157, released 3168, both `_append_jsonl` and `_save_manifest` inside). Extracting it as one unit **preserves that fix** and makes the atomicity boundary a named, testable seam. Do not split append from save.
+
+### 4. `_index_finding`
+```python
+def _index_finding(finding: dict, investigation_id: str, text: str,
+                   source: str, finding_type: str, confidence: str, tier: str) -> bool:
+    """Post-persist fan-out to the secondary stores (all fail-open, none gate
+    the store): mnemosyne mirror, tiered Qdrant embed (cold-skip), event-log
+    append, Kuzu mirror + autolink. Returns mnemo_stored."""
+```
+**Moves in:** Regions E (3170-3181), F (3183-3185), G (3186-3193), H (3194-3197). These four run unconditionally post-lock, share no early-return, and only produce `mnemo_stored` for the result. Bundling them is safe because ordering among them is not externally observable (each is an independent side-effect to a different store). Keep the *relative* order to minimize diff risk.
+
+### Conflict detection (Region I)
+Leave the `try/except` orchestration inline at 3199-3211 **as-is**, or extract to:
+```python
+def _run_conflict_detection(investigation_id: str, finding: dict) -> tuple[bool, str | None, str | None]:
+    """Fail-open. Returns (conflict_detected, conflicting_finding_id, conflict_id)."""
+```
+`_detect_conflicts`/`_write_conflict` are already leaves; this just moves the try/except + tuple assembly. Low value but clean — optional. Regions J (session hints) and K (entities.jsonl) are already single helper calls; leave them inline.
+
+---
+
+## Resulting orchestrator (shape, not final code)
+```python
+manifest = _load_manifest(investigation_id)
+if not manifest: return <not found>
+err = _validate_store_args(finding_type, confidence, tier)
+if err: return err
+derived = _normalize_derived_from(derived_from)
+if derived:
+    <inline parent-existence check → early-return on unknown>   # 3137-3143 stays
+finding = _build_finding(...)          # +derived injected
+_persist_finding_locked(investigation_id, finding, manifest)
+mnemo_stored = _index_finding(finding, investigation_id, text, source, finding_type, confidence, tier)
+conflict_detected, conflicting_finding_id, conflict_id = _run_conflict_detection(...)  # or inline
+_session_hints_push(...)               # 3215-3222 stays
+_update_entities_jsonl(...)            # 3225 stays
+return json.dumps(<result>, indent=2)  # 3227-3239 unchanged
+```
+
+---
+
+## Safe leaf-first extraction order + per-step proof
+
+Extract in dependency-leaf order so each step is a pure move with no reordering. After **every** step: run the existing suite (grounding says 276 pass on the RAG-injection branch; investigation_store has direct coverage via investigation tests) and confirm the returned JSON is unchanged.
+
+1. **`_validate_store_args`** (pure function, no I/O). *Proof:* unit-test all invalid enum combos return the same 3 error strings as lines 3101/3103/3105; valid combo returns None. Zero behavior change — it only relocates string literals.
+
+2. **`_index_finding`** (side-effects, but each already fail-open and non-gating). *Proof:* it produces exactly one observable output, `mnemo_stored`, which flows into the result. Assert the store still returns the identical result dict for a warm finding (mnemo mirrored, qdrant upserted) and a cold finding (qdrant skipped — the `tier != "cold"` guard at 3184 must move in intact). Spy/mock each of the four helpers to confirm they're still called once, in order, with the same args.
+
+3. **`_persist_finding_locked`** (the atomicity seam — do this deliberately, alone). *Proof:* assert findings.jsonl gains exactly one line, `finding_counts[type]` increments by exactly one, hot-tier notes append only when `tier=="hot"`, and — critically — that the flock is still held across append+save (test by asserting the `.lock` file is created and that a concurrent writer blocks, or at minimum that the code path still enters the `with open(_lock_path...)` context). This preserves the June [rag] fix; regression here is the highest risk.
+
+4. **`_build_finding`** (largest move; do last so the orchestrator is already thin). *Proof:* golden-value test — call with a fixed input and a frozen `_now()`/`uuid` and assert the full finding dict equals the pre-refactor dict field-for-field (id, ts, record_type+type duality at 3123-3124, tags parse from both str and list forms per 3129-3131, valid_from default at 3132, entities, procedure_meta only for procedures). Keep `derived_from` validation inline per option (a) so this step never touches JSONL.
+
+5. *(optional)* **`_run_conflict_detection`**. *Proof:* assert the result's `conflict_detected`/`conflicting_finding_id`/`conflict_id` keys are populated identically, and that a raised `_detect_conflicts` still fails open (logged, store succeeds).
+
+**Cross-cutting proof at each step:** the MCP tool signature (3026-3042) and docstring-declared return contract (3087-3090) must not change — diff the `@mcp.tool()` schema before/after. A characterization test that stores one finding of each `finding_type` (observed/inferred/assumed/gap/procedure) across all three tiers and snapshots the returned JSON is the strongest single guard; run it unchanged through all five steps.
+
+---
+
+## Flags (grounding is silent — verify before acting, do not treat as settled)
+- The [rag] June concern about the unlocked append+manifest pair is **resolved in live code** (flock now wraps both, 3156-3168). `_persist_finding_locked` should preserve, not re-introduce, this.
+- Separately observed while reading (out of scope for this decomposition, grounding silent): `_update_entities_jsonl` (Region K, 3225) and `_detect_conflicts` (Region I) both read/write investigation files *outside* the `.lock` held only in Region D. That's a pre-existing property, unchanged by this refactor — but if a future step tries to "consolidate locking," that's a behavior change and must not ride along on a pure-extraction commit.
+- Cosmetic: line 3224 comment is over-indented (8 spaces inside a 4-space block). Harmless; a formatter pass would fix it — leave out of the behavior-preserving extraction commits.
+
+No files written. Source of truth: `/home/rjmendez/development/loci/mcp/server.py` lines 3025-3239.
+
+---
+
+I have everything I need. I verified the implementation, the chokepoint helpers, and the existing test style (`server.MEMORY_DIR` swapped to a `TemporaryDirectory` in `setUp`/`tearDown`, `_new_id()` for unique ids, `_json()` parse helper, tests run without Qdrant/Ollama which "degrade gracefully").
+
+Two grounding-relevant facts I confirmed against live code before proposing:
+- The `[rag]` June concern (manifest save unguarded) is **RESOLVED on main**: `server.py:3155-3168` wraps BOTH `_append_jsonl(findings.jsonl)` and `_save_manifest(...)` inside one `.lock` `fcntl.flock`. So `finding_counts` consistency is now lockable behavior worth pinning.
+- `conflict-detect` ([case P2]) is **Qdrant+embedding dependent** (`_detect_conflicts`, server.py:2760 — returns `[]` when `_get_qdrant()` is None). Since the test env runs without Qdrant, `conflict_detected` is *always False* on the happy path. To characterize the conflict-detect side effect deterministically you MUST monkeypatch `server._detect_conflicts` / `server._write_conflict` — a test that relies on live Qdrant would silently assert nothing. Same for `_autolink_finding_to_kuzu` (server.py:3197): spy on it, don't depend on a live Kuzu graph.
+
+---
+
+# Characterization test proposal — `investigation_store`
+
+**File:** `mcp/tests/test_investigation_store_characterization.py` (new; mirrors `test_mcp_integration.py`)
+
+**Shared fixture** (identical style to `TestInvestigationLifecycle`):
+```python
+def setUp(self):
+    self._tmp = tempfile.TemporaryDirectory()
+    self._orig = server.MEMORY_DIR
+    server.MEMORY_DIR = Path(self._tmp.name)
+def tearDown(self):
+    server.MEMORY_DIR = self._orig
+    self._tmp.cleanup()
+```
+Helpers reused from that module: `_json(result)`, `_new_id(prefix)`. Add one local reader:
+`_findings(inv_id) -> list[dict]` = `server._read_jsonl(server._inv_dir(inv_id) / "findings.jsonl")`, and `_manifest(inv_id)` = `server._load_manifest(inv_id)`.
+
+Each test does `server.investigation_start(...)` first, then acts.
+
+## A. Return-value shape (locks the JSON contract in the docstring)
+
+1. **`test_return_shape_happy_path_keys`** — a single `observed`/warm store returns exactly the keys `{stored, finding_id, type, mnemo_stored, conflict_detected, tier}`; asserts `stored is True`, `type == "observed"`, `tier == "warm"`, `conflict_detected is False`, `finding_id` is a valid UUID (`uuid.UUID(...)` parses), and `conflicting_finding_id`/`conflict_id` are **absent** when no conflict. Also assert the raw return is `indent=2`-pretty JSON (`"\n"` in the string) to pin the `json.dumps(..., indent=2)` format.
+
+2. **`test_return_finding_id_matches_persisted_record`** — the returned `finding_id` equals the `id` of the single row in `findings.jsonl` (ties the return value to the side effect).
+
+## B. `findings.jsonl` contents (locks the persisted record schema)
+
+3. **`test_persisted_finding_full_field_set`** — after one store, the JSONL row has exactly these keys: `{id, investigation_id, ts, created_at_ts, record_type, type, text, source, confidence, numeric_confidence, tags, valid_from, valid_until, authored_by, tier, entities}`. Assert the **dual type fields** both equal the input (`record_type == type == "observed"` — the backwards-compat duplication at server.py:3123-3124), `authored_by == ""` default, `valid_until is None` default, and `valid_from == ts` when `valid_from` not supplied (server.py:3132).
+
+4. **`test_tags_normalized_to_stripped_list`** — passing `tags="a, b ,,c"` persists `tags == ["a","b","c"]` (empty segments dropped, whitespace stripped — server.py:3129-3131); and passing `tags=["x","y"]` (list form) persists `["x","y"]`. Pins both accepted input forms.
+
+5. **`test_numeric_confidence_derivation_and_clamp`** — three sub-asserts on the persisted `numeric_confidence`: omitted + `confidence="high"` → `0.9`, `"medium"` → `0.6`, `"low"` → `0.3` (server.py:3108-3110); explicit `numeric_confidence=1.7` → clamped to `1.0`; explicit `-0.5` → `0.0` (server.py:3113). (Overlaps existing tests at line 518+ but pins it as a *store* invariant, not a search one.)
+
+6. **`test_procedure_meta_written_for_procedure_type`** — `finding_type="procedure"` persists a `procedure_meta` dict with `success_count == 0`, `attempt_count == 0`, and the passed `preconditions/steps/postconditions`; and a non-procedure finding has **no** `procedure_meta` key (server.py:3146-3153).
+
+7. **`test_derived_from_valid_parent_links_and_unknown_rejected`** — storing with `derived_from=<real parent id>` persists `derived_from == [parent_id]` and returns no error; storing with `derived_from="nonexistent-id"` returns `{"error": ...}` containing `"unknown parent id"` **and writes no new JSONL row** (assert findings count unchanged — pins the pre-write validation at server.py:3139-3142).
+
+8. **`test_append_only_multiple_findings_preserve_order`** — three sequential stores yield three JSONL rows in insertion order with distinct `id`s (pins append-only semantics that the decomposition must not reorder/dedupe).
+
+## C. Manifest `finding_counts` (the June/[rag] concurrency-adjacent invariant)
+
+9. **`test_finding_counts_increment_per_type`** — after 2×`observed` + 1×`gap`, `manifest["finding_counts"]["observed"] == 2` and `["gap"] == 1` (server.py:3160).
+
+10. **`test_finding_counts_equals_jsonl_length`** — the key invariant the lock protects: `sum(manifest["finding_counts"].values()) == len(findings.jsonl rows)` after N mixed stores. This is the exact consistency the flock (server.py:3155-3168) guarantees; the refactor must preserve it.
+
+11. **`test_hot_tier_appends_manifest_notes_warm_does_not`** — `tier="hot"` appends `text[:200]` to `manifest["notes"]` (server.py:3162-3165); `tier="warm"` leaves `notes` unchanged; a second hot store joins with `"; "`. Pins the hot-tier notes side effect.
+
+## D. Autolink + conflict-detect side effects (must monkeypatch — see grounding note)
+
+12. **`test_autolink_invoked_with_persisted_finding`** — monkeypatch `server._autolink_finding_to_kuzu` (and `server._mirror_finding_to_kuzu`) with a spy capturing its arg; assert it's called **exactly once** and the captured finding's `id` equals the returned `finding_id`. Locks that decomposition still routes the finding to the graph layer (server.py:3196-3197) regardless of Kuzu availability.
+
+13. **`test_conflict_detect_writes_conflicts_jsonl_and_return_fields`** — monkeypatch `server._detect_conflicts` to return `[{"neighbor_id": "<a prior finding id>", "neighbor_type": "gap", "score": 0.9}]`. Assert: (a) return now has `conflict_detected is True`, `conflicting_finding_id == "<that id>"`, and a non-null `conflict_id`; (b) `conflicts.jsonl` gains exactly one row whose `finding_id_a == this finding's id`, `finding_id_b == neighbor_id`, `status == "open"`, `resolution is None` (server.py:3204-3209, 2850-2862).
+
+14. **`test_conflict_detect_failure_is_fail_open`** — monkeypatch `server._detect_conflicts` to raise; assert the store still returns `stored is True`, `conflict_detected is False`, the finding is persisted, and `conflicts.jsonl` is absent/empty. Pins the fail-open contract (server.py:3210-3211) so the refactor can't turn a conflict-path exception into a store failure.
+
+## E. Error paths (pre-write guards — no partial writes)
+
+15. **`test_error_paths_write_nothing`** — parametrized over the three rejections: unknown `investigation_id` (server.py:3097), bad `finding_type` (3100), bad `confidence` (3102), bad `tier` (3104). Each returns `{"error": ...}` and — for the existing investigation cases — leaves `findings.jsonl` empty and `finding_counts` all-zero. Locks that validation precedes any side effect.
+
+---
+
+**Coverage map to the 5 requested surfaces:** return shape → tests 1,2,5(return),13; `findings.jsonl` → 3–8; manifest `finding_counts` → 9–11,15; autolink → 12; conflict-detect → 13,14.
+
+**Minimality:** 15 tests, one new file, zero external services required (Qdrant/mnemo/Kuzu are monkeypatched-or-degraded, matching the existing suite's stated design). I deliberately did **not** propose tests for `mnemo_stored` truthiness (nondeterministic — depends on live mnemosyne; existing suite already treats it as best-effort), for `_qdrant_upsert`, `_session_hints_push`, or `_update_entities_jsonl` — the grounding names only the four observable surfaces in the task, and those three are either untestable without a service or out of the stated scope. Flagging them as **grounding-silent** rather than inventing assertions.
+
+**Key files:** implementation `/home/rjmendez/development/loci/mcp/server.py:3026-3239`; helpers `_detect_conflicts:2760`, `_write_conflict:2850`, `_inv_dir:1700`, `_load_manifest:1709`, `_read_jsonl:1755`; style reference `/home/rjmendez/development/loci/mcp/tests/test_mcp_integration.py:48-58` (fixture), `:30-45` (`_json`/`_new_id`).
+
+---
+
+VERDICT: The claim HOLDS. Every load-bearing assertion checks out against live code.
+
+Verified against `/home/rjmendez/development/loci/mcp/server.py` (8607 lines total):
+
+**Line refs — all accurate:**
+- Signature 3025-3042, docstring 3043-3095, Regions A(3096-3105) B(3107-3115) C(3117-3153) D(3155-3168) E(3170-3181) F(3183-3185) G(3186-3193) H(3194-3197) I(3199-3211) J(3213-3222) K(3224-3225) L(3227-3239) — all confirmed exact.
+- All 9 cited helper definition lines are correct: `_event_log_append`103, `_extract_entities`129, `_mirror_finding_to_kuzu`277, `_autolink_finding_to_kuzu`346, `_mnemo_remember`477, `_qdrant_upsert`934, `_session_hints_push`1823, `_normalize_derived_from`2133, `_detect_conflicts`2760, `_write_conflict`2850, `_update_entities_jsonl`2948.
+
+**Key substantive claims — all hold:**
+- The [rag] June "unlocked append+manifest-save" concern IS resolved in live code: `_append_jsonl` (3159) and `_save_manifest` (3166) are both inside the `flock(LOCK_EX)` context (3156-3168). The plan's insistence that `_persist_finding_locked` move this block verbatim as one unit correctly preserves the fix.
+- E/F/G/H/I/J/K really are already thin helper calls; the "four extractions, not seven" framing is accurate.
+- `mnemo_stored` is genuinely the *sole* observable output of Regions E-H flowing into the result dict (F/G/H return None), so bundling them into `_index_finding` is safe as claimed.
+- Cold-skip guard `if tier != "cold"` is at 3184 as stated (3185 does the upsert).
+- `record_type`/`type` duality (3123-3124), dual-form tags parse (3129-3131), `valid_from` default (3132), procedure_meta block (3146-3153) all located as described.
+- The derived_from parent-existence check (3138-3142) does read `findings.jsonl` via `_read_jsonl(_inv_dir(...)/"findings.jsonl")` and can early-return — the plan's option-(a) to keep it inline is sound.
+- Conflict detect (I, 3204-3211) and `_update_entities_jsonl` (K, 3225) run *outside* the `.lock` (which wraps only D) — the "pre-existing property, don't consolidate locking on a pure-extraction commit" flag is correct.
+- Cosmetic: line 3224 comment is confirmed 8-space indented inside the 4-space block (`        # Background entity extraction…`).
+- Test-coverage claim holds: `investigation_store` is exercised by 4 test files (test_grounding, test_mcp_integration, test_graph_integration, test_reflection_loop), 42 call sites — so "direct coverage via investigation tests" is real, not assumed. (The grounding's "276 pass" figure is correctly cited as branch-specific / to-be-reverified, not asserted as current.)
+
+**Unsupported / contradicted points:** none material. One minor nuance the plan itself already flags but worth naming: its proposed orchestrator hoists the `derived_from` check to *before* `_build_finding`, whereas live code runs it mid-construction (after the base dict at 3137, before `_extract_entities` at 3144). This reorders the findings.jsonl read relative to entities extraction — but entities extraction is side-effect-free and touches no investigation files, so the "read-before-any-write" boundary is preserved and the reorder is non-observable. The claim explicitly argues this, so it is not a defect, just the one place where "pure move, no reordering" is technically a benign micro-reorder rather than literally zero movement.

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -4836,7 +4836,7 @@ def _health_probe_embeddings_dense(sink: dict) -> tuple:
         return (
             "fail",
             "dense embedder (Ollama) unavailable — semantic/hybrid search "
-            "is disabled; hermes runs on keyword fallback only.",
+            "is disabled; the server runs on keyword fallback only.",
             "ensure Ollama is running and the nomic-embed-text model is available "
             "(OLLAMA_BASE_URL and EMBED_MODEL env vars can override defaults).",
         )

--- a/scripts/a2a_watchdog.py
+++ b/scripts/a2a_watchdog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-a2a_watchdog.py — Health check + WSL portproxy maintenance for the Hermes A2A server.
+a2a_watchdog.py — Health check + WSL portproxy maintenance for the Loci A2A server.
 
 Two jobs in one:
 1. Health-check the A2A server; restart via systemd if down.
@@ -94,12 +94,13 @@ netsh interface portproxy add v4tov4 `
     connectaddress=$WslIP `
     connectport=$Port
 
-$ruleName = "Hermes A2A Server ({A2A_PORT})"
+$ruleName = "Loci A2A Server ({A2A_PORT})"
 netsh advfirewall firewall delete rule name="$ruleName" 2>$null
+netsh advfirewall firewall delete rule name="Hermes A2A Server ({A2A_PORT})" 2>$null
 netsh advfirewall firewall add rule `
     name="$ruleName" dir=in action=allow protocol=TCP `
     localport=$Port localip=$TailscaleIP `
-    description="Hermes A2A server accessible over Tailscale mesh"
+    description="Loci A2A server accessible over Tailscale mesh"
 
 Write-Host "Portproxy updated: ${{TailscaleIP}}:${{Port}} -> ${{WslIP}}:${{Port}}"
 """


### PR DESCRIPTION
**1,013 occurrences across 138 files — and most of them are not stale branding.** The audit is the deliverable here; the code change is six lines.

## What is actually there

| what | hits | files | what renaming costs |
|---|---:|---:|---|
| Qdrant collection names | 332 | 49 | live data migration — 3,086 points |
| Environment variable names | 284 | 64 | redeploying every consumer |
| Filesystem paths under `~/.hermes/` | 222 | 81 | moving 182 MB + 1.6 GB of live data |
| **References to the real Hermes** | **71** | **22** | **nothing — they are correct** |
| Prose and other | 70 | 25 | nothing |
| Docker image / volume / entrypoint | 34 | 5 | breaks existing deployments |

## Hermes is a running system, not a former name

`~/.hermes/hermes-agent` is a 6.8 GB codebase with its own README, Dockerfile and licence. Three processes were running during the audit:

```
hermes_cli.main --profile mrpink gateway run
profiles/mrpink/scripts/grounding_daemon.py
profiles/mrpink/a2a_server/server.py
```

The third is **Loci's own code** (`Loci A2A Server v0.1.0`) deployed into a Hermes profile directory. That is the shape of the whole relationship: Loci is a tenant of a Hermes installation, sharing its home directory, its profile `.env`, and its Mnemosyne database.

So every mention of `HERMES_PROFILE`, `hermes-agent`, the `pre_llm_call` event name, or "the Hermes shape" of a hook payload is **correct**. Renaming those would break integration with a live system.

I checked rather than assumed: the hermes-agent codebase references **none** of `hermes_memory`, `hermes_sessions`, `hermes_verdicts` or `memory-sessions` — only `mnemosyne`, which is genuinely shared. So the collections and the memory directory *are* Loci's own data wearing an old name.

## What is Loci's, wearing the old name

| name | holds | rename path |
|---|---|---|
| `hermes_memory` | 2,769 points | Qdrant alias → dual-read → migrate |
| `hermes_sessions` | 317 points | same |
| `hermes_verdicts` | **absent from the live instance** | rename freely |
| `~/.hermes/memory-sessions` | 142 investigations + 40 MB code graph | move with a compatibility symlink |

The 23 `HERMES_*` env vars are read at ~62 sites and can go behind a resolver that reads `LOCI_*` first — but the consumers include the deployed hooks in `~/.claude/hooks`, so it is a redeploy as well as an edit.

## The six that were genuinely stale — fixed

Loci components describing themselves as Hermes': the A2A `README` and `client.py`, the `a2a_watchdog` docstring, its Windows firewall rule name and description, and a user-facing health message in `mcp/server.py` reading *"hermes runs on keyword fallback only"*.

**The firewall rule needed more than a rename.** The watchdog deletes and re-adds the rule by name on every run, so changing the constant alone would have left `Hermes A2A Server (port)` in place forever and added a second rule beside it. The generated PowerShell now deletes the legacy name too.

## Also surfaced

`hermes_verdicts` is absent from the live Qdrant instance, and `memcheck/cli.py` creates it 384-dim via `hash_embed` while `verdict_ops.py` writes 768-dim and never creates it. That is a defect, not a naming problem — same one flagged in #232, now with the added detail that the collection does not exist at all.

## Verification

- `mcp/`: 771 passed (`test_graph_integration::test_code_graph_ingest_and_query` fails identically on clean `main` — pre-existing).
- `scripts/` + `a2a_server/`: 799 passed.
- ruff: same 9 pre-existing `F401`s as `main`, none introduced.