### PR TITLE
grounding: run the cross-validation folds in parallel

### DIFF
--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -33,6 +33,15 @@ def _resolve_backends() -> None:
         pass  # a missing config is not a reason to refuse to run
 
 
+# Folds are independent, so they run in parallel. Serial 10-fold
+# GradientBoosting over 12,684 x 1,540 took over 45 minutes on a 28-core box —
+# long enough that the loop's own 3600s step bound would cut the nightly before
+# it finished. Measured 5.2x here (not 10x: GBC is single-threaded per fold, the
+# folds do not balance evenly, and BLAS threads contend). Parallelism lives at
+# the CV level only; giving the estimators n_jobs as well just oversubscribes.
+CV_JOBS = int(os.environ.get("LOCI_TRAIN_CV_JOBS", "-1"))
+
+
 def _emb_model():
     """Read at call time: _resolve_backends() runs after import."""
     return os.environ.get("EMBED_MODEL") or "nomic-embed-text"
@@ -352,12 +361,14 @@ def main():
         # matrix is 2,000 trees x 10 folds and runs for tens of minutes; printing
         # only on completion leaves an unattended run silent and indistinguishable
         # from hung.
-        print(f"  {name}: fitting 10 folds on {X.shape[0]}x{X.shape[1]}...", flush=True)
+        print(f"  {name}: fitting 10 folds on {X.shape[0]}x{X.shape[1]} "
+              f"(n_jobs={CV_JOBS})...", flush=True)
         t0 = time.monotonic()
         proba = cross_val_predict(
             clf, X, labels,
             cv=StratifiedKFold(n_splits=10, shuffle=True, random_state=42),
             method="predict_proba",
+            n_jobs=CV_JOBS,
         )[:, 1]
         elapsed = time.monotonic() - t0
         per_fold_f1 = []

--- a/mlops/tests/test_train_parallel_folds.py
+++ b/mlops/tests/test_train_parallel_folds.py
@@ -1,0 +1,89 @@
+"""Serial cross-validation made the nightly uncompletable.
+
+A 10-fold GradientBoosting over the 12,684 x 1,540 feature matrix ran for more
+than 45 minutes on a 28-core box, one fold at a time — longer than the loop's own
+3600s step bound, so the step would be cut every night before it produced a
+score. The folds are independent; nothing required them to be serial.
+"""
+import ast
+import os
+import pathlib
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+TRAIN = REPO / "mlops" / "grounding" / "train.py"
+sys.path.insert(0, str(REPO))
+
+
+def _call(name):
+    for node in ast.walk(ast.parse(TRAIN.read_text())):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id == name:
+            return node
+    return None
+
+
+def test_cross_validation_is_parallel():
+    call = _call("cross_val_predict")
+    assert call is not None, "no cross_val_predict — did the trainer change shape?"
+    kw = {k.arg for k in call.keywords}
+    assert "n_jobs" in kw, (
+        "cross_val_predict without n_jobs runs one fold at a time; the real "
+        "matrix takes >45 min that way and the step bound cuts it"
+    )
+
+
+def test_the_estimators_do_not_also_claim_every_core():
+    """Parallelism belongs at the CV level. An estimator n_jobs on top of it
+    oversubscribes: 10 folds x 28 workers on 28 cores is slower, not faster."""
+    src = TRAIN.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id in ("RandomForestClassifier",
+                                     "GradientBoostingClassifier",
+                                     "LogisticRegression"):
+            assert not any(k.arg == "n_jobs" for k in node.keywords), (
+                f"{node.func.id} sets n_jobs; keep parallelism at the CV level"
+            )
+
+
+def test_the_job_count_is_configurable():
+    """A shared or small box needs a way to not take every core."""
+    import importlib
+    os.environ["LOCI_TRAIN_CV_JOBS"] = "3"
+    spec = importlib.util.spec_from_file_location("train_probe", TRAIN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    try:
+        assert mod.CV_JOBS == 3
+    finally:
+        del os.environ["LOCI_TRAIN_CV_JOBS"]
+
+
+def test_parallel_folds_are_actually_faster():
+    """Measured, not assumed — the speedup is the entire justification. Kept small
+    so it costs a couple of seconds; the real matrix is 30x wider."""
+    import time
+    import numpy as np
+    from sklearn.ensemble import GradientBoostingClassifier
+    from sklearn.model_selection import StratifiedKFold, cross_val_predict
+
+    if (os.cpu_count() or 1) < 4:
+        pytest.skip("needs at least 4 cores to show a difference")
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(400, 200)).astype(np.float32)
+    y = (X[:, 0] + rng.normal(scale=0.5, size=400) > 0).astype(int)
+    clf = GradientBoostingClassifier(n_estimators=60, max_depth=3, random_state=42)
+    cv = StratifiedKFold(n_splits=10, shuffle=True, random_state=42)
+
+    def run(jobs):
+        t = time.monotonic()
+        cross_val_predict(clf, X, y, cv=cv, method="predict_proba", n_jobs=jobs)
+        return time.monotonic() - t
+
+    serial, parallel = run(None), run(-1)
+    assert parallel < serial, f"parallel {parallel:.1f}s not faster than serial {serial:.1f}s"


