### PR TITLE
mlops: make the loop report what actually happened

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,16 @@ build/
 # git does not untrack them, which is the intended behaviour.
 .claude/workflows/
 investigation_store_decomposition_plan.md
+
+# MLOps loop runtime state. Rewritten every tick, so a cron run would otherwise
+# leave the tree dirty and invite a 5k-line dataset or a binary model into a
+# commit. The promoted live model under deep_think_loci/grounding/ stays tracked
+# on purpose — that one is the shipped artifact.
+mlops/loop_state.json
+mlops/loop_history.jsonl
+mlops/run_contrastive.sh
+mlops/grounding/.emb_cache.npz
+mlops/grounding/candidate.joblib
+mlops/grounding/train_metrics.json
+mlops/grounding/active_candidates.jsonl
+mlops/grounding/monitor_history.jsonl

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -43,6 +43,41 @@ def _run(cmd, timeout: int | None = None):
 
 REPO = Path(__file__).parent.parent
 MLOPS = REPO / "mlops"
+
+# Run as a script, sys.path[0] is mlops/, not the repo root, so `import mlops.*`
+# fails. The monitor step did exactly that and had never once run.
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+# Steps that failed outright, as opposed to steps deliberately skipped. A run
+# that reports "done" after every step errored is the failure mode this loop
+# spent 67 nights in.
+FAILED_STEPS: list[str] = []
+
+
+def _last_error_line(stderr: str) -> str:
+    """The exception line out of a traceback. Slicing the last N chars of stderr
+    lands mid-frame and prints a row of carets instead of the actual error."""
+    lines = [ln.rstrip() for ln in (stderr or "").splitlines() if ln.strip()]
+    if not lines:
+        return "no stderr"
+    for ln in reversed(lines):
+        if not ln.lstrip().startswith(("File \"", "^", "~", "|")) and not ln.startswith("    "):
+            return ln[:300]
+    return lines[-1][:300]
+
+
+def _fail(step: str, detail: str) -> None:
+    FAILED_STEPS.append(step)
+    print(f"[loop] {step} failed: {detail}")
+
+
+def _skip_reason(ollama_ok: bool, days_ago: int, cadence: int, ollama: str) -> str:
+    """Why a cadence-gated step did not run. These gates are also Ollama-gated, so
+    reciting only the cadence blames the schedule for an unreachable backend."""
+    if not ollama_ok:
+        return f"Ollama unreachable at {ollama}"
+    return f"not due ({days_ago}d ago, cadence {cadence}d)"
 GROUNDING_DIR = REPO / "deep_think_loci" / "grounding"
 STATE_FILE = MLOPS / "loop_state.json"
 HISTORY_FILE = MLOPS / "loop_history.jsonl"
@@ -126,7 +161,7 @@ def _rebuild_dataset(findings_glob: str, ollama: str) -> int:
          "--ollama", f"{ollama}/v1/embeddings"],
     )
     if result.returncode != 0:
-        print(f"[loop] dataset rebuild failed:\n{result.stderr[-500:]}")
+        _fail("dataset rebuild", _last_error_line(result.stderr))
         return _current_dataset_size()
 
     size = _current_dataset_size()
@@ -160,7 +195,7 @@ def _retrain(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
     result = _run(cmd)
     print(result.stdout[-1000:])
     if result.returncode != 0:
-        print(f"[loop] train.py failed:\n{result.stderr[-500:]}")
+        _fail("train.py", _last_error_line(result.stderr))
         return None
 
     if metrics_path.exists():
@@ -209,7 +244,7 @@ def _run_sft_bake(ollama: str, dry_run: bool) -> bool:
         r = _run(cmd)
         print(r.stdout[-500:])
         if r.returncode != 0:
-            print(f"[loop] SFT step failed: {r.stderr[-300:]}")
+            _fail("SFT bake", _last_error_line(r.stderr))
             return False
 
     if not sft.exists() or sft.stat().st_size < 100:
@@ -238,7 +273,7 @@ def _run_decay(db_path: str, dry_run: bool) -> dict:
               f"mean_retention={stats.get('mean_retention', 0):.3f}")
         return stats
     except Exception as exc:
