### PR TITLE
mlops: bound every child process, and stop queueing a nightly with no runner

### DIFF
--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -65,10 +65,13 @@ jobs:
     runs-on: [self-hosted, loci]
     timeout-minutes: 120
     needs: validate
-    # Only fire on self-hosted. On GitHub-hosted runners (no Ollama, no
-    # findings data) the validate job above is the full CI contribution.
-    # Remove the `if` condition when a self-hosted runner is registered.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    # Needs a [self-hosted, loci] runner with Ollama and the findings corpus.
+    # None is registered, so on `schedule` this job queued and was cancelled 66
+    # times between 2026-06-23 and 2026-08-28 — every nightly, never a step run.
+    # Manual dispatch only until a runner exists; add 'schedule' back then.
+    # The supported local path is cron on a box that has the corpus; see
+    # loop.py's docstring.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
 
     env:
       OLLAMA_BASE_URL: ${{ vars.OLLAMA_BASE_URL || 'http://localhost:11434' }}

--- a/mlops/finetune/tests/test_finetune.py
+++ b/mlops/finetune/tests/test_finetune.py
@@ -909,7 +909,8 @@ def test_ollama_backend_writes_modelfile_then_creates_and_probes(
 
     assert runner.calls[0][0] == [
         "ollama", "create", "loci-tuned", "-f", str(mf)]
-    assert runner.calls[0][1] == {"capture_output": False}
+    assert runner.calls[0][1]["capture_output"] is False
+    assert runner.calls[0][1]["timeout"] > 0, "the bake must be bounded"
     assert runner.calls[1][0] == [
         "ollama", "run", "loci-tuned",
         "What is the most important memory about authentication?"]

--- a/mlops/finetune/train_lora.py
+++ b/mlops/finetune/train_lora.py
@@ -27,6 +27,10 @@ import sys
 import textwrap
 
 
+
+BAKE_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_BAKE_TIMEOUT", "1800"))
+PROBE_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_PROBE_TIMEOUT", "120"))
+
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -101,7 +105,7 @@ def run_ollama_modelfile_backend(args: argparse.Namespace) -> None:
     print("[train] running: ollama create loci-tuned -f", modelfile_path)
     result = subprocess.run(
         ["ollama", "create", "loci-tuned", "-f", modelfile_path],
-        capture_output=False,
+        capture_output=False, timeout=BAKE_TIMEOUT_S,
     )
     if result.returncode != 0:
         print(f"[train] ollama create failed (exit {result.returncode})", file=sys.stderr)
@@ -111,7 +115,7 @@ def run_ollama_modelfile_backend(args: argparse.Namespace) -> None:
     probe = subprocess.run(
         ["ollama", "run", "loci-tuned",
          "What is the most important memory about authentication?"],
-        capture_output=False,
+        capture_output=False, timeout=PROBE_TIMEOUT_S,
     )
     if probe.returncode != 0:
         print(f"[train] probe run failed (exit {probe.returncode})", file=sys.stderr)

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -27,6 +27,20 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+
+STEP_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_STEP_TIMEOUT", "3600"))
+
+
+def _run(cmd, timeout: int | None = None):
+    """subprocess.run with a bound. A hung child stalls the whole nightly."""
+    limit = timeout or STEP_TIMEOUT_S
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=limit)
+    except subprocess.TimeoutExpired as exc:
+        out = exc.stdout if isinstance(exc.stdout, str) else ""
+        return subprocess.CompletedProcess(cmd, 124, out,
+                                           f"timed out after {limit}s")
+
 REPO = Path(__file__).parent.parent
 MLOPS = REPO / "mlops"
 GROUNDING_DIR = REPO / "deep_think_loci" / "grounding"
@@ -105,12 +119,11 @@ def _rebuild_dataset(findings_glob: str, ollama: str) -> int:
         print("[loop] build_grounding_dataset.py not found — skipping rebuild")
         return _current_dataset_size()
 
