### PR TITLE
Apply each retrain threshold where its input is actually knowable

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -562,28 +562,48 @@ def main() -> int:
     new_runs = _discover_runs(args.findings, state["runs_seen"])
     print(f"[loop] new investigation runs: {len(new_runs)} {new_runs}")
 
-    # ── 3. Decide whether to retrain ──────────────────────────────────────────
+    # ── 3. Decide whether to rebuild ──────────────────────────────────────────
+    #
+    # Each threshold is applied where its input is actually knowable.
+    # min_new_runs gates the REBUILD and is decidable now: discovery has just run.
+    # min_new_pairs gates the TRAINING and is not — grounding_dataset.jsonl is an
+    # OUTPUT of the rebuild, so its size here is last run's result. Under the cron
+    # wrapper it is not even that: that wrapper resets its worktree to origin/main
+    # nightly, restoring the committed 5,418-row file while loop_state.json outside
+    # the worktree still holds the previous run's 12,684. The delta came out at
+    # -7,266 and vetoed everything on the night three new investigations carrying
+    # 1,139 findings had just been found.
     current_size = _current_dataset_size()
-    new_pairs = current_size - state["last_dataset_size"]
+    stale_delta = current_size - state["last_dataset_size"]
 
-    should_retrain = args.force or (
-        ollama_ok and
-        len(new_runs) >= args.min_new_runs and
-        new_pairs >= args.min_new_pairs
-    )
-    print(f"[loop] dataset pairs: {current_size} (+{new_pairs} new) | retrain={should_retrain}")
+    should_rebuild = args.force or (ollama_ok and len(new_runs) >= args.min_new_runs)
+    why = ("forced" if args.force
+           else f"Ollama unreachable at {args.ollama}" if not ollama_ok
+           else f"{len(new_runs)} new runs >= {args.min_new_runs}" if should_rebuild
+           else f"{len(new_runs)} new runs < {args.min_new_runs}")
+    print(f"[loop] dataset on disk: {current_size} pairs "
+          f"({stale_delta:+d} vs last run, pre-rebuild) | rebuild={should_rebuild} ({why})")
 
     promoted = False
     train_metrics = None
 
-    if should_retrain:
+    should_retrain = should_rebuild
+    if should_rebuild:
         # ── 4. Rebuild dataset ────────────────────────────────────────────────
         new_size = _rebuild_dataset(args.findings, args.ollama)
         new_pairs = new_size - state["last_dataset_size"]
-        print(f"[loop] dataset after rebuild: {new_size} pairs (+{new_pairs})")
+        print(f"[loop] dataset after rebuild: {new_size} pairs ({new_pairs:+d})")
+
+        # NOW the pair delta is real, so min_new_pairs can be applied to it.
+        if not args.force and new_pairs < args.min_new_pairs:
+            should_retrain = False
+            print(f"[loop] rebuild produced {new_pairs:+d} pairs, under the "
+                  f"{args.min_new_pairs} needed to justify training — skipping the "
+                  "retrain. The dataset is still refreshed and the counts below "
+                  "are current.")
 
         # ── 5. Retrain ────────────────────────────────────────────────────────
