### PR TITLE
Pin observable behavior in two tests that could only pass

### DIFF
--- a/mcp/tests/test_llm_truncation_and_routing.py
+++ b/mcp/tests/test_llm_truncation_and_routing.py
@@ -84,8 +84,9 @@ class TruncationDetectionTest(unittest.TestCase):
         log.warning.assert_not_called()
 
     def test_a_garbage_count_does_not_raise(self):
-        with mock.patch.object(llm, "_log"):
+        with mock.patch.object(llm, "_log") as log:
             llm._warn_if_truncated("x" * 100, {"prompt_eval_count": "many"}, "m")
+        log.warning.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/mcp/tests/test_mnemosyne_backend.py
+++ b/mcp/tests/test_mnemosyne_backend.py
@@ -199,7 +199,8 @@ class TestNoneCallableSafetyGuard(unittest.IsolatedAsyncioTestCase):
     async def test_record_none_does_not_raise(self):
         backend = MnemosyneBackend(remember=None)
         v = _make_verdict("memory")
-        await backend.record(v)  # should not raise
+        result = await backend.record(v)  # should not raise
+        self.assertIsNone(result)
 
     async def test_both_none_recall_empty(self):
         backend = MnemosyneBackend()


### PR DESCRIPTION
## What was wrong

Two tests asserted nothing at all. Their entire pass condition was "no exception
escaped", enforced implicitly by the runner rather than by any assert. A
regression that swallowed the error but then did the wrong thing — logged a
bogus warning, or returned non-None from a should-be-no-op — would still pass
them green.

- `test_a_garbage_count_does_not_raise` called
  `llm._warn_if_truncated("x"*100, {"prompt_eval_count": "many"}, "m")` inside
  `mock.patch.object(llm, "_log")` and never looked at the mock.
- `test_record_none_does_not_raise` awaited `MnemosyneBackend(remember=None).record(v)`
  under a `# should not raise` comment and discarded the result.

Both target real fail-open contracts worth testing — a malformed
`prompt_eval_count` from Ollama must not crash the caller, and a disabled
mnemosyne integration must be a silent no-op. The contracts were right; the
tests just never checked the outcome.

## Evidence it was real

Verified by injecting a source-level regression and re-running (test files
untouched during the injection, source restored and diffed clean afterwards):

| Regression | Old test | New test |
|---|---|---|
| `llm.py`: log a warning on the `except (TypeError, ValueError)` branch instead of returning silently | **13 passed** | **1 failed** — `Expected 'warning' to not have been called. Called 1 times.` |
| `mnemosyne.py`: `record()` returns `False` instead of implicit `None` on the `remember is None` branch | **26 passed** | **1 failed** — `AssertionError: False is not None` |

The left column is the point: each broken source sailed through the old test.
The assertions added here are load-bearing, not decorative.

## What changed

Test files only — no production code is touched by this PR.

- `mcp/tests/test_llm_truncation_and_routing.py`: bind the existing
  `mock.patch.object(llm, "_log")` to `log` and add `log.warning.assert_not_called()`,
  matching `test_a_missing_count_is_not_a_warning` directly above it and the
  sibling `TruncationSignatureEdgesTest` below, which already assert on
  `log.warning`. The machinery was present and simply unused.
- `mcp/tests/test_mnemosyne_backend.py`: capture the result and
  `self.assertIsNone(result)`.

Four lines across two files. No renames, no reformatting.

`assertIsNone` pins the declared contract rather than inventing one: the
`VerdictBackend.record` ABC declares `-> None`, all four implementations
(`backend.py` x2, `mnemosyne.py`, `qdrant.py`) declare `-> None` and none
returns a value, and all four call sites (`verdict_ops.py:205`, `cli.py:218`,
`engine.py:73`, `server.py:4170`) discard the result. Nothing depends on any
other return value.

## Verification

`mcp/tests/test_llm_truncation_and_routing.py`, `mcp/tests/test_mnemosyne_backend.py`
and `scripts/hooks/tests/test_pre_tool_grounding.py`: **294 passed, 4 subtests**.

## Deliberately left alone

`scripts/hooks/tests/test_pre_tool_grounding.py:747 test_rotate_swallows_all_exceptions`,
the third finding in the same sweep. It injects a `Boom` object whose `.exists()`
raises. `_rotate_if_needed` opens with
`if _audit_log.exists() and _audit_log.stat().st_size > MAX_AUDIT_BYTES`, so the
raise happens on the first expression and nothing downstream ever runs — there is
no post-call state on that mock worth asserting, and any assertion would be
checking the stub's own shape rather than rotation behaviour. The real
non-rotation state is already asserted by the test immediately above it, against
a genuine `tmp_path` file. Strengthening it would mean restructuring the test for
a LOW finding the report itself calls "optional, not a bug". Ran as an unchanged
regression check: 255 passed.

## Known residual, not addressed here

Two measured limits, both pre-existing and neither introduced by this change:

1. The garbage-count assertion catches a spurious-warning regression but not an
   invented-default one. Substituting `evaluated = 4096` for the silent `return`
   still passes, because the 100-char prompt gives `estimated = 25` and the
   detector additionally requires `estimated > window`. Catching that would mean
   changing the test's input, which is a larger change than the finding asked for.
2. `test_llm_truncation_and_routing.py:91` has `if __name__ == "__main__": unittest.main()`
   in the middle of the file, with `TruncationSignatureEdgesTest` defined after it.
   Under pytest all 13 tests collect and run; run directly as
   `python mcp/tests/test_llm_truncation_and_routing.py` only 10 run and the last
   class silently never executes. Untouched here to keep the diff minimal, but
   it is arguably the same bug class and worth a separate fix.
