### PR TITLE
Act on the Copilot review of the reporting and cron PRs

### DIFF
--- a/docs/grounding-corpus-limits.md
+++ b/docs/grounding-corpus-limits.md
@@ -8,7 +8,7 @@ and the printed ones are the ones that get quoted later.
 
 `grounding_dataset.jsonl` holds pairs, and pairs are `C(n,2)` within a topic:
 
-| findings | positives | |
+| findings | positives | note |
 |---|---|---|
 | 303 (now) | 4,203 | |
 | 454 (1.5x) | 9,560 | 2.3x the rows from 1.5x the evidence |

--- a/mlops/finetune/train_lora.py
+++ b/mlops/finetune/train_lora.py
@@ -38,7 +38,10 @@ def _env_int(name: str, default: int) -> int:
     except ValueError:
         print(f"[{name}] ignoring non-integer {raw!r}, using {default}")
         return default
-    return val if val > 0 else default
+    if val <= 0:
+        print(f"[{name}] ignoring non-positive {val}, using {default}")
+        return default
+    return val
 
 
 BAKE_TIMEOUT_S = _env_int("LOCI_MLOPS_BAKE_TIMEOUT", 1800)

--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -377,11 +377,11 @@ def main():
 
     cos_cv_mean, cos_cv_std = cosine_f1_on_folds(cos_scores, labels, fold_indices)
     # These folds split PAIRS, so a finding lands on both sides of a split and
-    # every number below is optimistic. Measured on this corpus: GBC scores 0.944
-    # here and 0.908 when findings are split before pairs are built, against a
-    # cosine baseline that barely moves (0.864 -> 0.878). Two thirds of the
-    # apparent margin over cosine is the leak. Say so on every line, because this
-    # is the figure that gets quoted later as though it were the model's score.
+    # every number below is optimistic — most of the apparent margin over cosine
+    # is that leak. Say so on every line, because this is the figure that gets
+    # quoted later as though it were the model's score. The measured size of the
+    # gap lives in docs/grounding-corpus-limits.md, where it can be updated when
+    # the corpus changes; figures pinned in a comment only go stale.
     print(f"\nPair-level 10-fold CV (optimistic — a finding appears in train and test):")
     print(f"  cosine baseline: F1 = {cos_cv_mean:.3f} ± {cos_cv_std:.3f}")
 
@@ -398,10 +398,10 @@ def main():
             clf, X, labels,
             # The same folds per_fold_f1 scores below. A fresh StratifiedKFold
             # here stratifies on labels while fold_indices stratifies on cosine
-            # quartiles, and the two partitions agree at chance — measured 10.3%
-            # overlap on a 12,684-row matrix. The mean survives that (every
-            # sample still gets an out-of-fold prediction) but the reported std
-            # was the spread across arbitrary subsets, not across folds.
+            # quartiles, and the two partitions overlap at chance. The mean
+            # survives that (every sample still gets an out-of-fold prediction)
+            # but the reported std becomes the spread across arbitrary subsets
+            # rather than across folds.
             cv=fold_indices,
             method="predict_proba",
             n_jobs=CV_JOBS,
@@ -442,15 +442,26 @@ def main():
 
     beat_baseline = best_f1 > eval_baseline
     decision = "PROMOTE" if beat_baseline else "HOLD"
-    basis = "leave-one-run-out OOS" if oos_results else "pair-level CV (OPTIMISTIC)"
+    # Requested is not the same as used: --findings-glob can be passed and OOS
+    # still return {} (fewer than 2 runs, or no fold with both classes). The
+    # banner used to blame a missing flag for that, which sends the reader to fix
+    # the one thing that was already right.
+    if oos_results:
+        basis = "leave-one-run-out OOS"
+    elif args.findings_glob:
+        basis = "pair-level CV (OPTIMISTIC) — OOS was requested but produced no folds"
+    else:
+        basis = "pair-level CV (OPTIMISTIC) — no --findings-glob"
     print(f"\n{'='*60}")
     print(f"Decision: {decision}   [on {basis}]")
     print(f"  Best model F1:    {best_f1:.3f}  ({best_name})")
     print(f"  Cosine baseline:  {eval_baseline:.3f}")
     print(f"  Beat baseline:    {beat_baseline}")
     if not oos_results:
-        print("  WARNING: no --findings-glob, so this decision rests on the leaky")
-        print("           pair-level split. Expect ~2/3 of the margin to be leak.")
+        why = ("--findings-glob was passed but leave-one-run-out produced no usable "
+               "folds" if args.findings_glob else "no --findings-glob was passed")
+        print(f"  WARNING: {why}, so this decision rests on the")
+        print("           leaky pair-level split — see docs/grounding-corpus-limits.md")
     print(f"{'='*60}\n")
 
     best_clf = candidates[best_name]

