### PR TITLE
mlops: stream a child's output instead of dumping a tail after it exits

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -34,22 +35,79 @@ STEP_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_STEP_TIMEOUT", "3600"))
 CHILD_ENV: dict[str, str] = {}
 
 
-def _run(cmd, timeout: int | None = None):
-    """subprocess.run with a bound, plus whatever backends resolved for the children.
+def _child_label(cmd) -> str:
+    """The script being run, for prefixing its output in a merged log."""
+    for part in cmd[1:]:
+        if isinstance(part, str) and part.endswith(".py"):
+            return Path(part).stem
+    return Path(str(cmd[0])).stem
 
-    A hung child stalls the whole nightly, and a child that cannot see
-    OLLAMA_BASE_URL falls back to a localhost nothing listens on. The resolved
-    values are handed over here rather than written into this process's own
-    environment, so importing this module changes nothing for anyone else.
+
+def _run(cmd, timeout: int | None = None, stream: bool = True):
+    """Run a child with a bound, resolved backends, and its output echoed live.
+
+    Three things a nightly needs and subprocess.run does not give together.
+
+    A hung child stalls the whole run, so every call is bounded and a timeout
+    comes back as returncode 124 rather than an exception.
+
+    A child that cannot see OLLAMA_BASE_URL falls back to a localhost nothing
+    listens on, so CHILD_ENV carries what backends resolved. It is handed over
+    here rather than written into this process's own environment, so importing
+    this module changes nothing for anyone else.
+
+    And capture_output alone buffers everything until the child exits: train.py
+    prints which model it is fitting, and none of that reached this log until the
+    step was already over — 17 minutes of silence in the log cron actually mails
+    you. Output is streamed as it arrives AND captured, so callers that parse
+    result.stdout keep working. PYTHONUNBUFFERED is set because a child writing
+    to a pipe block-buffers by default, which would make the streaming a no-op.
     """
     limit = timeout or STEP_TIMEOUT_S
-    env = {**os.environ, **CHILD_ENV} if CHILD_ENV else None
+    env = {**os.environ, **CHILD_ENV}
+    env["PYTHONUNBUFFERED"] = "1"
+    if not stream:
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True,
+                                  timeout=limit, env=env)
+        except subprocess.TimeoutExpired as exc:
+            out = exc.stdout if isinstance(exc.stdout, str) else ""
+            return subprocess.CompletedProcess(cmd, 124, out,
+                                               f"timed out after {limit}s")
+
+    label = _child_label(cmd)
+    captured: dict[str, list[str]] = {"out": [], "err": []}
+
+    def drain(pipe, key, echo):
+        try:
+            for line in pipe:
+                captured[key].append(line)
+                if echo:
+                    print(f"  [{label}] {line.rstrip()}", flush=True)
+        finally:
+            pipe.close()
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            text=True, bufsize=1, env=env)
+    threads = [
+        threading.Thread(target=drain, args=(proc.stdout, "out", True), daemon=True),
+        threading.Thread(target=drain, args=(proc.stderr, "err", False), daemon=True),
+    ]
+    for t in threads:
+        t.start()
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=limit, env=env)
-    except subprocess.TimeoutExpired as exc:
-        out = exc.stdout if isinstance(exc.stdout, str) else ""
-        return subprocess.CompletedProcess(cmd, 124, out,
-                                           f"timed out after {limit}s")
+        code = proc.wait(timeout=limit)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        code = 124
+    for t in threads:
+        t.join(timeout=5)
+    err = "".join(captured["err"])
+    if code == 124:
+        err = (err + f"\ntimed out after {limit}s").strip()
+    return subprocess.CompletedProcess(cmd, code, "".join(captured["out"]), err)
+
 
 REPO = Path(__file__).parent.parent
 MLOPS = REPO / "mlops"
@@ -236,7 +294,6 @@ def _retrain(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
         cmd.append("--dry-run")
 
     result = _run(cmd)
-    print(result.stdout[-1000:])
     if result.returncode != 0:
         _fail("train.py", f"train.py failed: {_last_error_line(result.stderr)}")
         return None
@@ -264,7 +321,6 @@ def _run_canary(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
         cmd.append("--dry-run")
 
     result = _run(cmd)
-    print(result.stdout[-1000:])
     if result.returncode == 1:
         print("[loop] ALERT: canary drift detected")
     return {"exit_code": result.returncode, "stdout": result.stdout[-500:]}
@@ -285,7 +341,6 @@ def _run_sft_bake(ollama: str, dry_run: bool) -> bool:
          "--traces", str(traces), "--out", str(sft), "--mode", "both"],
     ]:
         r = _run(cmd)
-        print(r.stdout[-500:])
         if r.returncode != 0:
             _fail("SFT bake", f"SFT step failed: {_last_error_line(r.stderr)}")
             return False
@@ -300,7 +355,6 @@ def _run_sft_bake(ollama: str, dry_run: bool) -> bool:
             "--sft", str(sft), "--backend", "ollama-modelfile",
         ]
         r = _run(bake_cmd)
-        print(r.stdout[-500:])
         return r.returncode == 0
     return True
 
@@ -372,14 +426,12 @@ def _run_embedding_drift(ollama: str, dry_run: bool) -> dict:
                "--dataset", str(DATASET), "--ollama", ollama,
                "--anchor", str(anchor), "--build-anchor"]
         result = _run(cmd)
-        print(result.stdout[-300:])
         return {"built_anchor": True}
     out_path = MLOPS / "embedding" / "drift_result.json"
     cmd = [sys.executable, str(drift_script),
            "--dataset", str(DATASET), "--ollama", ollama,
            "--anchor", str(anchor), "--out", str(out_path)]
     result = _run(cmd)
-    print(result.stdout[-300:])
     if result.returncode == 1:
         print("[loop] ALERT: embedding drift detected — scheduling embedding fine-tune")
         if not dry_run:
@@ -407,7 +459,6 @@ def _run_active_learn(ollama: str) -> dict:
          "--out", str(ACTIVE_CANDIDATES),
          "--ollama", ollama],
     )
-    print(result.stdout[-300:])
     return {"exit_code": result.returncode}
 
 

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -94,7 +94,11 @@ def env(tmp_path, monkeypatch):
     monkeypatch.setattr(loop, "ACTIVE_CANDIDATES", mlops / "grounding" / "active_candidates.jsonl")
 
     runner = Runner()
-    monkeypatch.setattr(loop.subprocess, "run", runner)
+    # Patch _run, not subprocess.run: _run streams a live child through Popen, and
+    # what these tests are about is what the callers do with the result. _run's own
+    # bounding and streaming are covered against real children in
+    # test_loop_timeouts.py and test_loop_streaming.py.
+    monkeypatch.setattr(loop, "_run", runner)
 
     saved_path = list(sys.path)
     yield types.SimpleNamespace(
@@ -408,10 +412,13 @@ def test_retrain_propagates_malformed_metrics_json(env):
         loop._retrain("g", "o", False)
 
 
-def test_retrain_prints_last_1000_chars_of_stdout(env, capsys):
+def test_retrain_does_not_re_print_stdout_after_the_fact(env, capsys):
+    """It used to dump the last 1000 chars once train.py had exited, which is the
+    one moment the output is no longer useful. _run streams it live instead, so
+    printing it again here would only duplicate it."""
     env.run.set("train.py", FakeResult(0, stdout="Y" * 1500))
     loop._retrain("g", "o", False)
-    assert capsys.readouterr().out.count("Y") == 1000
+    assert capsys.readouterr().out.count("Y") == 0
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/mlops/tests/test_loop_streaming.py
+++ b/mlops/tests/test_loop_streaming.py
@@ -1,0 +1,139 @@
+"""A nightly that shows nothing until a step finishes cannot be watched.
+
+train.py announces which model it is fitting, but loop.py collected that with
+capture_output and printed a tail once the child had exited — so the log cron
+mails you was silent for the 17 minutes the step actually took, which is
+indistinguishable from a hang. These run real children, because the defect was
+in the plumbing, not in a caller.
+"""
+import subprocess
+import sys
+import threading
+import textwrap
+import time
+
+import pytest
+
+sys.path.insert(0, __file__.rsplit("/mlops/", 1)[0])
+from mlops import loop  # noqa: E402
+
+
+def _child(body: str):
+    return [sys.executable, "-c", textwrap.dedent(body)]
+
+
+class _Recorder:
+    """Thread-safe stand-in for sys.stdout so the main thread can watch what the
+    drain thread has written so far."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._buf = []
+
+    def write(self, text):
+        with self._lock:
+            self._buf.append(text)
+        return len(text)
+
+    def flush(self):
+        pass
+
+    def seen(self):
+        with self._lock:
+            return "".join(self._buf)
+
+
+def test_output_appears_while_the_child_is_still_running(monkeypatch):
+    """The whole point. capfd cannot tell live output from a dump at exit, so
+    watch the parent's stdout from another thread while the child still sleeps."""
+    rec = _Recorder()
+    monkeypatch.setattr(sys, "stdout", rec)
+    result = {}
+
+    def go():
+        result["r"] = loop._run(_child("""
+            import time
+            print("first line")
+            time.sleep(4.0)
+            print("second line")
+        """), timeout=30)
+
+    t = threading.Thread(target=go, daemon=True)
+    started = time.monotonic()
+    t.start()
+
+    deadline = started + 3.0          # comfortably inside the child's 4s sleep
+    while time.monotonic() < deadline and "first line" not in rec.seen():
+        time.sleep(0.05)
+
+    saw_at = time.monotonic() - started
+    assert "first line" in rec.seen(), (
+        f"nothing after {saw_at:.1f}s while the child was still running — "
+        "output is being buffered until exit, which is the bug"
+    )
+    assert "second line" not in rec.seen(), "the child cannot have finished yet"
+
+    t.join(timeout=30)
+    assert result["r"].returncode == 0
+    assert "first line" in result["r"].stdout, "streaming must not stop capture"
+    assert "second line" in result["r"].stdout
+
+
+def test_a_child_writing_to_a_pipe_is_not_block_buffered(capfd):
+    """Without PYTHONUNBUFFERED the child buffers 8KB before the first flush, and
+    the streaming is a no-op for exactly the small progress lines it exists for."""
+    result = loop._run(_child('''
+        print("tiny")
+    '''), timeout=30)
+    assert "tiny" in capfd.readouterr().out
+    assert "tiny" in result.stdout
+
+
+def test_stdout_is_still_captured_for_callers_that_parse_it(capfd):
+    """_run_active_learn and the drift step read result.stdout as data."""
+    result = loop._run(_child('''
+        import json
+        print(json.dumps({"drift": 0.4}))
+    '''), timeout=30)
+    capfd.readouterr()
+    assert '"drift"' in result.stdout
+    assert result.returncode == 0
+
+
+def test_stderr_is_captured_but_not_echoed(capfd):
+    """Failures print one extracted line via _fail; echoing the whole traceback
+    live would bury it."""
+    result = loop._run(_child('''
+        import sys
+        sys.stderr.write("boom\\n")
+        sys.exit(3)
+    '''), timeout=30)
+    assert "boom" not in capfd.readouterr().out
+    assert "boom" in result.stderr
+    assert result.returncode == 3
+
+
+def test_a_hung_child_is_killed_and_reported_as_124(capfd):
+    result = loop._run(_child('''
+        import time
+        print("started")
+        time.sleep(60)
+    '''), timeout=2)
+    assert result.returncode == 124
+    assert "timed out after 2s" in result.stderr
+    assert "started" in capfd.readouterr().out, "output before the kill is kept"
+
+
+def test_the_label_names_the_script_not_the_interpreter():
+    assert loop._child_label([sys.executable, "/a/b/train.py", "--x"]) == "train"
+    assert loop._child_label([sys.executable, "/a/build_grounding_dataset.py"]) \
+        == "build_grounding_dataset"
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_both_modes_return_the_same_completedprocess_shape(stream, capfd):
+    result = loop._run(_child('print("x")'), timeout=30, stream=stream)
+    capfd.readouterr()
+    assert isinstance(result, subprocess.CompletedProcess)
+    assert result.returncode == 0
+    assert "x" in result.stdout


