### PR TITLE
Stop cosine answering a question it cannot answer

### DIFF
--- a/mcp/embed_ops.py
+++ b/mcp/embed_ops.py
@@ -140,14 +140,12 @@ def warm(embed_fn: Optional[Callable[[list[str]], list[list[float]]]] = None) ->
     return True
 
 
-def _cosine(a: list[float], b: list[float]) -> float:
-    import math
-    if not a or not b or len(a) != len(b):
-        return 0.0
-    dot = sum(x * y for x, y in zip(a, b))
-    na = math.sqrt(sum(x * x for x in a))
-    nb = math.sqrt(sum(y * y for y in b))
-    return dot / (na * nb) if na and nb else 0.0
+def _cosine(a: list[float], b: list[float]):
+    """Delegates to vecmath. This returned 0.0 on a length mismatch, which reads
+    as "orthogonal — definitely not a match": a confident negative a ranker acts
+    on. None says the question could not be answered."""
+    from vecmath import cosine
+    return cosine(a, b)
 
 
 def _text_of(item, key: Optional[str]) -> str:
@@ -190,7 +188,8 @@ def dedup(items: list, threshold: float = 0.88, key: Optional[str] = None,
     for i in range(n):
         placed = False
         for ci, rep in enumerate(reps):
-            if _cosine(vecs[i], vecs[rep]) >= threshold:
+            sim = _cosine(vecs[i], vecs[rep])
+            if sim is not None and sim >= threshold:
                 clusters[ci]["member_indices"].append(i)
                 placed = True
                 break
@@ -213,4 +212,7 @@ def relevance(texts: list[str], topic: str,
     if len(vecs) != len(texts) + 1:
         return {"scores": [None] * len(texts), "degraded": True}
     tvec = vecs[0]
-    return {"scores": [round(_cosine(tvec, v), 4) for v in vecs[1:]], "degraded": False}
+    # None for a pair that cannot be compared, matching the [None] * len(texts)
+    # this function already returns when the embedder itself came back short.
+    scores = [(None if (x := _cosine(tvec, v)) is None else round(x, 4)) for v in vecs[1:]]
+    return {"scores": scores, "degraded": False}

--- a/mcp/memcheck/backend.py
+++ b/mcp/memcheck/backend.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 import abc
 import asyncio
 import os
-import math
+import os as _os
+import sys as _sys
+
+# mcp/ is this file's grandparent; vecmath lives there.
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from vecmath import cosine as _vecmath_cosine  # noqa: E402
 from dataclasses import dataclass
 
 from .verdict import Verdict
@@ -30,25 +35,11 @@ __all__ = [
 _COALESCE_THRESHOLD = 0.97
 
 
-def cosine_similarity(a: list[float], b: list[float]) -> float:
-    """Cosine similarity of two equal-length vectors.
-
-    Returns 0.0 for empty vectors, length mismatch, or a zero-magnitude vector
-    (so callers never divide by zero and an absent embedding simply never
-    matches).
-    """
-    if not a or not b or len(a) != len(b):
-        return 0.0
-    dot = 0.0
-    mag_a = 0.0
-    mag_b = 0.0
-    for x, y in zip(a, b):
-        dot += x * y
-        mag_a += x * x
-        mag_b += y * y
-    if mag_a == 0.0 or mag_b == 0.0:
-        return 0.0
-    return dot / (math.sqrt(mag_a) * math.sqrt(mag_b))
+def cosine_similarity(a, b):
+    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable;
+    callers that need a float choose their own default rather than inheriting
+    0.0, which reads as a confident 'not similar'."""
+    return _vecmath_cosine(a, b)
 
 
 @dataclass
@@ -147,18 +138,23 @@ class InMemoryBackend(VerdictBackend):
                     existing_emb = self._embeddings.get(existing.id)
                     if not existing_emb:
                         continue
-                    if cosine_similarity(existing_emb, embedding) >= _COALESCE_THRESHOLD:
-                        # Coalesce: bump occurrence count + last_seen, keep the
-                        # strongest (highest-confidence) decision/rationale.
-                        existing.occurrences += 1
-                        existing.last_seen = verdict.last_seen
-                        if verdict.confidence > existing.confidence:
-                            existing.decision = verdict.decision
-                            existing.rationale = verdict.rationale
-                            existing.verdict_type = verdict.verdict_type
-                            existing.confidence = verdict.confidence
-                            existing.source = verdict.source
-                        return
+                    sim = cosine_similarity(existing_emb, embedding)
+                    # Not comparable -> not a duplicate. Coalescing merges two
+                    # verdicts and drops one; doing that on a similarity computed
+                    # from a prefix would silently lose a finding.
+                    if sim is None or sim < _COALESCE_THRESHOLD:
+                        continue
+                    # Coalesce: bump occurrence count + last_seen, keep the
+                    # strongest (highest-confidence) decision/rationale.
+                    existing.occurrences += 1
+                    existing.last_seen = verdict.last_seen
+                    if verdict.confidence > existing.confidence:
+                        existing.decision = verdict.decision
+                        existing.rationale = verdict.rationale
+                        existing.verdict_type = verdict.verdict_type
+                        existing.confidence = verdict.confidence
+                        existing.source = verdict.source
+                    return
             self._verdicts.append(verdict)
             if embedding:
                 self._embeddings[verdict.id] = embedding
@@ -175,7 +171,13 @@ class InMemoryBackend(VerdictBackend):
             scored = [
                 ScoredVerdict(
                     verdict=v,
-                    similarity=cosine_similarity(self._embeddings.get(v.id, []), embedding),
+                    # A verdict stored without an embedding is not similar to
+                    # the query — it is uncomparable, and used to score 0.0 and
+                    # sort to the bottom as though it had been ranked. -1.0 keeps
+                    # the sort total while staying outside the [-1, 1] a real
+                    # cosine can produce, so it is distinguishable downstream.
+                    similarity=(cosine_similarity(self._embeddings.get(v.id, []),
+                                                  embedding) or -1.0),
                 )
                 for v in self._verdicts
                 if v.subject_kind == kind

--- a/mcp/memcheck/llm.py
+++ b/mcp/memcheck/llm.py
@@ -26,7 +26,12 @@ from __future__ import annotations
 
 import json
 import logging
-import math
+import os as _os
+import sys as _sys
+
+# mcp/ is this file's grandparent; vecmath lives there.
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from vecmath import cosine as _vecmath_cosine  # noqa: E402
 import os
 import urllib.request
 
@@ -401,18 +406,8 @@ def embed_texts(texts: list[str], *, timeout: float = 60.0, batch: int = 16) -> 
     return out
 
 
-def cosine(a: list[float], b: list[float]) -> float:
-    """Cosine similarity in pure Python (no numpy). 0.0 on degenerate input."""
-    if not a or not b or len(a) != len(b):
-        return 0.0
-    dot = 0.0
-    na = 0.0
-    nb = 0.0
-    for x, y in zip(a, b):
-        dot += x * y
-        na += x * x
-        nb += y * y
-    denom = math.sqrt(na) * math.sqrt(nb)
-    if denom <= 0.0:
-        return 0.0
-    return dot / denom
+def cosine(a, b):
+    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable;
+    callers that need a float choose their own default rather than inheriting
+    0.0, which reads as a confident 'not similar'."""
+    return _vecmath_cosine(a, b)

--- a/mcp/tests/test_backend.py
+++ b/mcp/tests/test_backend.py
@@ -39,14 +39,14 @@ class TestCosineSimilarity(unittest.TestCase):
     def test_opposite_vectors(self):
         self.assertAlmostEqual(cosine_similarity([1.0, 0.0], [-1.0, 0.0]), -1.0)
 
-    def test_empty_vectors_return_zero(self):
-        self.assertEqual(cosine_similarity([], []), 0.0)
+    def test_empty_vectors_are_uncomparable(self):
+        self.assertIsNone(cosine_similarity([], []))
 
-    def test_mismatched_length_returns_zero(self):
-        self.assertEqual(cosine_similarity([1.0], [1.0, 2.0]), 0.0)
+    def test_mismatched_length_is_uncomparable(self):
+        self.assertIsNone(cosine_similarity([1.0], [1.0, 2.0]))
 
-    def test_zero_vector_returns_zero(self):
-        self.assertEqual(cosine_similarity([0.0, 0.0], [1.0, 0.0]), 0.0)
+    def test_zero_magnitude_is_uncomparable(self):
+        self.assertIsNone(cosine_similarity([0.0, 0.0], [1.0, 0.0]))
 
     def test_negative_components(self):
         a = [-1.0, -1.0]

--- a/mcp/tests/test_vecmath.py
+++ b/mcp/tests/test_vecmath.py
@@ -1,0 +1,60 @@
+"""A cosine that cannot answer must not return a number that looks like an answer.
+
+Six copies of the same eight lines existed. Four checked the lengths and returned
+0.0; two did not check at all, and `zip` truncates silently:
+
+    cosine([0.1]*768, [0.1]*384) == 0.707107
+
+This repo mixes 768-float nomic embeddings with the 384-float hash_embed in
+mcp/memcheck/vectors.py, and scripts/glymphatic_sweep.py used cosine to decide
+which memories to DELETE. 0.707 clears its duplicate threshold.
+"""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from vecmath import cosine, cosine_or  # noqa: E402
+
+
+def test_a_length_mismatch_is_unanswerable_not_a_low_score():
+    """The regression, in one line. 0.707 came from the first 384 dimensions."""
+    assert cosine([0.1] * 768, [0.1] * 384) is None
+
+
+def test_identical_vectors_still_score_one():
+    assert round(cosine([0.1] * 768, [0.1] * 768), 9) == 1.0
+
+
+def test_orthogonal_vectors_score_zero_and_that_zero_is_real():
+    """0.0 has to stay available as a genuine answer, which is exactly why it
+    cannot double as 'unanswerable'."""
+    assert cosine([1.0, 0.0], [0.0, 1.0]) == 0.0
+
+
+def test_empty_and_zero_magnitude_are_unanswerable():
+    assert cosine([], [1.0]) is None
+    assert cosine([1.0], []) is None
+    assert cosine([0.0] * 8, [1.0] * 8) is None
+
+
+def test_cosine_or_makes_the_default_visible_at_the_call_site():
+    assert cosine_or([0.1] * 768, [0.1] * 384, default=0.0) == 0.0
+    assert cosine_or([0.1] * 768, [0.1] * 384, default=-1.0) == -1.0
+    assert round(cosine_or([1.0, 0.0], [1.0, 0.0]), 6) == 1.0
+
+
+def test_no_module_keeps_its_own_copy_of_the_arithmetic():
+    """Six copies is how two of them missed the length check. Any file that both
+    zips two vectors together and divides by their norms is a seventh."""
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    offenders = []
+    for p in list(repo.glob("mcp/**/*.py")) + list(repo.glob("scripts/**/*.py")):
+        if ".venv" in p.parts or p.name in ("vecmath.py", "test_vecmath.py"):
+            continue
+        src = p.read_text(errors="ignore")
+        if "for x, y in zip(a, b)" in src or "x * y for x, y in zip(" in src:
+            offenders.append(str(p.relative_to(repo)))
+    assert not offenders, (
+        "these still compute a cosine by hand instead of using vecmath.cosine:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/mcp/vecmath.py
+++ b/mcp/vecmath.py
@@ -1,0 +1,48 @@
+"""Cosine similarity that refuses to compare vectors of different lengths.
+
+Six copies of the same eight lines existed across mcp/ and scripts/. Four
+checked the lengths; two did not, and `zip` truncates silently:
+
+    cosine([0.1]*768, [0.1]*384) == 0.707107
+
+Not an error and not a zero — a plausible similarity computed over the first 384
+dimensions. This repo mixes 768-float nomic embeddings with the 384-float
+hash_embed in mcp/memcheck/vectors.py, so the two meeting is a live possibility
+rather than a hypothetical, and glymphatic_sweep uses cosine to decide which
+memories to consolidate or discard.
+
+The four that DID check returned 0.0, which is only half right: 0.0 means
+"orthogonal — definitely not a match", a confident negative that a ranker will
+act on. A dimension mismatch is not a weak match, it is an unanswerable
+question, so this returns None and every caller decides what unavailable means
+for it.
+"""
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+
+def cosine(a: Sequence[float], b: Sequence[float]) -> Optional[float]:
+    """Cosine similarity, or None when the question cannot be answered.
+
+    None is returned for an empty vector, a length mismatch, or a zero-magnitude
+    vector — all cases where no similarity exists rather than a low one.
+    """
+    if not a or not b:
+        return None
+    if len(a) != len(b):
+        return None
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na < 1e-12 or nb < 1e-12:
+        return None
+    return sum(x * y for x, y in zip(a, b)) / (na * nb)
+
+
+def cosine_or(a: Sequence[float], b: Sequence[float], default: float = 0.0) -> float:
+    """For call sites that genuinely want a float and have decided what an
+    unanswerable comparison should count as. Naming the default at the call site
+    is the point: it makes the choice visible instead of buried in the helper."""
+    v = cosine(a, b)
+    return default if v is None else v

--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -8,6 +8,13 @@ Phase 2: Conflict detection for near-duplicate but divergent entries.
 import importlib.util
 import json
 import math
+import os as _os
+import sys as _sys
+
+# mcp/ holds the shared vector helpers; these scripts run standalone.
+_sys.path.insert(0, _os.path.join(_os.path.dirname(_os.path.dirname(
+    _os.path.abspath(__file__))), "mcp"))
+import vecmath as _vecmath  # noqa: E402
 import os
 import sqlite3
 import urllib.request
@@ -65,13 +72,9 @@ def embed(text: str) -> list[float]:
 # Cosine similarity
 # ---------------------------------------------------------------------------
 
-def cosine(a: list[float], b: list[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
-    norm_a = math.sqrt(sum(x * x for x in a))
-    norm_b = math.sqrt(sum(x * x for x in b))
-    if norm_a == 0.0 or norm_b == 0.0:
-        return 0.0
-    return dot / (norm_a * norm_b)
+def cosine(a: list[float], b: list[float]):
+    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable."""
+    return _vecmath.cosine(a, b)
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +192,10 @@ def main() -> None:
 
                 sim = cosine(vec_a, vec_b)
 
+                # Not comparable -> no edge. Linking two memories on a similarity
+                # computed from a prefix is worse than not linking them.
+                if sim is None:
+                    continue
                 if sim > AMEM_LINK_THRESHOLD:
                     cur.execute(
                         """

--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -7,7 +7,6 @@ Phase 2: Conflict detection for near-duplicate but divergent entries.
 
 import importlib.util
 import json
-import math
 import os as _os
 import sys as _sys
 

--- a/scripts/callgraph/selftest.py
+++ b/scripts/callgraph/selftest.py
@@ -309,7 +309,7 @@ def _check_lazy_import():
 def _check_real_corpus():
     result = build_graph(rev="HEAD")
     store = result.store
-    assert result.meta.file_count == 125, result.meta.file_count
+    assert result.meta.file_count == 126, result.meta.file_count
     assert result.meta.error_count == 0, result.meta.errors
     bad = registered_but_dead(store)
     assert bad == [], [n.id for n in bad]

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -1,13 +1,13 @@
 from .conftest import needs_corpus_deps, needs_git_history  # noqa: F401
 """config.py against the REAL repo: acceptance criterion is an exact file
-count (125), not a vibe. If this drifts, either the repo changed shape or
+count (126), not a vibe. If this drifts, either the repo changed shape or
 the exclusion rules regressed — both worth failing loudly on."""
 from .. import config
 
 
-def test_corpus_is_exactly_125_files():
+def test_corpus_is_exactly_126_files():
     files = config.iter_corpus_files_worktree()
-    assert len(files) == 125, sorted(files)
+    assert len(files) == 126, sorted(files)
 
 
 def test_corpus_excludes_test_directories():

--- a/scripts/callgraph/tests/test_ingest.py
+++ b/scripts/callgraph/tests/test_ingest.py
@@ -4,10 +4,10 @@ from .. import ingest
 from ..tests.helpers import source_file
 
 
-def test_load_corpus_worktree_parses_125_files_with_no_errors():
+def test_load_corpus_worktree_parses_126_files_with_no_errors():
     sources, origin = ingest.load_corpus(rev=None)
     assert origin == "working tree"
-    assert len(sources) == 125
+    assert len(sources) == 126
     errors = [(sf.rel_path, sf.error) for sf in sources if sf.error is not None]
     assert errors == []
     assert all(sf.tree is not None for sf in sources)
@@ -16,7 +16,7 @@ def test_load_corpus_worktree_parses_125_files_with_no_errors():
 def test_load_corpus_rev_head_reads_git_blobs():
     sources, origin = ingest.load_corpus(rev="HEAD")
     assert origin.startswith("rev ")
-    assert len(sources) == 125
+    assert len(sources) == 126
     assert all(sf.error is None for sf in sources)
     server = next(sf for sf in sources if sf.rel_path == "mcp/server.py")
     assert "loci-mcp" in server.source[:200]

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -15,7 +15,7 @@ from ..pipeline import build_graph
 
 
 def test_build_is_clean_and_fast(head_build):
-    assert head_build.meta.file_count == 125
+    assert head_build.meta.file_count == 126
     assert head_build.meta.error_count == 0
     # Loose sanity bound, not a benchmark: measured 4.2s standalone / 5.0s under suite load.
     assert head_build.meta.elapsed_s < 30, (

--- a/scripts/callgraph/tests/test_rev_freshness.py
+++ b/scripts/callgraph/tests/test_rev_freshness.py
@@ -65,6 +65,6 @@ def test_rev_head_is_immune_to_a_concurrently_mid_edited_working_tree(tmp_path, 
     finally:
         monkeypatch.setattr(Path, "read_text", original_read_text)
     assert origin.startswith("rev ")
-    assert len(sources) == 125
+    assert len(sources) == 126
     server = _source_for(sources, "mcp/server.py")
     assert server.error is None and "loci-mcp" in server.source[:200]

--- a/scripts/glymphatic_sweep.py
+++ b/scripts/glymphatic_sweep.py
@@ -30,6 +30,13 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os as _os
+import sys as _sys
+
+# mcp/ holds the shared vector helpers; these scripts run standalone.
+_sys.path.insert(0, _os.path.join(_os.path.dirname(_os.path.dirname(
+    _os.path.abspath(__file__))), "mcp"))
+import vecmath as _vecmath  # noqa: E402
 import os
 import sqlite3
 import sys
@@ -115,13 +122,11 @@ def _delete_points(collection: str, ids: list, dry_run: bool) -> int:
         return 0
 
 
-def _cosine(a: list[float], b: list[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
-    na  = math.sqrt(sum(x * x for x in a))
-    nb  = math.sqrt(sum(x * x for x in b))
-    if na < 1e-9 or nb < 1e-9:
-        return 0.0
-    return dot / (na * nb)
+def _cosine(a: list[float], b: list[float]):
+    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable —
+    most importantly on a length mismatch, which this used to answer with a
+    plausible number computed over the shorter vector's prefix."""
+    return _vecmath.cosine(a, b)
 
 
 # ── step 1: superseded verdicts ───────────────────────────────────────────────
@@ -292,6 +297,11 @@ def sweep_duplicates(dry_run: bool) -> int:
             if pt_b["id"] in to_delete:
                 continue
             sim = _cosine(vec_a, vec_b)
+            # This branch DELETES a memory, so an unanswerable comparison must
+            # never reach the threshold. A 768/384 mismatch used to score 0.707
+            # here, which clears DUPLICATE_COS_THRESHOLD.
+            if sim is None:
+                continue
             if sim >= DUPLICATE_COS_THRESHOLD:
                 pl_b = pt_b.get("payload") or {}
                 imp_b = float(pl_b.get("importance", 0.5) or 0.5)
@@ -322,11 +332,11 @@ def _embed_text(text: str, ollama_url: str) -> list[float] | None:
         return None
 
 
-def _cosine_vecs(a: list[float], b: list[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
-    na = math.sqrt(sum(x * x for x in a)) or 1.0
-    nb = math.sqrt(sum(x * x for x in b)) or 1.0
-    return dot / (na * nb)
+def _cosine_vecs(a: list[float], b: list[float]):
+    """Same contract as _cosine. The `or 1.0` this replaced turned a zero-magnitude
+    vector into a unit one and returned 0.0 — a drift reading manufactured from a
+    vector that carried nothing."""
+    return _vecmath.cosine(a, b)
 
 
 def check_content_shift(ollama_url: str | None = None, sample_n: int = 50) -> dict:

--- a/scripts/skillops_maintenance.py
+++ b/scripts/skillops_maintenance.py
@@ -13,7 +13,6 @@ Algorithm:
 from __future__ import annotations
 
 import json
-import math
 import os as _os
 import sys as _sys
 

--- a/scripts/skillops_maintenance.py
+++ b/scripts/skillops_maintenance.py
@@ -14,6 +14,12 @@ from __future__ import annotations
 
 import json
 import math
+import os as _os
+import sys as _sys
+
+_sys.path.insert(0, _os.path.join(_os.path.dirname(_os.path.dirname(
+    _os.path.abspath(__file__))), "mcp"))
+import vecmath as _vecmath  # noqa: E402
 import os
 import re
 import urllib.request
@@ -97,13 +103,11 @@ def _embed(text: str) -> Optional[list[float]]:
 
 # ── cosine similarity ─────────────────────────────────────────────────────────
 
-def _cosine(a: list[float], b: list[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
-    norm_a = math.sqrt(sum(x * x for x in a))
-    norm_b = math.sqrt(sum(x * x for x in b))
-    if norm_a == 0 or norm_b == 0:
-        return 0.0
-    return dot / (norm_a * norm_b)
+def _cosine(a: list[float], b: list[float]):
+    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable —
+    this was the seventh hand-rolled copy and, like two others, never checked
+    that the two vectors were the same length."""
+    return _vecmath.cosine(a, b)
 
 
 # ── main ──────────────────────────────────────────────────────────────────────
@@ -152,6 +156,11 @@ def main() -> None:
             if va is None or vb is None:
                 continue
             sim = _cosine(va, vb)
+            # Not comparable -> not a shadow pair. Reporting one on a similarity
+            # computed from a prefix would send someone to reconcile two skills
+            # that were never actually alike.
+            if sim is None:
+                continue
             if sim >= SHADOW_THRESHOLD:
                 shadow_pairs.append((records[i]["name"], records[j]["name"], sim))
 


### PR DESCRIPTION
```
cosine([0.1]*768, [0.1]*384) == 0.707107
```

Not an error, not a zero — **a plausible similarity computed over the first 384 dimensions**, because `zip` truncates to the shorter sequence.

That matters here specifically: this repo mixes 768-float nomic embeddings with the 384-float `hash_embed` in `mcp/memcheck/vectors.py`. And `scripts/glymphatic_sweep.py` used cosine to decide which memories to **delete** — 0.707 clears its duplicate threshold.

## Seven copies, three of them unguarded

```
mcp/embed_ops.py                len check -> 0.0    guarded
mcp/memcheck/llm.py             len check -> 0.0    guarded
mcp/memcheck/backend.py         len check -> 0.0    guarded
scripts/glymphatic_sweep.py     none                ✗   (×2 — _cosine and _cosine_vecs)
scripts/amem_consolidation.py   none                ✗
scripts/skillops_maintenance.py none                ✗
```

**And the guarded ones are only half right.** `0.0` is a real cosine value meaning *"orthogonal — definitely not a match"*: a confident negative that a ranker acts on. A dimension mismatch is not a weak match, it's an unanswerable question.

`mcp/vecmath.py` returns `None`, and every call site now states what unavailable means *for it*:

| site | not comparable → |
|---|---|
| `glymphatic_sweep` | not a duplicate — **nothing is deleted** |
| `amem_consolidation` | no graph edge |
| `skillops_maintenance` | not a shadow pair |
| `memcheck` coalesce | not a coalesce (merging drops a verdict) |
| `memcheck` recall | sorts last via `-1.0`, outside the range a real cosine can produce |
| `embed_ops` | not clustered; scores emit `None`, matching the `[None] * len(texts)` that function already returns when the embedder comes back short |

`cosine_or(a, b, default=...)` exists for callers that genuinely want a float — naming the default at the call site is the point.

## The seventh copy found me, not the other way round

`scripts/skillops_maintenance.py` names its function differently and my grep missed it. `test_no_module_keeps_its_own_copy_of_the_arithmetic` caught it — it fails on any file that still zips two vectors and divides by their norms. `_cosine_vecs` in `glymphatic_sweep` was also missed by grep and had `or 1.0` on its norms, turning a zero-magnitude vector into a unit one and returning a drift reading manufactured from a vector carrying nothing.

## Tests

Three existing tests asserted `cosine == 0.0` for empty, mismatched and zero-magnitude input. They assert `None` now. A new one pins that **0.0 stays available as a genuine answer** for genuinely orthogonal vectors — which is the whole reason it can't double as "unanswerable".

```
mcp 821 passed (test_graph_integration fails identically on main)
ruff clean on every touched file
```