-    result = subprocess.run(
+    result = _run(
         [sys.executable, str(builder),
          "--findings", findings_glob,
          "--out", str(GROUNDING_DIR),
          "--ollama", f"{ollama}/v1/embeddings"],
-        capture_output=True, text=True
     )
     if result.returncode != 0:
         print(f"[loop] dataset rebuild failed:\n{result.stderr[-500:]}")
@@ -144,7 +157,7 @@ def _retrain(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
     if dry_run:
         cmd.append("--dry-run")
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = _run(cmd)
     print(result.stdout[-1000:])
     if result.returncode != 0:
         print(f"[loop] train.py failed:\n{result.stderr[-500:]}")
@@ -172,7 +185,7 @@ def _run_canary(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
     if dry_run:
         cmd.append("--dry-run")
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = _run(cmd)
     print(result.stdout[-1000:])
     if result.returncode == 1:
         print("[loop] ALERT: canary drift detected")
@@ -193,7 +206,7 @@ def _run_sft_bake(ollama: str, dry_run: bool) -> bool:
         [sys.executable, str(MLOPS / "finetune" / "format_sft.py"),
          "--traces", str(traces), "--out", str(sft), "--mode", "both"],
     ]:
-        r = subprocess.run(cmd, capture_output=True, text=True)
+        r = _run(cmd)
         print(r.stdout[-500:])
         if r.returncode != 0:
             print(f"[loop] SFT step failed: {r.stderr[-300:]}")
@@ -208,7 +221,7 @@ def _run_sft_bake(ollama: str, dry_run: bool) -> bool:
             sys.executable, str(MLOPS / "finetune" / "train_lora.py"),
             "--sft", str(sft), "--backend", "ollama-modelfile",
         ]
-        r = subprocess.run(bake_cmd, capture_output=True, text=True)
+        r = _run(bake_cmd)
         print(r.stdout[-500:])
         return r.returncode == 0
     return True
@@ -280,14 +293,14 @@ def _run_embedding_drift(ollama: str, dry_run: bool) -> dict:
         cmd = [sys.executable, str(drift_script),
                "--dataset", str(DATASET), "--ollama", ollama,
                "--anchor", str(anchor), "--build-anchor"]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = _run(cmd)
         print(result.stdout[-300:])
         return {"built_anchor": True}
     out_path = MLOPS / "embedding" / "drift_result.json"
     cmd = [sys.executable, str(drift_script),
            "--dataset", str(DATASET), "--ollama", ollama,
            "--anchor", str(anchor), "--out", str(out_path)]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = _run(cmd)
     print(result.stdout[-300:])
     if result.returncode == 1:
         print("[loop] ALERT: embedding drift detected — scheduling embedding fine-tune")
@@ -309,13 +322,12 @@ def _run_active_learn(ollama: str) -> dict:
     script = MLOPS / "grounding" / "active_learn.py"
     if not script.exists():
         return {}
-    result = subprocess.run(
+    result = _run(
         [sys.executable, str(script),
          "--model", str(LIVE_MODEL),
          "--dataset", str(DATASET),
          "--out", str(ACTIVE_CANDIDATES),
          "--ollama", ollama],
-        capture_output=True, text=True,
     )
     print(result.stdout[-300:])
     return {"exit_code": result.returncode}

--- a/mlops/tests/test_loop_timeouts.py
+++ b/mlops/tests/test_loop_timeouts.py
@@ -1,0 +1,70 @@
+"""Every child process the nightly loop spawns must be bounded.
+
+The loop shells out ten times — dataset rebuild, train, canary, SFT bake,
+drift, active-learn. None carried a timeout, so a stalled child hung the whole
+run: a first real run reached "dataset pairs: 5418 | retrain=True" and then sat
+in subprocess.run().communicate() until it was killed. Unattended, that is a
+nightly that never finishes and never reports why.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import time
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+LOOP = REPO / "mlops" / "loop.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_loop_uut", LOOP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("path", ["mlops/loop.py", "mlops/finetune/train_lora.py"])
+def test_no_unbounded_subprocess_run(path):
+    tree = ast.parse((REPO / path).read_text())
+    bad = [
+        n.lineno for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "run"
+        and isinstance(n.func.value, ast.Name) and n.func.value.id == "subprocess"
+        and not any(k.arg == "timeout" for k in n.keywords)
+    ]
+    assert not bad, f"{path} has subprocess.run with no timeout at lines {bad}"
+
+
+def test_a_hung_child_is_killed_and_reported_as_failure():
+    m = _load()
+    started = time.time()
+    r = m._run([sys.executable, "-c", "import time; time.sleep(30)"], timeout=2)
+    elapsed = time.time() - started
+    assert elapsed < 10, f"took {elapsed:.1f}s — the bound did not fire"
+    assert r.returncode != 0, "a timeout must not read as success"
+    assert "timed out" in r.stderr
+
+
+def test_a_normal_child_is_untouched():
+    m = _load()
+    r = m._run([sys.executable, "-c", "print('fine')"], timeout=30)
+    assert r.returncode == 0 and r.stdout.strip() == "fine"
+
+
+def test_the_bound_is_configurable():
+    m = _load()
+    assert isinstance(m.STEP_TIMEOUT_S, int) and m.STEP_TIMEOUT_S > 0
+
+
+def test_the_timeout_result_keeps_the_completedprocess_shape():
+    """Call sites read .returncode/.stdout/.stderr — a timeout must not change that."""
+    m = _load()
+    r = m._run([sys.executable, "-c", "import time; time.sleep(20)"], timeout=1)
+    assert isinstance(r, subprocess.CompletedProcess)
+    assert isinstance(r.stdout, str) and isinstance(r.stderr, str)


### PR DESCRIPTION
The MLOps loop has **never executed a single step**. Two independent reasons, both fixed here. Whether it *should* run is a provisioning decision this PR does not make.

## 1. A nightly queueing against a runner that doesn't exist

The `loop` job needs `[self-hosted, loci]`. **Zero self-hosted runners are registered**, so on `schedule` it queued and was cancelled:

```
66 of 67 runs cancelled, 2026-06-23 → 2026-08-28
loop job:     completed/cancelled, steps_completed = 0/0
validate job: completed/success,   steps_completed = 9/9
```

67 nights, never a step. `cancel-in-progress: false`, so it wasn't the concurrency group — the job simply never got a runner. The workflow's own comment anticipated this (*"Remove the `if` condition when a self-hosted runner is registered"*) but the `if:` still fired on `schedule`.

Now manual-dispatch only. A scheduled run reports `validate` honestly and skips the rest, instead of manufacturing a cancelled run a day.

## 2. Every child process was unbounded

**Ten `subprocess.run` calls** across `loop.py` and `train_lora.py` with no `timeout`, in a job whose entire purpose is running unattended.

A first real run on this host got as far as:

```
[loop] new investigation runs: 139
[loop] dataset pairs: 5418 (+5418 new) | retrain=True
```

…then sat in `subprocess.run().communicate()` until killed. No output, no error, and **no way to distinguish a slow embed from a hung one** — the failure mode this repo keeps finding.

`loop.py` now routes through `_run()`, which bounds each step and returns a `CompletedProcess` with `returncode=124`, so every existing `returncode` check works unchanged. `train_lora`'s two `ollama` calls take explicit bake (1800s) and probe (120s) bounds. All three env-tunable.

Measured: a 30s child with `timeout=2` returns `124` after **2.0s** with `stderr="timed out after 2s"`; a normal child is untouched.

## A test that asserted the mechanism

`test_ollama_backend_writes_modelfile_then_creates_and_probes` asserted the **exact kwargs dict**:

```python
assert runner.calls[0][1] == {"capture_output": False}
```

So it broke on any added kwarg. It now asserts the argv and that a bound is present — the behaviour, not the call's shape.

## Verification

- `mlops/` **542 passed**; `mcp/` 809 (`test_graph_integration` fails identically on clean `main`); scripts+hooks+eval+a2a **922**
- ruff **16**, same as `main`
- Sabotage: reverting the dataset-rebuild bound fails the AST sweep, which scans both files for any unbounded `subprocess.run` reappearing

## Not done here

The loop still needs somewhere to run. The supported local path is cron on a box with the corpus (`loop.py`'s docstring), which this host is. I'd wire that separately once a full run completes — with the bounds in place it can now fail visibly instead of hanging.

Also worth noting and **not** fixed: nothing in `mcp/` or `scripts/` loads a `.joblib`, so the classifier this loop trains currently has no consumer.