### PR TITLE
Stop encoding absence as a plausible value (dead-code counts, cosine baseline, chain confidence, success rate)

### DIFF
--- a/mcp/graph/code_parse.py
+++ b/mcp/graph/code_parse.py
@@ -806,8 +806,24 @@ def _empty(file: str, lang: Optional[str]) -> Dict[str, Any]:
     }
 
 
+# Grammars do not agree on one node type for "a name". Counting only `identifier`
+# silently drops whole languages: Kotlin spells every name `simple_identifier`, so a
+# Kotlin file yields {} and every symbol in it scores zero occurrences; TS/JS use
+# `property_identifier` and Go/Rust/C++ `field_identifier` for method names, so a
+# called method scores zero the same way. Zero occurrences is what dead-code
+# detection reads as "delete this", so a missing node type becomes a delete
+# recommendation. Count every name-bearing type.
+_NAME_NODE_TYPES = frozenset({
+    "identifier",
+    "simple_identifier",    # kotlin
+    "property_identifier",  # typescript / javascript
+    "field_identifier",     # go / rust / c / c++
+    "type_identifier",      # kotlin / typescript / go / rust / c++
+})
+
+
 def _identifier_counts(root) -> Dict[str, int]:
-    """Count every identifier token in the tree (name -> occurrences).
+    """Count every name token in the tree (name -> occurrences).
 
     A defined symbol whose name occurs MORE than it is defined is *used* somewhere
     (called, referenced in a registry list, passed as a callback, dispatched
@@ -820,7 +836,7 @@ def _identifier_counts(root) -> Dict[str, int]:
     try:
         while stack:
             n = stack.pop()
-            if n.type == "identifier":
+            if n.type in _NAME_NODE_TYPES:
                 t = _text(n)
                 if t:
                     counts[t] = counts.get(t, 0) + 1

--- a/mcp/inv_store.py
+++ b/mcp/inv_store.py
@@ -43,6 +43,31 @@ def _safe_float(value, default: float = 0.0) -> float:
 # Defined once here to avoid the same dict appearing inline in multiple functions.
 _CONFIDENCE_RANK: dict[str, int] = {"low": 0, "medium": 1, "high": 2}
 
+# The numeric weight each confidence label carries into a derived_from chain product.
+# Lives here, not in server.py, because investigation_tools reads the same chain and
+# must not import server.
+_CONFIDENCE_TO_NUMERIC: dict[str, float] = {"high": 0.9, "medium": 0.6, "low": 0.3}
+_NEUTRAL_NUMERIC_CONFIDENCE = 0.6
+
+
+def _node_numeric_confidence(node: dict) -> float:
+    """The confidence a stored finding contributes to a derived_from chain product.
+
+    Absence is not certainty. A record whose writer never stamped numeric_confidence
+    has no measured value, and scoring that 1.0 puts it at the TOP of the scale — it
+    reads as perfect certainty and, because the chain is a product, stops the record
+    constraining the aggregate at all. Fall back to the record's own confidence label,
+    then to the same neutral 0.6 _store_numeric_confidence uses when there is no label.
+    """
+    nc = node.get("numeric_confidence")
+    if nc is not None:
+        try:
+            return max(0.0, min(1.0, float(nc)))
+        except (TypeError, ValueError):
+            pass
+    label = str(node.get("confidence") or "").strip().lower()
+    return _CONFIDENCE_TO_NUMERIC.get(label, _NEUTRAL_NUMERIC_CONFIDENCE)
+
 
 # Finding lifecycle/resolution states. "open" is the default and the implied value for
 # any finding record stored before this field existed (absent -> "open"). The three

--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -27,6 +27,8 @@ from inv_store import (
     _now,
     _read_jsonl,
     _save_manifest,
+    _node_numeric_confidence,
+    _NEUTRAL_NUMERIC_CONFIDENCE,
 )
 
 logger = logging.getLogger("loci-mcp")
@@ -648,7 +650,7 @@ def investigation_finding_provenance(
             "ts": node.get("ts"),
             "record_type": node.get("record_type") or node.get("type"),
             "confidence": node.get("confidence"),
-            "numeric_confidence": node.get("numeric_confidence", 1.0),
+            "numeric_confidence": _node_numeric_confidence(node),
             "source": node.get("source"),
             "text": str(node.get("text", ""))[:400],
             "derived_from": node.get("derived_from", []),
@@ -663,12 +665,13 @@ def investigation_finding_provenance(
     root_type = root.get("record_type") if root else None
     grounded = root_type == "observed"
 
-    # A finding without numeric_confidence counts as 1.0.
+    # A finding without numeric_confidence resolves from its own confidence label
+    # (_node_numeric_confidence); an unstamped record is not worth 1.0.
     try:
         aggregate_confidence = 1.0
         for node_entry in chain:
             if "error" not in node_entry:
-                nc = node_entry.get("numeric_confidence", 1.0)
+                nc = node_entry.get("numeric_confidence", _NEUTRAL_NUMERIC_CONFIDENCE)
                 try:
                     aggregate_confidence *= float(nc)
                 except (TypeError, ValueError) as exc:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -208,7 +208,7 @@ from inv_store import (  # noqa: E402,F401
     _atomic_write_text, _append_jsonl, _read_jsonl, _finding_updates_path,
     _load_resolution_overrides, _load_retracted_ids, _make_ref, _tag_finding_ids,
     _summarise_finding, _safe_float, _CONFIDENCE_RANK, _RESOLUTION_STATES,
-    _distinctive_entity_set,
+    _distinctive_entity_set, _CONFIDENCE_TO_NUMERIC, _node_numeric_confidence,
 )
 
 
@@ -1574,7 +1574,9 @@ def _compute_aggregate_confidence(
     """Walk the derived_from chain for a finding and return the product of
     numeric_confidence values along the chain (up to max_depth nodes).
 
-    Findings without numeric_confidence are treated as 1.0 (backward compat).
+    A finding with no numeric_confidence is resolved from its own confidence label
+    (_node_numeric_confidence), not scored 1.0 — absence is not perfect certainty,
+    and in a product a 1.0 node silently stops constraining the aggregate.
     Returns 1.0 if the finding_id is not found or the chain is empty.
     """
     try:
@@ -1587,7 +1589,7 @@ def _compute_aggregate_confidence(
             node = findings_by_id.get(current_id)
             if not node:
                 break
-            nc = node.get("numeric_confidence", 1.0)
+            nc = _node_numeric_confidence(node)
             try:
                 product *= float(nc)
             except (TypeError, ValueError) as exc:
@@ -2123,7 +2125,6 @@ def _update_entities_jsonl(investigation_id: str, finding_id: str, text: str) ->
 _STORE_FINDING_TYPES = {"observed", "inferred", "assumed", "gap", "procedure"}
 _STORE_CONFIDENCES = {"high", "medium", "low"}
 _STORE_TIERS = {"hot", "warm", "cold"}
-_CONFIDENCE_TO_NUMERIC = {"high": 0.9, "medium": 0.6, "low": 0.3}
 
 
 def _store_validate(finding_type: str, confidence: str, tier: str, resolution: str) -> Optional[str]:
@@ -2504,7 +2505,7 @@ def procedure_attempt(
 
     Returns:
         JSON: {"finding_id": "<id>", "success_count": int, "attempt_count": int,
-               "success_rate": float}
+               "success_rate": float|null}
         On error: {"error": "<message>"}
     """
     try:
@@ -5729,6 +5730,7 @@ def contract_declare(
         "text": text,
         "source": "contract_declare",
         "confidence": "medium",
+        "numeric_confidence": _store_numeric_confidence("medium", None),
         "tags": tags,
         "derived_from": [],
         "entities": {},
@@ -5933,6 +5935,7 @@ def wiring_obligation_declare(
         "text": text,
         "source": "wiring_obligation_declare",
         "confidence": "medium",
+        "numeric_confidence": _store_numeric_confidence("medium", None),
         "tags": tags,
         "derived_from": [],
         "entities": {},

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -2483,6 +2483,19 @@ def finding_resolve(
     }, indent=2)
 
 
+def _procedure_success_rate(success_count: int, attempt_count: int) -> float | None:
+    """Successes per attempt, or None when the procedure has never been attempted.
+
+    Untried and always-failed are the two states a caller most needs to tell apart
+    when picking a procedure to follow, and 0.0 spells both. A brand-new procedure
+    — exactly the one whose author wants it exercised — read as a 0% success rate
+    and lost to anything that had ever succeeded once. Never measured has no number.
+    """
+    if attempt_count <= 0:
+        return None
+    return round(success_count / attempt_count, 4)
+
+
 # ---- Tool: procedure_attempt ----
 
 @mcp.tool()
@@ -2506,6 +2519,8 @@ def procedure_attempt(
     Returns:
         JSON: {"finding_id": "<id>", "success_count": int, "attempt_count": int,
                "success_rate": float|null}
+        ``success_rate`` is null for a procedure that has never been attempted —
+        that is not the same as a 0.0 success rate.
         On error: {"error": "<message>"}
     """
     try:
@@ -2541,7 +2556,7 @@ def procedure_attempt(
 
         attempt_count = target["procedure_meta"]["attempt_count"]
         success_count = target["procedure_meta"]["success_count"]
-        success_rate = round(success_count / attempt_count, 4) if attempt_count > 0 else 0.0
+        success_rate = _procedure_success_rate(success_count, attempt_count)
 
         # Atomic rewrite: write to temp file then rename
         import tempfile as _tempfile
@@ -2599,6 +2614,9 @@ def procedure_search(
     Returns:
         JSON: {"procedures": [{"finding_id", "text", "source", "success_rate",
                "procedure_meta", "investigation_id", "score"}], "count": int}
+        ``success_rate`` is null for a procedure that has never been attempted —
+        that is not the same as a 0.0 success rate. ``procedure_meta`` carries
+        ``attempt_count`` if you need to rank the untried ones yourself.
         On error: {"error": "<message>", "procedures": [], "count": 0}
     """
     try:
@@ -2626,7 +2644,7 @@ def procedure_search(
                     pm = h.get("procedure_meta", {})
                     attempt_count = pm.get("attempt_count", 0) if pm else 0
                     success_count = pm.get("success_count", 0) if pm else 0
-                    success_rate = round(success_count / attempt_count, 4) if attempt_count > 0 else 0.0
+                    success_rate = _procedure_success_rate(success_count, attempt_count)
                     procedures.append({
                         "finding_id": h.get("id", ""),
                         "text": h.get("text", ""),
@@ -2667,7 +2685,7 @@ def procedure_search(
                                 pm = f.get("procedure_meta", {})
                                 attempt_count = pm.get("attempt_count", 0) if pm else 0
                                 success_count = pm.get("success_count", 0) if pm else 0
-                                success_rate = round(success_count / attempt_count, 4) if attempt_count > 0 else 0.0
+                                success_rate = _procedure_success_rate(success_count, attempt_count)
                                 candidates.append({
                                     "finding_id": f.get("id", ""),
                                     "text": text,

--- a/mcp/tests/test_code_parse.py
+++ b/mcp/tests/test_code_parse.py
@@ -257,3 +257,78 @@ def test_parse_path_walks_dir(tmp_path):
     files = {os.path.basename(r["file"]) for r in results}
     assert "notes.txt" not in files
     assert "b.py" not in files
+
+
+# --------------------------------------------------------------------------- #
+# ident_counts — the usage signal behind dead-code detection.
+#
+# ladybug_store marks a symbol referenced when ident_counts[name] > (times it is
+# defined). Counting only tree-sitter's `identifier` node type made a name the
+# grammar spells differently score zero occurrences, which reads as "never used"
+# and is returned as a delete-this candidate. Each case below is a method that is
+# both defined AND called in the same snippet.
+# --------------------------------------------------------------------------- #
+
+_USED_METHOD_SNIPPETS = {
+    # (file, source, method name, times the name is defined in the snippet)
+    "kotlin": ("F.kt", b"class Foo {\n"
+                       b"    fun greetUser(x: Int): Int { return x + 1 }\n"
+                       b"    fun other() { greetUser(1) }\n"
+                       b"}\n", "greetUser"),
+    "typescript": ("f.ts", b"class Foo {\n"
+                           b"  greetUser(x: number): number { return x + 1; }\n"
+                           b"}\n"
+                           b"const y = new Foo().greetUser(1);\n", "greetUser"),
+    "javascript": ("f.js", b"class Foo { greetUser(x) { return x + 1; } }\n"
+                           b"new Foo().greetUser(1);\n", "greetUser"),
+    "go": ("f.go", b"package main\n"
+                   b"type F struct{}\n"
+                   b"func (f *F) GreetUser(x int) int { return x + 1 }\n"
+                   b"func Run() { f := &F{}; x := f.GreetUser(1); _ = x }\n", "GreetUser"),
+    "rust": ("f.rs", b"struct S;\n"
+                     b"impl S { fn greet_user(&self, x: i32) -> i32 { x + 1 } }\n"
+                     b"fn run() { let s = S; let _ = s.greet_user(1); }\n", "greet_user"),
+    "java": ("Foo.java", b"class Foo {\n"
+                         b"  int greetUser(int x) { return x + 1; }\n"
+                         b"  void other() { greetUser(1); }\n"
+                         b"}\n", "greetUser"),
+    "python": ("f.py", b"class Foo:\n"
+                       b"    def greet_user(self, x):\n"
+                       b"        return x + 1\n"
+                       b"    def other(self):\n"
+                       b"        return self.greet_user(1)\n", "greet_user"),
+}
+
+
+def test_ident_counts_see_a_called_method_in_every_language():
+    """A method defined once and called once must out-count its definitions.
+
+    This is exactly the comparison ladybug_store makes to set `referenced`, so a
+    language missing here is a language whose every method is reported dead.
+    """
+    for lang, (fname, src, method) in _USED_METHOD_SNIPPETS.items():
+        res = parse_source(fname, src)
+        counts = res["ident_counts"]
+        defs = sum(1 for s in res["symbols"] if s["name"] == method)
+        assert defs == 1, f"{lang}: expected one definition of {method}, got {defs}"
+        assert counts.get(method, 0) > defs, (
+            f"{lang}: {method} is called but scores "
+            f"{counts.get(method, 0)} occurrences vs {defs} definitions "
+            f"-> dead-code detection would flag it. ident_counts={counts}"
+        )
+
+
+def test_ident_counts_non_empty_for_every_supported_language():
+    """An empty ident_counts is a silent zero for every symbol in the file."""
+    for lang, (fname, src, _method) in _USED_METHOD_SNIPPETS.items():
+        res = parse_source(fname, src)
+        assert res["ident_counts"], f"{lang}: ident_counts is empty for {fname}"
+
+
+def test_ident_counts_still_flags_a_genuinely_uncalled_method():
+    """The broadened count must not make everything look used."""
+    _fname, src, _m = _USED_METHOD_SNIPPETS["kotlin"]
+    res = parse_source("F.kt", src)
+    # `other` is defined but never called anywhere in the snippet.
+    assert res["ident_counts"].get("other", 0) == 1
+    assert sum(1 for s in res["symbols"] if s["name"] == "other") == 1

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -796,6 +796,62 @@ class TestNumericConfidence(unittest.TestCase):
                 self.assertIn("numeric_confidence", node,
                               f"Chain node missing numeric_confidence: {node}")
 
+    def test_declare_tools_stamp_numeric_confidence(self):
+        """contract_declare / wiring_obligation_declare build their finding dict
+        by hand, bypassing _store_build_finding. Without a stamped
+        numeric_confidence the reader defaulted them to 1.0 — a "gap" record,
+        the weakest tier there is, scoring perfect certainty."""
+        inv_id = _new_id("declare-nc")
+        server.investigation_start(investigation_id=inv_id, title="Declare nc test")
+
+        server.contract_declare(
+            investigation_id=inv_id, entity="POST /api/users", role="producer",
+            fields='{"user_id": "int"}',
+        )
+        server.wiring_obligation_declare(
+            investigation_id=inv_id, class_name="MetricsPublisher",
+            method_name="publish", expected_effect="publishes to MQTT",
+        )
+
+        rows = [json.loads(l) for l in
+                (server._inv_dir(inv_id) / "findings.jsonl")
+                .read_text().splitlines() if l.strip()]
+        by_source = {r.get("source"): r for r in rows}
+        for src in ("contract_declare", "wiring_obligation_declare"):
+            self.assertIn(src, by_source)
+            row = by_source[src]
+            self.assertIn("numeric_confidence", row,
+                          f"{src} wrote a finding with no numeric_confidence")
+            self.assertAlmostEqual(row["numeric_confidence"], 0.6, places=5,
+                                   msg=f"{src} is confidence 'medium' -> 0.6")
+
+    def test_unstamped_finding_does_not_score_perfect_certainty(self):
+        """A record with no numeric_confidence must resolve from its own
+        confidence label, not 1.0. 1.0 is the top of the scale, and in a
+        product it also stops the node constraining the aggregate at all."""
+        self.assertAlmostEqual(
+            server._node_numeric_confidence({"confidence": "medium"}), 0.6, places=5)
+        self.assertAlmostEqual(
+            server._node_numeric_confidence({"confidence": "low"}), 0.3, places=5)
+        self.assertAlmostEqual(
+            server._node_numeric_confidence({"confidence": "high"}), 0.9, places=5)
+        # No label either -> neutral, still not 1.0.
+        self.assertAlmostEqual(server._node_numeric_confidence({}), 0.6, places=5)
+        # An explicitly stamped value still wins.
+        self.assertAlmostEqual(
+            server._node_numeric_confidence(
+                {"confidence": "low", "numeric_confidence": 0.95}), 0.95, places=5)
+
+    def test_aggregate_confidence_of_unstamped_chain(self):
+        """_compute_aggregate_confidence over unstamped nodes must not be 1.0."""
+        findings_by_id = {
+            "a": {"id": "a", "confidence": "medium", "derived_from": ["b"]},
+            "b": {"id": "b", "confidence": "medium", "derived_from": []},
+        }
+        agg = server._compute_aggregate_confidence("a", findings_by_id)
+        self.assertAlmostEqual(agg, 0.36, places=5,
+                               msg="two unstamped 'medium' nodes are 0.6*0.6, not 1.0")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -945,6 +945,41 @@ class TestProceduralMemory(unittest.TestCase):
         self.assertEqual(r3.get("success_count"), 2)
         self.assertAlmostEqual(r3.get("success_rate"), 2 / 3, places=3)
 
+    def test_never_attempted_procedure_has_no_success_rate(self):
+        """Untried and always-failed are the two states a caller most needs to
+        tell apart when picking a procedure, and 0.0 spelled both."""
+        self.assertIsNone(server._procedure_success_rate(0, 0),
+                          "never attempted has no measured success rate")
+        self.assertEqual(server._procedure_success_rate(0, 1), 0.0,
+                         "one attempt, no successes, IS a measured 0.0")
+        self.assertEqual(server._procedure_success_rate(1, 2), 0.5)
+        # A never-attempted procedure must not be ranked below one that has failed.
+        untried = server._procedure_success_rate(0, 0)
+        failed = server._procedure_success_rate(0, 4)
+        self.assertNotEqual(untried, failed,
+                            "a brand-new procedure and a 0-for-4 procedure must "
+                            "not report the same success_rate")
+
+    def test_procedure_search_reports_null_rate_for_an_untried_procedure(self):
+        inv_id = _new_id("proc-untried")
+        server.investigation_start(investigation_id=inv_id, title="Untried procedure")
+        server.investigation_store(
+            investigation_id=inv_id,
+            finding_type="procedure",
+            text="Drain the node before kernel upgrade.",
+            source="runbook:kernel-upgrade",
+            confidence="medium",
+            procedure_steps="1. cordon\n2. drain\n3. upgrade",
+        )
+        res = _json(server.procedure_search(query="kernel upgrade", investigation_id=inv_id))
+        self.assertNotIn("error", res, f"Unexpected error: {res}")
+        rows = res.get("procedures") or []
+        self.assertTrue(rows, "the stored procedure should be findable")
+        row = rows[0]
+        self.assertEqual(row.get("procedure_meta", {}).get("attempt_count"), 0)
+        self.assertIsNone(row.get("success_rate"),
+                          "a never-attempted procedure must not report 0.0")
+
     def test_procedure_attempt_rejects_nonexistent_finding(self):
         inv_id = _new_id("proc-miss")
         server.investigation_start(investigation_id=inv_id, title="Proc miss test")

--- a/mlops/grounding/tests/test_grounding.py
+++ b/mlops/grounding/tests/test_grounding.py
@@ -767,6 +767,70 @@ def test_cosine_f1_on_folds_ignores_the_train_index():
     assert a == b == (1.0, 0.0)
 
 
+def test_measured_cosines_keeps_absence_distinct_from_zero():
+    rows = [
+        {"cos": 0.8, "label": 1},     # measured
+        {"cos": 0.0, "label": 0},     # measured, and genuinely 0.0
+        {"label": 1, "signal": "lineage"},   # never computed
+        {"cos": None, "label": 1},    # written, but not a number
+    ]
+    scores, measured = train.measured_cosines(rows)
+    assert list(measured) == [True, True, False, False]
+    assert scores[0] == np.float32(0.8)
+    assert scores[1] == np.float32(0.0), "a real 0.0 must survive as a measurement"
+    assert np.isnan(scores[2]) and np.isnan(scores[3])
+
+
+def test_cosine_f1_on_folds_excludes_rows_with_no_measured_cosine():
+    """A row whose cosine was never computed is not a row with cosine 0.0.
+
+    The grounding dataset's unmeasured rows are all positives (the `lineage`
+    pairs, which the builder writes without a `cos` field). Scoring them 0.0
+    makes them false negatives at every threshold in the sweep, which can only
+    push the cosine baseline DOWN — and that baseline is what a candidate model
+    must beat before train.py overwrites the deployed classifier.
+    """
+    # Two clean positives, two clean negatives, plus two positives whose cosine
+    # was never measured (the nan rows).
+    cos = np.array([0.9, 0.85, 0.1, 0.2, np.nan, np.nan])
+    lab = np.array([1, 1, 0, 0, 1, 1])
+    measured = np.array([True, True, True, True, False, False])
+    folds = [(np.array([0]), np.array([0, 1, 2, 3, 4, 5]))]
+
+    honest = train.cosine_f1_on_folds(cos, lab, folds, measured=measured)
+    assert honest == (1.0, 0.0), (
+        "the four rows with a measured cosine separate perfectly; the unmeasured "
+        f"rows must not drag the baseline down, got {honest}"
+    )
+
+    # Same fold, the shipped behaviour: absence spelled 0.0.
+    as_zero = train.cosine_f1_on_folds(np.nan_to_num(cos, nan=0.0), lab, folds)
+    assert as_zero[0] < honest[0], (
+        "sanity: spelling the missing cosines 0.0 is what depressed the baseline"
+    )
+
+
+def test_cosine_f1_on_folds_returns_nan_when_no_fold_is_measurable():
+    """An unmeasurable baseline must not read as 0.0 — 0.0 is beatable by anything."""
+    cos = np.array([np.nan, np.nan])
+    lab = np.array([1, 0])
+    mean, std = train.cosine_f1_on_folds(cos, lab, [(np.array([0]), np.array([0, 1]))],
+                                         measured=np.array([False, False]))
+    assert np.isnan(mean) and np.isnan(std)
+    # And NaN cannot be beaten, so the promotion gate holds.
+    assert not (0.99 > mean)
+
+
+def test_cosine_f1_on_folds_skips_a_fold_left_single_class_by_the_mask():
+    cos = np.array([0.9, 0.8, 0.1])
+    lab = np.array([1, 1, 0])
+    measured = np.array([True, True, False])
+    # Masking row 2 away leaves only positives in the validation set.
+    mean, std = train.cosine_f1_on_folds(cos, lab, [(np.array([0]), np.array([0, 1, 2]))],
+                                         measured=measured)
+    assert np.isnan(mean) and np.isnan(std)
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # train._extract_topic
 # ══════════════════════════════════════════════════════════════════════════════

--- a/mlops/grounding/train.py
+++ b/mlops/grounding/train.py
@@ -144,11 +144,44 @@ def make_features(claims: list, evidences: list, emb_claims, emb_evidences):
 # Cosine baseline F1 (best threshold on same fold split)
 # ---------------------------------------------------------------------------
 
-def cosine_f1_on_folds(cos_scores: np.ndarray, labels: np.ndarray, fold_indices: list) -> tuple:
+def measured_cosines(rows: list) -> tuple:
+    """Split ``rows`` into (cos_scores, measured).
+
+    ``measured[i]`` is True only when row i actually carries a numeric ``cos``;
+    its score is NaN otherwise. The dataset builder writes ``cos`` on the topical
+    rows only, so the lineage rows (all label=1) have none — and a real cosine of
+    0.0 must stay distinguishable from a cosine that was never computed.
+    """
+    measured = np.array(
+        [isinstance(r.get("cos"), (int, float)) and not isinstance(r.get("cos"), bool)
+         for r in rows], dtype=bool)
+    scores = np.array([float(r["cos"]) if m else np.nan
+                       for r, m in zip(rows, measured)], dtype=np.float32)
+    return scores, measured
+
+
+def cosine_f1_on_folds(cos_scores: np.ndarray, labels: np.ndarray, fold_indices: list,
+                       measured: np.ndarray | None = None) -> tuple:
+    """Best-threshold F1 of the raw cosine, per fold.
+
+    ``measured`` marks the rows whose cosine was actually computed. Rows without
+    one are dropped from the validation set rather than scored: a row with no
+    cosine is not a row with cosine 0.0, and the dataset's unmeasured rows are
+    ALL positives, so scoring them 0.0 is a guaranteed false negative at every
+    threshold and can only push this baseline down. That baseline is what the
+    candidate model has to beat to overwrite the deployed one.
+
+    Returns (nan, nan) if no fold had a usable validation set — the caller must
+    not promote off a baseline that was never measured.
+    """
     from sklearn.metrics import f1_score
     per_fold = []
     thresholds = np.linspace(0.2, 0.9, 71)
     for train_idx, val_idx in fold_indices:
+        if measured is not None:
+            val_idx = np.asarray(val_idx)[measured[np.asarray(val_idx)]]
+            if len(val_idx) == 0 or len(np.unique(labels[val_idx])) < 2:
+                continue
         cos_val = cos_scores[val_idx]
         y_val = labels[val_idx]
         best_f1 = max(
@@ -156,6 +189,8 @@ def cosine_f1_on_folds(cos_scores: np.ndarray, labels: np.ndarray, fold_indices:
             for t in thresholds
         )
         per_fold.append(best_f1)
+    if not per_fold:
+        return float("nan"), float("nan")
     return float(np.mean(per_fold)), float(np.std(per_fold))
 
 
@@ -340,7 +375,12 @@ def main():
     claims = [r["claim"] for r in rows]
     evidences = [r["evidence"] for r in rows]
     labels = np.array([r["label"] for r in rows], dtype=np.int32)
-    cos_scores = np.array([r.get("cos", 0.0) for r in rows], dtype=np.float32)
+    # `cos` is written only on the topical rows; the lineage rows carry none and are
+    # all label=1. r.get("cos", 0.0) turned "never computed" into "maximally
+    # dissimilar", which is a free head start for the candidate at the promotion gate.
+    # Keep absence explicit and exclude those rows from the baseline and the strata.
+    cos_scores, cos_measured = measured_cosines(rows)
+    n_no_cos = int((~cos_measured).sum())
 
     all_texts = list(dict.fromkeys(claims + evidences))
     print(f"Embedding {len(all_texts)} unique texts (cache has {len(cache)} entries)...",
@@ -366,11 +406,20 @@ def main():
         ),
     }
 
-    cos_quartiles = np.digitize(cos_scores, np.percentile(cos_scores, [25, 50, 75]))
+    # Bin 0 is reserved for "no measured cosine" so the strata are not partly invented.
+    cos_quartiles = np.zeros(len(rows), dtype=np.int64)
+    if cos_measured.any():
+        _qs = np.percentile(cos_scores[cos_measured], [25, 50, 75])
+        cos_quartiles[cos_measured] = np.digitize(cos_scores[cos_measured], _qs) + 1
     skf = StratifiedKFold(n_splits=10, shuffle=True, random_state=42)
     fold_indices = list(skf.split(X, cos_quartiles))
 
-    cos_cv_mean, cos_cv_std = cosine_f1_on_folds(cos_scores, labels, fold_indices)
+    cos_cv_mean, cos_cv_std = cosine_f1_on_folds(cos_scores, labels, fold_indices,
+                                                 measured=cos_measured)
+    if n_no_cos:
+        print(f"\ncosine baseline computed over {len(rows) - n_no_cos}/{len(rows)} rows "
+              f"— {n_no_cos} rows carry no measured cosine and were excluded "
+              f"(they are not cosine 0.0).")
     # These folds split PAIRS, so a finding lands on both sides of a split and
     # every number below is optimistic — most of the apparent margin over cosine
     # is that leak. Say so on every line, because this is the figure that gets
@@ -435,7 +484,11 @@ def main():
     else:
         eval_baseline = cos_cv_mean
 
-    beat_baseline = best_f1 > eval_baseline
+    # NaN baseline = never measured. `>` on NaN is already False, so this HOLDs; say why.
+    if not np.isfinite(eval_baseline):
+        print("  WARNING: the cosine baseline could not be measured on any fold — "
+              "HOLDing rather than promoting against an unknown.")
+    beat_baseline = bool(np.isfinite(eval_baseline) and best_f1 > eval_baseline)
     decision = "PROMOTE" if beat_baseline else "HOLD"
     # Requested is not the same as used: --findings-glob can be passed and OOS
     # still return {} (fewer than 2 runs, or no fold with both classes). The
@@ -484,6 +537,8 @@ def main():
         "cv_f1_mean": round(cv_results[best_name]["mean"], 4),
         "cv_f1_std": round(cv_results[best_name]["std"], 4),
         "cosine_baseline_cv_f1": round(cos_cv_mean, 4),
+        "cosine_baseline_n_rows": len(rows) - n_no_cos,
+        "cosine_baseline_rows_without_cos": n_no_cos,
         "beat_baseline": beat_baseline,
         "decision": decision,
         "decision_basis": "oos_leave_one_run_out" if oos_results else "pair_level_cv_optimistic",


### PR DESCRIPTION
Four places where a value that was never measured was written down as a plausible
number, and then read by something that acts on it. Each is fixed at the point the
absence is created, not where it is displayed.

## 1. `_identifier_counts` counted one node type, so whole languages scored zero

`mcp/graph/code_parse.py` counted only tree-sitter nodes of type `identifier`.
Grammars do not agree on that spelling. `ladybug_store.py:822` then does
`ident_total.get(name, 0) > def_count.get(name, 0)` to set `referenced`, and
`analytics.py:307` returns un-referenced functions/methods to the caller as, in its
own words, "a reliable dead-code list".

**Evidence it was real** (measured on the pinned venv, tree_sitter 0.26.0 +
language-pack 1.12.2, both before and after):

| language | node type used for names | before | after |
|---|---|---|---|
| kotlin | `simple_identifier` | `ident_counts == {}` for the whole file | called method scores 2 > 1 def |
| typescript / tsx / javascript | `property_identifier` | called method scores 0 | 2 > 1 |
| go | `field_identifier` | called method scores 0 | 2 > 1 |
| rust | `field_identifier` | scores exactly 1, and 1 > 1 is False | 2 > 1 |

A Kotlin method *called from the line below its own definition* was reported dead.

**Change:** count `simple_identifier` / `property_identifier` / `field_identifier` /
`type_identifier` alongside `identifier`. This only ever raises a count, so it can
add no new delete recommendations — it removes them.

**Not a regression:** a genuinely uncalled method still scores exactly its
definitions and is still flagged, verified per language. The only symbols whose
`referenced` flips from False to True are structs/classes (`F`, `S`, `Handler`),
which `dead_code_candidates` already excludes via `s.kind IN ['function','method']`.
`c`/`cpp` have no tree-sitter query at all and emit no symbols, so nothing there
reaches the graph.

**Test:** `mcp/tests/test_code_parse.py::test_ident_counts_see_a_called_method_in_every_language`
plus two siblings. Reverting `code_parse.py` to `origin/main` and re-running:
**3 failed, 13 passed** — `"kotlin: greetUser is called but scores 0 occurrences vs
1 definitions"`. With the change: **16 passed**.

## 2. `r.get("cos", 0.0)` turned "never computed" into "maximally dissimilar"

`mlops/grounding/train.py` read the per-row cosine with a 0.0 default. The dataset
builder writes `cos` on its `topical` rows only; the `lineage` rows it appends carry
none — **183 of 5,418 rows, all `label=1`** (9.5% of every positive). A cosine of 0.0
on a positive is a false negative at every threshold in the sweep, so the fabricated
value could only push the baseline *down* — and that baseline is `eval_baseline`, the
number a candidate has to beat before `joblib.dump` overwrites the deployed
`grounding_bleed_clf.joblib`.

**Evidence it was real**, reproduced with the repo's own `cosine_f1_on_folds` and
`StratifiedKFold(10, random_state=42)` on the checked-in `grounding_dataset.jsonl`:

```
as shipped (absence = 0.0)     F1 = 0.8223 +/- 0.0160
rows with a measured cosine    F1 = 0.8656 +/- 0.0112   (+0.0433)
```

a 0.043 F1 head start handed to every candidate at the promotion gate. The same 183
rows also collapsed into `digitize` bin 0, so the CV folds were stratified on a
partly invented variable.

**Change:** rows with no `cos` carry NaN, not 0.0; they are dropped from the
baseline's validation folds and get their own stratification bin; `train_metrics.json`
records `cosine_baseline_n_rows` / `cosine_baseline_rows_without_cos` so the number
says what it was computed over. If no fold is measurable the baseline is NaN and the
run HOLDs rather than promoting against an unknown. A real cosine of 0.0 is still a
measurement and still counts. The leave-one-run-out OOS path computes its cosines
from the embeddings directly and never had this bug.

**Test:** `mlops/grounding/tests/test_grounding.py::test_cosine_f1_on_folds_excludes_rows_with_no_measured_cosine`
plus three siblings. Against `origin/main`'s `train.py`: **4 failed, 3 passed**
(no `measured_cosines`; `cosine_f1_on_folds() got an unexpected keyword argument
'measured'`). Because that red is API-shaped, the behavioural control is inside the
test and was run directly: same fold, same labels — honest `(1.0, 0.0)` vs
absence-as-zero `(0.667, 0.0)`.

## 3. A finding with no `numeric_confidence` scored 1.0 — the top of the scale

`_compute_aggregate_confidence` read `node.get("numeric_confidence", 1.0)`. The
docstring called that backward compat, but it was live-reachable: `contract_declare`
(`server.py:5722`) and `wiring_obligation_declare` (`:5926`) build their finding dict
by hand and `_append_jsonl` it, bypassing `_store_build_finding`, so the key was
genuinely absent on fresh records. Both are `record_type "gap"` — the weakest tier
there is — and `wiring_obligation_declare` stamps its own text `[UNVERIFIED]`.

The aggregate is a product taken as a `min` over chains, so a node scored 1.0 also
stops constraining the aggregate at all. A claim supported only by one such gap
finding got `min_chain_confidence` 1.0 and the label `"high (>=0.8)"` out of
`investigation_pre_answer_check` — the tool an agent is told to call before asserting
a claim. From the record's own `"medium"` it is 0.6, which reads `"medium (0.5-0.8)"`.

**Change, at both ends:**
- both declare paths now stamp `numeric_confidence`, so it is never absent on a fresh
  write;
- the read resolves a missing value through the record's own `confidence` label, and
  through the same neutral 0.6 `_store_numeric_confidence` (`server.py:2145`) already
  uses when there is no label either. No new default was invented for this.

`_CONFIDENCE_TO_NUMERIC` moves to `inv_store` with the new helper because
`investigation_tools` reads the same chain and must not import `server`; `server`
re-exports it, so `server._CONFIDENCE_TO_NUMERIC` still resolves.

**Test:** `TestNumericConfidence::test_aggregate_confidence_of_unstamped_chain` and
`::test_declare_tools_stamp_numeric_confidence`. Against `origin/main`'s three
modules: **3 failed, 2 passed** — `"AssertionError: 1.0 != 0.36 ... two unstamped
'medium' nodes are 0.6*0.6, not 1.0"` and `"'numeric_confidence' not found in {...}"`.
Explicitly stamped values are unchanged: the pre-existing 0.72 provenance assertion
still passes.

## 4. A never-attempted procedure reported a 0% success rate

`procedure_attempt` and both `procedure_search` paths computed
`round(success_count / attempt_count, 4) if attempt_count > 0 else 0.0`, so a
procedure nobody has run reported the same number as one attempted ten times and
failed all ten. Untried and always-failed are the two states an agent most needs to
tell apart when choosing a procedure, and `success_rate` is the only ranking-shaped
number in the row — a brand-new procedure, exactly the one its author wants
exercised, lost to anything that had ever succeeded once.

**Change:** `success_rate` is `null` when `attempt_count == 0`. `attempt_count` still
travels in `procedure_meta` for callers that want to rank the untried themselves, and
both tool docstrings now say so. A measured 0.0 is unchanged. `success_rate` has no
consumer outside these two tools' return values — nothing sorts or arithmetics on it.

**Test:** `TestProceduralMemory::test_procedure_search_reports_null_rate_for_an_untried_procedure`.
Reverting *only* this change's hunks on top of the otherwise-fixed file: **2 failed,
6 passed** — `"AssertionError: 0.0 is not None : a never-attempted procedure must not
report 0.0"`, through the real `procedure_search` tool.

## Deliberately left alone

- **`mcp/server.py:7146`** — `conf_tiers.get(conf, 0.5)` in `_confidence_cues`, feeding
  the `trust` cue (weight 0.25) of the `memory_confidence` verdict. Confirmed real:
  `audit_log` upserts `record_type "audit"` rows with no `confidence` key into the same
  Qdrant collection `_confidence_retrieve` queries, so an audit receipt scores 0.5 and
  outranks a finding its author stamped `"low"` (0.4). Not fixed here because the
  correct value for absence is not determined: skipping unstamped rows makes
  `trust = 0.0` when nothing in the top-k is tiered — the same bug inverted — and
  pinning them at 0.4 leaves an unassessed receipt indistinguishable from an
  author-stamped "low". Either choice recalibrates a live verdict whose sigmoid is
  steep (`1/(1+exp(-8*(raw-0.5)))`) right at the 0.50/0.30 recommendation boundaries,
  with no ground truth to check the recalibration against, and needs the sibling
  ranker in `scripts/hooks/pre_llm_grounding.py:358` (`_CONF_TRUST.get(conf, 0.6)`)
  changed in step. That wants a decision from whoever owns the `memory_confidence`
  calibration.

- **`mcp/graph/ladybug_store.py:822`** — the second half of finding 1's fix shape
  (write `referenced` as NULL-with-a-reason when a file's identifier lane produced
  nothing). `analytics.py:307` already reads `s.referenced = false OR s.referenced IS
  NULL`, so NULL is *also* treated as dead; making absence honest there needs a
  coordinated `CodeSymbol` schema + query-semantics change on a graph store in daily
  use. The node-type fix removes the measured false-positive class without touching
  the store.

- **`mlops/grounding/train.py`** — `make_features` already computes a real cosine for
  every row, including the 183, so those cosines could be *measured* rather than the
  rows dropped. Dropping is the conservative direction (the baseline rises, so the
  promotion gate gets stricter) and keeps this change small, but it does leave the
  model's F1 and the baseline measured over slightly different row populations. A
  follow-up should either backfill `cos` in `build_grounding_dataset.py` or read the
  cosine column out of `X`.

## Verification

Run on the exact committed bytes, `mcp/tests/test_graph_integration.py` excluded
throughout. CI runs these as two jobs (`ci.yml` / `mlops.yml`) because
`mcp/tests/test_grounding.py` and `mlops/grounding/tests/test_grounding.py` collide on
basename in a single pytest invocation — a pre-existing condition, unrelated to this
branch.

```
mcp/tests/  (--ignore=test_graph_integration.py, -p no:randomly)   main 809  ->  branch 817   (+8 = the 8 new tests)
mlops/ tests/                                                      main 585  ->  branch 589   (+4 = the 4 new tests)
ruff check --select E9,F401,F811,F821,F841 --ignore E402           clean on every touched module
git diff --check                                                   clean
```

No file was reformatted, nothing was renamed, and no venv symlink is in the tree.
