### PR TITLE
Tell a failed lookup apart from an empty one in six fail-open lanes

### DIFF
--- a/eval/harness.py
+++ b/eval/harness.py
@@ -138,10 +138,12 @@ def upsert_score(
 # Grounding call
 # ---------------------------------------------------------------------------
 
-def call_grounding(prompt: str) -> str:
+def call_grounding(prompt: str) -> "str | None":
     """
     Invoke pre_llm_grounding.py, sending the prompt as a JSON payload on stdin.
-    Returns the context string, or empty string on failure.
+    Returns the context string, or None if the call could not be made — a broken
+    harness and a genuinely empty recall must not both score 0.000 into the
+    longitudinal eval_scores series.
     """
     payload = json.dumps(
         {"hook_event_name": "pre_llm_call", "extra": {"user_message": prompt}}
@@ -160,12 +162,15 @@ def call_grounding(prompt: str) -> str:
             timeout=60,
         )
         if result.returncode != 0:
-            return ""
+            err = (result.stderr or b"").decode("utf-8", "replace").strip()
+            print(f"  [warn] grounding exited {result.returncode}: {err[-2000:]}",
+                  file=sys.stderr)
+            return None
         parsed = json.loads(result.stdout)
         return parsed.get("context", "")
     except Exception as exc:
         print(f"  [warn] grounding call failed: {exc}", file=sys.stderr)
-        return ""
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +196,7 @@ def run() -> None:
         ensure_collection()
 
     scores: list[float] = []
+    skipped = 0
     for task in TASKS:
         task_id: str = task["id"]
         task_name: str = task["name"]
@@ -199,6 +205,12 @@ def run() -> None:
         expected_keywords: list[str] = task["expected_keywords"]
 
         context = call_grounding(prompt)
+        if context is None:
+            # The grounding call never ran. Record no measurement rather than a
+            # fabricated 0.000 that is indistinguishable from a quality regression.
+            skipped += 1
+            print(f"  [{category}] {task_id}: SKIPPED (grounding unavailable)")
+            continue
         score = score_context(context, expected_keywords)
         scores.append(score)
 
@@ -224,6 +236,9 @@ def run() -> None:
 
     mean_score = sum(scores) / len(scores) if scores else 0.0
     print(f"[eval] mean_score={mean_score:.3f} ({len(scores)} tasks)")
+    if skipped:
+        print(f"[eval] WARNING: {skipped} task(s) skipped — grounding unavailable, "
+              "this run is not comparable to a full one")
 
 
 if __name__ == "__main__":

--- a/eval/tests/test_eval.py
+++ b/eval/tests/test_eval.py
@@ -415,10 +415,13 @@ def test_call_grounding_default_interpreter_is_the_hermes_venv(monkeypatch):
     assert seen["argv"][0].endswith("/.hermes/hermes-agent/venv/bin/python3")
 
 
-def test_call_grounding_nonzero_exit_returns_empty_silently(monkeypatch, capsys):
-    monkeypatch.setattr(harness.subprocess, "run", lambda *a, **k: FakeProc(3, b"boom"))
-    assert harness.call_grounding("x") == ""
-    assert capsys.readouterr().err == ""  # no warning on this branch
+def test_call_grounding_nonzero_exit_reports_none_and_prints_the_stderr(monkeypatch, capsys):
+    """None, not "": a broken harness must not score like an empty recall."""
+    monkeypatch.setattr(harness.subprocess, "run",
+                        lambda *a, **k: FakeProc(3, b"boom", b"ModuleNotFoundError: qdrant"))
+    assert harness.call_grounding("x") is None
+    err = capsys.readouterr().err
+    assert "grounding exited 3" in err and "ModuleNotFoundError: qdrant" in err
 
 
 def test_call_grounding_missing_context_key_returns_empty(monkeypatch):
@@ -426,15 +429,15 @@ def test_call_grounding_missing_context_key_returns_empty(monkeypatch):
     assert harness.call_grounding("x") == ""
 
 
-def test_call_grounding_unparseable_stdout_warns_and_returns_empty(monkeypatch, capsys):
+def test_call_grounding_unparseable_stdout_warns_and_returns_none(monkeypatch, capsys):
     monkeypatch.setattr(harness.subprocess, "run", lambda *a, **k: FakeProc(0, b"not json"))
-    assert harness.call_grounding("x") == ""
+    assert harness.call_grounding("x") is None
     assert "grounding call failed" in capsys.readouterr().err
 
 
-def test_call_grounding_non_dict_json_warns_and_returns_empty(monkeypatch, capsys):
+def test_call_grounding_non_dict_json_warns_and_returns_none(monkeypatch, capsys):
     monkeypatch.setattr(harness.subprocess, "run", lambda *a, **k: FakeProc(0, b"[1,2]"))
-    assert harness.call_grounding("x") == ""
+    assert harness.call_grounding("x") is None
     err = capsys.readouterr().err
     assert "'list' object has no attribute 'get'" in err
 
@@ -444,14 +447,14 @@ def test_call_grounding_timeout_is_fail_open(monkeypatch, capsys):
         raise subprocess.TimeoutExpired(cmd="py", timeout=60)
 
     monkeypatch.setattr(harness.subprocess, "run", _boom)
-    assert harness.call_grounding("x") == ""
+    assert harness.call_grounding("x") is None
     assert "grounding call failed" in capsys.readouterr().err
 
 
 def test_call_grounding_missing_interpreter_is_fail_open(monkeypatch, capsys):
     """The real degraded path on CI: the hermes venv does not exist."""
     monkeypatch.setenv("LOCI_PY", "/nonexistent/python-does-not-exist")
-    assert harness.call_grounding("anything") == ""
+    assert harness.call_grounding("anything") is None
     assert "grounding call failed" in capsys.readouterr().err
 
 
@@ -553,8 +556,8 @@ def test_run_with_no_tasks_reports_zero_mean(monkeypatch, capsys):
     assert "[eval] mean_score=0.000 (0 tasks)" in capsys.readouterr().out
 
 
-def test_run_scores_zero_when_grounding_is_unavailable(monkeypatch, capsys):
-    """Fail-open: a dead grounding hook produces a clean 0.000 run, not an error."""
+def test_run_scores_zero_when_grounding_returns_an_empty_context(monkeypatch, capsys):
+    """The hook RAN and matched nothing: that is a real 0.000 measurement."""
     monkeypatch.setattr(harness, "DRY_RUN", True)
     monkeypatch.setattr(harness, "TASKS", _TWO_TASKS)
     monkeypatch.setattr(harness, "call_grounding", lambda p: "")
@@ -562,6 +565,27 @@ def test_run_scores_zero_when_grounding_is_unavailable(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "score=0.000" in out
     assert "[eval] mean_score=0.000 (2 tasks)" in out
+    assert "SKIPPED" not in out
+
+
+def test_run_skips_tasks_whose_grounding_call_never_ran(monkeypatch, capsys):
+    """A dead hook must not write a full run of fabricated 0.000 into eval_scores --
+    the longitudinal series would show a quality regression that never happened."""
+    monkeypatch.setattr(harness, "DRY_RUN", False)
+    monkeypatch.setattr(harness, "TASKS", _TWO_TASKS)
+    monkeypatch.setattr(harness, "call_grounding", lambda p: None if p == "p1" else "gamma")
+    monkeypatch.setattr(harness, "ensure_collection", lambda *a, **k: None)
+    monkeypatch.setattr(harness, "embed", lambda t: [1.0])
+    upserts = []
+    monkeypatch.setattr(harness, "upsert_score", lambda **kw: upserts.append(kw))
+
+    harness.run()
+    out = capsys.readouterr().out
+
+    assert [u["task_id"] for u in upserts] == ["t2"]      # no fabricated row for t1
+    assert "t1: SKIPPED (grounding unavailable)" in out
+    assert "[eval] mean_score=1.000 (1 tasks)" in out
+    assert "WARNING: 1 task(s) skipped" in out
 
 
 def test_run_propagates_keyerror_for_a_malformed_task(monkeypatch):

--- a/mcp/graph/analytics.py
+++ b/mcp/graph/analytics.py
@@ -30,13 +30,25 @@ def _ok(ks: Any) -> bool:
         return False
 
 
-def _q(ks: Any, cypher: str, params: dict | None = None) -> list:
-    """Fail-open read via the store's read-only code_query."""
+def _q(ks: Any, cypher: str, params: dict | None = None, failures: list | None = None) -> list:
+    """Fail-open read via the store's read-only code_query.
+
+    ``failures``: optional list; every read that did not run gets its cypher appended.
+    The store swallows read errors to [] internally, so failure is detected via its
+    monotonic ``code_query_failures`` counter — [] alone cannot say whether the graph
+    held no rows or the query never ran.
+    """
+    before = getattr(ks, "code_query_failures", 0)
     try:
-        return ks.code_query(cypher, params) or []
+        rows = ks.code_query(cypher, params) or []
     except Exception as exc:
         logger.debug("analytics query failed: %s", exc)
+        if failures is not None:
+            failures.append(cypher)
         return []
+    if failures is not None and getattr(ks, "code_query_failures", 0) != before:
+        failures.append(cypher)
+    return rows
 
 
 def impact_report(ks: Any, symbol: str, hops: int = 3, limit: int = 200) -> dict:
@@ -49,20 +61,28 @@ def impact_report(ks: Any, symbol: str, hops: int = 3, limit: int = 200) -> dict
 
     Shape: ``{symbol, resolved:[{id,name,kind}], direct_callers:[names],
     transitive_caller_count, referencing_finding_count,
-    investigations:[{id, finding_count, sample}], co_referenced:[{name,count}]}``.
+    investigations:[{id, finding_count, sample}], co_referenced:[{name,count}],
+    partial, queries_failed}``.
+
+    ``partial`` is the honesty flag: reads fail open, so a dead CALLS query would
+    otherwise report a resolved symbol as having zero callers — a positive claim,
+    and the exact input to a decision to change or delete it. When ``partial`` is
+    true the counts are floors, not measurements.
     """
     empty = {"symbol": symbol, "resolved": [], "direct_callers": [],
              "transitive_caller_count": 0, "referencing_finding_count": 0,
-             "investigations": [], "co_referenced": []}
+             "investigations": [], "co_referenced": [],
+             "partial": False, "queries_failed": 0}
     if not _ok(ks) or not symbol:
         return empty
     hops = max(1, min(int(hops or 1), 6))
+    failed: list = []
 
     # 1) Resolve the name to target symbol ids (by id first, else by name).
     rows = _q(ks, "MATCH (s:CodeSymbol) WHERE s.id = $s OR s.name = $s "
-                  "RETURN s.id, s.name, s.kind, s.file", {"s": symbol})
+                  "RETURN s.id, s.name, s.kind, s.file", {"s": symbol}, failures=failed)
     if not rows:
-        return empty
+        return {**empty, "partial": bool(failed), "queries_failed": len(failed)}
     targets = {r[0]: {"id": r[0], "name": r[1], "kind": r[2], "file": r[3]} for r in rows}
 
     # 2) For class-like targets, fold in the class's own methods (prefix match on id).
@@ -71,7 +91,7 @@ def impact_report(ks: Any, symbol: str, hops: int = 3, limit: int = 200) -> dict
         if t["kind"] in type_kinds:
             prefix = f"{t['file']}::{t['name']}."
             for r in _q(ks, "MATCH (s:CodeSymbol) WHERE s.file = $f AND s.kind = 'method' "
-                            "RETURN s.id, s.name, s.kind, s.file", {"f": t["file"]}):
+                            "RETURN s.id, s.name, s.kind, s.file", {"f": t["file"]}, failures=failed):
                 if r[0].startswith(prefix):
                     targets.setdefault(r[0], {"id": r[0], "name": r[1], "kind": r[2], "file": r[3]})
     target_ids = list(targets)
@@ -81,17 +101,17 @@ def impact_report(ks: Any, symbol: str, hops: int = 3, limit: int = 200) -> dict
         f"MATCH (c:CodeSymbol)-[:CALLS*1..{hops}]->(t:CodeSymbol) "
         "WHERE t.id IN $ids AND NOT c.id IN $ids "
         "RETURN DISTINCT c.id, c.name LIMIT $lim",
-        {"ids": target_ids, "lim": int(limit)})
+        {"ids": target_ids, "lim": int(limit)}, failures=failed)
     caller_ids = [r[0] for r in caller_rows]
     direct = _q(ks,
         "MATCH (c:CodeSymbol)-[:CALLS]->(t:CodeSymbol) WHERE t.id IN $ids AND NOT c.id IN $ids "
-        "RETURN DISTINCT c.name LIMIT 40", {"ids": target_ids})
+        "RETURN DISTINCT c.name LIMIT 40", {"ids": target_ids}, failures=failed)
 
     # 4) Findings referencing any target OR caller; grouped by investigation.
     affected = target_ids + caller_ids
     fi = _q(ks,
         "MATCH (f:Finding)-[:REFERENCES]->(s:CodeSymbol) WHERE s.id IN $ids "
-        "RETURN DISTINCT f.id, f.investigation, f.text", {"ids": affected})
+        "RETURN DISTINCT f.id, f.investigation, f.text", {"ids": affected}, failures=failed)
     by_inv: dict[str, dict] = {}
     seen_f: set = set()
     for fid, inv, text in fi:
@@ -107,7 +127,7 @@ def impact_report(ks: Any, symbol: str, hops: int = 3, limit: int = 200) -> dict
     co = _q(ks,
         "MATCH (f:Finding)-[:REFERENCES]->(t:CodeSymbol) WHERE t.id IN $ids "
         "MATCH (f)-[:REFERENCES]->(o:CodeSymbol) WHERE NOT o.id IN $ids "
-        "RETURN o.name, count(DISTINCT f) AS c ORDER BY c DESC LIMIT 8", {"ids": target_ids})
+        "RETURN o.name, count(DISTINCT f) AS c ORDER BY c DESC LIMIT 8", {"ids": target_ids}, failures=failed)
 
     return {
         "symbol": symbol,
@@ -117,6 +137,8 @@ def impact_report(ks: Any, symbol: str, hops: int = 3, limit: int = 200) -> dict
         "referencing_finding_count": len(seen_f),
         "investigations": investigations,
         "co_referenced": [{"name": r[0], "count": r[1]} for r in co],
+        "partial": bool(failed),
+        "queries_failed": len(failed),
     }
 
 

--- a/mcp/graph/ladybug_store.py
+++ b/mcp/graph/ladybug_store.py
@@ -256,6 +256,10 @@ class LadybugStore:
         self._schema_ready = False    # schema ensured once per process (idempotent)
         # "worth attempting" — the DB is opened per-op, so the store self-heals when the lock frees.
         self.ok = bool(_HAS_LADYBUG and db_path)
+        # Monotonic count of read errors swallowed by code_query(). Fail-open callers
+        # sample it around a call to tell "the graph held no rows" from "the query
+        # never ran" — an empty list on its own says both.
+        self.code_query_failures = 0
         if not _HAS_LADYBUG:
             logger.info("ladybug not importable; LadybugStore unavailable")
 
@@ -1050,6 +1054,7 @@ class LadybugStore:
             return self._rows(cypher, params)
         except Exception as exc:
             logger.debug("code_query failed: %s", exc)
+            self.code_query_failures += 1
             return []
 
     # ------------------------------------------------------------------ #

--- a/mcp/ladybug_ops.py
+++ b/mcp/ladybug_ops.py
@@ -127,7 +127,14 @@ def _get_symbol_index(ks):
         return None
     try:
         rows = ks.code_query("MATCH (s:CodeSymbol) RETURN count(s)")
-        count = int(rows[0][0]) if rows and rows[0] else 0
+        if not rows or not rows[0]:
+            # A successful count always returns one row, so this is the query failing
+            # (code_query swallows read errors to []). Keep whatever index is already
+            # warm — evicting it here would drop every later finding's code links on a
+            # transient store error and report it as "no code graph ingested yet".
+            logger.warning("symbol index: CodeSymbol count query failed; keeping cached index")
+            return _symbol_index_cache
+        count = int(rows[0][0])
         if count == 0:
             _symbol_index_cache, _symbol_index_count = None, 0
             return None
@@ -218,10 +225,16 @@ def _ladybug_backfill_if_empty(ks) -> None:
         for iv in invs:
             ks.upsert_investigation(iv, "")
         n = ks.upsert_findings_batch(finding_rows)
-        ks.link_mentions_batch(mention_rows)
-        ks.link_derived_from_batch(derived_rows)
+        m = ks.link_mentions_batch(mention_rows)
+        d = ks.link_derived_from_batch(derived_rows)
         logger.info("LadybugDB backfill: mirrored %d findings, %d mentions, %d derivations (batched).",
-                    n, len(mention_rows), len(derived_rows))
+                    n, m, d)
+        # The batch writers fail open to 0 (store down, write lease contended), so
+        # report what was written, not what was offered.
+        if n < len(finding_rows) or m < len(mention_rows) or d < len(derived_rows):
+            logger.warning("LadybugDB backfill short-wrote: findings %d/%d, mentions %d/%d, "
+                           "derivations %d/%d — graph analytics will under-report.",
+                           n, len(finding_rows), m, len(mention_rows), d, len(derived_rows))
     except Exception as exc:
         logger.debug("LadybugDB backfill batch failed (fail-open): %r", exc)
 

--- a/mcp/memcheck/cli.py
+++ b/mcp/memcheck/cli.py
@@ -534,7 +534,7 @@ def _cmd_stats(argv: list[str]) -> int:
     engine = VerdictEngine(backend, EmlConfig())
     stats = asyncio.run(engine.stats())
     print(json.dumps(stats, indent=2, sort_keys=True))
-    return 0
+    return 0 if stats.get("ok", True) else 1
 
 
 # --------------------------------------------------------------------------- #

--- a/mcp/memcheck/engine.py
+++ b/mcp/memcheck/engine.py
@@ -137,12 +137,17 @@ class VerdictEngine:
             return 0
 
     async def stats(self) -> dict:
-        """Backend stats. Fail-open: returns zeroed stats on error."""
+        """Backend stats. Fail-open: returns zeroed stats marked ``ok: False`` on error.
+
+        The zeros are invented, not measured, and they are exactly what a memcheck
+        that has never fired also reports — so the caller is told which one it got.
+        """
         try:
             return await self.backend.stats()
         except Exception as exc:  # noqa: BLE001 — fail-open boundary
             _log.debug("memcheck stats failed, degrading to zeros: %r", exc)
-            return {"total_verdicts": 0, "recurring_blocks": 0}
+            return {"total_verdicts": 0, "recurring_blocks": 0,
+                    "ok": False, "error": repr(exc)}
 
     def summary(self) -> str:
         """Human-readable one-liner describing the engine configuration."""

--- a/mcp/tests/test_analytics.py
+++ b/mcp/tests/test_analytics.py
@@ -108,6 +108,39 @@ def test_dead_code_candidates(tmp_path):
     assert names.isdisjoint({"tool_fn", "_private", "main", "setUp", "used_fn"})
 
 
+def test_impact_report_healthy_run_is_not_partial(ks):
+    r = A.impact_report(ks, "foo")
+    assert r["partial"] is False
+    assert r["queries_failed"] == 0
+
+
+def test_impact_report_flags_a_dead_caller_query_instead_of_claiming_no_callers(ks, monkeypatch):
+    """Reads fail open to [], so a dead CALLS query would otherwise report a symbol
+    that IS in the graph as having zero callers — the input to a delete decision."""
+    real_rows = ks._rows
+
+    def flaky(cypher, params=None):
+        if "CALLS" in cypher:
+            raise RuntimeError("ladybug read session unavailable")
+        return real_rows(cypher, params)
+
+    monkeypatch.setattr(ks, "_rows", flaky)
+    r = A.impact_report(ks, "foo")
+
+    assert {x["name"] for x in r["resolved"]} == {"foo"}   # the symbol resolved fine
+    assert r["direct_callers"] == []                       # ... but nobody asked
+    assert r["transitive_caller_count"] == 0
+    assert r["partial"] is True
+    assert r["queries_failed"] == 2                        # transitive + direct
+
+
+def test_impact_report_flags_a_dead_resolve_query(ks, monkeypatch):
+    monkeypatch.setattr(ks, "_rows", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("down")))
+    r = A.impact_report(ks, "foo")
+    assert r["resolved"] == []
+    assert r["partial"] is True   # "not in the graph" and "never asked" are different
+
+
 def test_fail_open():
     class Dead:
         def available(self):

--- a/mcp/tests/test_cli_dispatch.py
+++ b/mcp/tests/test_cli_dispatch.py
@@ -186,5 +186,46 @@ class TestProcessCode(unittest.TestCase):
         self.assertIsInstance(record, dict)
 
 
+class TestStatsDegradation(unittest.TestCase):
+    """A zeroed stats page is what a never-firing memcheck AND an unreachable store
+    both produce. The degraded one has to say so."""
+
+    class _DeadBackend(InMemoryBackend):
+        async def stats(self) -> dict:
+            raise RuntimeError("qdrant unreachable")
+
+    def test_healthy_stats_pass_through_without_an_ok_flag(self):
+        import asyncio
+
+        stats = asyncio.run(_engine().stats())
+        self.assertEqual(stats.get("total_verdicts"), 0)
+        self.assertNotIn("error", stats)
+        self.assertTrue(stats.get("ok", True))
+
+    def test_backend_error_is_marked_not_measured(self):
+        import asyncio
+
+        engine = VerdictEngine(self._DeadBackend(), EmlConfig())
+        stats = asyncio.run(engine.stats())
+        self.assertEqual(stats["total_verdicts"], 0)
+        self.assertIs(stats["ok"], False)
+        self.assertIn("qdrant unreachable", stats["error"])
+
+    def test_cmd_stats_exit_code_follows_the_ok_flag(self):
+        import io
+        import contextlib
+        from unittest import mock
+
+        with mock.patch.object(cli, "_build_qdrant_backend", lambda: self._DeadBackend()), \
+                contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = cli._cmd_stats([])
+        self.assertEqual(rc, 1)
+        self.assertIn('"ok": false', out.getvalue())
+
+        with mock.patch.object(cli, "_build_qdrant_backend", lambda: InMemoryBackend()), \
+                contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(cli._cmd_stats([]), 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/mcp/tests/test_ladybug_ops_degraded.py
+++ b/mcp/tests/test_ladybug_ops_degraded.py
@@ -1,0 +1,105 @@
+"""ladybug_ops: a graph read that FAILED must not be reported as a graph that is EMPTY.
+
+Both paths here fail open on purpose; what is under test is that the failure leaves
+a trace instead of a clean, wrong-looking success.
+"""
+import json
+import logging
+
+import pytest
+
+import ladybug_ops as L
+
+
+class FakeStore:
+    """Stands in for LadybugStore: code_query fails open to [] the way the real one does."""
+
+    def __init__(self, count_rows, write_returns=(0, 0, 0)):
+        self.count_rows = count_rows
+        self.write_returns = write_returns
+        self.investigations = []
+
+    def code_query(self, cypher, params=None):
+        return self.count_rows
+
+    def _rows(self, cypher, params=None):
+        return [["a.py::foo", "foo", "function", "a.py"]]
+
+    def upsert_investigation(self, iv, title=""):
+        self.investigations.append(iv)
+
+    def upsert_findings_batch(self, rows):
+        return self.write_returns[0]
+
+    def link_mentions_batch(self, rows):
+        return self.write_returns[1]
+
+    def link_derived_from_batch(self, rows):
+        return self.write_returns[2]
+
+
+@pytest.fixture(autouse=True)
+def _clean_index_cache():
+    L.invalidate_symbol_index()
+    yield
+    L.invalidate_symbol_index()
+
+
+# --------------------------------------------------------------------------- #
+# _get_symbol_index
+# --------------------------------------------------------------------------- #
+
+def test_failed_count_query_keeps_the_warm_index_instead_of_evicting_it(caplog):
+    """A count query ALWAYS returns one row, so [] is the query failing.
+
+    Evicting here drops every subsequent finding's REFERENCES edges on a transient
+    store error, and _autolink then reports it as "no code graph ingested yet".
+    """
+    L._symbol_index_cache, L._symbol_index_count = {"warm": ["a.py::foo"]}, 7
+    with caplog.at_level(logging.WARNING, logger="loci-mcp"):
+        index = L._get_symbol_index(FakeStore(count_rows=[]))
+
+    assert index == {"warm": ["a.py::foo"]}
+    assert L._symbol_index_cache == {"warm": ["a.py::foo"]}
+    assert L._symbol_index_count == 7
+    assert "count query failed" in caplog.text
+
+
+def test_a_genuinely_empty_graph_still_clears_the_index():
+    L._symbol_index_cache, L._symbol_index_count = {"warm": ["a.py::foo"]}, 7
+    assert L._get_symbol_index(FakeStore(count_rows=[[0]])) is None
+    assert L._symbol_index_cache is None
+    assert L._symbol_index_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# _ladybug_backfill_if_empty
+# --------------------------------------------------------------------------- #
+
+def _seed_memory(tmp_path):
+    inv = tmp_path / "inv1"
+    inv.mkdir()
+    (inv / "findings.jsonl").write_text(
+        json.dumps({"id": "f1", "text": "t", "entities": {"file": ["a.py"]},
+                    "derived_from": ["f0"]}) + "\n"
+    )
+    return tmp_path
+
+
+def test_backfill_logs_what_was_written_not_what_was_offered(tmp_path, caplog, monkeypatch):
+    """Under a contended write lease every batch writes nothing and returns 0."""
+    monkeypatch.setattr(L, "_get_memory_dir", lambda: _seed_memory(tmp_path))
+    with caplog.at_level(logging.INFO, logger="loci-mcp"):
+        L._ladybug_backfill_if_empty(FakeStore(count_rows=[[0]], write_returns=(0, 0, 0)))
+
+    assert "mirrored 0 findings, 0 mentions, 0 derivations" in caplog.text
+    assert "short-wrote" in caplog.text
+
+
+def test_backfill_is_quiet_when_every_batch_wrote_its_input(tmp_path, caplog, monkeypatch):
+    monkeypatch.setattr(L, "_get_memory_dir", lambda: _seed_memory(tmp_path))
+    with caplog.at_level(logging.INFO, logger="loci-mcp"):
+        L._ladybug_backfill_if_empty(FakeStore(count_rows=[[0]], write_returns=(1, 1, 1)))
+
+    assert "mirrored 1 findings, 1 mentions, 1 derivations" in caplog.text
+    assert "short-wrote" not in caplog.text

--- a/mcp/tests/test_ladybug_store.py
+++ b/mcp/tests/test_ladybug_store.py
@@ -394,6 +394,19 @@ def test_code_query_write_guard(tmp_path):
             store.code_query(bad)
 
 
+def test_code_query_counts_the_reads_it_swallows(tmp_path, monkeypatch):
+    """code_query fails open to [], which is also what "no rows" looks like. The
+    counter is the only way a fail-open caller can tell the two apart."""
+    store = LadybugStore(str(tmp_path / "counterdb"))
+    assert store.available()
+    assert store.code_query("MATCH (s:CodeSymbol) RETURN s.id") == []
+    assert store.code_query_failures == 0
+
+    monkeypatch.setattr(store, "_rows", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("down")))
+    assert store.code_query("MATCH (s:CodeSymbol) RETURN s.id") == []
+    assert store.code_query_failures == 1
+
+
 def _sym(sid, name, file, line=1, lang="python"):
     return {"id": sid, "name": name, "kind": "function",
             "line": line, "lang": lang, "file": file}

--- a/scripts/hooks/pre_llm_grounding.py
+++ b/scripts/hooks/pre_llm_grounding.py
@@ -480,7 +480,11 @@ def _clean_content(content: str) -> str:
     return f"user: {m.group(1)[:200]}" if m else ""
 
 
-def _format_results(hits: list[dict], query: str, used_fallback: bool) -> str:
+def _format_results(hits: list[dict], query: str, used_fallback: bool,
+                    unreachable: int = 0) -> str:
+    """Render the recall block. ``unreachable`` is the number of collections whose
+    search failed this turn; the header states real coverage, because the model is
+    asked to trust it as "this is what memory holds"."""
     lines = []
     seen = set()
     for h in hits:
@@ -502,7 +506,14 @@ def _format_results(hits: list[dict], query: str, used_fallback: bool) -> str:
     if not lines:
         return GROUNDING_DIRECTIVE
 
-    src = "BeamMemory fallback" if used_fallback else f"{len(COLLECTIONS)} Qdrant collections"
+    if used_fallback:
+        src = "BeamMemory fallback"
+    elif unreachable:
+        reached = max(len(COLLECTIONS) - unreachable, 0)
+        src = (f"{reached} of {len(COLLECTIONS)} Qdrant collections "
+               f"({unreachable} unreachable)")
+    else:
+        src = f"{len(COLLECTIONS)} Qdrant collections"
     header = f'MEMORY MATCH ({len(lines)} results from {src}) for "{query}":'
     body = "\n".join(lines)
     footer = (
@@ -589,6 +600,7 @@ def main() -> None:
     # ── v3: embed → parallel Qdrant fan-out (main session) ───────────────────
     vector = _embed(intent)
     used_fallback = False
+    failed = 0
 
     if vector is None:
         hits = _beam_fallback(intent)
@@ -616,7 +628,7 @@ def main() -> None:
                 ): col
                 for col, cf, impf, named in COLLECTIONS
             }
-            searched = failed = 0
+            searched = 0
             for f in as_completed(futures):
                 searched += 1
                 try:
@@ -680,7 +692,17 @@ def main() -> None:
                 pass
 
     if hits:
-        recall_block = _format_results(hits, intent, used_fallback)
+        recall_block = _format_results(hits, intent, used_fallback, failed)
+    elif failed:
+        # Nothing came back AND part of memory was dark: an empty result is what a
+        # genuine miss looks like too, so say which one this was.
+        recall_block = (
+            f"[WARNING: memory grounding INCOMPLETE this turn — {failed} of "
+            f"{len(COLLECTIONS)} Qdrant collections were unreachable and no result "
+            "came back. Treat this as 'memory was not searched', not as 'memory "
+            "holds nothing'. Read the relevant files before using any name.]\n\n"
+            + GROUNDING_DIRECTIVE
+        )
     else:
         recall_block = GROUNDING_DIRECTIVE
 

--- a/scripts/hooks/session_end_sync.py
+++ b/scripts/hooks/session_end_sync.py
@@ -351,12 +351,14 @@ def qdrant_upsert(point_id: int, vector: list, payload: dict):
         result = json.loads(resp.read())
     return result.get("status") == "ok"
 
-def _check_wiring_obligations(investigation_id: str, payload: dict) -> str:
+def _check_wiring_obligations(investigation_id: str, payload: dict) -> "str | None":
     """Query Loci for unresolved wiring obligations and append to upsert payload.
 
     Uses the MCP HTTP API if QDRANT-side Loci is available; otherwise reads
     the investigation findings.jsonl directly for the wiring_obligation tag.
-    Non-fatal: returns empty string on any error.
+    Non-fatal. Returns "" when the check ran and found nothing outstanding, and
+    None when the check could not run — a health report whose failure mode is a
+    clean line is worse than no report.
     """
     loci_dir = os.path.expanduser(
         os.environ.get("LOCI_INVESTIGATIONS_DIR", "~/.loci/investigations")
@@ -382,8 +384,9 @@ def _check_wiring_obligations(investigation_id: str, payload: dict) -> str:
             tags = rec.get("tags", [])
             if "wiring_obligation" in tags and rec.get("record_type") == "gap":
                 unresolved.append(rec.get("text", fid)[:120])
-    except Exception:
-        return ""
+    except Exception as e:
+        print(f"[session_end_sync] wiring-obligation check failed: {e}", file=sys.stderr)
+        return None
 
     count = len(unresolved)
     if count == 0:
@@ -459,8 +462,11 @@ def main():
         if ACTIVE_INV:
             try:
                 unresolved_note = _check_wiring_obligations(ACTIVE_INV, payload)
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"[session_end_sync] wiring-obligation check failed: {e}", file=sys.stderr)
+                unresolved_note = None
+            if unresolved_note is None:
+                unresolved_note = " | wiring-obligation check FAILED"
 
         print(f"[session_end_sync] synced {session_id[:20]} ({sess['msg_count']} msgs) in {elapsed:.2f}s{unresolved_note}")
 

--- a/scripts/hooks/tests/test_pre_llm_grounding.py
+++ b/scripts/hooks/tests/test_pre_llm_grounding.py
@@ -907,6 +907,16 @@ def test_format_results_skips_hits_cleaned_to_empty(hook):
     assert out.count("[c|") == 1 and "real content" in out
 
 
+def test_format_results_header_states_real_coverage_on_a_partial_outage(hook):
+    """The header is a coverage claim the model is asked to trust: on a partial
+    outage it must not assert that all three collections answered."""
+    hits = [{"collection": "loci_memory", "score": 0.5, "content": "x"}]
+    out = hook._format_results(hits, "q", False, 2)
+    assert out.splitlines()[0] == (
+        'MEMORY MATCH (1 results from 1 of 3 Qdrant collections (2 unreachable)) for "q":'
+    )
+
+
 def test_format_results_returns_directive_when_nothing_survives(hook):
     assert hook._format_results([], "q", False) == hook.GROUNDING_DIRECTIVE
     only_empty = [{"collection": "c", "score": 0.9, "content": "   "}]
@@ -1107,6 +1117,33 @@ def test_main_one_collection_blowing_up_does_not_sink_the_turn(hook):
     assert "from loci_sessions" in ctx and "from loci_memory" in ctx
     assert "from mnemosyne" not in ctx
     assert "(2 results" in ctx
+    assert "2 of 3 Qdrant collections (1 unreachable)" in ctx
+
+
+def test_main_partial_outage_with_no_hits_warns_instead_of_a_bare_directive(hook):
+    """An empty result is what a genuine miss looks like too. When part of memory
+    was dark, say so -- the total-outage path already does."""
+    def _search(col, vec, cf, impf, named, top_k):
+        if col == "mnemosyne":
+            raise RuntimeError("collection on fire")
+        return []
+
+    hook._embed = lambda t: [0.1]
+    hook._search_collection = _search
+    hook._load_rules_summary = lambda: ""
+    _, out = run_main(hook, _prompt())
+    ctx = context_of(out)
+    assert ctx.startswith("[WARNING: memory grounding INCOMPLETE this turn")
+    assert "1 of 3 Qdrant collections were unreachable" in ctx
+    assert ctx.endswith(hook.GROUNDING_DIRECTIVE)
+
+
+def test_main_healthy_empty_search_stays_a_bare_directive(hook):
+    hook._embed = lambda t: [0.1]
+    hook._search_collection = lambda *a, **k: []
+    hook._load_rules_summary = lambda: ""
+    _, out = run_main(hook, _prompt())
+    assert context_of(out) == hook.GROUNDING_DIRECTIVE
 
 
 def test_main_filters_hits_below_min_importance(hook):

--- a/scripts/hooks/tests/test_session_end_sync.py
+++ b/scripts/hooks/tests/test_session_end_sync.py
@@ -865,17 +865,34 @@ def test_wiring_samples_capped_at_three_but_count_is_total(inv_env):
     assert payload["unresolved_wiring_obligation_samples"] == ["t6", "t5", "t4"]
 
 
-def test_wiring_explicit_null_text_aborts_the_whole_scan(inv_env):
-    """BUG: `rec.get("text", fid)` returns None for `"text": null`; the
-    resulting TypeError is swallowed by the outer handler, so *every*
-    obligation in the file is discarded, not just the bad record."""
+def test_wiring_explicit_null_text_aborts_the_whole_scan(inv_env, capsys):
+    """BUG (still): `rec.get("text", fid)` returns None for `"text": null`, and the
+    resulting TypeError discards *every* obligation in the file, not just the bad
+    record. It now reports None ("could not check") rather than "" ("none open")."""
     write_findings(inv_env, "inv1", [
         gap("f1", "real obligation"),
         {"id": "f2", "text": None, "tags": ["wiring_obligation"], "record_type": "gap"},
     ])
     payload = {}
-    assert inv_env._check_wiring_obligations("inv1", payload) == ""
+    assert inv_env._check_wiring_obligations("inv1", payload) is None
     assert payload == {}
+    assert "wiring-obligation check failed" in capsys.readouterr().err
+
+
+def test_wiring_unreadable_findings_file_is_reported_not_read_as_zero(inv_env, capsys):
+    """A health report whose failure mode is "healthy" is worse than no report:
+    "" means checked-and-clean, None means the check could not run."""
+    d = pathlib.Path(inv_env.os.environ["LOCI_INVESTIGATIONS_DIR"]) / "inv1"
+    (d / "findings.jsonl").mkdir(parents=True)      # exists, but open() blows up
+    payload = {}
+    assert inv_env._check_wiring_obligations("inv1", payload) is None
+    assert payload == {}
+    assert "wiring-obligation check failed" in capsys.readouterr().err
+
+
+def test_wiring_returns_empty_string_when_it_checked_and_found_nothing(inv_env):
+    write_findings(inv_env, "inv1", [gap("f1", tags=["other"])])
+    assert inv_env._check_wiring_obligations("inv1", {}) == ""
 
 
 def test_wiring_reads_the_investigations_dir_at_call_time(hook, tmp_path, monkeypatch):
@@ -1122,12 +1139,24 @@ def test_main_skips_the_wiring_check_without_an_active_investigation(wired, caps
     assert "unresolved_wiring_obligations" not in wired._rec["upsert"][0]["payload"]
 
 
-def test_main_wiring_check_failure_is_swallowed(wired, capsys):
+def test_main_wiring_check_failure_is_non_fatal_but_visible(wired, capsys):
     wired.ACTIVE_INV = "inv1"
     wired._check_wiring_obligations = mock.Mock(side_effect=RuntimeError("nope"))
     seed_session(wired)
     assert run_main(wired, {"session_id": "s1"}) is None
-    assert "[session_end_sync] synced s1 (2 msgs)" in capsys.readouterr().out
+    cap = capsys.readouterr()
+    assert "[session_end_sync] synced s1 (2 msgs)" in cap.out
+    assert "| wiring-obligation check FAILED" in cap.out
+    assert "nope" in cap.err
+
+
+def test_main_reports_a_check_that_could_not_run(wired, capsys):
+    """The unreadable-file path: the sync line must not read as a clean bill."""
+    wired.ACTIVE_INV = "inv1"
+    wired._check_wiring_obligations = mock.Mock(return_value=None)
+    seed_session(wired)
+    run_main(wired, {"session_id": "s1"})
+    assert "| wiring-obligation check FAILED" in capsys.readouterr().out
 
 
 def test_main_end_to_end_over_a_patched_urlopen(hook, capsys):


### PR DESCRIPTION
## What was wrong

Six lanes collapse a *failed* lookup into the exact value a *successful but empty*
lookup produces. The caller — sometimes an operator, sometimes the model itself —
then reads an outage as a measurement.

| Site | Failure renders as |
|---|---|
| `mcp/graph/analytics.py` `impact_report` | a symbol that IS in the graph reported with `direct_callers: []`, `transitive_caller_count: 0` |
| `scripts/hooks/pre_llm_grounding.py` | `MEMORY MATCH (N results from 3 Qdrant collections)` when one answered; bare directive when none did |
| `mcp/ladybug_ops.py` `_get_symbol_index` | `# no code graph ingested yet` — and a warm index evicted |
| `mcp/ladybug_ops.py` backfill log | `mirrored 0 findings, 8421 mentions, 300 derivations` with nothing written |
| `mcp/memcheck/engine.py` `stats()` | `total_verdicts: 0, recurring_blocks: 0`, exit 0 |
| `scripts/hooks/session_end_sync.py` | a clean `synced s1 (2 msgs)` line with the obligations warning deleted |
| `eval/harness.py` `call_grounding` | `0.000` written into the longitudinal `eval_scores` series |

### Evidence it was real

Each of these was reproduced by reverting the file and running the new test — the
old code produces the wrong-looking success, verbatim. Two are worth quoting:

- Backfill, on `origin/main`, with all three batch writers returning 0:
  `INFO LadybugDB backfill: mirrored 0 findings, 1 mentions, 1 derivations (batched).`
  Two of the three numbers came from `len()` of the *input* lists.
- `impact_report`, on `origin/main`, with only the `CALLS` reads failing: the symbol
  resolves fine and the report asserts zero callers. That is the input to a decision
  to change or delete it. `dead_code_candidates` in the same file fails in the safe
  direction; `impact_report` fails in the unsafe one.

The `_SearchFailed` docstring in `pre_llm_grounding.py` already states the principle
("an empty list is what a genuinely unmatched query looks like") — the total-failure
fix landed there, the partial-failure one did not.

## What changed

- **`LadybugStore.code_query_failures`** — a monotonic count of the reads `code_query`
  swallows to `[]`. Additive; no existing caller's contract changes. The write-guard
  `ValueError` still raises before the counter, so a rejected query is not counted.
- **`analytics._q(..., failures=[])`** — opt-in failure channel, sampling that counter
  around the call. Default `failures=None` keeps the old signature and behaviour, so
  `subsystem_report`, `finding_code_context` and `dead_code_candidates` are untouched.
- **`impact_report`** gains `partial` / `queries_failed`. Consumers read specific keys
  (`graph_tools`, `grounding.py`, `graph_facts.py`, `investigation_code_briefing`) —
  all checked, none break on two extra keys.
- **`pre_llm_grounding`** — `_format_results` takes an optional `unreachable` count and
  states real coverage (`1 of 3 Qdrant collections (2 unreachable)`); a dark-and-empty
  turn gets the same kind of WARNING block the total-outage path already emits instead
  of the bare directive. The BeamMemory-fallback label still wins when it applies.
- **`_get_symbol_index`** — a count query always returns one row, so no rows means the
  query failed: keep the warm cache, log the real cause at WARNING. A genuine `count == 0`
  still clears it.
- **Backfill** — capture all three returned counts, log those, and warn on a short write.
- **`memcheck stats`** — degraded dict carries `ok: false` + `error`; `_cmd_stats` exits 1.
  No backend emits an `ok` key, so `stats.get("ok", True)` leaves healthy output unchanged.
- **`session_end_sync._check_wiring_obligations`** — `Optional[str]`: `""` = checked and
  clean, `None` = could not check. The caller's bare `except: pass` now prints the
  exception and the sync line says `| wiring-obligation check FAILED`.
- **`eval/harness.call_grounding`** — returns `None` when the call could not be made,
  and prints the subprocess stderr that was previously discarded. `run()` skips those
  tasks (no `upsert_score` row) and warns that the run is not comparable.

## Tests

23 tests added or rewritten. Each fix is pinned by a pair: the failure case *and* the
genuinely-empty case, so the distinction itself is what is under test, not just the new
field. Red-then-green was re-verified independently for every one by restoring the
`origin/main` version of each source file:

| Reverted | Fails |
|---|---|
| `analytics.py` + `ladybug_store.py` | 4 — `KeyError: 'partial'` ×3, `AttributeError: 'LadybugStore' object has no attribute 'code_query_failures'` |
| `ladybug_ops.py` | 2 — `assert None == {'warm': ['a.py::foo']}`; log said `mirrored 0 findings, 1 mentions, 1 derivations` |
| `memcheck/engine.py` + `cli.py` | 2 — `KeyError: 'ok'`; `AssertionError: 0 != 1` |
| `pre_llm_grounding.py` | 3 — `_format_results() takes 3 positional arguments but 4 were given`; missing coverage string; bare directive |
| `session_end_sync.py` | 4 — `assert '' is None` ×2; `'\| wiring-obligation check FAILED' not in ...` ×2 |
| `eval/harness.py` | 6 — `assert '' is None` ×5; `'NoneType' object has no attribute 'lower'` |

The control halves (`test_impact_report_healthy_run_is_not_partial`,
`test_a_genuinely_empty_graph_still_clears_the_index`,
`test_backfill_is_quiet_when_every_batch_wrote_its_input`,
`test_main_healthy_empty_search_stays_a_bare_directive`,
`test_wiring_returns_empty_string_when_it_checked_and_found_nothing`) pass on both sides
by design — they exist so an over-correction (warning unconditionally, never clearing the
cache) fails.

Full run: `mcp/tests eval/tests scripts/hooks/tests` → **1515 passed, 1 failed**; the one
failure is `test_graph_integration.py::test_code_graph_ingest_and_query` (`KeyError:
'ingested'`), confirmed pre-existing on clean `origin/main` in a separate worktree.
`tests scripts/tests` → 164 passed. The changed suites also pass in randomized order
(743 passed), which matters because the new `test_ladybug_ops_degraded.py` touches module
globals — it restores them via an autouse fixture.

## Deliberately left alone

Five of the eleven verified sites are not touched, because the honest fix for each is a
schema or policy decision rather than a reporting one:

- **`mcp/server.py:5311` `_semantic_neighbor_ids` (HIGH)** — `memory_retract`'s semantic
  lane fails open and the permanent audit record writes the *requested* `scope_semantic`
  flag, not what ran. Fixing it changes the shape of the dry-run response, the apply
  response, and an append-only audit record whose older entries lack the field.
- **`mcp/server.py:5362` `_forget_finding_verdicts` (MEDIUM)** — same audit record
  (`verdicts_forgotten: 0` means both "none on record" and "store unreachable"). Belongs
  with the retract fix as one change; half-fixing one field would make the trail harder
  to read.
- **`mcp/verify.py:123` `_lazy_rag` (HIGH)** — an ungrounded skeptic's refutation is
  written indistinguishably from a grounded one. The recording half (`grounded_on`
  provenance) is worth doing, but it is only useful with the counting half — excluding
  ungrounded refutations from `counts['refuted']` silently changes every refutation count
  the tool has produced, in the lane already known to have a 22% false-refutation rate.
  That is a counting-policy decision.
- **`mlops/grounding/active_learn.py:92` (MEDIUM)** — an Ollama outage truncates the
  candidate file to hard-negatives only and the loop records success. The fix changes the
  exit code and the overwrite semantics of the out file, which changes what `mlops/loop.py`
  does on that step and what the next retrain is fed — a training-loop behaviour change,
  not a reporting one.
- **`analytics.subsystem_report` / `finding_code_context`** — layer on the same `_q` and
  could carry the same `partial` flag. Only `impact_report` was changed, because it is the
  one that fails in the unsafe direction. `_q` keeps its old signature by default.

## Known residual (non-blocking, all pre-existing)

- `impact_report` returns `partial: false` on the `not _ok(ks)` path. `available()` is a
  static "ladybug importable and a db path configured" fact, and `graph_tools.impact_report`
  returns an explicit `{"error": ...}` before reaching it, so this is the unconfigured case,
  not an outage.
- `LadybugStore` is a process-wide singleton, so a concurrent `code_query` failure elsewhere
  can raise a spurious `partial: true`. Over-warning is the safe direction here.
- The batch writers return `len(norm)` (well-formed rows offered) rather than a DB-verified
  count, so the new short-write warning covers the documented fail-open-to-0 modes (store
  down, lease contended, exception) and not a silent partial write inside `_exec`.
- `investigation_code_briefing` and `graph_facts._summarize_impact` consume `impact_report`
  and drop the new `partial` flag from their own summaries.
- `eval/harness` still exits 0 when every task is skipped; the WARNING is for a human reader.
  Nothing currently parses its stdout — `run_eval.sh` only invokes it.