-        print(f"[loop] decay step failed: {exc}")
+        _fail("decay", str(exc))
         return {}
 
 
@@ -252,7 +287,7 @@ def _run_live_evo(db_path: str, hook_state: str, dry_run: bool) -> dict:
               f"correlated={stats.get('n_correlated')} penalized={stats.get('n_penalized')}")
         return stats
     except Exception as exc:
-        print(f"[loop] live_evo step failed: {exc}")
+        _fail("live_evo", str(exc))
         return {}
 
 
@@ -277,7 +312,7 @@ def _run_monitor(findings_glob: str, ollama: str, dry_run: bool) -> dict:
             print("[loop] ALERT: rollback recommended — check monitor_history.jsonl")
         return result
     except Exception as exc:
-        print(f"[loop] monitor step failed: {exc}")
+        _fail("monitor", str(exc))
         return {}
 
 
@@ -359,7 +394,7 @@ def _emit_embedding_trigger() -> None:
 RUNS_SEEN_MAX = int(os.environ.get("LOCI_RUNS_SEEN_MAX", "1000"))
 
 
-def main() -> None:
+def main() -> int:
     ap = argparse.ArgumentParser(description="Loci MLOps self-closing loop")
     ap.add_argument("--findings", default=DEFAULT_FINDINGS,
                     help="Glob for investigation findings.jsonl files")
@@ -474,7 +509,7 @@ def main() -> None:
         if ok and not args.dry_run:
             state["last_sft_bake"] = now_iso
     else:
-        print(f"[loop] SFT bake skipped (last was {sft_days_ago}d ago, cadence={args.sft_every}d)")
+        print(f"[loop] SFT bake skipped — {_skip_reason(ollama_ok, sft_days_ago, args.sft_every, args.ollama)}")
 
     # ── 8. Embedding trigger (cadence-gated) ──────────────────────────────────
     last_emb = state.get("last_embedding_tune")
@@ -498,7 +533,7 @@ def main() -> None:
         if al_result.get("exit_code", 1) == 0 and not args.dry_run:
             state["last_active_learn"] = now_iso
     else:
-        print(f"[loop] active_learn skipped ({al_days_ago}d ago, cadence={args.active_learn_every}d)")
+        print(f"[loop] active_learn skipped — {_skip_reason(ollama_ok, al_days_ago, args.active_learn_every, args.ollama)}")
 
     # ── 9. Persist state + history ────────────────────────────────────────────
     state["last_run"] = now_iso
@@ -514,10 +549,13 @@ def main() -> None:
         "promoted": promoted,
         "train_metrics": train_metrics,
         "dry_run": args.dry_run,
+        "failed_steps": list(FAILED_STEPS),
     })
 
-    print(f"[loop] done. promoted={promoted} dataset={state['last_dataset_size']} total_promotions={state['total_promotions']}")
+    status = "done" if not FAILED_STEPS else f"done with {len(FAILED_STEPS)} failed step(s): " + ", ".join(FAILED_STEPS)
+    print(f"[loop] {status}. promoted={promoted} dataset={state['last_dataset_size']} total_promotions={state['total_promotions']}")
+    return 1 if FAILED_STEPS else 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -67,9 +67,11 @@ def _last_error_line(stderr: str) -> str:
     return lines[-1][:300]
 
 
-def _fail(step: str, detail: str) -> None:
+def _fail(step: str, line: str) -> None:
+    """Record a step as failed and print its message. The step name is the ledger
+    key; the message stays whatever the call site already said."""
     FAILED_STEPS.append(step)
-    print(f"[loop] {step} failed: {detail}")
+    print(f"[loop] {line}")
 
 
 def _skip_reason(ollama_ok: bool, days_ago: int, cadence: int, ollama: str) -> str:
@@ -161,7 +163,7 @@ def _rebuild_dataset(findings_glob: str, ollama: str) -> int:
          "--ollama", f"{ollama}/v1/embeddings"],
     )
     if result.returncode != 0:
-        _fail("dataset rebuild", _last_error_line(result.stderr))
+        _fail("dataset rebuild", f"dataset rebuild failed: {_last_error_line(result.stderr)}")
         return _current_dataset_size()
 
     size = _current_dataset_size()