### PR DESCRIPTION
#242 made `train.py` announce each fit before starting it. That fixed nothing for the loop.

`_run` collected the child with `capture_output=True`, and every caller then printed a tail of `result.stdout` **once the step was over**. Watching a real run:

```
[loop] dataset rebuilt → 12684 pairs
[loop] dataset after rebuild: 12684 pairs (+7266)
  ← 17 minutes, nothing
```

The progress lines existed. They were sitting in a pipe. This is the same silence #242 set out to remove, one level up — in the log cron actually mails you.

## The fix

`_run` drives the child through `Popen` and drains both pipes on threads: stdout is echoed line by line as it arrives *and* accumulated, so `result.stdout` still works for the callers that parse it. Lines carry the script name, since several children write into one log:

```
  [train] LogisticRegression: fitting 10 folds on 12684x1540...
  [train] LogisticRegression: CV F1 = 0.898 ± 0.007  (18s)
  [train] GradientBoostingClassifier: fitting 10 folds on 12684x1540...
```

`PYTHONUNBUFFERED=1` is set for the child. A process writing to a pipe block-buffers at 8KB by default, so **without this the streaming is a no-op** for exactly the short progress lines it exists for. Removing that one line fails two of these tests.

`stderr` is captured but not echoed — failures surface one extracted line through `_fail()` (#240), and echoing whole tracebacks live would bury it.

The seven `print(result.stdout[-N:])` calls are gone; they would now only repeat what has already been printed. `_run_active_learn` still returns its stdout as *data*, which is a different thing.

## Test boundary moved

The suite patched `subprocess.run`, which a streaming `_run` no longer calls. The fixture patches `loop._run` instead — those tests are about what the callers do with a result, and `_run`'s own behaviour is covered against real children here and in `test_loop_timeouts.py`.

## Tests

Eight, all driving real subprocesses. The liveness one is the important one: `capfd` **cannot tell live output from a dump at exit**, so it watches the parent's stdout from a second thread while the child is still sleeping, and fails if nothing has appeared 3s into a 4s sleep.

| reverted | fails |
|---|---|
| `stream` defaults to False | 3 tests, incl. liveness |
| drop `PYTHONUNBUFFERED` | 2 tests |
| echo stderr live too | `test_stderr_is_captured_but_not_echoed` |
| stop capturing while streaming | 5 tests |

`mlops` **561 passed**, `a2a_server` 96, `mcp` 813 (`test_graph_integration` fails identically on clean `main`). ruff clean.

## Note

`eval/tests/test_eval.py::test_gge_run_reads_the_real_repo_dataset_in_dry_mode` asserts `pairs=5235` against the **live** `deep_think_loci/grounding/grounding_dataset.jsonl`, so it fails on any machine where a real loop run has rebuilt it — mine, right now, at 12,684. Not touched here, but it means the eval suite is not safe to run beside a live loop.