### PR TITLE
Make the grounding gate build features for the model it loaded

### DIFF
--- a/deep_think_loci/grounding/features.py
+++ b/deep_think_loci/grounding/features.py
@@ -1,0 +1,62 @@
+"""The grounding feature contract, in one place.
+
+Three sites built these vectors independently and two of them drifted apart:
+build_grounding_dataset.py and ground_gate.py emit 1537 columns, while
+mlops/grounding/train.py emits 1540 — it added cos**2, a length ratio and a token
+overlap. Nothing noticed because the loop has never promoted a model. The first
+promotion would have handed ground_gate a 1540-column classifier and fed it 1537,
+raising at runtime inside the live grounding path.
+
+So the shape is defined once here, and the version a model was trained against is
+recoverable from the model itself via n_features_in_.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# Embedding width is fixed by the embedder (nomic-embed-text, 768).
+EMBED_DIM = 768
+# |a-b| + a*b + cos  — what build_grounding_dataset.py and ground_gate.py have
+# always produced, and what the currently shipped joblib expects.
+LEGACY_DIM = 2 * EMBED_DIM + 1
+# ... + cos**2 + length ratio + token overlap.
+CURRENT_DIM = LEGACY_DIM + 3
+
+
+def token_overlap(a: str, b: str) -> float:
+    sa, sb = set(a.split()), set(b.split())
+    if not sa and not sb:
+        return 1.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def len_ratio(a: str, b: str) -> float:
+    la, lb = len(a), len(b)
+    return min(la, lb) / (max(la, lb) + 1)
+
+
+def make_features(claims, evidences, emb_claims, emb_evidences, *, dim: int = CURRENT_DIM):
+    """Feature matrix for (claim, evidence) pairs.
+
+    `dim` selects the contract version. Pass a model's n_features_in_ to build
+    exactly what that model was trained on, rather than assuming.
+    """
+    emb_claims = np.asarray(emb_claims, dtype=np.float32)
+    emb_evidences = np.asarray(emb_evidences, dtype=np.float32)
+    diff = np.abs(emb_claims - emb_evidences)
+    prod = emb_claims * emb_evidences
+    cos = prod.sum(axis=1, keepdims=True)
+    if dim == LEGACY_DIM:
+        return np.concatenate([diff, prod, cos], axis=1)
+    if dim != CURRENT_DIM:
+        raise ValueError(
+            f"no grounding feature contract produces {dim} columns "
+            f"(known: {LEGACY_DIM} legacy, {CURRENT_DIM} current)"
+        )
+    lr = np.array([[len_ratio(c, e)] for c, e in zip(claims, evidences)], dtype=np.float32)
+    jac = np.array([[token_overlap(c, e)] for c, e in zip(claims, evidences)], dtype=np.float32)
+    return np.concatenate([diff, prod, cos, cos ** 2, lr, jac], axis=1)
+
+
+def supported_dims() -> tuple[int, ...]:
+    return (LEGACY_DIM, CURRENT_DIM)

--- a/deep_think_loci/grounding/ground_gate.py
+++ b/deep_think_loci/grounding/ground_gate.py
@@ -20,6 +20,10 @@ Exit: prints JSON {kept:[...], dropped:[...], threshold, mode} to --out or stdou
 import argparse, json, os, sys, urllib.request
 import numpy as np
 
+# features.py sits beside this file; the gate is run as a script, so its own
+# directory is not otherwise importable when invoked from the repo root.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 # Loci convention: OLLAMA_BASE_URL has no /v1 suffix; EMBED_MODEL names the embedder.
 _BASE = (os.environ.get("OLLAMA_BASE_URL") or "http://ollama.internal:11434").rstrip("/")
 OLLAMA = _BASE + "/v1/embeddings"
@@ -58,11 +62,25 @@ def gate(query, cands, threshold=0.59, model=None):
 
     if model:
         import joblib
+        import features as _feat
         clf = joblib.load(model)
-        feats = np.array([np.concatenate([np.abs(cv[i] - qv), cv[i] * qv, [cos[i]]]) for i in range(len(cands))])
+        # Build exactly what THIS model was trained on. The trainer and this gate
+        # drifted to different widths (1540 vs 1537) and nothing caught it, because
+        # no model has ever been promoted — the first promotion would have raised
+        # here, inside the live grounding path.
+        dim = int(getattr(clf, "n_features_in_", _feat.LEGACY_DIM))
+        if dim not in _feat.supported_dims():
+            raise ValueError(
+                f"{model} expects {dim} features; this gate builds "
+                f"{_feat.supported_dims()}. Refusing to score with a model whose "
+                "feature contract is unknown."
+            )
+        texts = [c.get("text", "") for c in cands]
+        feats = _feat.make_features(texts, [query] * len(cands), cv,
+                                    np.tile(qv, (len(cands), 1)), dim=dim)
         score = clf.predict_proba(feats)[:, 1].tolist()
         keep = [s >= 0.5 for s in score]
-        mode = "model:" + model.split("/")[-1]
+        mode = f"model:{model.split('/')[-1]}:{dim}f"
     else:
         score = cos
         keep = [c >= threshold for c in cos]

--- a/deep_think_loci/grounding/tests/test_feature_contract.py
+++ b/deep_think_loci/grounding/tests/test_feature_contract.py
@@ -1,0 +1,71 @@
+"""A promoted model must be one the live gate can feed.
+
+build_grounding_dataset.py and ground_gate.py emit 1537 columns; the MLOps
+trainer emits 1540 because it adds cos**2, a length ratio and a token overlap.
+Nothing caught it: the loop has never promoted, so the mismatched model never
+reached the gate. The first promotion would have raised inside the live
+grounding path, on real traffic.
+"""
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+GROUNDING = pathlib.Path(__file__).resolve().parents[1]
+REPO = GROUNDING.parents[1]
+sys.path.insert(0, str(GROUNDING))
+import features as F  # noqa: E402
+
+
+def _emb(n=5):
+    rng = np.random.default_rng(0)
+    return rng.random((n, F.EMBED_DIM)).astype(np.float32)
+
+
+def test_both_contract_versions_have_the_widths_the_models_expect():
+    a, b = _emb(), _emb()
+    txt = ["alpha beta"] * 5
+    assert F.make_features(txt, txt, a, b, dim=F.LEGACY_DIM).shape[1] == 1537
+    assert F.make_features(txt, txt, a, b).shape[1] == 1540
+    assert F.supported_dims() == (1537, 1540)
+
+
+def test_an_unknown_width_is_refused_rather_than_guessed():
+    a, b = _emb(), _emb()
+    with pytest.raises(ValueError, match="no grounding feature contract"):
+        F.make_features(["x"] * 5, ["y"] * 5, a, b, dim=1539)
+
+
+def test_the_trainer_uses_the_shared_definition():
+    """A second copy is how the two drifted apart in the first place."""
+    src = (REPO / "mlops" / "grounding" / "train.py").read_text()
+    assert "import features as _feat" in src
+    assert "_feat.make_features" in src
+    assert "def _token_overlap" not in src, "trainer still has its own copy"
+    assert "def _len_ratio" not in src, "trainer still has its own copy"
+
+
+def test_the_gate_builds_for_the_model_it_loaded_not_a_fixed_width():
+    src = (GROUNDING / "ground_gate.py").read_text()
+    assert "n_features_in_" in src, "gate must ask the model what it expects"
+    assert "supported_dims" in src, "gate must refuse an unknown contract"
+    assert "np.abs(cv[i] - qv), cv[i] * qv, [cos[i]]" not in src, \
+        "gate still hardcodes the 1537 layout"
+
+
+def test_the_shipped_model_is_still_loadable_under_the_contract():
+    """The live joblib is 1537. The point of keeping LEGACY_DIM is that this
+    change must not break the model currently in production."""
+    import warnings
+    joblib = pytest.importorskip("joblib")
+    p = GROUNDING / "grounding_bleed_clf.joblib"
+    if not p.exists():
+        pytest.skip("no shipped model in this checkout")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        clf = joblib.load(p)
+    dim = int(getattr(clf, "n_features_in_", 0))
+    assert dim in F.supported_dims(), f"shipped model wants {dim}, contract offers {F.supported_dims()}"
+    feats = F.make_features(["a b"] * 3, ["b c"] * 3, _emb(3), _emb(3), dim=dim)
+    assert clf.predict_proba(feats).shape == (3, 2)

--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -4,6 +4,7 @@ import glob
 import hashlib
 import json
 import os
+import sys
 import pathlib
 import time
 import urllib.request
@@ -122,27 +123,21 @@ def embed_texts(texts: list, ollama_base: str, cache: dict) -> np.ndarray:
 # Feature engineering
 # ---------------------------------------------------------------------------
 
-def _token_overlap(a: str, b: str) -> float:
-    sa = set(a.split())
-    sb = set(b.split())
-    if not sa and not sb:
-        return 1.0
-    return len(sa & sb) / len(sa | sb)
+sys.path.insert(0, os.path.join(REPO_ROOT, "deep_think_loci", "grounding"))
+import features as _feat  # noqa: E402
 
 
-def _len_ratio(a: str, b: str) -> float:
-    la, lb = len(a), len(b)
-    return min(la, lb) / (max(la, lb) + 1)
+# Kept as names, not as second copies: existing tests and callers reach for
+# train._len_ratio / train._token_overlap, and re-exporting them keeps that
+# surface while leaving exactly one definition.
+_token_overlap = _feat.token_overlap
+_len_ratio = _feat.len_ratio
 
 
-def make_features(claims: list, evidences: list, emb_claims: np.ndarray, emb_evidences: np.ndarray) -> np.ndarray:
-    diff = np.abs(emb_claims - emb_evidences)
-    prod = emb_claims * emb_evidences
-    cos = (emb_claims * emb_evidences).sum(axis=1, keepdims=True)
-    cos_sq = cos ** 2
-    lr = np.array([[_len_ratio(c, e)] for c, e in zip(claims, evidences)], dtype=np.float32)
-    jac = np.array([[_token_overlap(c, e)] for c, e in zip(claims, evidences)], dtype=np.float32)
-    return np.concatenate([diff, prod, cos, cos_sq, lr, jac], axis=1)
+def make_features(claims: list, evidences: list, emb_claims, emb_evidences):
+    """One definition, in deep_think_loci/grounding/features.py, so this trainer
+    cannot drift away from what ground_gate.py is able to build."""
+    return _feat.make_features(claims, evidences, emb_claims, emb_evidences)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three places built these vectors independently and two drifted apart.

```
build_grounding_dataset.py   1537   |a-b|, a*b, cos
ground_gate.py               1537   |a-b|, a*b, cos          <- the live consumer
mlops/grounding/train.py     1540   ... + cos^2, len_ratio, token_overlap
```

**Nothing caught it because the MLOps loop has never promoted a model** (`total_promotions=0`), so the 1540-column candidate never met the gate. Demonstrated end to end:

```
candidate a promotion would ship: n_features_in_ = 1540
  old gate -> ValueError: X has 1537 features, but LogisticRegression is expecting 1540
  new gate -> scored fine, shape (3, 2)
```

That exception would have been raised **inside the live grounding path, on real traffic, by a nightly whose entire purpose is to promote.** Latent only because the loop had never succeeded.

## One definition, two named widths

`deep_think_loci/grounding/features.py` holds the contract. `LEGACY_DIM` (1537) is what the shipped model expects; `CURRENT_DIM` (1540) is what the trainer produces.

The gate reads `n_features_in_` off the classifier it just loaded and builds **that**, so the shipped model and a promoted one both work. A width matching neither is refused rather than guessed:

```python
raise ValueError(f"{model} expects {dim} features; this gate builds "
                 f"{_feat.supported_dims()}. Refusing to score with a model whose "
                 "feature contract is unknown.")
```

An unknown contract should stop the gate, not silently score — that is the difference between this and the class of bug the rest of this repo keeps turning up.

`train.py` imports the shared definition instead of keeping its own copy, which is how they diverged. `_len_ratio` and `_token_overlap` stay as re-exported *names* because tests and callers reach for them, but there is one implementation.

## Also

`train.py` was missing `import sys`. It only ever ran as a script, where the name happened to be available; adding a module-scope `sys.path` line surfaced it immediately as a collection error.

## Verification

Five tests, including one that loads the **shipped** `grounding_bleed_clf.joblib` and scores through the contract — so this cannot break the model currently in production. Two assert the drift cannot come back: the trainer must not carry its own `_token_overlap`/`_len_ratio`, and the gate must not hardcode the 1537 layout.

```
mlops + deep_think_loci + eval   676 passed
scripts                          985 passed
a2a_server                        96 passed
mcp                              815 passed (test_graph_integration fails identically on main)
ruff                               2 errors, same 2 as main
```