### PR DESCRIPTION
The first complete `train.py` run took **45 minutes and was still going** when I killed it at 50 — all of it one fold at a time on a **28-core box**. `cross_val_predict` defaults to `n_jobs=None`, so ten independent folds ran serially while 27 cores sat idle. The loop's own 3600s step bound (#238) would have cut the nightly before the step ever produced a score.

The folds are independent. Same work, same data, same seeds, with `n_jobs=-1`:

| model | serial | parallel |
|---|---|---|
| LogisticRegression | 18s | **3s** |
| GradientBoostingClassifier | >45 min (killed unfinished at 50) | **1055s** |
| RandomForestClassifier | never reached | **65s** |

A complete run in about **twenty minutes**, comfortably inside the bound.

## What that first complete run showed

Worth recording, because it inverts an assumption I had stated:

```
Cosine baseline 10-fold CV: F1 = 0.864 ± 0.012
  LogisticRegression:         CV F1 = 0.898 ± 0.007  (3s)
  GradientBoostingClassifier: CV F1 = 0.944 ± 0.005  (1055s)
  RandomForestClassifier:     CV F1 = 0.929 ± 0.005  (65s)

Best CV model: GradientBoostingClassifier (F1=0.944)
Decision: PROMOTE
```

I had suggested the ensemble candidates might not earn their runtime, reasoning that the live `.joblib` is a `LogisticRegression`. That reasoning was wrong: the live model is LR because `build_grounding_dataset.py` writes it, and that script only ever fits LR. `train.py` had **never completed a run**, so no candidate had ever recorded a score and nothing had ever been selected over anything.

Given a chance to run, GradientBoosting beats LogisticRegression by **+0.046 F1** and the cosine baseline by +0.080. Dropping it would have cost the loop its best model. It stays — the parallelism is what makes it affordable.

## Scope

Parallelism stays at the CV level. Giving the estimators `n_jobs` on top of it oversubscribes — ten folds each claiming every core on one machine is slower, not faster — so a test asserts none of the three candidates sets it. `LOCI_TRAIN_CV_JOBS` overrides for a shared or smaller box.

## Tests

Four, one a measurement rather than an assumption since the speedup is the entire justification:

| test | pins |
|---|---|
| `test_cross_validation_is_parallel` | `n_jobs` is passed at all |
| `test_the_estimators_do_not_also_claim_every_core` | no estimator sets `n_jobs` |
| `test_the_job_count_is_configurable` | `LOCI_TRAIN_CV_JOBS` |
| `test_parallel_folds_are_actually_faster` | parallel < serial, measured |

`mlops` **565 passed**.

## Separate, not fixed here

The `0.944` above is pair-level `StratifiedKFold`, which splits **pairs**, not findings — so the same finding appears on both sides of a split and the number is optimistic. `train.py` has an honest leave-one-run-out path (`oos_from_findings`) that the loop does invoke via `--findings-glob`; my standalone run omitted the flag. The promotion gate uses the OOS number when it is available, so the gate itself is sound; the CV figure is what gets printed and it should say what it is.