### PR TITLE
mlops: resolve backends from the config file, not from a localhost that isn't there

### DIFF
--- a/deep_think_loci/grounding/build_grounding_dataset.py
+++ b/deep_think_loci/grounding/build_grounding_dataset.py
@@ -16,14 +16,41 @@ drop-in upgrade for when the corpus grows (high CV AUC = headroom).
 Usage:
   python3 build_grounding_dataset.py \
     --findings ~/.hermes/memory-sessions/dt-loci-*/findings.jsonl \
-    --out . [--ollama http://ollama.internal:11434/v1/embeddings]
+    --out . [--ollama http://ollama-host:11434/v1/embeddings]
 """
-import argparse, glob, itertools, json, os, random, re, urllib.request
+import argparse, glob, itertools, json, os, pathlib, random, re, urllib.request
 from collections import Counter
 import numpy as np
 
-EMB_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
-DEFAULT_OLLAMA = (os.environ.get("OLLAMA_BASE_URL") or "http://ollama.internal:11434").rstrip("/") + "/v1/embeddings"
+def _resolve_backends() -> None:
+    """Fill OLLAMA_BASE_URL/EMBED_MODEL from ~/.loci/backends.toml when unset.
+
+    Run standalone or from cron this inherits no MCP environment, and nothing
+    listens on ollama.internal or the localhost default. backends.py already
+    reads the config file that records the real endpoint; without this the run
+    dies at the first embedding call with a bare name-resolution error.
+
+    Called from main(), not on import: it writes to os.environ, which is right
+    for a run and wrong on import — a test that imports this module would
+    otherwise change what every other module in the process resolves."""
+    try:
+        import sys as _sys
+        _repo = pathlib.Path(__file__).resolve().parents[2]
+        _sys.path.insert(0, str(_repo / "mcp"))
+        import backends
+        backends.load_env(_repo)
+    except Exception:
+        pass  # a missing config is not a reason to refuse to run
+
+
+def _emb_model():
+    """Read at call time: _resolve_backends() runs after import."""
+    return os.environ.get("EMBED_MODEL") or "nomic-embed-text"
+
+
+def _default_ollama():
+    base = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
+    return base.rstrip("/") + "/v1/embeddings"
 
 
 def topic_of(rec):
@@ -42,7 +69,8 @@ def topic_of(rec):
 def embed(texts, url):
     out = []
     for i in range(0, len(texts), 16):
-        body = json.dumps({"model": EMB_MODEL, "input": [t[:2000] for t in texts[i:i + 16]]}).encode()
+        body = json.dumps({"model": _emb_model(),
+                           "input": [t[:2000] for t in texts[i:i + 16]]}).encode()
         req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
         out += [d["embedding"] for d in json.loads(urllib.request.urlopen(req, timeout=60).read())["data"]]
     v = np.array(out, dtype=np.float32)
@@ -53,9 +81,13 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--findings", nargs="+", required=True, help="findings.jsonl glob(s)")
     ap.add_argument("--out", default=".")
-    ap.add_argument("--ollama", default=DEFAULT_OLLAMA, help="embeddings endpoint (default: $OLLAMA_BASE_URL/v1/embeddings)")
+    ap.add_argument("--ollama", default=None,
+                    help="embeddings endpoint (default: $OLLAMA_BASE_URL, else "
+                         "~/.loci/backends.toml, else localhost:11434, + /v1/embeddings)")
     ap.add_argument("--neg-ratio", type=int, default=2)
     a = ap.parse_args()
+    _resolve_backends()
+    a.ollama = a.ollama or _default_ollama()
     random.seed(0); np.random.seed(0)
 
     files = [f for pat in a.findings for f in glob.glob(pat)]

--- a/mcp/backends.py
+++ b/mcp/backends.py
@@ -183,6 +183,67 @@ def memory_dir() -> str:
             or os.environ.get("LOCI_MEMORY_DIR") or os.environ.get("HERMES_MEMORY_DIR", "") or "")
 
 
+def load_env(repo: "Path | None" = None) -> dict:
+    """Put resolved backends into os.environ so unattended entry points can reach them.
+
+    A cron or CI run inherits none of the MCP launcher's environment, and on this
+    host the only record of the Ollama and Qdrant endpoints lives inside that
+    launcher's process. Without this, a scheduled job resolves the localhost
+    default, finds nothing listening, and reports every backend step "skipped" —
+    which reads as a schedule decision rather than a missing endpoint.
+
+    Precedence is unchanged: anything already in the environment wins, then the
+    repo .env files, then ~/.loci/backends.toml. Returns only what it set, so a
+    caller can log what it had to fill in. Also propagates to child processes,
+    which is what mlops/loop.py depends on.
+    """
+    root = Path(repo) if repo else Path(__file__).resolve().parent.parent
+    try:
+        from dotenv import load_dotenv
+        load_dotenv(root / ".env")
+        load_dotenv(root / "mcp" / ".env", override=True)
+    except Exception as exc:
+        logger.warning("load_env: .env unreadable (%r) — env-file settings, including "
+                       "LOCI_QDRANT_RETENTION_DAYS, will NOT be applied", exc)
+
+    resolved: dict = {}
+    if not os.environ.get("QDRANT_URL"):
+        try:
+            url, key = qdrant()
+            if url:
+                os.environ["QDRANT_URL"] = resolved["QDRANT_URL"] = url
+                if key and not os.environ.get("QDRANT_API_KEY"):
+                    os.environ["QDRANT_API_KEY"] = key
+        except Exception as exc:
+            logger.warning("load_env: could not resolve Qdrant: %r", exc)
+
+    if not os.environ.get("OLLAMA_BASE_URL"):
+        try:
+            url = ollama_url()
+            if url:
+                os.environ["OLLAMA_BASE_URL"] = resolved["OLLAMA_BASE_URL"] = url
+        except Exception as exc:
+            logger.warning("load_env: could not resolve Ollama: %r", exc)
+
+    if not os.environ.get("EMBED_MODEL"):
+        try:
+            model = embed_model()
+            if model:
+                os.environ["EMBED_MODEL"] = resolved["EMBED_MODEL"] = model
+        except Exception as exc:
+            logger.warning("load_env: could not resolve the embed model: %r", exc)
+
+    # backends.toml is stdlib tomllib, so the setting that protects the corpus needs no import.
+    if not os.environ.get("LOCI_QDRANT_RETENTION_DAYS"):
+        try:
+            days = _cfg("qdrant", "retention_days", None)
+            if days is not None:
+                os.environ["LOCI_QDRANT_RETENTION_DAYS"] = resolved["LOCI_QDRANT_RETENTION_DAYS"] = str(days)
+        except Exception as exc:
+            logger.warning("load_env: could not resolve retention: %r", exc)
+    return resolved
+
+
 def _reset_cache() -> None:
     """Test hook: clear memoized resolutions (env/config may have changed)."""
     for fn in (_config, ollama_url, vllm_url):

--- a/mcp/tests/test_backends_load_env.py
+++ b/mcp/tests/test_backends_load_env.py
@@ -1,0 +1,98 @@
+"""A scheduled run inherits none of the MCP launcher's environment.
+
+On this host the Ollama and Qdrant endpoints existed only inside that launcher's
+process, so cron resolved localhost:11434, found nothing listening, and reported
+every embedding step "skipped" — which reads as a schedule decision rather than a
+missing endpoint. load_env() puts the config file's values into os.environ, where
+child processes can see them too.
+"""
+import os
+import sys
+import pathlib
+import importlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import backends  # noqa: E402
+
+
+VARS = ("OLLAMA_BASE_URL", "QDRANT_URL", "QDRANT_API_KEY", "EMBED_MODEL",
+        "LOCI_QDRANT_RETENTION_DAYS", "OLLAMA_URL")
+
+
+def _clean(monkeypatch):
+    for v in VARS:
+        monkeypatch.delenv(v, raising=False)
+    backends._reset_cache()
+
+
+def _config(monkeypatch, tmp_path, body):
+    cfg = tmp_path / "backends.toml"
+    cfg.write_text(body)
+    monkeypatch.setenv("LOCI_CONFIG", str(cfg))
+    monkeypatch.setattr(backends, "_CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(backends, "_alive", lambda url, timeout=1.0: False)
+    backends._reset_cache()
+
+
+def test_config_file_reaches_the_environment(monkeypatch, tmp_path):
+    _clean(monkeypatch)
+    _config(monkeypatch, tmp_path, '''
+[ollama]
+url = "http://gpu-host:11434"
+[embed]
+model = "some-embed-model"
+[qdrant]
+url = "http://qdrant-host:6333"
+api_key = "sekrit"
+retention_days = 0
+''')
+    resolved = backends.load_env(tmp_path)
+
+    assert os.environ["OLLAMA_BASE_URL"] == "http://gpu-host:11434"
+    assert os.environ["QDRANT_URL"] == "http://qdrant-host:6333"
+    assert os.environ["QDRANT_API_KEY"] == "sekrit"
+    assert os.environ["EMBED_MODEL"] == "some-embed-model"
+    assert os.environ["LOCI_QDRANT_RETENTION_DAYS"] == "0"
+    assert set(resolved) >= {"OLLAMA_BASE_URL", "QDRANT_URL", "EMBED_MODEL"}
+
+
+def test_an_existing_environment_variable_always_wins(monkeypatch, tmp_path):
+    """A power-user override must survive; the config file is the fallback."""
+    _clean(monkeypatch)
+    _config(monkeypatch, tmp_path, '[ollama]\nurl = "http://from-config:11434"\n')
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://from-env:11434")
+
+    resolved = backends.load_env(tmp_path)
+
+    assert os.environ["OLLAMA_BASE_URL"] == "http://from-env:11434"
+    assert "OLLAMA_BASE_URL" not in resolved, "must not report what it did not set"
+
+
+def test_a_missing_config_file_is_not_an_error(monkeypatch, tmp_path):
+    """Fail-open: an unconfigured machine still runs, on its own local backends."""
+    _clean(monkeypatch)
+    monkeypatch.setattr(backends, "_CONFIG_PATH", str(tmp_path / "nope.toml"))
+    monkeypatch.setattr(backends, "_alive", lambda url, timeout=1.0: False)
+    backends._reset_cache()
+
+    resolved = backends.load_env(tmp_path)
+    assert "OLLAMA_BASE_URL" not in resolved
+    assert isinstance(resolved, dict)
+
+
+def test_the_loop_resolves_at_run_time_not_import_time(monkeypatch, tmp_path):
+    """An import-time default is fixed before the config file is ever read, and
+    mutating os.environ on import leaks into every other module in the process."""
+    _clean(monkeypatch)
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location("loop_probe", repo / "mlops" / "loop.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert os.environ.get("OLLAMA_BASE_URL") is None, (
+        "importing mlops.loop must not write to the environment"
+    )
+    src = (repo / "mlops" / "loop.py").read_text()
+    assert 'ap.add_argument("--ollama", default=None' in src, (
+        "--ollama must default to None so the config file gets a say"
+    )

--- a/mlops/grounding/tests/test_grounding.py
+++ b/mlops/grounding/tests/test_grounding.py
@@ -862,7 +862,7 @@ def test_embed_texts_batches_by_sixteen_and_hits_the_v1_endpoint(fake_ollama):
     out = train.embed_texts([f"text {i}" for i in range(20)], "http://host:11434/", cache)
     assert [len(c["body"]["input"]) for c in fake_ollama] == [16, 4]
     assert fake_ollama[0]["url"] == "http://host:11434/v1/embeddings"
-    assert fake_ollama[0]["body"]["model"] == train.EMB_MODEL == "nomic-embed-text"
+    assert fake_ollama[0]["body"]["model"] == train._emb_model() == "nomic-embed-text"
     assert fake_ollama[0]["timeout"] == 60
     assert out.shape == (20, 2)
 
@@ -1211,3 +1211,12 @@ def test_hard_negatives_defaults_missing_label_to_zero(tmp_path):
     recs = [{"text": "the quick brown fox"}, {"text": "the quick brown dog"}]
     p.write_text("".join(json.dumps(r) + "\n" for r in recs))
     assert al.hard_negatives(str(p)) == []
+
+
+def test_embed_model_is_read_at_call_time_not_import_time(monkeypatch):
+    """A module constant is fixed before _resolve_backends() has read the config
+    file, so an EMBED_MODEL set there would never reach the request body."""
+    monkeypatch.setenv("EMBED_MODEL", "some-other-embedder")
+    assert train._emb_model() == "some-other-embedder"
+    monkeypatch.delenv("EMBED_MODEL")
+    assert train._emb_model() == "nomic-embed-text"

--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -4,13 +4,38 @@ import glob
 import hashlib
 import json
 import os
+import pathlib
 import time
 import urllib.request
 from datetime import datetime, timezone
 
 import numpy as np
 
-EMB_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+
+def _resolve_backends() -> None:
+    """Fill OLLAMA_BASE_URL/EMBED_MODEL from ~/.loci/backends.toml when unset.
+
+    Run standalone or from cron this inherits no MCP environment, and nothing
+    listens on the localhost default. backends.py already reads the config file
+    that records the real endpoint; without this the run fails at the first
+    embedding call with a bare connection-refused.
+
+    Called from __main__ only. It writes to os.environ, which is right for a run
+    and wrong on import — a test that imports this module would otherwise change
+    what every other module in the process resolves."""
+    try:
+        import sys as _sys
+        _repo = pathlib.Path(__file__).resolve().parents[2]
+        _sys.path.insert(0, str(_repo / "mcp"))
+        import backends
+        backends.load_env(_repo)
+    except Exception:
+        pass  # a missing config is not a reason to refuse to run
+
+
+def _emb_model():
+    """Read at call time: _resolve_backends() runs after import."""
+    return os.environ.get("EMBED_MODEL") or "nomic-embed-text"
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 CLF_PATH = os.path.join(REPO_ROOT, "deep_think_loci", "grounding", "grounding_bleed_clf.joblib")
 CACHE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".emb_cache.npz")
@@ -51,7 +76,7 @@ def embed_texts(texts: list, ollama_base: str, cache: dict) -> np.ndarray:
     need = [t for t in texts if _sha(t) not in cache]
     for i in range(0, len(need), 16):
         batch = [t[:2000] for t in need[i:i + 16]]
-        body = json.dumps({"model": EMB_MODEL, "input": batch}).encode()
+        body = json.dumps({"model": _emb_model(), "input": batch}).encode()
         req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
         resp = json.loads(urllib.request.urlopen(req, timeout=60).read())
         for j, d in enumerate(resp["data"]):
@@ -253,11 +278,15 @@ def main():
     ap.add_argument("--dataset", default=os.path.join(REPO_ROOT, "deep_think_loci", "grounding", "grounding_dataset.jsonl"))
     ap.add_argument("--out", default=os.path.join(REPO_ROOT, "mlops", "grounding", "train_metrics.json"))
     ap.add_argument("--findings-glob", default=None)
-    ap.add_argument("--ollama", default=(os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"))
+    ap.add_argument("--ollama", default=None,
+                    help="Ollama base URL. Default: $OLLAMA_BASE_URL, else "
+                         "~/.loci/backends.toml, else http://localhost:11434")
     ap.add_argument("--dry-run", action="store_true", help="Eval only; never write the joblib")
     ap.add_argument("--candidate-out", default=None,
                     help="Write winning candidate model here instead of live path (used by loop.py)")
     args = ap.parse_args()
+    _resolve_backends()
+    args.ollama = args.ollama or os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
 
     from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
     from sklearn.linear_model import LogisticRegression

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -31,11 +31,21 @@ from pathlib import Path
 STEP_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_STEP_TIMEOUT", "3600"))
 
 
+CHILD_ENV: dict[str, str] = {}
+
+
 def _run(cmd, timeout: int | None = None):
-    """subprocess.run with a bound. A hung child stalls the whole nightly."""
+    """subprocess.run with a bound, plus whatever backends resolved for the children.
+
+    A hung child stalls the whole nightly, and a child that cannot see
+    OLLAMA_BASE_URL falls back to a localhost nothing listens on. The resolved
+    values are handed over here rather than written into this process's own
+    environment, so importing this module changes nothing for anyone else.
+    """
     limit = timeout or STEP_TIMEOUT_S
+    env = {**os.environ, **CHILD_ENV} if CHILD_ENV else None
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=limit)
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=limit, env=env)
     except subprocess.TimeoutExpired as exc:
         out = exc.stdout if isinstance(exc.stdout, str) else ""
         return subprocess.CompletedProcess(cmd, 124, out,
@@ -87,6 +97,37 @@ CANDIDATE_MODEL = MLOPS / "grounding" / "candidate.joblib"
 LIVE_MODEL = GROUNDING_DIR / "grounding_bleed_clf.joblib"
 DATASET = GROUNDING_DIR / "grounding_dataset.jsonl"
 ACTIVE_CANDIDATES = MLOPS / "grounding" / "active_candidates.jsonl"
+
+def _resolve_backends() -> dict:
+    """Fill OLLAMA_BASE_URL and friends from ~/.loci/backends.toml at run time.
+
+    Nothing listens on localhost:11434 on a scheduled host — the endpoint is
+    recorded in the config file that backends.py already reads, and until now
+    only the MCP launcher's own process environment carried it. Without this the
+    loop resolves the localhost default, every embedding step fails or skips, and
+    the log blames the cadence.
+
+    backends.load_env writes into os.environ, which is right for a real run and
+    wrong for a test process, so the values are captured, this process is put
+    back the way it was, and CHILD_ENV carries them to the children instead.
+    """
+    before = dict(os.environ)
+    try:
+        sys.path.insert(0, str(REPO / "mcp"))
+        import backends
+        resolved = backends.load_env(REPO)
+    except Exception as exc:  # never block a run on config resolution
+        print(f"[loop] backend resolution unavailable: {exc}")
+        resolved = {}
+    for key in resolved:
+        if key in before:
+            os.environ[key] = before[key]
+        else:
+            os.environ.pop(key, None)
+    CHILD_ENV.clear()
+    CHILD_ENV.update(resolved)
+    return resolved
+
 
 DEFAULT_OLLAMA = (os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434").rstrip("/")
 DEFAULT_FINDINGS = os.path.expanduser("~/.hermes/memory-sessions/dt-loci-*/findings.jsonl")
@@ -400,7 +441,9 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Loci MLOps self-closing loop")
     ap.add_argument("--findings", default=DEFAULT_FINDINGS,
                     help="Glob for investigation findings.jsonl files")
-    ap.add_argument("--ollama", default=DEFAULT_OLLAMA)
+    ap.add_argument("--ollama", default=None,
+                    help="Ollama base URL. Default: $OLLAMA_BASE_URL, else ~/.loci/backends.toml, "
+                         "else http://localhost:11434")
     ap.add_argument("--min-new-runs", type=int, default=2,
                     help="Minimum new investigation runs before retraining (default: 2)")
     ap.add_argument("--min-new-pairs", type=int, default=200,
@@ -423,12 +466,19 @@ def main() -> int:
     args = ap.parse_args()
 
     FAILED_STEPS.clear()  # module-global; a second main() in one process must start clean
+    resolved = _resolve_backends()
+    if args.ollama is None:
+        args.ollama = (os.environ.get("OLLAMA_BASE_URL")
+                       or resolved.get("OLLAMA_BASE_URL")
+                       or "http://localhost:11434").rstrip("/")
 
     now = datetime.now(timezone.utc)
     now_iso = now.isoformat()
     state = _load_state()
 
     print(f"[loop] starting at {now_iso}")
+    if resolved:
+        print("[loop] resolved from backends.toml: " + ", ".join(sorted(resolved)))
     print(f"[loop] state: last_run={state['last_run']} dataset={state['last_dataset_size']} promotions={state['total_promotions']}")
 
     # ── 1. Ollama probe ────────────────────────────────────────────────────────

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -882,6 +882,10 @@ def mainenv(env, monkeypatch):
             return ret
         return f
 
+    # Hermetic: without this the suite reads the developer's ~/.loci/backends.toml
+    # and the asserted Ollama default becomes whatever that machine has configured.
+    monkeypatch.setattr(loop, "_resolve_backends", lambda: {})
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
     monkeypatch.setattr(loop, "_ollama_ok", lambda base: rv["ollama_ok"])
     monkeypatch.setattr(loop, "_discover_runs", lambda g, seen: list(rv["new_runs"]))
     monkeypatch.setattr(loop, "_rebuild_dataset", lambda g, o: (

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -1417,11 +1417,13 @@ def test_main_default_thresholds(mainenv, capsys):
 
 def test_main_argparse_defaults(mainenv, monkeypatch):
     captured = {}
+    namespaces = []
     real_parse = loop.argparse.ArgumentParser.parse_args
 
     def spy(self, *a, **k):
         ns = real_parse(self, *a, **k)
         captured.update(vars(ns))
+        namespaces.append(ns)
         return ns
 
     monkeypatch.setattr(loop.argparse.ArgumentParser, "parse_args", spy)
@@ -1435,7 +1437,10 @@ def test_main_argparse_defaults(mainenv, monkeypatch):
     assert captured["dry_run"] is False
     assert captured["force"] is False
     assert captured["findings"] == loop.DEFAULT_FINDINGS
-    assert captured["ollama"] == loop.DEFAULT_OLLAMA
+    # --ollama parses as None and is resolved after, so the config file gets a say;
+    # an import-time default would have been fixed before backends.toml was read.
+    assert captured["ollama"] is None
+    assert namespaces[0].ollama, "main() must fill in an Ollama URL"
     assert captured["db"] == loop.DEFAULT_DB
     assert captured["hook_state"] == loop.DEFAULT_HOOK_STATE
 


### PR DESCRIPTION
The last thing standing between the MLOps loop and running unattended.

`mlops/loop.py`, `mlops/grounding/train.py` and `deep_think_loci/grounding/build_grounding_dataset.py` each defaulted Ollama to `localhost:11434` — the builder to `ollama.internal:11434`. **Nothing listens on either here.** The reachable instance is recorded in `~/.loci/backends.toml`, which `backends.py` has always read:

```
$ env -u OLLAMA_BASE_URL python -c "import backends; print(backends.ollama_url())"
http://10.42.0.1:11434      ← reachable, serving nomic-embed-text
```

But only the MCP server ever called it, so the endpoint existed solely inside that launcher's process environment. A cron or CI run inherits none of it, resolves the localhost default, and every embedding step fails or "skips" — and #240 showed those skips get reported as cadence decisions.

`scripts/loci_groom.py` hit this first and says so in its own docstring (*"A cron job does not inherit the MCP launcher's environment"*). The MLOps path never got the same treatment.

## `backends.load_env()`

The resolution, in the module that already owns it: env wins, then repo `.env`, then `backends.toml`; returns only what it filled in.

`loci_groom` keeps its own copy. Its guard test pins that it resolves through backends' *primitives* itself, and that guard exists because `load_env` once reported success while leaving retention at 30 — which would have let the groomer purge the corpus it was there to repair. Not worth weakening to save a duplicate.

## Everything resolves at run time

`--ollama` defaults to `None` in all three and is filled after `parse_args`; `EMBED_MODEL` is read per request rather than captured into a module constant. An import-time default is fixed before the config file is ever read.

The first version of this change proved the other half. Writing to `os.environ` on import leaked into every module in the process:

```
FAILED test_canary_constants - assert 'http://localhost:11434' == 'http://10.42.0.1:11434'
```

`canary`'s own default changed because `train` had been imported first. So the loop hands resolved values to its children through `subprocess(env=...)` and restores its own environment; the two scripts resolve inside `main()`.

## Verified with the environment stripped

```
$ env -u OLLAMA_BASE_URL -u OLLAMA_URL -u EMBED_MODEL -u QDRANT_URL \
    python deep_think_loci/grounding/build_grounding_dataset.py ...
wrote grounding_dataset.jsonl (12684), grounding_bleed_clf.joblib, metrics.json
```

Before: `urllib.error.URLError: <urlopen error [Errno -2] Name or service not known>`. `train.py` likewise embeds and starts fitting on a bare environment.

## Tests

`mcp/tests/test_backends_load_env.py` — config reaches the environment; an existing variable always wins and is *not* reported as resolved; a missing file is not an error; importing `mlops.loop` writes nothing. Plus one pinning `EMBED_MODEL` to call-time. Each fails under the matching mutation:

| reverted | fails |
|---|---|
| `load_env` overrides an existing env var | `test_an_existing_environment_variable_always_wins` |
| `--ollama` back to an import-time default | `test_the_loop_resolves_at_run_time_not_import_time` |
| config no longer reaches `EMBED_MODEL` | `test_config_file_reaches_the_environment` |

Also made `mainenv` hermetic. Two existing tests asserted the default is `localhost:11434` — true in CI, which has no `backends.toml`, and false on any machine that does. A test whose result depends on the developer's config file is not testing the loop.

`mlops` + `eval` **650 passed**, `a2a_server` 96, `mcp` 813 (`test_graph_integration` fails identically on clean `main` — checked both ways). ruff unchanged.