-        train_metrics = _retrain(args.findings, args.ollama, args.dry_run)
+        train_metrics = _retrain(args.findings, args.ollama, args.dry_run) if should_retrain else None
         if train_metrics:
             decision = train_metrics.get("decision", "HOLD")
             print(f"[loop] train decision: {decision}  model={train_metrics.get('model')}  "

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -1423,7 +1423,10 @@ def test_main_default_thresholds(mainenv, capsys):
     write_dataset(e, 100)
     e.main()
     out = capsys.readouterr().out
-    assert "dataset pairs: 100 (+100 new) | retrain=False" in out
+    # One new run is under min_new_runs (2), so nothing is rebuilt, and the line
+    # says which threshold decided rather than only reporting the outcome.
+    assert "rebuild=False" in out
+    assert "1 new runs < 2" in out
 
 
 def test_main_argparse_defaults(mainenv, monkeypatch):
@@ -1472,3 +1475,48 @@ def test_main_forwards_findings_glob_to_every_consumer(mainenv):
     assert e.calls["retrain"][0][0] == ("GLOB", "http://o", False)
     assert e.calls["canary"][0][0] == ("GLOB", "http://o", False)
     assert e.calls["monitor"][0][0] == ("GLOB", "http://o", False)
+
+
+# --- the retrain gate decides from inputs -------------------------------------
+
+def test_new_runs_alone_trigger_a_rebuild_even_when_the_file_shrank(mainenv, capsys):
+    """The bug this split fixes. The cron wrapper resets its worktree to
+    origin/main nightly, restoring the committed dataset while loop_state.json
+    outside the worktree holds the previous run's larger count. The delta came out
+    at -7,266 and vetoed everything on the night three new investigations carrying
+    1,139 findings had just been discovered."""
+    e = mainenv
+    seed_state(e, last_dataset_size=12684)
+    e.rv["new_runs"] = ["hunt-a", "hunt-b", "hunt-c"]
+    write_dataset(e, 5418)                      # the reset artifact
+    e.rv["rebuild"] = 12684                     # what the rebuild actually finds
+    e.main()
+    out = capsys.readouterr().out
+    assert "rebuild=True" in out, out
+    assert "3 new runs >= 2" in out
+    assert len(e.calls["rebuild"]) == 1
+
+
+def test_the_pair_threshold_is_applied_to_the_real_delta_not_the_stale_one(mainenv, capsys):
+    """min_new_pairs still matters — it just has to be measured after the rebuild,
+    which is the only point the number exists."""
+    e = mainenv
+    seed_state(e, last_dataset_size=1000)
+    e.rv["new_runs"] = ["a", "b"]
+    write_dataset(e, 1000)
+    e.rv["rebuild"] = 1010                      # rebuild adds only 10 pairs
+    e.main()
+    out = capsys.readouterr().out
+    assert len(e.calls["rebuild"]) == 1, "the rebuild should still run"
+    assert e.calls["retrain"] == [], "training on +10 pairs is not justified"
+    assert "under the 200 needed" in out
+
+
+def test_a_shrinking_dataset_is_reported_rather_than_silently_vetoing(mainenv, capsys):
+    e = mainenv
+    seed_state(e, last_dataset_size=12684)
+    e.rv["new_runs"] = ["a", "b"]
+    write_dataset(e, 5418)
+    e.rv["rebuild"] = 12684
+    e.main()
+    assert "-7266 vs last run, pre-rebuild" in capsys.readouterr().out


### PR DESCRIPTION
The loop found three new investigations carrying 1,139 findings and refused to do anything with them:

```
[loop] new investigation runs: 3 ['dt-loci-hunt-...copilot', ...wiring, ...liveness]
[loop] dataset pairs: 5418 (+-7266 new) | retrain=False
```

`grounding_dataset.jsonl` is an **output** of the rebuild the gate is deciding whether to run, so its size at that point is *last run's result*. Under the cron wrapper it isn't even that: the wrapper resets its worktree to `origin/main` nightly, restoring the committed 5,418-row file, while `loop_state.json` lives outside the worktree and still held the previous run's 12,684.

```python
new_pairs = current_size - state["last_dataset_size"]   # 5418 - 12684 = -7266
should_retrain = ... and new_pairs >= args.min_new_pairs
```

The `and` vetoed the rebuild, the retrain, and everything after it. On the current wiring that would recur every night.

## Splitting the decision, not swapping `and` for `or`

`or` would have worked here and been wrong in general — it would let a rebuild that genuinely adds nothing trigger a full retrain. Each threshold belongs where its input exists:

| threshold | gates | decidable |
|---|---|---|
| `min_new_runs` | the **rebuild** | now — discovery has just run |
| `min_new_pairs` | the **training** | after the rebuild, the first moment the number exists |

Both keep their meaning. A rebuild producing `+10` pairs still skips training:

```
[loop] rebuild produced +10 pairs, under the 200 needed to justify training —
       skipping the retrain. The dataset is still refreshed and the counts below
       are current.
```

## Reporting

A negative delta is now stated rather than silently vetoing, and the decision line names the threshold that decided instead of only printing the outcome:

```
[loop] dataset on disk: 5418 pairs (-7266 vs last run, pre-rebuild) | rebuild=True (3 new runs >= 2)
[loop] the dataset on disk is 7266 rows SMALLER than last run recorded — a reset
       worktree or a corpus that shrank. Not a reason to skip: the rebuild below
       establishes the real count.
```

## Tests

Three, one per property — new runs trigger a rebuild through a shrunken file, the pair threshold is applied to the *real* delta, and a negative delta is reported. **Restoring the `and` fails two of them.**

```
mlops 577 passed · eval 97 · deep_think_loci 9 · ruff unchanged (3, same as main)
```

Worth noting the three existing tests that encoded the old behaviour still pass untouched — including `test_main_new_pairs_can_be_negative_and_blocks_retrain`, because a negative delta *does* still block the retrain. It just no longer blocks the rebuild that would have corrected it.