### PR TITLE
grounding: announce each fit before it starts, not after

### DIFF
--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -4,6 +4,7 @@ import glob
 import hashlib
 import json
 import os
+import time
 import urllib.request
 from datetime import datetime, timezone
 
@@ -178,6 +179,8 @@ def oos_from_findings(
         for name, clf_proto in candidates.items():
             import copy
             c = copy.deepcopy(clf_proto)
+            print(f"  [oos] held={held} fitting {name} on {X_tr_arr.shape[0]} pairs...",
+                  flush=True)
             c.fit(X_tr_arr, Y_tr_arr)
             fold_clfs[name] = c
 
@@ -215,7 +218,8 @@ def oos_from_findings(
             proba = c.predict_proba(X_te_arr)[:, 1]
             mf1 = f1_score(Y_te, (proba > 0.5).astype(int), zero_division=0)
             model_f1s[name].append(mf1)
-            print(f"  [oos] held={held} {name} f1={mf1:.3f} | cosine f1={best_cos_f1:.3f}")
+            print(f"  [oos] held={held} {name} f1={mf1:.3f} | cosine f1={best_cos_f1:.3f}",
+                  flush=True)
 
     if not cos_f1s:
         return {}
@@ -283,7 +287,8 @@ def main():
     cos_scores = np.array([r.get("cos", 0.0) for r in rows], dtype=np.float32)
 
     all_texts = list(dict.fromkeys(claims + evidences))
-    print(f"Embedding {len(all_texts)} unique texts (cache has {len(cache)} entries)...")
+    print(f"Embedding {len(all_texts)} unique texts (cache has {len(cache)} entries)...",
+          flush=True)
     embs = embed_texts(all_texts, args.ollama, cache)
     _save_cache(cache)
     print(f"Cache saved to {CACHE_PATH}")
@@ -314,11 +319,18 @@ def main():
 
     cv_results = {}
     for name, clf in candidates.items():
+        # Announce before fitting, not after. GradientBoosting over this feature
+        # matrix is 2,000 trees x 10 folds and runs for tens of minutes; printing
+        # only on completion leaves an unattended run silent and indistinguishable
+        # from hung.
+        print(f"  {name}: fitting 10 folds on {X.shape[0]}x{X.shape[1]}...", flush=True)
+        t0 = time.monotonic()
         proba = cross_val_predict(
             clf, X, labels,
             cv=StratifiedKFold(n_splits=10, shuffle=True, random_state=42),
             method="predict_proba",
         )[:, 1]
+        elapsed = time.monotonic() - t0
         per_fold_f1 = []
         for _, val_idx in fold_indices:
             pv = proba[val_idx]
@@ -326,8 +338,8 @@ def main():
             per_fold_f1.append(f1_score(yv, (pv > 0.5).astype(int), zero_division=0))
         mean_f1 = float(np.mean(per_fold_f1))
         std_f1 = float(np.std(per_fold_f1))
-        cv_results[name] = {"mean": mean_f1, "std": std_f1}
-        print(f"  {name}: CV F1 = {mean_f1:.3f} ± {std_f1:.3f}")
+        cv_results[name] = {"mean": mean_f1, "std": std_f1, "fit_seconds": round(elapsed, 1)}
+        print(f"  {name}: CV F1 = {mean_f1:.3f} ± {std_f1:.3f}  ({elapsed:.0f}s)", flush=True)
 
     best_name = max(cv_results, key=lambda n: cv_results[n]["mean"])
     best_f1 = cv_results[best_name]["mean"]
@@ -362,7 +374,10 @@ def main():
     print(f"{'='*60}\n")
 
     best_clf = candidates[best_name]
+    print(f"Refitting {best_name} on all {X.shape[0]} rows...", flush=True)
+    t0 = time.monotonic()
     best_clf.fit(X, labels)
+    print(f"  refit done in {time.monotonic() - t0:.0f}s", flush=True)
 
     all_proba = best_clf.predict_proba(X)[:, 1]
     thresholds = np.linspace(0.2, 0.9, 71)

--- a/mlops/tests/test_train_progress.py
+++ b/mlops/tests/test_train_progress.py
@@ -1,0 +1,46 @@
+"""An unattended trainer that prints only on completion cannot be told from a hung one.
+
+The 2026-08-29 run sat on one line for 31 minutes while GradientBoosting fit
+2,000 trees across 10 folds of a 12,684 x 1,540 matrix. Nothing was wrong; there
+was simply no way to know that from the log.
+"""
+import ast
+import pathlib
+
+TRAIN = pathlib.Path(__file__).resolve().parents[2] / "mlops" / "grounding" / "train.py"
+
+
+def _calls(tree):
+    return [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+
+
+def _is_print(node):
+    return isinstance(node.func, ast.Name) and node.func.id == "print"
+
+
+def test_every_fit_announces_itself_before_it_starts_and_flushes():
+    """A flushed print must precede each cross_val_predict and .fit, so the log
+    names the model currently running. Redirected to a file, an unflushed print
+    buys nothing — a 0-byte log is exactly what a hung process looks like."""
+    src = TRAIN.read_text()
+    tree = ast.parse(src)
+    fits = [n for n in _calls(tree)
+            if (isinstance(n.func, ast.Name) and n.func.id == "cross_val_predict")
+            or (isinstance(n.func, ast.Attribute) and n.func.attr == "fit")]
+    assert fits, "no model fits found — did the trainer change shape?"
+
+    prints = {n.lineno: n for n in _calls(tree) if _is_print(n)}
+    for call in fits:
+        window = range(max(1, call.lineno - 8), call.lineno)
+        near = [prints[ln] for ln in window if ln in prints]
+        assert near, f"fit at line {call.lineno} has no print in the 8 lines above it"
+        assert any(any(k.arg == "flush" for k in n.keywords) for n in near), (
+            f"the print announcing the fit at line {call.lineno} does not flush"
+        )
+
+
+def test_cv_results_record_how_long_each_model_took():
+    """Without a per-model duration nobody can tell which candidate costs the hour."""
+    src = TRAIN.read_text()
+    assert "fit_seconds" in src, "cv_results must carry a per-model fit duration"
+    assert "time.monotonic()" in src, "duration must come from a monotonic clock"


### PR DESCRIPTION
`train.py` printed a model's CV score only once that model had **finished**. On the first real run it sat on one line for **31 minutes**:

```
Cosine baseline 10-fold CV: F1 = 0.864 ± 0.012
  LogisticRegression: CV F1 = 0.898 ± 0.007
  ← 31 minutes, no output
```

Nothing was wrong. `GradientBoostingClassifier(n_estimators=200)` was fitting **2,000 trees across 10 folds of a 12,684 × 1,540 matrix** at 199% CPU. But an unattended job that goes silent for half an hour is indistinguishable from a hung one — which is the failure this loop has spent all week being (#238, #240, #241).

## After

```
  LogisticRegression: fitting 10 folds on 12684x1540...
  LogisticRegression: CV F1 = 0.898 ± 0.007  (18s)
  GradientBoostingClassifier: fitting 10 folds on 12684x1540...
```

Live output from this branch. **LogisticRegression is 18 seconds** — so the entire 31-minute silence is GradientBoosting, which was previously unknowable from the log.

Three fits announce themselves first now:

| site | was silent for |
|---|---|
| each candidate's `cross_val_predict` | the whole fit |
| each per-run `.fit` in the out-of-sample loop | the whole fit |
| the final refit of the winner on all rows | the whole fit |

Every progress print carries `flush=True`. Redirected to a file an unflushed print buys nothing, and a 0-byte log is exactly what a hang looks like — I watched this happen for 14 minutes before realising the run was fine.

Each candidate's wall time comes off a monotonic clock, prints with its score, and is kept in `cv_results` as `fit_seconds`, so it is answerable which model costs the hour.

## Tests

`mlops/tests/test_train_progress.py`, AST-based so they hold as the trainer changes shape. Three mutations, each caught:

| reverted | fails with |
|---|---|
| drop `flush=True` | `the print announcing the fit at line 328 does not flush` |
| announce after the fit | `fit at line 327 has no print in the 8 lines above it` |
| drop `fit_seconds` | `cv_results must carry a per-model fit duration` |

`mlops/` **552 passed**, ruff clean.

## Not fixed here

`mlops/grounding/train.py:183-196` contains a dead block — a `for topic in topics:` loop whose body computes `topic_emb`, calls `feat_pair(topic_emb if False else x["text"], x["text"])`, and ends in `pass`, followed by a comment reading `# Simpler: all pairs in test findings`. It computes a mean embedding per topic per held-out run and throws all of it away. Removing it is a behaviour-free speedup but a separate change.