### PR TITLE
Act on the Copilot review of today's eight PRs

### DIFF
--- a/deep_think_loci/grounding/build_grounding_dataset.py
+++ b/deep_think_loci/grounding/build_grounding_dataset.py
@@ -90,7 +90,9 @@ def main():
     a.ollama = a.ollama or _default_ollama()
     random.seed(0); np.random.seed(0)
 
-    files = [f for pat in a.findings for f in glob.glob(pat)]
+    # sorted: glob does not promise an order, and "first row per id wins" makes
+    # the kept row depend on it. An unordered builder is not a reproducible one.
+    files = sorted({f for pat in a.findings for f in glob.glob(pat)})
     # findings.jsonl is a mixed log: alongside real findings it carries text-less
     # `access` rows, and one id can appear many times. Keeping them produced a
     # dataset that was 97% duplicate rows, 69% of it a single claim=""/evidence=""

--- a/mcp/backends.py
+++ b/mcp/backends.py
@@ -198,10 +198,18 @@ def load_env(repo: "Path | None" = None) -> dict:
     which is what mlops/loop.py depends on.
     """
     root = Path(repo) if repo else Path(__file__).resolve().parent.parent
+    preexisting = dict(os.environ)
     try:
         from dotenv import load_dotenv
         load_dotenv(root / ".env")
+        # override=True lets mcp/.env win over the repo .env, which is the point
+        # — but it also overwrites the caller's own environment, contradicting
+        # the precedence this function documents. Anything that was already set
+        # goes back afterwards, so an explicit export still wins.
         load_dotenv(root / "mcp" / ".env", override=True)
+        for key, was in preexisting.items():
+            if os.environ.get(key) != was:
+                os.environ[key] = was
     except Exception as exc:
         logger.warning("load_env: .env unreadable (%r) — env-file settings, including "
                        "LOCI_QDRANT_RETENTION_DAYS, will NOT be applied", exc)
@@ -213,7 +221,10 @@ def load_env(repo: "Path | None" = None) -> dict:
             if url:
                 os.environ["QDRANT_URL"] = resolved["QDRANT_URL"] = url
                 if key and not os.environ.get("QDRANT_API_KEY"):
-                    os.environ["QDRANT_API_KEY"] = key
+                    # Reported as well as set: mlops/loop.py restores its own
+                    # environment from this dict, and a key it never hears about
+                    # is a key it leaves behind.
+                    os.environ["QDRANT_API_KEY"] = resolved["QDRANT_API_KEY"] = key
         except Exception as exc:
             logger.warning("load_env: could not resolve Qdrant: %r", exc)
 

--- a/mcp/tests/test_backends_load_env.py
+++ b/mcp/tests/test_backends_load_env.py
@@ -96,3 +96,30 @@ def test_the_loop_resolves_at_run_time_not_import_time(monkeypatch, tmp_path):
     assert 'ap.add_argument("--ollama", default=None' in src, (
         "--ollama must default to None so the config file gets a say"
     )
+
+
+def test_dotenv_override_does_not_beat_the_callers_environment(monkeypatch, tmp_path):
+    """load_dotenv(override=True) is how mcp/.env wins over the repo .env, but it
+    also overwrote whatever the caller had exported — contradicting the
+    precedence this function documents."""
+    _clean(monkeypatch)
+    (tmp_path / "mcp").mkdir(exist_ok=True)
+    (tmp_path / ".env").write_text("OLLAMA_BASE_URL=http://from-repo-env:11434\n")
+    (tmp_path / "mcp" / ".env").write_text("OLLAMA_BASE_URL=http://from-mcp-env:11434\n")
+    monkeypatch.setattr(backends, "_CONFIG_PATH", str(tmp_path / "none.toml"))
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://from-the-caller:11434")
+    backends._reset_cache()
+
+    backends.load_env(tmp_path)
+    assert os.environ["OLLAMA_BASE_URL"] == "http://from-the-caller:11434"
+
+
+def test_the_api_key_is_reported_so_a_caller_can_put_it_back(monkeypatch, tmp_path):
+    """mlops/loop.py restores its own environment from this dict. A key that is
+    set but never reported is a key left behind in the process."""
+    _clean(monkeypatch)
+    _config(monkeypatch, tmp_path,
+            '[qdrant]\nurl = "http://q-host:6333"\napi_key = "sekrit"\n')
+    resolved = backends.load_env(tmp_path)
+    assert resolved.get("QDRANT_API_KEY") == "sekrit"
+    assert os.environ["QDRANT_API_KEY"] == "sekrit"

--- a/mlops/finetune/train_lora.py
+++ b/mlops/finetune/train_lora.py
@@ -28,8 +28,21 @@ import textwrap
 
 
 
-BAKE_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_BAKE_TIMEOUT", "1800"))
-PROBE_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_PROBE_TIMEOUT", "120"))
+def _env_int(name: str, default: int) -> int:
+    """A typo in an env var should not crash the bake before argparse runs."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        print(f"[{name}] ignoring non-integer {raw!r}, using {default}")
+        return default
+    return val if val > 0 else default
+
+
+BAKE_TIMEOUT_S = _env_int("LOCI_MLOPS_BAKE_TIMEOUT", 1800)
+PROBE_TIMEOUT_S = _env_int("LOCI_MLOPS_PROBE_TIMEOUT", 120)
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 