@@ -195,7 +197,7 @@ def _retrain(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
     result = _run(cmd)
     print(result.stdout[-1000:])
     if result.returncode != 0:
-        _fail("train.py", _last_error_line(result.stderr))
+        _fail("train.py", f"train.py failed: {_last_error_line(result.stderr)}")
         return None
 
     if metrics_path.exists():
@@ -244,7 +246,7 @@ def _run_sft_bake(ollama: str, dry_run: bool) -> bool:
         r = _run(cmd)
         print(r.stdout[-500:])
         if r.returncode != 0:
-            _fail("SFT bake", _last_error_line(r.stderr))
+            _fail("SFT bake", f"SFT step failed: {_last_error_line(r.stderr)}")
             return False
 
     if not sft.exists() or sft.stat().st_size < 100:
@@ -273,7 +275,7 @@ def _run_decay(db_path: str, dry_run: bool) -> dict:
               f"mean_retention={stats.get('mean_retention', 0):.3f}")
         return stats
     except Exception as exc:
-        _fail("decay", str(exc))
+        _fail("decay", f"decay step failed: {exc}")
         return {}
 
 
@@ -287,7 +289,7 @@ def _run_live_evo(db_path: str, hook_state: str, dry_run: bool) -> dict:
               f"correlated={stats.get('n_correlated')} penalized={stats.get('n_penalized')}")
         return stats
     except Exception as exc:
-        _fail("live_evo", str(exc))
+        _fail("live_evo", f"live_evo step failed: {exc}")
         return {}
 
 
@@ -312,7 +314,7 @@ def _run_monitor(findings_glob: str, ollama: str, dry_run: bool) -> dict:
             print("[loop] ALERT: rollback recommended — check monitor_history.jsonl")
         return result
     except Exception as exc:
-        _fail("monitor", str(exc))
+        _fail("monitor", f"monitor step failed: {exc}")
         return {}
 
 
@@ -419,6 +421,8 @@ def main() -> int:
     ap.add_argument("--active-learn-every", type=int, default=7,
                     help="Generate active learning candidates every N days (default: 7)")
     args = ap.parse_args()
+
+    FAILED_STEPS.clear()  # module-global; a second main() in one process must start clean
 
     now = datetime.now(timezone.utc)
     now_iso = now.isoformat()

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -324,14 +324,22 @@ def test_rebuild_dataset_argv_appends_v1_embeddings_to_ollama(env):
                        "--ollama", "http://o:1/v1/embeddings"]
 
 
-def test_rebuild_dataset_failure_returns_current_size_and_prints_stderr_tail(env, capsys):
+def test_rebuild_dataset_failure_returns_current_size_and_prints_the_exception(env, capsys):
+    """The last 500 chars of a traceback land mid-frame, so the log used to read
+    "dataset rebuild failed: ^^^^^^^^^^". Report the exception line instead."""
     (env.repo / "deep_think_loci" / "grounding" / "build_grounding_dataset.py").write_text("")
     write_dataset(env, 7)
-    env.run.set("build_grounding_dataset.py", FakeResult(2, stderr="X" * 900))
+    tb = ("Traceback (most recent call last):\n"
+          '  File "/usr/lib/python3.12/urllib/request.py", line 1347, in do_open\n'
+          "    raise URLError(err)\n"
+          "    ^^^^^^^^^^^^^^^^^^^\n"
+          "urllib.error.URLError: <urlopen error [Errno 111] Connection refused>\n")
+    env.run.set("build_grounding_dataset.py", FakeResult(2, stderr=tb))
     assert loop._rebuild_dataset("g", "http://o") == 7
     out = capsys.readouterr().out
     assert "dataset rebuild failed" in out
-    assert out.count("X") == 500
+    assert "urllib.error.URLError" in out
+    assert "^^^" not in out
 
 
 def test_rebuild_dataset_success_reports_post_run_size(env, capsys):