--- a/mlops/tests/test_train_parallel_folds.py
+++ b/mlops/tests/test_train_parallel_folds.py
@@ -103,7 +103,6 @@ def test_the_scored_folds_are_the_folds_that_made_the_predictions():
     a 12,684-row matrix the two partitions agree at 10.3% — chance. The mean
     survived (every sample still gets an out-of-fold prediction) but the reported
     std was the spread across arbitrary subsets, not across folds."""
-    tree = ast.parse(TRAIN.read_text())
     call = _call("cross_val_predict")
     assert call is not None
     cv = next((k.value for k in call.keywords if k.arg == "cv"), None)
@@ -124,3 +123,31 @@ def test_env_int_rejects_junk_without_crashing_the_import(monkeypatch):
         assert mod._env_int("X_JOBS", -1, allow="n_jobs") == -1
     monkeypatch.setenv("X_JOBS", "4")
     assert mod._env_int("X_JOBS", -1, allow="n_jobs") == 4
+
+
+def test_the_banner_distinguishes_oos_requested_from_oos_used():
+    """--findings-glob can be passed and OOS still return {} — fewer than 2 runs,
+    or no fold carrying both classes. The banner blamed a missing flag for that,
+    which sends the reader to fix the one thing that was already right."""
+    src = TRAIN.read_text()
+    assert "OOS was requested but produced no folds" in src, (
+        "the basis line must separate 'requested' from 'used'"
+    )
+    assert "no --findings-glob" in src, "the genuinely-absent-flag case must stay"
+    assert "elif args.findings_glob:" in src, (
+        "the two cases must be distinguished on args.findings_glob, not on "
+        "oos_results alone"
+    )
+
+
+def test_no_measured_figures_are_pinned_in_code_comments():
+    """A comment carrying 0.944/0.908/0.864 goes stale the moment the corpus
+    changes, and a stale figure in code reads as current. The numbers live in
+    docs/grounding-corpus-limits.md, which can be updated with the measurement."""
+    import re as _re
+    comments = [ln for ln in TRAIN.read_text().splitlines() if ln.lstrip().startswith("#")]
+    for ln in comments:
+        # F1-shaped literals: a bare 0.NNN in prose
+        assert not _re.search(r"\b0\.\d{3}\b", ln), (
+            f"measured figure pinned in a comment, put it in the doc instead:\n  {ln.strip()}"
+        )


### PR DESCRIPTION
Eight comments across #246–#249. Five here; the three on `scripts/mlops_loop_cron.sh` went to **#249's own branch** — one of them was a path guard, and shipping that broken for a round would have been the wrong order.

## The decision banner blamed a missing flag for something else

`--findings-glob` can be passed and `oos_from_findings` still return `{}` — fewer than two runs, or no fold carrying both classes. The banner keyed off `oos_results` alone, so it said `no --findings-glob` in that case, sending the reader to fix the one thing that was already right.

```
Decision: PROMOTE   [on pair-level CV (OPTIMISTIC) — OOS was requested but produced no folds]
  WARNING: --findings-glob was passed but leave-one-run-out produced no usable
           folds, so this decision rests on the leaky pair-level split
```

## Two comments carried figures that will go stale

`0.944`, `0.908`, `0.864`, a `10.3%` fold overlap. All true this morning; none of them true after the next corpus rebuild — and a stale number in a comment reads as a current one, which is the failure this repo spent the day on. The **warnings** stay, the **figures** move to `docs/grounding-corpus-limits.md` where they can be updated alongside the measurement.

A test now fails on any bare `0.NNN` in a comment in that file, so the next person to paste a result in gets stopped.

## Three smaller ones

- `train_lora._env_int` logged non-integers but swallowed `0` and negatives **silently** — unlike the two copies in `loop.py` and `train.py` that the same PR added. A misconfigured timeout should be as visible as a misspelled one.
- A test parsed `train.py` into a variable it never used, beside a helper that re-parses the file anyway.
- The corpus table in the doc had an unlabelled third column.

## Verification

| reverted | fails |
|---|---|
| basis keyed on `oos_results` alone | `test_the_banner_distinguishes_oos_requested_from_oos_used` |
| a measured figure back in a comment | `test_no_measured_figures_are_pinned_in_code_comments` |

`mlops` **570**, `eval` 97, `a2a_server` 96, `mcp` 815 (`test_graph_integration` fails identically on clean `main`). ruff **0**.