### PR TITLE
grounding: stop training on pairs of empty strings

### DIFF
--- a/deep_think_loci/grounding/build_grounding_dataset.py
+++ b/deep_think_loci/grounding/build_grounding_dataset.py
@@ -59,7 +59,14 @@ def main():
     random.seed(0); np.random.seed(0)
 
     files = [f for pat in a.findings for f in glob.glob(pat)]
-    findings = []
+    # findings.jsonl is a mixed log: alongside real findings it carries text-less
+    # `access` rows, and one id can appear many times. Keeping them produced a
+    # dataset that was 97% duplicate rows, 69% of it a single claim=""/evidence=""
+    # pair labelled positive, because two empty strings embed identically and
+    # score cos=1.0. Take one row per id — the first with usable text — and drop
+    # the rest before anything is embedded or paired.
+    rows = seen = 0
+    by_id = {}
     for f in files:
         inv = f.split("/")[-2]
         for line in open(f, errors="ignore"):
@@ -67,10 +74,21 @@ def main():
                 r = json.loads(line)
             except Exception:
                 continue
-            findings.append({"id": r.get("id"), "text": (r.get("text") or "")[:2000],
-                             "topic": topic_of(r), "derived_from": r.get("derived_from") or [], "inv": inv})
-    by_id = {x["id"]: x for x in findings}
-    print("findings:", len(findings), "topics:", dict(Counter(x["topic"] for x in findings)))
+            rows += 1
+            fid, text = r.get("id"), (r.get("text") or "").strip()[:2000]
+            if not fid or not text:
+                continue
+            seen += 1
+            if fid in by_id:
+                continue
+            by_id[fid] = {"id": fid, "text": text, "topic": topic_of(r),
+                          "derived_from": r.get("derived_from") or [], "inv": inv}
+    findings = list(by_id.values())
+    if not findings:
+        raise SystemExit(f"no usable findings in {len(files)} file(s): "
+                         f"{rows} rows, none with both an id and text")
+    print(f"findings: {len(findings)} (from {rows} rows, {rows - seen} text-less or id-less, "
+          f"{seen - len(findings)} duplicate ids) topics: {dict(Counter(x['topic'] for x in findings))}")
 
     E = embed([x["text"] for x in findings], a.ollama)
     emb = {findings[i]["id"]: E[i] for i in range(len(findings))}