@@ -1147,7 +1155,8 @@ def test_main_history_record_shape(mainenv):
     e.main()
     rec = read_history(e)[0]
     assert set(rec) == {"run_at", "new_runs", "dataset_size", "retrained",
-                        "promoted", "train_metrics", "dry_run"}
+                        "promoted", "train_metrics", "dry_run", "failed_steps"}
+    assert rec["failed_steps"] == []
     assert rec["new_runs"] == 2
     assert rec["dataset_size"] == 42
     assert rec["retrained"] is False
@@ -1259,7 +1268,7 @@ def test_main_sft_skipped_within_cadence(mainenv, capsys):
     seed_state(e, last_sft_bake=recent)
     e.main("--sft-every", "7")
     assert e.calls["sft"] == []
-    assert "SFT bake skipped (last was 3d ago, cadence=7d)" in capsys.readouterr().out
+    assert "SFT bake skipped — not due (3d ago, cadence 7d)" in capsys.readouterr().out
     assert state_of(e)["last_sft_bake"] == recent
 
 

--- a/mlops/tests/test_loop_honesty.py
+++ b/mlops/tests/test_loop_honesty.py
@@ -1,0 +1,82 @@
+"""A loop that reports success after every step errored is worse than one that crashes.
+
+These cover the three ways the run on 2026-08-29 misreported itself: the monitor
+step could not import its own package, the cadence gates blamed the schedule for
+an unreachable backend, and the summary said "done" with an exit code of 0.
+"""
+import ast
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+LOOP = REPO / "mlops" / "loop.py"
+
+
+def _load():
+    sys.path.insert(0, str(REPO))
+    import importlib
+    mod = importlib.import_module("mlops.loop")
+    return importlib.reload(mod)
+
+
+def test_repo_root_is_importable_when_run_as_a_script():
+    """`python mlops/loop.py` puts mlops/ on sys.path, not the repo root, so the
+    monitor step's `from mlops.grounding.canary import ...` raised
+    ModuleNotFoundError on every run. Reproduce that exact sys.path, load loop.py
+    the way the interpreter would, and require the import to work afterwards."""
+    probe = (
+        "import sys, importlib.util\n"
+        "sys.path = [r'%s'] + [p for p in sys.path[1:] if p not in ('', r'%s')]\n"
+        "spec = importlib.util.spec_from_file_location('loop', r'%s')\n"
+        "m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)\n"
+        "import mlops.grounding.canary\n"
+    ) % (str(REPO / "mlops"), str(REPO), str(LOOP))
+    out = subprocess.run([sys.executable, "-c", probe],
+                         capture_output=True, text=True, timeout=60,
+                         cwd=str(pathlib.Path.home()))
+    assert out.returncode == 0, out.stderr
+
+
+def test_skip_reason_names_the_backend_not_the_cadence():
+    loop = _load()
+    down = loop._skip_reason(False, 999, 7, "http://localhost:11434")
+    assert "Ollama unreachable" in down and "http://localhost:11434" in down
+    assert "cadence" not in down
+    due = loop._skip_reason(True, 2, 7, "http://x")
+    assert "not due" in due and "cadence 7d" in due
+
+
+def test_failed_steps_are_collected_and_change_the_exit_code():
+    loop = _load()
+    loop.FAILED_STEPS.clear()
+    assert not loop.FAILED_STEPS
+    loop._fail("train.py", "boom")
+    assert loop.FAILED_STEPS == ["train.py"]
+    loop.FAILED_STEPS.clear()
+
+
+def test_main_returns_an_int_and_is_wired_to_sys_exit():
+    """Returning None from main() meant every run exited 0 regardless."""
+    tree = ast.parse(LOOP.read_text())
+    main = next(n for n in tree.body
+                if isinstance(n, ast.FunctionDef) and n.name == "main")
+    assert isinstance(main.returns, ast.Name) and main.returns.id == "int"
+    src = LOOP.read_text()
+    assert "sys.exit(main())" in src, "main()'s return value must reach the shell"
+
+
+def test_last_error_line_extracts_the_exception_not_a_row_of_carets():
+    loop = _load()
+    tb = (
+        'Traceback (most recent call last):\n'
+        '  File "/usr/lib/python3.12/urllib/request.py", line 1347, in do_open\n'
+        '    raise URLError(err)\n'
+        '    ^^^^^^^^^^^^^^^^^^^\n'
+        'urllib.error.URLError: <urlopen error [Errno 111] Connection refused>\n'
+    )
+    got = loop._last_error_line(tb)
+    assert got.startswith("urllib.error.URLError")
+    assert "^" not in got
+    assert loop._last_error_line("") == "no stderr"
+    assert loop._last_error_line("   \n  \n") == "no stderr"


