### PR TITLE
Finish the LOCI migration: version-control the workflow gate, and make aliases work

### DIFF
--- a/mcp/qdrant_ops.py
+++ b/mcp/qdrant_ops.py
@@ -264,6 +264,13 @@ def _get_qdrant():
                                   timeout=_QDRANT_TIMEOUT)
             col = QDRANT_COLLECTION_PREFIX
             existing = {c.name for c in client.get_collections().collections}
+            # An alias is an addressable name: creating a collection over one
+            # fails with 400, so a name that resolves must count as existing.
+            # The rename migration points loci_* at the old collections this way.
+            try:
+                existing |= {a.alias_name for a in client.get_aliases().aliases}
+            except Exception:  # older server, or aliases unsupported — ignore
+                pass
 
             _hnsw   = HnswConfigDiff(m=32, ef_construct=200, on_disk=False)
             _quant  = ScalarQuantization(

--- a/mcp/tests/test_qdrant_alias_existence.py
+++ b/mcp/tests/test_qdrant_alias_existence.py
@@ -1,0 +1,86 @@
+"""A collection name that is an alias already exists.
+
+The LOCI_* rename points loci_memory and loci_sessions at the old collections
+with Qdrant aliases, which is the migration path docs/hermes-name-audit.md
+documents. get_collections() lists real collections only, so an aliased name
+read as absent, _get_qdrant tried to create it, and Qdrant answered:
+
+    400 Wrong input: Can't create collection with name loci_memory.
+    Alias with the same name already exists
+
+which surfaced as "qdrant unreachable" and took the every-6h index pass down.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _fake_client(collections, aliases, created):
+    class C:
+        def get_collections(self):
+            return types.SimpleNamespace(
+                collections=[types.SimpleNamespace(name=n) for n in collections])
+
+        def get_aliases(self):
+            return types.SimpleNamespace(
+                aliases=[types.SimpleNamespace(alias_name=a, collection_name=c)
+                         for a, c in aliases])
+
+        def create_collection(self, name, *a, **kw):
+            created.append(name)
+            raise AssertionError(
+                f"create_collection({name!r}) — Qdrant would answer 400 here")
+
+        def get_collection(self, name):
+            return types.SimpleNamespace()
+
+        def create_payload_index(self, **kw):
+            pass
+    return C()
+
+
+def _existing_names(client):
+    """The set _get_qdrant builds to decide whether to create."""
+    existing = {c.name for c in client.get_collections().collections}
+    try:
+        existing |= {a.alias_name for a in client.get_aliases().aliases}
+    except Exception:
+        pass
+    return existing
+
+
+def test_an_aliased_name_counts_as_existing():
+    created: list[str] = []
+    client = _fake_client(["hermes_memory"], [("loci_memory", "hermes_memory")], created)
+    assert "loci_memory" in _existing_names(client)
+    assert created == [], "must not try to create over an alias"
+
+
+def test_a_real_collection_still_counts_as_existing():
+    client = _fake_client(["loci_memory"], [], [])
+    assert "loci_memory" in _existing_names(client)
+
+
+def test_an_unknown_name_is_still_absent():
+    client = _fake_client(["something_else"], [("other_alias", "x")], [])
+    assert "loci_memory" not in _existing_names(client)
+
+
+def test_a_server_without_alias_support_does_not_break_the_check():
+    class C:
+        def get_collections(self):
+            return types.SimpleNamespace(
+                collections=[types.SimpleNamespace(name="loci_memory")])
+
+        def get_aliases(self):
+            raise RuntimeError("aliases unsupported")
+    assert _existing_names(C()) == {"loci_memory"}
+
+
+def test_the_shipped_code_consults_aliases():
+    """Guards the call itself, not just the logic mirrored above."""
+    src = open(os.path.join(os.path.dirname(__file__), "..", "qdrant_ops.py")).read()
+    assert "get_aliases()" in src, "the existence check must consider aliases"

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -309,7 +309,7 @@ def _check_lazy_import():
 def _check_real_corpus():
     result = build_graph(rev="HEAD")
     store = result.store
-    assert result.meta.file_count == 122, result.meta.file_count
+    assert result.meta.file_count == 123, result.meta.file_count
     assert result.meta.error_count == 0, result.meta.errors
     bad = registered_but_dead(store)
     assert bad == [], [n.id for n in bad]

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,13 +1,13 @@
 from .conftest import needs_corpus_deps, needs_git_history  # noqa: F401
 """config.py against the REAL repo: acceptance criterion is an exact file
-count (122), not a vibe. If this drifts, either the repo changed shape or
+count (123), not a vibe. If this drifts, either the repo changed shape or
 the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
-def test_corpus_is_exactly_122_files():
+def test_corpus_is_exactly_123_files():
     files = config.iter_corpus_files_worktree()
-    assert len(files) == 122, sorted(files)
+    assert len(files) == 123, sorted(files)
 
 
 def test_corpus_excludes_test_directories():

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -4,10 +4,10 @@ from .. import ingest
 from ..tests.helpers import source_file
 
 
-def test_load_corpus_worktree_parses_122_files_with_no_errors():
+def test_load_corpus_worktree_parses_123_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
-    assert len(sources) == 122
+    assert len(sources) == 123
     errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
     assert errors == []
     assert all(sf.tree is not None for sf in sources)
@@ -16,7 +16,7 @@ def test_load_corpus_worktree_parses_122_files_with_no_errors():
 def test_load_corpus_rev_head_reads_git_blobs():
     sources, origin = ingest.load_corpus(rev="HEAD")
     assert origin.startswith("rev ")
-    assert len(sources) == 122
+    assert len(sources) == 123
     assert all(sf.error is None for sf in sources)
     server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
     assert "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -15,7 +15,7 @@ from ..pipeline import build_graph
 
 
 def test_build_is_clean_and_fast(head_build):
-    assert head_build.meta.file_count == 122
+    assert head_build.meta.file_count == 123
     assert head_build.meta.error_count == 0
     # Loose sanity bound, not a benchmark: measured 4.2s standalone / 5.0s under suite load.
     assert head_build.meta.elapsed_s < 30, (

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -65,6 +65,6 @@ def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, 
     finally:
         monkeypatch.setattr(Path, "read_text", original_read_text)
     assert origin.startswith("rev ")
-    assert len(sources) == 122
+    assert len(sources) == 123
     server = _source_for(sources, "mcp/server.py")
     assert server.error is None and "loci-mcp" in server.source[:200]

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -11,7 +11,8 @@
 
 set -uo pipefail
 
-HOOKS=(pre_llm_grounding.py pre_tool_grounding.py session_end_sync.py legacy_env.py)
+HOOKS=(pre_llm_grounding.py pre_tool_grounding.py session_end_sync.py legacy_env.py
+       workflow_balanced_models.py)
 SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEST="${CLAUDE_HOOKS_DIR:-$HOME/.claude/hooks}"
 

--- a/scripts/hooks/tests/test_workflow_balanced_models.py
+++ b/scripts/hooks/tests/test_workflow_balanced_models.py
@@ -1,0 +1,121 @@
+"""The PreToolUse gate that keeps a workflow from running on one model tier.
+
+verdict() is pure so the rule is testable without the harness, which is the
+point of its shape. main() is covered too, because the interesting bug was
+there: it read only tool_input["script"] and returned 0 for a scriptPath, so a
+workflow invoked the way the Workflow tool recommends for iteration escaped the
+rule entirely. A uniformly-Opus workflow shipped that way before this was fixed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import pathlib
+from unittest import mock
+
+import pytest
+
+HOOK = pathlib.Path(__file__).resolve().parents[1] / "workflow_balanced_models.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_wbm_uut", HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+BALANCED = """
+const a = await agent('x', {model: 'haiku', effort: 'low'})
+const b = await agent('y', {model: 'opus', effort: 'xhigh'})
+"""
+UNIFORM = """
+const a = await agent('x', {model: 'opus', effort: 'high'})
+const b = await agent('y', {model: 'opus', effort: 'high'})
+"""
+NO_MODEL = "const a = await agent('x', {effort: 'high'})"
+NO_EFFORT = """
+const a = await agent('x', {model: 'haiku'})
+const b = await agent('y', {model: 'opus'})
+"""
+
+
+def test_two_tiers_and_an_effort_pass():
+    assert _load().verdict(BALANCED)[0] is True
+
+
+def test_one_tier_everywhere_fails():
+    ok, reason = _load().verdict(UNIFORM)
+    assert ok is False and "opus" in reason
+
+
+def test_no_model_key_at_all_fails():
+    ok, reason = _load().verdict(NO_MODEL)
+    assert ok is False and "model" in reason
+
+
+def test_models_without_an_effort_fails():
+    assert _load().verdict(NO_EFFORT)[0] is False
+
+
+def test_an_empty_script_passes():
+    assert _load().verdict("")[0] is True
+
+
+def _run(mod, payload):
+    out = io.StringIO()
+    with mock.patch.object(mod.sys, "stdin", io.StringIO(json.dumps(payload))), \
+            mock.patch.object(mod.sys, "stdout", out):
+        rc = mod.main()
+    return rc, out.getvalue()
+
+
+def test_an_inline_unbalanced_script_is_denied():
+    mod = _load()
+    rc, out = _run(mod, {"tool_name": "Workflow", "tool_input": {"script": UNIFORM}})
+    assert rc == 0
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_a_scriptpath_is_read_rather_than_waved_through(tmp_path):
+    """The Workflow tool recommends scriptPath for iteration, so a gate blind to
+    it is a gate that does not apply to the common case."""
+    p = tmp_path / "wf.js"
+    p.write_text(UNIFORM)
+    mod = _load()
+    rc, out = _run(mod, {"tool_name": "Workflow", "tool_input": {"scriptPath": str(p)}})
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_a_balanced_scriptpath_is_allowed(tmp_path):
+    p = tmp_path / "wf.js"
+    p.write_text(BALANCED)
+    mod = _load()
+    assert _run(mod, {"tool_name": "Workflow", "tool_input": {"scriptPath": str(p)}}) == (0, "")
+
+
+@pytest.mark.parametrize("tool_input", [
+    {"name": "some-saved-workflow"},
+    {"scriptPath": "/nonexistent/never.js"},
+    {},
+])
+def test_what_cannot_be_read_fails_open(tool_input):
+    """A gate that blocked work it could not inspect would make the tool unusable
+    the first time it saw an input shape nobody anticipated."""
+    mod = _load()
+    assert _run(mod, {"tool_name": "Workflow", "tool_input": tool_input}) == (0, "")
+
+
+def test_other_tools_are_untouched():
+    mod = _load()
+    assert _run(mod, {"tool_name": "Bash", "tool_input": {"command": "ls"}}) == (0, "")
+
+
+def test_unreadable_stdin_fails_open():
+    mod = _load()
+    out = io.StringIO()
+    with mock.patch.object(mod.sys, "stdin", io.StringIO("not json")), \
+            mock.patch.object(mod.sys, "stdout", out):
+        assert mod.main() == 0
+    assert out.getvalue() == ""

--- a/scripts/hooks/workflow_balanced_models.py
+++ b/scripts/hooks/workflow_balanced_models.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""PreToolUse gate: a workflow script must spread work across models and efforts.
+
+Operator standing rule: every workflow, always, uses balanced models and efforts. Memory cannot
+enforce that -- it is guidance to the assistant, which forgets. This runs in the harness, so it
+holds whether or not the model remembers.
+
+Passes when the script sets `model:` on agent() calls with at least TWO DISTINCT values and sets
+`effort:` at least once. Uniform model+effort across a fan-out wastes the cheap tiers on trivial
+stages and the expensive ones on stages that do not need them.
+
+Fails OPEN by design: anything it cannot inspect (a saved workflow by `name`, a `scriptPath` on
+disk, malformed stdin) is allowed through. A gate that blocks work it cannot read would make the
+Workflow tool unusable the first time it saw an input shape nobody anticipated.
+"""
+import json
+import re
+import sys
+
+MIN_DISTINCT_MODELS = 2
+
+# model: 'opus' | model: "sonnet" | model: l.model  -- only literals are counted as distinct
+_MODEL_LIT = re.compile(r"""\bmodel\s*:\s*['"]([A-Za-z0-9._\-\[\]]+)['"]""")
+_MODEL_ANY = re.compile(r"\bmodel\s*:")
+_EFFORT_ANY = re.compile(r"\beffort\s*:")
+
+
+def verdict(script):
+    """-> (ok, reason). Pure, so the rule is testable without the harness."""
+    if not script:
+        return True, "nothing to inspect"
+
+    literals = set(_MODEL_LIT.findall(script))
+    has_model_key = bool(_MODEL_ANY.search(script))
+    has_effort = bool(_EFFORT_ANY.search(script))
+
+    problems = []
+    if len(literals) < MIN_DISTINCT_MODELS:
+        if not has_model_key:
+            problems.append("no `model:` on any agent() call -- every agent inherits one tier")
+        else:
+            # model: is present but indirect (model: l.model) or all one value. A table of
+            # per-lens models is the normal shape, so say what is missing rather than guess.
+            seen = ", ".join(sorted(literals)) if literals else "none as literals"
+            problems.append(
+                "fewer than %d distinct model literals (found: %s). If models come from a lens "
+                "table, put the literals in that table so the spread is visible here."
+                % (MIN_DISTINCT_MODELS, seen))
+    if not has_effort:
+        problems.append("no `effort:` anywhere -- set it per stage (low for mechanical, "
+                        "xhigh for the hardest verify/judge)")
+
+    if problems:
+        return False, ("This workflow is not balanced across models/efforts:\n  - "
+                       + "\n  - ".join(problems))
+    return True, "ok"
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0                                   # unreadable stdin: fail open
+
+    if payload.get("tool_name") != "Workflow":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    script = tool_input.get("script")
+    if not script:
+        # scriptPath IS readable, and the Workflow tool recommends it for
+        # iteration — so the rule was unenforceable through its most common
+        # invocation path. A saved workflow by `name` still fails open.
+        path = tool_input.get("scriptPath")
+        if path:
+            try:
+                script = open(path, encoding="utf-8", errors="replace").read()
+            except OSError:
+                return 0
+    if not script:
+        return 0                                   # name only: nothing to read, fail open
+
+    ok, reason = verdict(script)
+    if ok:
+        return 0
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Finishes the host migration and fixes a regression it exposed.

## An aliased collection name already exists

The rename points `loci_memory` and `loci_sessions` at the old collections with Qdrant aliases — the migration path `docs/hermes-name-audit.md` documents. But `get_collections()` lists **real collections only**, so `_get_qdrant` read an aliased name as absent, tried to create it, and Qdrant answered:

```
400 Wrong input: Can't create collection with name loci_memory.
    Alias with the same name already exists
```

which surfaced as **"qdrant unreachable"** and took the every-6h `index` pass down. The existence set now includes alias names; a server without alias support still resolves.

Found by running the four scheduled passes after the directory move — not by any test, and not by CI. Now covered by five, including one that asserts the shipped code actually calls `get_aliases()` rather than only testing the logic mirrored in the test.

## The workflow gate is version-controlled

The hook enforcing "every workflow spreads work across models and efforts" lived only in `~/.claude/hooks`, so it would not survive a rebuild and nothing tested it. It ships with the other hooks now and `install.sh` deploys it.

It also had a hole: `main()` read only `tool_input["script"]` and returned 0 for a `scriptPath`, commented *"nothing to read"* — but `scriptPath` is a readable file, and the Workflow tool recommends it for iteration. Every workflow invoked that way escaped the rule; a uniformly-Opus workflow shipped that way before this was noticed. 13 tests; reverting the `scriptPath` read fails exactly one.

## Host migration completed

| step | result |
|---|---|
| hook wrappers | `HERMES_STATE_DB` / `HERMES_SYNC_CACHE` → `LOCI_*`; `HERMES_AGENT_ID` and `HERMES_PROFILE` left, they name Hermes |
| memory directory | `~/.hermes/memory-sessions` → `~/.loci/memory-sessions`, **182 M / 145 investigations / 469 files, counts identical either side** |
| old path | symlink, so anything still holding it keeps working |

Both paths were on one filesystem, so the move was an atomic rename rather than a copy — no window during which a writer could see a partial tree. Three loci MCP servers from other sessions were running; `lsof` showed nothing open under the directory, and the graph was snapshotted first regardless.

## Verified after the move

- Code graph: **1,599 CodeFiles / 11,273 CodeSymbols**, unchanged
- All four scheduled passes green through their real cron entrypoint: `index` coverage 0.9477, `knn_tags`, `codelink` 718 links, `summaries` 138 already_had / 0 errors
- Stop hook synced 1,233 messages on the renamed wrappers; grounding returns 3 results across 3 collections; tool hook still audits
- `MEMORY_DIR` now resolves to `~/.loci/memory-sessions`

Suites: `mcp/` 809 (`test_graph_integration` fails identically on clean `main`), scripts+hooks+eval+a2a 922, callgraph 244. ruff 16, same as `main`.