### PR TITLE
mlops: a cron entrypoint that does not dirty the working tree

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -137,6 +137,48 @@ each tier resolves its own.
 
 ---
 
+## MLOps loop
+
+`mlops/loop.py` rebuilds the grounding dataset, retrains the classifier
+ensemble, canary-evaluates the candidate and promotes it if it beats the
+baseline. It ran for the first time on 2026-08-29; before that it had queued
+against a self-hosted runner that does not exist for 67 consecutive nights, and
+every child process was unbounded (#238).
+
+Scheduled from the user crontab through `scripts/mlops_loop_cron.sh`:
+
+| When | What |
+|---|---|
+| `0 2 * * *` | full loop, into an isolated worktree |
+
+**The loop promotes by writing into the repo.** `grounding_bleed_clf.joblib`,
+`grounding_dataset.jsonl` and `metrics.json` under `deep_think_loci/grounding/`
+are all tracked, so running the loop in a working checkout leaves that checkout
+dirty — which is how a 12,684-row rebuilt dataset ends up in an unrelated
+commit. The wrapper runs it in `~/.loci/mlops/worktree`, reset to `origin/main`
+each night, and prints what changed. **Nothing is applied automatically**;
+adopting a promoted model is a deliberate commit.
+
+Roughly twenty minutes end to end, the bulk of it GradientBoosting under 10-fold
+CV. Each step is bounded at `LOCI_MLOPS_STEP_TIMEOUT` (3600s), and a step that
+times out comes back as returncode 124 rather than hanging the run. Child output
+is streamed as it arrives, prefixed with the script that produced it.
+
+| Code | Meaning |
+|---|---|
+| 0 | ok — including steps deliberately skipped (Ollama unreachable, nothing new) |
+| 1 | one or more steps **failed**, named in the summary line |
+
+A skip is not a failure, and the log says which it was: a cadence-gated step that
+could not run because the backend was unreachable says so rather than reciting
+the cadence.
+
+See [grounding-corpus-limits.md](grounding-corpus-limits.md) before reading much
+into the scores — the CV figure it prints is a pair-level split and optimistic by
+about two thirds of its margin over cosine.
+
+---
+
 ## Manual operations
 
 The repo is `loci` (github.com/rjmendez/loci). The commands below assume:

--- a/scripts/mlops_loop_cron.sh
+++ b/scripts/mlops_loop_cron.sh
@@ -23,12 +23,37 @@ mkdir -p "$STATE"
 
 [ -x "$PY" ] || { echo "mlops-loop: no interpreter at $PY" >&2; exit 1; }
 
+# RUN_TREE reaches `git reset --hard`, `git clean -fd` and `rm -rf`, and it comes
+# from the environment. A wrapper written to protect the working checkout must
+# not be one LOCI_MLOPS_TREE=$REPO turns into the thing that destroys it.
+case "$RUN_TREE" in
+  /*) ;;
+   *) echo "mlops-loop: LOCI_MLOPS_TREE must be an absolute path, got '$RUN_TREE'" >&2; exit 1 ;;
+esac
+RUN_TREE_RAW="$RUN_TREE"
+RUN_TREE="${RUN_TREE%/}"
+case "$RUN_TREE" in
+  "" | "/" | "$HOME" | "$REPO" | "$REPO"/*)
+    echo "mlops-loop: refusing to use '$RUN_TREE_RAW' as the run worktree — it is the" >&2
+    echo "            repo, inside it, \$HOME, or /; this path gets reset --hard and rm -rf" >&2
+    exit 1 ;;
+esac
+if [ -e "$RUN_TREE" ] && [ ! -e "$RUN_TREE/.git" ]; then
+  echo "mlops-loop: '$RUN_TREE' exists and is not a git worktree — refusing to remove it" >&2
+  exit 1
+fi
+mkdir -p "$(dirname "$RUN_TREE")"
+
 git -C "$REPO" fetch -q origin main 2>/dev/null || \
   echo "mlops-loop: fetch failed, running against whatever the worktree has" >&2
 
-if [ -d "$RUN_TREE/.git" ] || [ -f "$RUN_TREE/.git" ]; then
-  git -C "$RUN_TREE" reset -q --hard origin/main
-  git -C "$RUN_TREE" clean -qfd
+if [ -e "$RUN_TREE/.git" ]; then
+  # A failed reset means the loop would run against an unknown revision, which is
+  # exactly the baseline guarantee this wrapper exists to provide. Fail instead.
+  git -C "$RUN_TREE" reset -q --hard origin/main || {
+    echo "mlops-loop: reset to origin/main failed in $RUN_TREE — not running" >&2; exit 1; }
+  git -C "$RUN_TREE" clean -qfd || {
+    echo "mlops-loop: clean failed in $RUN_TREE — not running" >&2; exit 1; }
 else
   rm -rf "$RUN_TREE"
   git -C "$REPO" worktree add -q --detach "$RUN_TREE" origin/main || {
@@ -42,7 +67,7 @@ rc=$?
 changed="$(git -C "$RUN_TREE" status --porcelain -- deep_think_loci/grounding/)"
 if [ -n "$changed" ]; then
   echo "mlops-loop: the run produced new grounding artifacts in $RUN_TREE"
-  echo "$changed" | sed 's/^/  /'
+  printf '%s\n' "$changed" | sed 's/^/  /'
   echo "mlops-loop: review and commit them deliberately; nothing was applied to $REPO"
 fi
 

--- a/scripts/mlops_loop_cron.sh
+++ b/scripts/mlops_loop_cron.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Cron entrypoint for the MLOps loop.
+#
+# The loop promotes a model by WRITING INTO THE REPO — grounding_bleed_clf.joblib,
+# grounding_dataset.jsonl and metrics.json under deep_think_loci/grounding/ are
+# all tracked. Running it in the working tree leaves that tree dirty every
+# morning, in a checkout the operator also uses interactively, which is how a
+# rebuilt dataset ends up in an unrelated commit. So this runs in a dedicated
+# worktree pinned to origin/main and leaves the real checkout alone.
+#
+# A promotion is not applied automatically. If the loop promotes, the artifacts
+# sit in the run worktree and this says so; adopting them is a deliberate commit.
+#
+# Exit codes are loop.py's own: 0 clean, 1 one or more steps failed. A step that
+# was skipped (Ollama unreachable, nothing new to train on) is not a failure.
+set -uo pipefail
+
+REPO="${LOCI_REPO:-/home/rjmendez/development/loci}"
+PY="$REPO/mcp/.venv/bin/python"
+RUN_TREE="${LOCI_MLOPS_TREE:-$HOME/.loci/mlops/worktree}"
+STATE="${LOCI_MLOPS_STATE:-$HOME/.loci/mlops}"
+mkdir -p "$STATE"
+
+[ -x "$PY" ] || { echo "mlops-loop: no interpreter at $PY" >&2; exit 1; }
+
+git -C "$REPO" fetch -q origin main 2>/dev/null || \
+  echo "mlops-loop: fetch failed, running against whatever the worktree has" >&2
+
+if [ -d "$RUN_TREE/.git" ] || [ -f "$RUN_TREE/.git" ]; then
+  git -C "$RUN_TREE" reset -q --hard origin/main
+  git -C "$RUN_TREE" clean -qfd
+else
+  rm -rf "$RUN_TREE"
+  git -C "$REPO" worktree add -q --detach "$RUN_TREE" origin/main || {
+    echo "mlops-loop: could not create the run worktree at $RUN_TREE" >&2; exit 1; }
+fi
+
+# -u so the log is watchable while a step runs for twenty minutes.
+"$PY" -u "$RUN_TREE/mlops/loop.py" "$@"
+rc=$?
+
+changed="$(git -C "$RUN_TREE" status --porcelain -- deep_think_loci/grounding/)"
+if [ -n "$changed" ]; then
+  echo "mlops-loop: the run produced new grounding artifacts in $RUN_TREE"
+  echo "$changed" | sed 's/^/  /'
+  echo "mlops-loop: review and commit them deliberately; nothing was applied to $REPO"
+fi
+
+[ $rc -ne 0 ] && echo "mlops-loop: exit $rc — one or more steps failed, see above" >&2
+exit $rc


### PR DESCRIPTION
The loop is runnable now (#238, #240, #243, #244, #245). This schedules it.

**The loop promotes a model by writing into the repo.** `grounding_bleed_clf.joblib`, `grounding_dataset.jsonl` and `metrics.json` under `deep_think_loci/grounding/` are all tracked. Scheduling it against a working checkout leaves that checkout dirty every morning — in a tree the operator also uses interactively. That is not hypothetical: today's 12,684-row rebuild kept turning up in unrelated `git status` output, broke an eval test on every machine that had run the loop (#246), and I nearly committed it twice.

So `scripts/mlops_loop_cron.sh` runs it in `~/.loci/mlops/worktree`, reset to `origin/main` each night, and reports what changed:

```
mlops-loop: the run produced new grounding artifacts in ~/.loci/mlops/worktree
   M deep_think_loci/grounding/grounding_bleed_clf.joblib
   M deep_think_loci/grounding/grounding_dataset.jsonl
   M deep_think_loci/grounding/metrics.json
mlops-loop: review and commit them deliberately; nothing was applied to /home/rjmendez/development/loci
```

**Nothing is applied automatically.** Adopting a promoted model stays a deliberate commit — a nightly that grooms an index and a nightly that silently swaps the shipped classifier are different kinds of commitment.

## Verified through the wrapper, `env -i`

The actual cron case, not an approximation:

```
$ env -i HOME=$HOME PATH=/usr/bin:/bin scripts/mlops_loop_cron.sh --dry-run
[loop] resolved from backends.toml: EMBED_MODEL, OLLAMA_BASE_URL, QDRANT_URL
[loop] monitor: drift=False rollback_recommended=False
  [collect] negatives=0  positives=0  corrections=0
[loop] done. promoted=False dataset=12684 total_promotions=0
exit=0

$ git -C /home/rjmendez/development/loci status --porcelain
(clean)
```

Exit codes are the loop's own: `0` including steps deliberately skipped, `1` when one or more steps *failed* — the distinction #240 introduced.

Documented in `docs/OPERATIONS.md` beside the grooming tier, including the twenty-minute runtime, the 3600s per-step bound, and a pointer to `grounding-corpus-limits.md` so nobody reads too much into the printed CV score.

## Two things this run surfaced, not fixed here

- `--dry-run` still rebuilds the dataset. The flag gates promotion and the bake, not the rebuild, so a "dry" run is not read-only.
- Child lines can double-prefix: `[collect] [collect] negatives=0`. #244 prefixes with the script name and `collect.py` already tags its own output.

## Not scheduled by this PR

The crontab line itself is a local change, not a repo one. `0 2 * * *`, before the groom passes at 03:20, is what the docs describe.