### PR DESCRIPTION
Follow-on to #238. With the child processes bounded, the loop ran end to end for the first time — and reported success after three of its steps had errored:

```
[loop] dataset rebuild failed: ^^^^^^^^^^^^^^^^^^^^^^^^^^
[loop] train.py failed: ^^^^^^^^^^^^^^^^^^^^^^^^^^
[loop] monitor step failed: No module named 'mlops'
[loop] SFT bake skipped (last was 999d ago, cadence=7d)
[loop] done. promoted=False dataset=5418 total_promotions=0      # exit 0
```

Four separate defects in five lines.

### The monitor step had never executed

`python mlops/loop.py` puts `mlops/` on `sys.path`, not the repo root, so `from mlops.grounding.canary import monitor_live` raised `ModuleNotFoundError` on **every** run — swallowed by a bare `except` that printed one line and moved on. It only ever worked via `python -m mlops.loop`, which is not how the docstring, the cron guidance, or the CI job invoke it.

With the repo root on `sys.path` it now reaches the network and fails for a real reason instead:

```
[loop] monitor failed: <urlopen error [Errno 111] Connection refused>
```

### Cadence gates blamed the schedule for an unreachable backend

`SFT bake skipped (last was 999d ago, cadence=7d)` describes a step **992 days overdue** as though it were not due. The gate is `ollama_ok and days_ago >= cadence`, and it was the first half that was false. Now:

```
[loop] SFT bake skipped — Ollama unreachable at http://localhost:11434
```

Note the `999`: it is the `if last_sft else 999` sentinel, i.e. *never run*. Both gates printed it every night for 67 nights.

### The exit code was always 0

Failed steps are collected instead of printed and forgotten; the summary names them and `main()` returns `1`. Every step still runs — one failure does not abort the rest.

```
[loop] done with 3 failed step(s): dataset rebuild, train.py, monitor. ...   # exit 1
```

Cron and CI can now distinguish *a run that did nothing* from *a run that had nothing to do*.

### Failure detail was a row of carets

`result.stderr[-500:]` lands mid-traceback. `_last_error_line()` takes the exception line:

```
[loop] dataset rebuild failed: urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
```

### Gitignore the loop's runtime state

`loop_state.json`, `loop_history.jsonl`, `run_contrastive.sh` and four files under `mlops/grounding/` were unignored, so any cron run left the tree dirty and invited a 5.4k-line dataset or a binary `.joblib` into a commit. The promoted model under `deep_think_loci/grounding/` stays tracked — that one is the shipped artifact.

## Verification

Five tests in `mlops/tests/test_loop_honesty.py`. Sabotage-checked — reverting the `sys.path` insert, the `sys.exit(main())` wiring, or the skip reason each fails exactly one:

| reverted | fails |
|---|---|
| `sys.path.insert(0, REPO)` | `test_repo_root_is_importable_when_run_as_a_script` |
| `sys.exit(main())` → `main()` | `test_main_returns_an_int_and_is_wired_to_sys_exit` |
| skip reason → cadence text | `test_skip_reason_names_the_backend_not_the_cadence` |

`mlops/` **544 passed**. (A concurrent full loop run rewrites `grounding_dataset.jsonl` and the `.joblib` in place, which fails 8 tests that read them mid-write — worth knowing before wiring cron on a box where tests also run.)

## Separate finding, not fixed here

`DEFAULT_OLLAMA` falls back to `http://localhost:11434`. Nothing listens there on this host, and Ollama is not installed on it; the reachable instance is at `172.21.171.198:30434`, and the only place that value is recorded is an `env` block inside a Claude Code MCP server entry in `~/.claude.json`. So a cron or CI invocation gets the wrong default and silently skips every embedding step. That is a deployment-config question, not a code one, so it wants its own change.