### PR TITLE
Let the scope analyser handle a module-level `A = mod.B` without crashing

### DIFF
--- a/scripts/callgraph/scopes.py
+++ b/scripts/callgraph/scopes.py
@@ -115,8 +115,15 @@ class ModuleAssign:
     target: str
     value_kind: str    # "name" | "attribute" | "other"
     value_name: Optional[str]       # for "name": the RHS identifier
-    # No fields for the "attribute" kind: imports.py only resolves value_kind
-    # == "name", so an attribute alias is recorded and then ignored.
+    # For "attribute": the `A = mod.B` halves. These were removed once on the
+    # reasoning that imports.py only resolves value_kind == "name", but the call
+    # site below was left passing them, so constructing an attribute alias raised
+    # TypeError. Nothing noticed because the whole corpus contained exactly one
+    # module-level `A = mod.B`, in a test file. Adding two re-exports to
+    # mlops/grounding/train.py took the callgraph suite from 3 failures to 19
+    # failures and 32 errors.
+    value_module: Optional[str] = None   # for "attribute": the `mod` in mod.B
+    value_attr: Optional[str] = None     # for "attribute": the `B` in mod.B
 
 
 class ModuleScope:

--- a/scripts/callgraph/tests/test_module_assign_attribute.py
+++ b/scripts/callgraph/tests/test_module_assign_attribute.py
@@ -1,0 +1,63 @@
+"""A module-level `A = mod.B` must not crash the scope analyser.
+
+ModuleAssign lost its two attribute fields to a cleanup that reasoned imports.py
+only resolves value_kind == "name". The call site kept passing them, so every
+attribute alias raised TypeError. It never fired because the corpus contained
+exactly one such alias, in a test file — adding two re-exports to
+mlops/grounding/train.py took this suite from 3 failures to 19 failures and 32
+errors, which is how it was found.
+"""
+import ast
+import dataclasses
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from callgraph.scopes import ModuleAssign, ModuleScope  # noqa: E402
+from callgraph.ingest import SourceFile  # noqa: E402
+
+
+def test_the_attribute_branch_can_be_constructed_at_all():
+    """The regression, in one line. Six positional args against four fields."""
+    a = ModuleAssign(1, "alias", "attribute", None, "mod", "attr")
+    assert a.value_kind == "attribute"
+    assert (a.value_module, a.value_attr) == ("mod", "attr")
+
+
+def test_the_name_branch_is_unchanged():
+    a = ModuleAssign(1, "alias", "name", "other")
+    assert a.value_name == "other"
+    assert a.value_module is None and a.value_attr is None
+
+
+def test_the_call_site_and_the_dataclass_agree():
+    """The two drifted apart silently. Compare arity rather than trusting either."""
+    src = (pathlib.Path(__file__).resolve().parents[1] / "scopes.py").read_text()
+    tree = ast.parse(src)
+    n_fields = len(dataclasses.fields(ModuleAssign))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id == "ModuleAssign":
+            assert len(node.args) <= n_fields, (
+                f"scopes.py:{node.lineno} constructs ModuleAssign with "
+                f"{len(node.args)} positional args; the dataclass has {n_fields} fields"
+            )
+
+
+def test_a_real_module_with_an_attribute_alias_parses(tmp_path):
+    """End to end: the shape that broke it, through the actual analyser."""
+    p = tmp_path / "m.py"
+    p.write_text("import os\n\n_j = os.path\n_basename = os.path.basename\n\n"
+                 "def f():\n    return _j\n")
+    src = p.read_text()
+    tree = ast.parse(src)
+    sf = SourceFile(rel_path="m.py", source=src, tree=tree, error=None, origin="working tree")
+    scope = ModuleScope(sf)
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                and isinstance(node.targets[0], ast.Name):
+            scope._record_module_alias(node.targets[0].id, node.value, node.lineno)
+    kinds = {a.value_kind for a in scope.module_assigns}
+    assert "attribute" in kinds, f"no attribute alias recorded: {scope.module_assigns}"
+    attr = next(a for a in scope.module_assigns if a.value_kind == "attribute")
+    assert (attr.value_module, attr.value_attr) == ("os", "path")


### PR DESCRIPTION
`ModuleAssign` is a **four-field** dataclass. Its attribute branch constructs it with **six** positional arguments.

```python
@dataclass
class ModuleAssign:
    lineno: int
    target: str
    value_kind: str
    value_name: Optional[str]
    # No fields for the "attribute" kind: imports.py only resolves value_kind
    # == "name", so an attribute alias is recorded and then ignored.
```

```python
ModuleAssign(lineno, target_name, "attribute", None, value.value.id, value.attr)
```

Every module-level attribute alias raises:

```
TypeError: ModuleAssign.__init__() takes 5 positional arguments but 7 were given
```

The fields were removed in a cleanup that reasoned `imports.py` only resolves `value_kind == "name"`. A comment was added explaining why they weren't needed. **The call site four hundred lines below was left passing them.**

## Why it has never fired

The entire repo contains **exactly one** module-level `A = mod.B` — in `a2a_server/tests/test_client.py`.

Adding two re-exports to `mlops/grounding/train.py` (in #253):

```python
_token_overlap = _feat.token_overlap
_len_ratio     = _feat.len_ratio
```

took this suite from **3 failures to 19 failures and 32 errors**. The analyser walks the whole corpus, so any file anywhere can trigger it — and #253 is blocked behind it.

## The fix

The fields come back, with defaults, carrying what the call site was already trying to record: the module and the attribute halves of `A = mod.B`. Dropping the arguments instead would have kept the analyser silent about a construct it can see perfectly well.

## Tests

| test | pins |
|---|---|
| `test_the_attribute_branch_can_be_constructed_at_all` | the regression, in one line |
| `test_the_call_site_and_the_dataclass_agree` | AST-compares constructor arity to field count — the two drifting apart *silently* is what happened |
| `test_a_real_module_with_an_attribute_alias_parses` | drives the real `_record_module_alias` over both alias shapes |
| `test_the_name_branch_is_unchanged` | the working path stays working |

Removing the fields again fails all four.

```
with this fix:   253 passed, 0 failed
#253 alone:       19 failed, 198 passed, 32 errors
main:              3 failed, 246 passed
```

One caveat on that last line: one of main's three was `test_load_corpus_rev_head_differs_from_worktree_when_mcp_server_dirty`, which depends on the working tree being dirty, so it is environment-sensitive rather than necessarily this bug.