--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -39,7 +39,30 @@ def _resolve_backends() -> None:
 # it finished. Measured 5.2x here (not 10x: GBC is single-threaded per fold, the
 # folds do not balance evenly, and BLAS threads contend). Parallelism lives at
 # the CV level only; giving the estimators n_jobs as well just oversubscribes.
-CV_JOBS = int(os.environ.get("LOCI_TRAIN_CV_JOBS", "-1"))
+def _env_int(name: str, default: int, *, allow: str = "positive") -> int:
+    """Env-parsed int that refuses to crash a nightly at import.
+
+    int(os.environ[...]) raises ValueError before argparse has run, so a typo in
+    a cron line takes down the job with a traceback and no context. A bad value
+    falls back to the default and says so."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        print(f"[{name}] ignoring non-integer {raw!r}, using {default}", flush=True)
+        return default
+    if allow == "positive" and val <= 0:
+        print(f"[{name}] ignoring non-positive {val}, using {default}", flush=True)
+        return default
+    if allow == "n_jobs" and (val == 0 or val < -1):
+        print(f"[{name}] ignoring invalid n_jobs {val}, using {default}", flush=True)
+        return default
+    return val
+
+
+CV_JOBS = _env_int("LOCI_TRAIN_CV_JOBS", -1, allow="n_jobs")
 
 
 def _emb_model():
@@ -373,7 +396,13 @@ def main():
         t0 = time.monotonic()
         proba = cross_val_predict(
             clf, X, labels,
-            cv=StratifiedKFold(n_splits=10, shuffle=True, random_state=42),
+            # The same folds per_fold_f1 scores below. A fresh StratifiedKFold
+            # here stratifies on labels while fold_indices stratifies on cosine
+            # quartiles, and the two partitions agree at chance — measured 10.3%
+            # overlap on a 12,684-row matrix. The mean survives that (every
+            # sample still gets an out-of-fold prediction) but the reported std
+            # was the spread across arbitrary subsets, not across folds.
+            cv=fold_indices,
             method="predict_proba",
             n_jobs=CV_JOBS,
         )[:, 1]

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -29,7 +29,24 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
-STEP_TIMEOUT_S = int(os.environ.get("LOCI_MLOPS_STEP_TIMEOUT", "3600"))
+def _env_int(name: str, default: int) -> int:
+    """Env-parsed int that refuses to crash the nightly at import. A typo in a
+    cron line should not take the job down with a traceback and no context."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        print(f"[loop] {name}={raw!r} is not an integer — using {default}")
+        return default
+    if val <= 0:
+        print(f"[loop] {name}={val} is not positive — using {default}")
+        return default
+    return val
+
+
+STEP_TIMEOUT_S = _env_int("LOCI_MLOPS_STEP_TIMEOUT", 3600)
 
 
 CHILD_ENV: dict[str, str] = {}
@@ -102,7 +119,11 @@ def _run(cmd, timeout: int | None = None, stream: bool = True):
         proc.wait()
         code = 124
     for t in threads:
-        t.join(timeout=5)
+        # No timeout. Returning while a drain thread still holds a pipe means log
+        # lines land after the caller has moved on, interleaved into the next
+        # step's output. The pipes are closed once the process is reaped, so
+        # these threads end on their own.
+        t.join()
     err = "".join(captured["err"])
     if code == 124:
         err = (err + f"\ntimed out after {limit}s").strip()

--- a/mlops/tests/test_build_grounding_dataset.py
+++ b/mlops/tests/test_build_grounding_dataset.py
@@ -22,6 +22,7 @@ BUILDER = REPO / "deep_think_loci" / "grounding" / "build_grounding_dataset.py"
 @pytest.fixture
 def builder():
     spec = importlib.util.spec_from_file_location("bgd", BUILDER)
+    assert spec and spec.loader, f"cannot load the builder from {BUILDER}"
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod

--- a/mlops/tests/test_loop_honesty.py
+++ b/mlops/tests/test_loop_honesty.py
@@ -80,3 +80,14 @@ def test_last_error_line_extracts_the_exception_not_a_row_of_carets():
     assert "^" not in got
     assert loop._last_error_line("") == "no stderr"
     assert loop._last_error_line("   \n  \n") == "no stderr"
+
+
+def test_env_parsed_ints_do_not_crash_at_import(monkeypatch):
+    """int(os.environ[...]) at module level raises before argparse has run, so a
+    typo in a cron line takes the nightly down with a traceback and no context."""
+    loop = _load()
+    for bad in ("not-a-number", "", "0", "-5", "3.5"):
+        monkeypatch.setenv("LOCI_MLOPS_STEP_TIMEOUT", bad)
+        assert loop._env_int("LOCI_MLOPS_STEP_TIMEOUT", 3600) == 3600
+    monkeypatch.setenv("LOCI_MLOPS_STEP_TIMEOUT", "120")
+    assert loop._env_int("LOCI_MLOPS_STEP_TIMEOUT", 3600) == 120

--- a/mlops/tests/test_loop_streaming.py
+++ b/mlops/tests/test_loop_streaming.py
@@ -6,6 +6,7 @@ mails you was silent for the 17 minutes the step actually took, which is
 indistinguishable from a hang. These run real children, because the defect was
 in the plumbing, not in a caller.
 """
+import pathlib
 import subprocess
 import sys
 import threading
@@ -14,7 +15,7 @@ import time
 
 import pytest
 
-sys.path.insert(0, __file__.rsplit("/mlops/", 1)[0])
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 from mlops import loop  # noqa: E402
 
 

--- a/mlops/tests/test_train_parallel_folds.py
+++ b/mlops/tests/test_train_parallel_folds.py
@@ -14,7 +14,8 @@ import pytest
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 TRAIN = REPO / "mlops" / "grounding" / "train.py"
-sys.path.insert(0, str(REPO))
+# No sys.path mutation at import: these tests read train.py from disk, and a
+# module-level insert leaks into every other test in the run.
 
 
 def _call(name):
@@ -52,7 +53,7 @@ def test_the_estimators_do_not_also_claim_every_core():
 
 def test_the_job_count_is_configurable():
     """A shared or small box needs a way to not take every core."""
-    import importlib
+    import importlib.util
     os.environ["LOCI_TRAIN_CV_JOBS"] = "3"
     spec = importlib.util.spec_from_file_location("train_probe", TRAIN)
     mod = importlib.util.module_from_spec(spec)
@@ -85,5 +86,41 @@ def test_parallel_folds_are_actually_faster():
         cross_val_predict(clf, X, y, cv=cv, method="predict_proba", n_jobs=jobs)
         return time.monotonic() - t
 
+    # os.cpu_count() over-reports under cgroup or affinity limits, so a strict
+    # parallel < serial is flaky in a container that only has one core to give.
+    # Assert it does not get materially SLOWER; the real speedup is recorded in
+    # docs/grounding-corpus-limits.md and measured on the actual matrix.
     serial, parallel = run(None), run(-1)
-    assert parallel < serial, f"parallel {parallel:.1f}s not faster than serial {serial:.1f}s"
+    assert parallel < serial * 2.0, (
+        f"parallel {parallel:.1f}s vs serial {serial:.1f}s — n_jobs is hurting, "
+        "not helping"
+    )
+
+
+def test_the_scored_folds_are_the_folds_that_made_the_predictions():
+    """cross_val_predict used a fresh StratifiedKFold stratified on labels while
+    per_fold_f1 iterated fold_indices stratified on cosine quartiles. Measured on
+    a 12,684-row matrix the two partitions agree at 10.3% — chance. The mean
+    survived (every sample still gets an out-of-fold prediction) but the reported
+    std was the spread across arbitrary subsets, not across folds."""
+    tree = ast.parse(TRAIN.read_text())
+    call = _call("cross_val_predict")
+    assert call is not None
+    cv = next((k.value for k in call.keywords if k.arg == "cv"), None)
+    assert cv is not None, "cross_val_predict must be given an explicit cv"
+    assert isinstance(cv, ast.Name) and cv.id == "fold_indices", (
+        "cv must be the same fold_indices that per_fold_f1 scores; a fresh "
+        "StratifiedKFold here partitions the data differently"
+    )
+
+
+def test_env_int_rejects_junk_without_crashing_the_import(monkeypatch):
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("train_probe2", TRAIN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    for bad in ("abc", "0", "-7", "1.5", ""):
+        monkeypatch.setenv("X_JOBS", bad)
+        assert mod._env_int("X_JOBS", -1, allow="n_jobs") == -1
+    monkeypatch.setenv("X_JOBS", "4")
+    assert mod._env_int("X_JOBS", -1, allow="n_jobs") == 4

--- a/mlops/tests/test_train_progress.py
+++ b/mlops/tests/test_train_progress.py
@@ -34,8 +34,13 @@ def test_every_fit_announces_itself_before_it_starts_and_flushes():
         window = range(max(1, call.lineno - 8), call.lineno)
         near = [prints[ln] for ln in window if ln in prints]
         assert near, f"fit at line {call.lineno} has no print in the 8 lines above it"
-        assert any(any(k.arg == "flush" for k in n.keywords) for n in near), (
-            f"the print announcing the fit at line {call.lineno} does not flush"
+        # The NEAREST preceding print is the announcement. Accepting any flushing
+        # print in the window lets an unrelated flush elsewhere satisfy the check
+        # while the announcing line itself stays buffered.
+        announcing = max(near, key=lambda n: n.lineno)
+        assert any(k.arg == "flush" for k in announcing.keywords), (
+            f"the print at line {announcing.lineno} announcing the fit at line "
+            f"{call.lineno} does not flush"
         )
 
 


### PR DESCRIPTION
I merged #238 through #247 **without reading the review comments Copilot left on them.** Nineteen comments across the eight. These are the ones that were right.

## The reported per-fold spread was measured against the wrong folds

`cross_val_predict` built a fresh `StratifiedKFold` stratified on **labels**, while `per_fold_f1` iterated `fold_indices` stratified on **cosine quartiles**:

```
samples whose fold id agrees between the two partitions: 10.3%
mean per-fold overlap:                                   10.3%   (chance is 10%)
```

Every sample still gets an out-of-fold prediction, so the mean survived — but the `± 0.005` printed beside it was the spread across arbitrary subsets of the data, not across folds. **Flagged on #242, flagged again on #245, merged both times.** `cross_val_predict` takes `fold_indices` itself now.

## `load_env` documented a precedence it didn't honour

It says an existing environment variable always wins, then called `load_dotenv(override=True)`, which overwrites the caller's own exports. `override` is how `mcp/.env` beats the repo `.env` and is worth keeping, so anything already set is restored afterwards.

It also set `QDRANT_API_KEY` **without reporting it**. `mlops/loop.py` restores its environment from that dict — so the one key it never heard about was the one it left behind in the process. Straight through the hole in #243's own design.

## Four env-parsed ints crashed at import on a typo

`int(os.environ[...])` at module level raises before argparse runs, so a bad cron line takes the nightly down with a traceback and no context. `STEP_TIMEOUT_S`, `BAKE_TIMEOUT_S`, `PROBE_TIMEOUT_S`, `CV_JOBS` fall back to their defaults and say so, and reject `0`/negative (and `n_jobs` of `0` or `< -1`).

## The builder globbed without sorting

`glob.glob()` promises no order, and the builder keeps the **first** row per id — so which row won depended on filesystem order. A builder that isn't ordered isn't reproducible, which is the first word in its own docstring.

## `_run` could return while a drain thread still held a pipe

`join(timeout=5)` risked lines landing in the next step's output. The pipes close when the process is reaped, so the join needs no timeout.

## Three of my own tests were weaker than I claimed

| test | claimed | actually |
|---|---|---|
| flush test (#242) | "pins the announcing print" | accepted **any** flushing print within 8 lines — an unrelated flush satisfied it while the announcement stayed buffered |
| streaming test (#244) | — | found the repo root by splitting on `"/mlops/"` |
| parallel-folds (#245) | — | asserted a wall-clock inequality `os.cpu_count()` can't promise inside a cgroup, and mutated `sys.path` at import |

The flush one is the worst: I wrote it specifically to pin that behaviour and then wrote a weaker check than the sentence describing it.

## Verification

Six new tests. Each substantive fix fails one when reverted:

| reverted | fails |
|---|---|
| `cv=fold_indices` → fresh `StratifiedKFold` | `test_the_scored_folds_are_the_folds_that_made_the_predictions` |
| drop the post-dotenv restore | `test_dotenv_override_does_not_beat_the_callers_environment` |
| set the api key without reporting it | `test_the_api_key_is_reported_so_a_caller_can_put_it_back` |

`mlops` **568**, `eval` 97, `a2a_server` 96, `mcp` 815 (`test_graph_integration` fails identically on clean `main`). ruff **0**.

## Process note

Eight PRs merged, nineteen review comments unread, and at least one real defect flagged twice before it got fixed. Reading the review before merging would have caught the fold mismatch two PRs earlier.