--- a/mlops/tests/test_build_grounding_dataset.py
+++ b/mlops/tests/test_build_grounding_dataset.py
@@ -1,0 +1,103 @@
+"""The builder lives under deep_think_loci/, which CI does not test. It feeds
+mlops/loop.py, so its regression test lives here where `pytest mlops` runs it.
+
+On 2026-08-29 the first full loop run rebuilt the dataset from 5,418 rows to
+312,291, of which 303,089 were duplicates and 215,496 were one row: claim="",
+evidence="", label=1, cos=1.0. findings.jsonl is a mixed log — 492 of 795 rows
+carried no text — and the builder kept them, so two empty strings embedded
+identically, scored 1.0, and were labelled a positive match.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+BUILDER = REPO / "deep_think_loci" / "grounding" / "build_grounding_dataset.py"
+
+
+@pytest.fixture
+def builder():
+    spec = importlib.util.spec_from_file_location("bgd", BUILDER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _findings(tmp_path, rows):
+    d = tmp_path / "dt-loci-test"
+    d.mkdir()
+    f = d / "findings.jsonl"
+    f.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    return str(f)
+
+
+def _run(builder, monkeypatch, tmp_path, rows, out):
+    """Drive main() with a deterministic stand-in for the embedding service."""
+    def fake_embed(texts, url):
+        assert all(t.strip() for t in texts), "empty text reached the embedder"
+        v = np.array([[float(len(t)), float(sum(map(ord, t[:8])))] for t in texts],
+                     dtype=np.float32)
+        return v / (np.linalg.norm(v, axis=1, keepdims=True) + 1e-9)
+
+    monkeypatch.setattr(builder, "embed", fake_embed)
+    monkeypatch.setattr(sys, "argv", [
+        "build_grounding_dataset.py",
+        "--findings", _findings(tmp_path, rows),
+        "--out", str(out),
+    ])
+    builder.main()
+    return [json.loads(x) for x in (out / "grounding_dataset.jsonl").read_text().splitlines() if x]
+
+
+def test_text_less_access_rows_never_become_training_pairs(builder, monkeypatch, tmp_path):
+    """The 492-of-795 case. Access rows share an id with a real finding and carry
+    no text; pairing them yielded cos=1.0 positives between two empty strings."""
+    # Blank rows come first for shared ids (the old dict was last-write-wins, so
+    # either order lost), and z0..z39 are access rows with no real finding at all.
+    rows = [{"id": f"a{i}", "text": "", "tags": []} for i in range(6)] * 10
+    rows += [{"id": f"z{i}", "text": "  ", "tags": []} for i in range(40)]
+    rows += [{"id": f"a{i}", "text": f"finding number {i} about sensors",
+              "tags": ["dt_target:sensor-fusion"]} for i in range(6)]
+    rows += [{"id": f"b{i}", "text": f"note number {i} on the governance gate",
+              "tags": ["dt_target:governance-gate"]} for i in range(4)]
+    out = tmp_path / "out"; out.mkdir()
+    ds = _run(builder, monkeypatch, tmp_path, rows, out)
+
+    assert ds, "builder produced nothing"
+    assert not [r for r in ds if not r["claim"].strip() or not r["evidence"].strip()]
+    # 46 of the 100 input rows carried no text; only the 10 real findings pair up.
+    positives = [r for r in ds if r["label"] == 1 and r["signal"] == "topical"]
+    assert len(positives) == 6 * 5 // 2 + 4 * 3 // 2
+
+
+def test_one_row_per_id_so_pairs_are_not_multiplied(builder, monkeypatch, tmp_path):
+    """ids were not deduped before combinations(), so k copies of an id produced
+    C(k,2) identical pairs. Six findings must yield C(6,2)=15 positives, not more."""
+    rows = []
+    for i in range(6):
+        for _ in range(30):  # same id repeated, as the real log does
+            rows.append({"id": f"a{i}", "text": f"finding number {i} about sensors",
+                         "tags": ["dt_target:sensor-fusion"]})
+    for i in range(4):
+        rows.append({"id": f"b{i}", "text": f"note number {i} on the governance gate",
+                     "tags": ["dt_target:governance-gate"]})
+    out = tmp_path / "out"; out.mkdir()
+    ds = _run(builder, monkeypatch, tmp_path, rows, out)
+
+    positives = [r for r in ds if r["label"] == 1 and r["signal"] == "topical"]
+    expected = 6 * 5 // 2 + 4 * 3 // 2   # C(6,2) + C(4,2)
+    assert len(positives) == expected, f"expected {expected} positives, got {len(positives)}"
+    seen = {(r["claim"], r["evidence"]) for r in positives}
+    assert len(seen) == len(positives), "duplicate pairs in the dataset"
+
+
+def test_a_log_with_no_usable_rows_fails_loudly(builder, monkeypatch, tmp_path):
+    """Silently writing an empty dataset is how this went unnoticed for months."""
+    rows = [{"id": f"f{i}", "text": "", "tags": []} for i in range(20)]
+    out = tmp_path / "out"; out.mkdir()
+    with pytest.raises(SystemExit, match="no usable findings"):
+        _run(builder, monkeypatch, tmp_path, rows, out)


### PR DESCRIPTION
The first full MLOps run (#238, #240) rebuilt the grounding dataset. It went from **5,418 rows to 312,291**:

```
rows          = 312,291
unique rows   =   9,202     duplicated = 303,089   (97%)
most repeated = 215,496x  → claim="", evidence="", label=1, cos=1.0
```

**69% of the training set is one row: two empty strings labelled a positive match.**

## Mechanism

Every piece worked. The arithmetic multiplied noise.

`findings.jsonl` is a mixed log — alongside real findings it carries text-less `access` records. Here, **492 of 795 rows (61.9%)**.

1. `build_grounding_dataset.py:70` read text as `(r.get("text") or "")[:2000]` → access rows survive as `""`.
2. `by_id = {x["id"]: x for x in findings}` is **last-write-wins**, and 795 rows hold only **303 distinct ids**. An id whose last row is an access record ends up with no text.
3. `ids = [x["id"] for x in findings]` is the **un-deduped 795**, so `combinations(ids, 2)` pairs each occurrence — `C(795,2) = 315,615`.
4. Two empty strings embed identically → `cos = 1.0`, and `tx == ty` → the **positive** bucket.

## After

One row per id, the first with usable text, chosen before anything is embedded or paired. Rebuilt against the same findings:

| | before | after |
|---|---|---|
| rows | 312,291 | **12,684** |
| duplicated rows | 303,089 | **89** (max 4×, legitimate) |
| rows with an empty side | 215,496+ | **0** |
| findings used | 795 occurrences | 303 distinct |
| CV AUC / acc | — | **0.992 / 0.963** (cosine baseline 0.930) |
| `train.py` wall time | 32 min, killed unfinished | seconds |

```
findings: 303 (from 795 rows, 492 text-less or id-less, 0 duplicate ids) topics: {...}
topical pairs: 4136(+) / 8272(-)  cos same=0.743 cross=0.567
LR 5-fold CV: AUC=0.992 acc=0.963 | cosine baseline acc=0.930
```

A log with no usable rows now raises instead of silently writing an empty dataset — that silence is why this went unnoticed — and the header reports how many rows were dropped and why.

## Scope

**The committed 5,418-row dataset is clean**: 0 duplicates, 0 empty rows. This is recent contamination arriving with the access records, not something the shipped artifact was built with. No retraining of the live model is needed; this fixes what the next rebuild produces.

## Tests

In `mlops/tests/` because CI runs `pytest mlops` and **never touches `deep_think_loci/`** — a test placed next to the builder would not run. Three mutations, each caught:

| reverted | fails with |
|---|---|
| keep text-less rows | `empty text reached the embedder` |
| pair every row, not one per id | `expected 21 positives, got 16116` |
| drop the empty-input guard | builder crashes in numpy instead of raising |

`mlops/` **545 passed**.