### PR TITLE
Import the rerank budget instead of restating it

### DIFF
--- a/deep_think_loci/grounding/features.py
+++ b/deep_think_loci/grounding/features.py
@@ -16,11 +16,21 @@ import numpy as np
 
 # Embedding width is fixed by the embedder (nomic-embed-text, 768).
 EMBED_DIM = 768
-# |a-b| + a*b + cos  — what build_grounding_dataset.py and ground_gate.py have
-# always produced, and what the currently shipped joblib expects.
-LEGACY_DIM = 2 * EMBED_DIM + 1
-# ... + cos**2 + length ratio + token overlap.
-CURRENT_DIM = LEGACY_DIM + 3
+
+
+def dims_for(embed_dim: int) -> tuple[int, int]:
+    """(legacy, current) widths for pairs embedded at `embed_dim`.
+
+    The contract is a shape rule, not two magic numbers: legacy is
+    |a-b| + a*b + cos, current adds cos**2, a length ratio and a token overlap.
+    Callers that embed at something other than EMBED_DIM (tests, and any future
+    embedder swap) get the same two layouts at their own width.
+    """
+    return (2 * embed_dim + 1, 2 * embed_dim + 4)
+
+
+# The two widths at the production embedder's size.
+LEGACY_DIM, CURRENT_DIM = dims_for(EMBED_DIM)
 
 
 def token_overlap(a: str, b: str) -> float:
@@ -35,23 +45,27 @@ def len_ratio(a: str, b: str) -> float:
     return min(la, lb) / (max(la, lb) + 1)
 
 
-def make_features(claims, evidences, emb_claims, emb_evidences, *, dim: int = CURRENT_DIM):
+def make_features(claims, evidences, emb_claims, emb_evidences, *, dim: int | None = None):
     """Feature matrix for (claim, evidence) pairs.
 
     `dim` selects the contract version. Pass a model's n_features_in_ to build
-    exactly what that model was trained on, rather than assuming.
+    exactly what that model was trained on, rather than assuming; None means the
+    current layout at whatever width the embeddings came in.
     """
     emb_claims = np.asarray(emb_claims, dtype=np.float32)
     emb_evidences = np.asarray(emb_evidences, dtype=np.float32)
     diff = np.abs(emb_claims - emb_evidences)
     prod = emb_claims * emb_evidences
     cos = prod.sum(axis=1, keepdims=True)
-    if dim == LEGACY_DIM:
+    legacy, current = dims_for(emb_claims.shape[1])
+    if dim is None:
+        dim = current
+    if dim == legacy:
         return np.concatenate([diff, prod, cos], axis=1)
-    if dim != CURRENT_DIM:
+    if dim != current:
         raise ValueError(
             f"no grounding feature contract produces {dim} columns "
-            f"(known: {LEGACY_DIM} legacy, {CURRENT_DIM} current)"
+            f"(known: {legacy} legacy, {current} current)"
         )
     lr = np.array([[len_ratio(c, e)] for c, e in zip(claims, evidences)], dtype=np.float32)
     jac = np.array([[token_overlap(c, e)] for c, e in zip(claims, evidences)], dtype=np.float32)

--- a/deep_think_loci/grounding/tests/test_feature_contract.py
+++ b/deep_think_loci/grounding/tests/test_feature_contract.py
@@ -31,6 +31,22 @@ def test_both_contract_versions_have_the_widths_the_models_expect():
     assert F.supported_dims() == (1537, 1540)
 
 
+def test_the_contract_is_a_shape_rule_not_two_magic_numbers():
+    """The two layouts are 2d+1 and 2d+4 at whatever width the embeddings came
+    in. Pinning them to 768 made the shared definition unusable to the callers
+    that had to keep their own copy — which is how they drifted."""
+    assert F.dims_for(F.EMBED_DIM) == (F.LEGACY_DIM, F.CURRENT_DIM) == (1537, 1540)
+    assert F.dims_for(2) == (5, 8)
+    a, b = _emb(3), _emb(3)
+    txt = ["alpha beta"] * 3
+    small = np.ones((3, 2), dtype=np.float32)
+    assert F.make_features(txt, txt, small, small, dim=5).shape[1] == 5
+    assert F.make_features(txt, txt, small, small, dim=8).shape[1] == 8
+    # no dim = the current layout at that width, not the 768-sized constant
+    assert F.make_features(txt, txt, small, small).shape[1] == 8
+    assert F.make_features(txt, txt, a, b).shape[1] == 1540
+
+
 def test_an_unknown_width_is_refused_rather_than_guessed():
     a, b = _emb(), _emb()
     with pytest.raises(ValueError, match="no grounding feature contract"):

--- a/eval/grounding_gate_qf_eval.py
+++ b/eval/grounding_gate_qf_eval.py
@@ -26,6 +26,7 @@ import glob
 import json
 import math
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,6 +36,11 @@ from grounding_gate_eval import _metrics  # reuse metric computation
 THRESHOLD = float(os.environ.get("DTL_GROUND_THRESHOLD", "0.59"))
 CORPUS = os.environ.get("DTL_CORPUS_GLOB", os.path.expanduser("~/.hermes/memory-sessions/dt-loci-*/findings.jsonl"))
 MODEL = Path(__file__).resolve().parent.parent / "deep_think_loci/grounding/grounding_bleed_clf.joblib"
+
+# The pair-feature contract lives next to the model, in one place, so this eval
+# cannot drift away from the width the loaded classifier was trained on.
+sys.path.insert(0, str(MODEL.parent))
+import features as _feat  # noqa: E402
 
 # Built-in focus queries for the example dama-gotchi targets; override with
 # $DTL_TARGET_FOCUS (inline JSON or a path). Unknown targets fall back to the
@@ -102,7 +108,7 @@ def run():
             cos = sum(a * b for a, b in zip(q, cv))
             labels.append(1 if x["target"] == t else 0)
             cosv.append(cos)
-            feats.append((q, cv, cos))
+            feats.append((x["text"], focus.get(t, t), cv, q))
 
     print(f"[gate-qf-eval] run_date={run_date} targets={len(targets)} findings={len(findings)} "
           f"pairs={len(labels)} (pos={sum(labels)}) thr={THRESHOLD} dry_run={harness.DRY_RUN}")
@@ -129,14 +135,18 @@ def run():
     print("  COSINE @%.2f   :" % THRESHOLD, {k: round(v, 3) for k, v in cos_m.items()})
     print("  COSINE @best=%.3f:" % cos_best["thr"], {k: round(v, 3) for k, v in cos_best.items() if k != "thr"})
 
-    mdl_best = None
+    mdl_m = mdl_best = None
     if MODEL.exists():
         try:
             import joblib
             import numpy as np
             clf = joblib.load(str(MODEL))
-            X = np.array([np.concatenate([np.abs(np.array(q) - np.array(cv)), np.array(q) * np.array(cv), [cos]])
-                          for q, cv, cos in feats])
+            cvm = np.array([f[2] for f in feats], dtype=np.float32)
+            qvm = np.array([f[3] for f in feats], dtype=np.float32)
+            # Build for the model that was actually loaded: train.py writes this
+            # same path, and it emits the wider (2d+4) layout.
+            dim = int(getattr(clf, "n_features_in_", 0)) or _feat.dims_for(cvm.shape[1])[0]
+            X = _feat.make_features([f[0] for f in feats], [f[1] for f in feats], cvm, qvm, dim=dim)
             proba = clf.predict_proba(X)[:, 1].tolist()
             mdl_m = _metrics(labels, proba, 0.5)
             mdl_best = _best_f1(proba)

--- a/eval/tests/test_eval.py
+++ b/eval/tests/test_eval.py
@@ -2,9 +2,8 @@
 Characterization tests for eval/ (harness.py, tasks.py, grounding_gate_eval.py,
 grounding_gate_qf_eval.py, grounding_gate_oos_eval.py).
 
-These pin the behaviour AS IT IS TODAY -- including two genuine defects that are
-deliberately NOT fixed here (see test_qf_run_persist_raises_unbound_local_when_no_model
-and test_oos_verdict_else_branch_drops_the_verdict_text).
+These pin the behaviour AS IT IS TODAY -- including a genuine defect that is
+deliberately NOT fixed here (see test_oos_verdict_else_branch_drops_the_verdict_text).
 
 No network / Qdrant / Ollama / GPU is used: every outbound call goes through
 harness._http / harness.embed / subprocess.run, all of which are monkeypatched.
@@ -1087,39 +1086,70 @@ def test_qf_run_reports_but_survives_a_broken_model_file(tmp_path, monkeypatch, 
     assert "IN-SAMPLE" not in out
 
 
-def test_qf_run_persist_raises_unbound_local_when_no_model(tmp_path, monkeypatch):
-    """BUG (pinned, not fixed): `mdl_m` is only bound inside `if MODEL.exists()`,
-    but the persist loop references it unconditionally. A live run (HARNESS_DRY_RUN
-    unset) with no classifier on disk crashes AFTER printing the cosine metrics --
-    so the cosine scores are never persisted either."""
-    glob_pat = _write_corpus(tmp_path, QF_ROWS)
+def _live_run(tmp_path, monkeypatch, model_path):
+    """A live (persisting) qf run against the standard corpus; returns the upserts."""
+    upserts = []
     monkeypatch.setattr(harness, "OLLAMA_URL", "http://o")
     monkeypatch.setattr(harness, "DRY_RUN", False)
     monkeypatch.setattr(harness, "embed", unit_embedder(QF_VECTORS))
     monkeypatch.setattr(harness, "ensure_collection", lambda *a, **k: None)
-    monkeypatch.setattr(harness, "upsert_score", lambda **kw: pytest.fail("should not reach"))
-    monkeypatch.setattr(qf, "CORPUS", glob_pat)
-    monkeypatch.setattr(qf, "MODEL", tmp_path / "absent.joblib")
+    monkeypatch.setattr(harness, "upsert_score", lambda **kw: upserts.append(kw))
+    monkeypatch.setattr(qf, "CORPUS", _write_corpus(tmp_path, QF_ROWS))
+    monkeypatch.setattr(qf, "MODEL", model_path)
+    qf.run()
+    return upserts
 
-    with pytest.raises(UnboundLocalError, match="mdl_m"):
-        qf.run()
+
+def test_qf_run_persists_the_cosine_arm_when_there_is_no_model(tmp_path, monkeypatch):
+    """`mdl_m` was only bound inside `if MODEL.exists()` while the persist loop
+    referenced it unconditionally, so a live run with no classifier on disk died
+    of UnboundLocalError AFTER printing the cosine metrics -- losing those too."""
+    upserts = _live_run(tmp_path, monkeypatch, tmp_path / "absent.joblib")
+    ids = sorted(u["task_id"] for u in upserts)
+    assert ids == sorted(f"dtl.gate_qf.cosine.{m}" for m in
+                         ("recall", "bleed_rejection", "f1", "accuracy", "auc"))
 
 
-def test_qf_run_persist_also_crashes_when_the_model_fails_to_load(tmp_path, monkeypatch):
-    """Same defect via the other branch: joblib.load raising leaves mdl_m unbound."""
+def test_qf_run_persists_the_cosine_arm_when_the_model_fails_to_load(tmp_path, monkeypatch):
+    """Same defect via the other branch: joblib.load raising left mdl_m unbound."""
     bad = tmp_path / "bad.joblib"
     bad.write_bytes(b"garbage")
-    glob_pat = _write_corpus(tmp_path, QF_ROWS)
-    monkeypatch.setattr(harness, "OLLAMA_URL", "http://o")
-    monkeypatch.setattr(harness, "DRY_RUN", False)
-    monkeypatch.setattr(harness, "embed", unit_embedder(QF_VECTORS))
-    monkeypatch.setattr(harness, "ensure_collection", lambda *a, **k: None)
-    monkeypatch.setattr(harness, "upsert_score", lambda **kw: None)
-    monkeypatch.setattr(qf, "CORPUS", glob_pat)
-    monkeypatch.setattr(qf, "MODEL", bad)
+    upserts = _live_run(tmp_path, monkeypatch, bad)
+    assert {u["task_id"] for u in upserts} == {
+        f"dtl.gate_qf.cosine.{m}" for m in ("recall", "bleed_rejection", "f1", "accuracy", "auc")}
 
-    with pytest.raises(UnboundLocalError, match="mdl_m"):
-        qf.run()
+
+def _stub_model_wide(tmp_path):
+    """The same sigmoid(10*cos - 6) scorer, in the trainer's 2*d+4 layout.
+
+    Column order is [diff(d), prod(d), cos, cos^2, len_ratio, jaccard], so at
+    d=2 the cosine sits at index 4.
+    """
+    import joblib
+    import numpy as np
+    from sklearn.linear_model import LogisticRegression
+
+    clf = LogisticRegression()
+    clf.coef_ = np.array([[0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0]])
+    clf.intercept_ = np.array([-6.0])
+    clf.classes_ = np.array([0, 1])
+    clf.n_features_in_ = 8
+    p = tmp_path / "wide.joblib"
+    joblib.dump(clf, str(p))
+    return p
+
+
+def test_qf_run_scores_a_train_shaped_model_instead_of_skipping_it(tmp_path, monkeypatch, capsys):
+    """train.py writes THIS path in the wider layout. The eval built a hard-coded
+    2*d+1 vector, so predict_proba raised and the bare except printed
+    '[model skipped]' -- the model arm silently vanished from the trend."""
+    upserts = _live_run(tmp_path, monkeypatch, _stub_model_wide(tmp_path))
+    out = capsys.readouterr().out
+    assert "[model skipped]" not in out
+    assert ("  MODEL  @0.50  : {'recall': 1.0, 'bleed_rejection': 0.5, 'f1': 0.8, "
+            "'accuracy': 0.75, 'auc': 1.0}") in out
+    by_id = {u["task_id"]: u["score"] for u in upserts}
+    assert by_id["dtl.gate_qf.model.f1"] == pytest.approx(0.8)
 
 
 def test_qf_run_uses_target_name_as_query_for_unknown_targets(tmp_path, monkeypatch):

--- a/mlops/embedding/drift.py
+++ b/mlops/embedding/drift.py
@@ -60,7 +60,11 @@ def _sample_texts(dataset_path: str, n: int) -> list[str]:
             for line in fh:
                 try:
                     rec = json.loads(line.strip())
-                    t = rec.get("text") or rec.get("content") or rec.get("query", "")
+                    # grounding_dataset.jsonl rows are {claim, evidence, label,
+                    # signal, cos} — none of text/content/query exists on any of
+                    # them, so this sampled nothing and the anchor was never built.
+                    t = (rec.get("text") or rec.get("claim") or rec.get("content")
+                         or rec.get("query", ""))
                     if len(t) > 30:
                         texts.append(t)
                 except json.JSONDecodeError:

--- a/mlops/embedding/tests/test_embedding.py
+++ b/mlops/embedding/tests/test_embedding.py
@@ -191,6 +191,27 @@ def test_sample_texts_no_qualifying_rows_returns_empty_list(tmp_path):
     assert D._sample_texts(str(ds), 10) == []
 
 
+def test_sample_texts_reads_the_grounding_dataset_row_shape(tmp_path):
+    """The dataset drift.py is pointed at (mlops/loop.py DATASET) is written by
+    build_grounding_dataset.py as {claim, evidence, label, signal, cos} — no
+    text/content/query on any row. Reading only those three keys sampled nothing,
+    so build_anchor returned 'no texts found in dataset' and the drift detector
+    has never taken a measurement."""
+    ds = _write_jsonl(tmp_path / "grounding_dataset.jsonl", [
+        {"claim": _long("a"), "evidence": _long("b"), "label": 1,
+         "signal": "topical", "cos": 0.71},
+    ])
+    assert D._sample_texts(str(ds), 10) == [_long("a")]
+
+
+def test_sample_texts_finds_rows_in_the_committed_dataset():
+    """Against the real file, not a fixture of it."""
+    ds = Path(__file__).resolve().parents[3] / "deep_think_loci" / "grounding" / "grounding_dataset.jsonl"
+    if not ds.exists():
+        pytest.skip("no committed grounding dataset in this checkout")
+    assert len(D._sample_texts(str(ds), 20)) == 20
+
+
 def test_sample_texts_non_dict_json_line_raises_attributeerror(tmp_path):
     """BUG: only JSONDecodeError is caught. A valid-but-non-object line crashes."""
     ds = _write_jsonl(tmp_path / "d.jsonl", ["[1, 2, 3]"])

--- a/mlops/grounding/canary.py
+++ b/mlops/grounding/canary.py
@@ -30,6 +30,13 @@ from pathlib import Path
 import numpy as np
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# One definition of the pair-feature contract, shared with ground_gate.py and
+# train.py. This file used to carry its own inline copy, frozen at the legacy
+# width, so the first candidate train.py produced could not be scored at all.
+sys.path.insert(0, str(_REPO_ROOT / "deep_think_loci" / "grounding"))
+import features as _feat  # noqa: E402
+
 _HISTORY_PATH = Path(__file__).resolve().parent / "canary_history.jsonl"
 _PROMOTIONS_PATH = Path(__file__).resolve().parent / "promotions.jsonl"
 _MONITOR_PATH = Path(__file__).resolve().parent / "monitor_history.jsonl"
@@ -119,7 +126,8 @@ def _eval_run(findings, threshold, clf, ollama_url):
     text_idx = {t: i for i, t in enumerate(texts)}
     target_idx = {t: i for i, t in enumerate(targets)}
 
-    labels, cos_scores, model_scores = [], [], []
+    labels, cos_scores = [], []
+    pair_texts, pair_targets, pair_text_vecs, pair_target_vecs = [], [], [], []
 
     for target in targets:
         qv = target_vecs[target_idx[target]]
@@ -130,16 +138,21 @@ def _eval_run(findings, threshold, clf, ollama_url):
             labels.append(label)
             cos_scores.append(cos)
             if clf is not None:
-                feat = np.concatenate([np.abs(fv - qv), fv * qv, [cos]])
-                model_scores.append(feat)
+                pair_texts.append(f["text"])
+                pair_targets.append(target)
+                pair_text_vecs.append(fv)
+                pair_target_vecs.append(qv)
 
     if not labels or sum(labels) == 0:
         return None
 
     cos_m = _metrics(labels, cos_scores, threshold)
-    if clf is not None and model_scores:
-        import joblib as _joblib  # noqa: F401 — already imported at call site
-        X = np.array(model_scores)
+    if clf is not None and pair_texts:
+        # Build exactly what THIS candidate was trained on. train.py emits the
+        # current (2d+4) layout; the shipped model is the legacy (2d+1) one.
+        dim = int(getattr(clf, "n_features_in_", 0)) or _feat.dims_for(text_vecs.shape[1])[0]
+        X = _feat.make_features(pair_texts, pair_targets,
+                                np.array(pair_text_vecs), np.array(pair_target_vecs), dim=dim)
         proba = clf.predict_proba(X)[:, 1].tolist()
         model_m = _metrics(labels, proba, 0.5)
     else:

--- a/mlops/grounding/tests/test_grounding.py
+++ b/mlops/grounding/tests/test_grounding.py
@@ -297,11 +297,8 @@ def test_eval_run_enumerates_every_target_x_finding_pair(no_network_embed):
 
 
 def test_eval_run_feature_layout_is_absdiff_prod_cos(no_network_embed):
-    """Pins the 2*d+1 feature vector canary builds: [|f-q|, f*q, cos].
-
-    NOTE: train.make_features builds 2*d+4 features ([diff, prod, cos, cos^2,
-    len_ratio, jaccard]). The two are incompatible — see bugs_found.
-    """
+    """A model that does not say what it wants is fed the legacy 2*d+1 layout:
+    [|f-q|, f*q, cos]. That is the shipped classifier's contract."""
     findings = [{"text": "alpha one", "target": "alpha"}, {"text": "beta two", "target": "beta"}]
     clf = CosClf()
     canary._eval_run(findings, 0.5, clf, "http://unused")
@@ -425,21 +422,52 @@ def test_evaluate_gate_averages_across_runs(no_network_embed, tmp_path):
     assert out["cosine"]["std_f1"] == pytest.approx(abs(11 / 12 - 1.0) / 2)
 
 
-def test_evaluate_gate_rejects_a_train_shaped_model(no_network_embed, one_run_glob,
-                                                    stub_joblib_load, tmp_path):
-    """BUG PIN: a model trained by train.py (2*d+4 features) cannot be scored.
-
-    canary feeds 2*d+1 features, so sklearn raises and the exception escapes
-    evaluate_gate uncaught — the canary crashes instead of holding.
-    """
+def _fit_lr(n_features, seed=0):
     from sklearn.linear_model import LogisticRegression
-    rng = np.random.RandomState(0)
-    X = rng.rand(40, 2 * 2 + 4)
+    rng = np.random.RandomState(seed)
+    X = rng.rand(40, n_features)
     y = (X[:, 0] > 0.5).astype(int)
     y[0], y[1] = 0, 1
-    path = stub_joblib_load(tmp_path / "cand.joblib", LogisticRegression(max_iter=500).fit(X, y))
-    with pytest.raises(ValueError, match="8 features"):
+    return LogisticRegression(max_iter=500).fit(X, y)
+
+
+def test_evaluate_gate_scores_a_train_shaped_model(no_network_embed, one_run_glob,
+                                                   stub_joblib_load, tmp_path):
+    """A candidate from train.py (the wider 2*d+4 layout) must be scoreable.
+
+    canary used to build a hard-coded 2*d+1 vector, so sklearn raised and the
+    exception escaped evaluate_gate uncaught — the promotion gate could never
+    pass, and loop.py read the crash as 'canary drift detected'.
+    """
+    path = stub_joblib_load(tmp_path / "cand.joblib", _fit_lr(2 * 2 + 4))
+    out = canary.evaluate_gate(findings_glob=one_run_glob, candidate_model_path=path,
+                               threshold=0.5)
+    assert out["decision"] in ("PROMOTE", "HOLD")
+    assert out["model"]["mean_f1"] == out["model"]["mean_f1"]  # scored, not NaN
+
+
+def test_evaluate_gate_still_scores_the_legacy_shipped_model(no_network_embed, one_run_glob,
+                                                             stub_joblib_load, tmp_path):
+    """The joblib in production is the 2*d+1 one; it must keep working."""
+    path = stub_joblib_load(tmp_path / "cand.joblib", _fit_lr(2 * 2 + 1))
+    out = canary.evaluate_gate(findings_glob=one_run_glob, candidate_model_path=path,
+                               threshold=0.5)
+    assert out["model"]["mean_f1"] == out["model"]["mean_f1"]
+
+
+def test_evaluate_gate_refuses_a_model_of_unknown_width(no_network_embed, one_run_glob,
+                                                        stub_joblib_load, tmp_path):
+    """Neither contract produces 2*d+2 columns — say so rather than guess."""
+    path = stub_joblib_load(tmp_path / "cand.joblib", _fit_lr(2 * 2 + 2))
+    with pytest.raises(ValueError, match="no grounding feature contract produces 6"):
         canary.evaluate_gate(findings_glob=one_run_glob, candidate_model_path=path, threshold=0.5)
+
+
+def test_canary_has_no_second_copy_of_the_feature_layout(tmp_path):
+    """A private copy is how canary drifted away from the trainer in the first place."""
+    src = (Path(canary.__file__)).read_text()
+    assert "_feat.make_features" in src
+    assert "np.abs(fv - qv), fv * qv, [cos]" not in src
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -735,12 +763,13 @@ def test_make_features_layout_and_dimension():
     assert list(X[1]) == pytest.approx([0.6, 0.2, 0.0, 0.8, 0.8, 0.64, 8 / 9, 0.5], abs=1e-6)
 
 
-def test_make_features_dimension_differs_from_canary_feature_builder():
-    """Regression guard for the train/canary feature mismatch (see bugs_found)."""
+def test_make_features_dimension_is_what_canary_now_builds_for_such_a_model():
+    """The trainer's default is 2*d+4, and canary builds that width when the
+    candidate says it wants it — the mismatch the two used to have."""
     d = 5
     ec = np.zeros((1, d), dtype=np.float32)
     ee = np.zeros((1, d), dtype=np.float32)
-    assert train.make_features(["a"], ["b"], ec, ee).shape[1] == 2 * d + 4  # canary builds 2*d+1
+    assert train.make_features(["a"], ["b"], ec, ee).shape[1] == 2 * d + 4
 
 
 def test_cosine_f1_on_folds_picks_the_best_threshold_per_validation_fold():

--- a/scripts/hooks/pre_llm_grounding.py
+++ b/scripts/hooks/pre_llm_grounding.py
@@ -145,7 +145,10 @@ _DEFAULT_EXTRA_FIELDS = ("text", None, True)
 _BASE_COLLECTIONS = [
     ("mnemosyne",       "content",         "importance", True),
     ("loci_sessions", "content_preview", None,         True),
-    ("loci_memory",   "text",            "confidence", True),
+    # numeric_confidence, not confidence: the producer writes BOTH — a float
+    # here and the 'high'/'medium'/'low' label that _multi_signal_score reads.
+    # float()ing the label raised, losing this lane on every prompt.
+    ("loci_memory",   "text",            "numeric_confidence", True),
 ]
 _extra_names = [
     c.strip() for c in os.environ.get("GROUNDING_EXTRA_COLLECTIONS", "").split(",")
@@ -559,7 +562,7 @@ def main() -> None:
             if sub_vec is not None:
                 try:
                     sub_hits = _search_collection(
-                        "loci_memory", sub_vec, "text", "confidence", True,
+                        "loci_memory", sub_vec, "text", "numeric_confidence", True,
                         top_k=min(RECALL_TOP_K, 2),
                     )
                 except _SearchFailed:

--- a/scripts/hooks/tests/test_pre_llm_grounding.py
+++ b/scripts/hooks/tests/test_pre_llm_grounding.py
@@ -168,7 +168,7 @@ def test_collections_base_set_and_field_mapping():
     assert h.COLLECTIONS == [
         ("mnemosyne", "content", "importance", True),
         ("loci_sessions", "content_preview", None, True),
-        ("loci_memory", "text", "confidence", True),
+        ("loci_memory", "text", "numeric_confidence", True),
     ]
 
 
@@ -370,9 +370,9 @@ def test_search_collection_importance_defaults_and_falsy_coercion(hook):
 
 
 def test_search_collection_non_numeric_importance_raises(hook):
-    """BUG: the try/except only wraps the HTTP call. A textual confidence
-    ('high'/'medium'/'low' -- exactly what _multi_signal_score expects to see
-    in that field) makes float() raise straight out of the search."""
+    """The importance field must be numeric: float() on a label raises straight
+    out of the search (the try/except only wraps the HTTP call). That is why
+    loci_memory reads numeric_confidence -- see the tests below."""
     pts = [{"id": "a", "score": 0.9, "payload": {"text": "x", "confidence": "high"}}]
     calls = fake_urlopen(hook, _hit_response(pts))
     try:
@@ -380,6 +380,26 @@ def test_search_collection_non_numeric_importance_raises(hook):
             hook._search_collection("loci_memory", [1.0], "text", "confidence", True)
     finally:
         calls.stop()
+
+
+def test_loci_memory_reads_the_numeric_confidence_the_producer_writes(hook):
+    """A loci_memory finding carries BOTH fields: 'confidence' is the
+    high/medium/low label _multi_signal_score reads, and 'numeric_confidence' is
+    the float. Reading the label as importance made float() raise, so the lane
+    contributed nothing on every prompt -- silently in the main session, and
+    fatally in a subagent, where only _SearchFailed is caught."""
+    pts = [{"id": "a", "score": 0.9,
+            "payload": {"text": "x", "confidence": "high", "numeric_confidence": 0.9}}]
+    calls = fake_urlopen(hook, _hit_response(pts))
+    try:
+        col, _, impf, named = hook.COLLECTIONS[2]
+        assert col == "loci_memory"
+        hits = hook._search_collection(col, [1.0], "text", impf, named)
+    finally:
+        calls.stop()
+    assert [h["importance"] for h in hits] == [0.9]
+    # and the label is still there for the ranker that wants a label
+    assert hook._multi_signal_score(hits[0], time.time()) > 0
 
 
 def test_search_collection_raises_on_transport_error(hook):
@@ -1088,7 +1108,7 @@ def test_main_fans_out_over_every_configured_collection(hook):
     assert sorted(calls) == sorted([
         ("mnemosyne", (0.25,), "content", "importance", True, 3),
         ("loci_sessions", (0.25,), "content_preview", None, True, 3),
-        ("loci_memory", (0.25,), "text", "confidence", True, 3),
+        ("loci_memory", (0.25,), "text", "numeric_confidence", True, 3),
     ])
 
 
@@ -1301,7 +1321,7 @@ def test_subagent_detection_sources(hook, payload_extra, session_id, env):
     # lightweight path: exactly one collection, capped at 2 results
     assert len(seen) == 1
     assert seen[0][0][0] == "loci_memory"
-    assert seen[0][0][2:] == ("text", "confidence", True)
+    assert seen[0][0][2:] == ("text", "numeric_confidence", True)
     assert seen[0][1] == {"top_k": 2}
     assert "grounding unavailable in subagent context" in context_of(out)
 

--- a/scripts/shadow_eval.py
+++ b/scripts/shadow_eval.py
@@ -45,7 +45,14 @@ def _load_corpus(limit_scan: int) -> list:
 
 
 def _make_retrieve(pool: int):
-    """retrieve_fn(query, exclude_id) -> [{id, text}] dense-search candidate pool."""
+    """retrieve_fn(query, exclude_id) -> [{id, text}] dense-search candidate pool.
+
+    Passages are truncated to the SAME budget production feeds the cross-encoder
+    (qdrant_ops.RERANK_MAX_CHARS). A hard-coded 512 here scored every arm at a
+    length the repo separately measured as worse than no reranker at all, so the
+    ordering this gate produced was not evidence about the pipeline that runs.
+    """
+    import qdrant_ops
     import server as S
     client, col = S._get_qdrant()
 
@@ -60,7 +67,8 @@ def _make_retrieve(pool: int):
             rid = str(r.id)
             if rid == str(exclude_id):
                 continue
-            out.append({"id": rid, "text": str((r.payload or {}).get("text", ""))[:512]})
+            out.append({"id": rid,
+                        "text": str((r.payload or {}).get("text", ""))[:qdrant_ops.RERANK_MAX_CHARS]})
         return out[:pool]
 
     return retrieve

--- a/scripts/tests/test_shadow_eval_truncation.py
+++ b/scripts/tests/test_shadow_eval_truncation.py
@@ -49,8 +49,9 @@ class _Client:
 
 
 @pytest.fixture
-def stub_server(monkeypatch, se):
-    """Stand in for mcp/server.py rather than importing it.
+def long_passage(monkeypatch, se):
+    """Stand in for mcp/server.py rather than importing it, and hand back the
+    stored passage.
 
     Importing the real module pulls in `from dotenv import load_dotenv` at
     server.py:66, and the test-scripts CI job installs only pytest, pytest-timeout
@@ -59,7 +60,10 @@ def stub_server(monkeypatch, se):
     errors; this stub gives 0.
 
     _make_retrieve reaches for exactly two names, so a module carrying those two
-    is a complete stand-in, and the test still fails against origin/main."""
+    is a complete stand-in, and the test still fails against origin/main.
+
+    The passage is returned so a caller can assert it overran the budget:
+    "the result fits" would also pass on a passage that was never cut."""
     import sys
     import types
 
@@ -71,16 +75,18 @@ def stub_server(monkeypatch, se):
     return text
 
 
-def test_retrieved_passages_are_cut_at_the_production_rerank_budget(se, stub_server):
+def test_retrieved_passages_are_cut_at_the_production_rerank_budget(se, long_passage):
+    assert len(long_passage) > qdrant_ops.RERANK_MAX_CHARS, "fixture no longer overruns the budget"
     cands = se._make_retrieve(5)("some query", exclude_id="other")
     assert len(cands) == 1
     assert len(cands[0]["text"]) == qdrant_ops.RERANK_MAX_CHARS
     assert qdrant_ops.RERANK_MAX_CHARS == 1024, "the swept default moved; re-check the gate"
 
 
-def test_the_budget_is_imported_not_restated(se, stub_server, monkeypatch):
+def test_the_budget_is_imported_not_restated(se, long_passage, monkeypatch):
     """Overriding the module constant must move the harness with it — a second
     literal is exactly how the two copies drifted apart."""
+    assert len(long_passage) > 777
     monkeypatch.setattr(qdrant_ops, "RERANK_MAX_CHARS", 777)
     cands = se._make_retrieve(5)("some query", exclude_id="other")
     assert len(cands[0]["text"]) == 777

--- a/scripts/tests/test_shadow_eval_truncation.py
+++ b/scripts/tests/test_shadow_eval_truncation.py
@@ -1,0 +1,73 @@
+"""The shadow-eval gate must score arms at the passage budget production uses.
+
+_make_retrieve truncated each candidate to a hard-coded 512 chars before handing
+it to reranker.rerank(), which truncates nothing of its own. Production feeds the
+cross-encoder qdrant_ops.RERANK_MAX_CHARS (1024). The repo measured 512 as worse
+than using no reranker at all on a 1,048-char median finding, so every arm was
+ranked in a regime the running pipeline never sees — and judge_eval.py imports
+this same function, which is what flipped the production RERANK_MODEL default.
+"""
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "shadow_eval.py"
+sys.path.insert(0, str(REPO / "mcp"))
+
+import qdrant_ops  # noqa: E402
+
+
+@pytest.fixture
+def se():
+    spec = importlib.util.spec_from_file_location("shadow_eval", SCRIPT)
+    assert spec and spec.loader, f"cannot load {SCRIPT}"
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+class _Point:
+    def __init__(self, pid, text):
+        self.id = pid
+        self.payload = {"text": text}
+
+
+class _Result:
+    def __init__(self, points):
+        self.points = points
+
+
+class _Client:
+    def __init__(self, points):
+        self._points = points
+
+    def query_points(self, **kw):
+        return _Result(self._points)
+
+
+@pytest.fixture
+def stub_server(monkeypatch, se):
+    """Replace the Qdrant/Ollama halves of mcp/server.py, keep _make_retrieve real."""
+    import server as S
+    text = "x" * 5000
+    monkeypatch.setattr(S, "_get_qdrant", lambda: (_Client([_Point("p1", text)]), "col"))
+    monkeypatch.setattr(S, "_embed", lambda q: [0.1])
+    return text
+
+
+def test_retrieved_passages_are_cut_at_the_production_rerank_budget(se, stub_server):
+    cands = se._make_retrieve(5)("some query", exclude_id="other")
+    assert len(cands) == 1
+    assert len(cands[0]["text"]) == qdrant_ops.RERANK_MAX_CHARS
+    assert qdrant_ops.RERANK_MAX_CHARS == 1024, "the swept default moved; re-check the gate"
+
+
+def test_the_budget_is_imported_not_restated(se, stub_server, monkeypatch):
+    """Overriding the module constant must move the harness with it — a second
+    literal is exactly how the two copies drifted apart."""
+    monkeypatch.setattr(qdrant_ops, "RERANK_MAX_CHARS", 777)
+    cands = se._make_retrieve(5)("some query", exclude_id="other")
+    assert len(cands[0]["text"]) == 777

--- a/scripts/tests/test_shadow_eval_truncation.py
+++ b/scripts/tests/test_shadow_eval_truncation.py
@@ -50,11 +50,24 @@ class _Client:
 
 @pytest.fixture
 def stub_server(monkeypatch, se):
-    """Replace the Qdrant/Ollama halves of mcp/server.py, keep _make_retrieve real."""
-    import server as S
+    """Stand in for mcp/server.py rather than importing it.
+
+    Importing the real module pulls in `from dotenv import load_dotenv` at
+    server.py:66, and the test-scripts CI job installs only pytest, pytest-timeout
+    and aiohttp — so this errored at setup there while passing locally. Verified
+    against that exact dependency set: importing the real module gives 2 setup
+    errors; this stub gives 0.
+
+    _make_retrieve reaches for exactly two names, so a module carrying those two
+    is a complete stand-in, and the test still fails against origin/main."""
+    import sys
+    import types
+
     text = "x" * 5000
-    monkeypatch.setattr(S, "_get_qdrant", lambda: (_Client([_Point("p1", text)]), "col"))
-    monkeypatch.setattr(S, "_embed", lambda q: [0.1])
+    mod = types.ModuleType("server")
+    mod._get_qdrant = lambda: (_Client([_Point("p1", text)]), "col")
+    mod._embed = lambda q: [0.1]
+    monkeypatch.setitem(sys.modules, "server", mod)
     return text
 
 


### PR DESCRIPTION
Two copies of the same constant, one of which moved.

`mcp/qdrant_ops.RERANK_MAX_CHARS` is **1024**. `scripts/shadow_eval.py` restated it as its own literal **512**, so the shadow-eval harness truncated retrieved passages to half what production feeds the cross-encoder. Every shadow evaluation was scored on shorter passages than the live path sees — and nothing compared the two numbers.

Same shape as the three found earlier today: one definition copied, then one copy changed.

```
without the fix:  AssertionError: assert 512 == 1024
with the fix:     2 passed
```

The second test overrides the module constant and asserts the harness moves with it, because a second literal is exactly how the two drifted apart.

## Held once, and rightly

The review held this branch: the new fixture did `import server as S`, `mcp/server.py:66` does `from dotenv import load_dotenv`, and the `test-scripts` CI job installs only `pytest pytest-timeout aiohttp`. Green locally, **two setup errors on the runner**.

That's the **fifth** undeclared module-scope import to bite this fleet today — after scipy, paho-mqtt, Pillow and pandas in the sibling repo. The reviewer reproduced it in a venv with exactly the CI dependency set, proposed the remedy, and verified the remedy itself before holding.

`_make_retrieve` reaches for exactly `_get_qdrant` and `_embed`, so a `types.ModuleType` carrying those two is a complete stand-in via `monkeypatch.setitem(sys.modules, "server", mod)`.

Verified in a venv with **only** `pytest pytest-timeout aiohttp`:

```
scripts/tests/   158 passed, 0 errors
against origin/main's shadow_eval.py   assert 512 == 1024   (still red)
```

The stub costs the test nothing.

## Also in this branch

Four more sites where the same class had already bitten, each with a test that fails when its source file is reverted to `origin/main`:

| file | reverted → |
|---|---|
| `scripts/hooks/pre_llm_grounding.py` | 7 failed, load-bearing one `ValueError: could not convert string to float: 'high'` |
| `mlops/embedding/drift.py` | 2 failed |
| `mlops/grounding/canary.py` | 3 failed — `X has 5 features, but LogisticRegression is expecting 8` |
| `eval/grounding_gate_qf_eval.py` | 3 failed — `UnboundLocalError: mdl_m` |
| `deep_think_loci/grounding/features.py` | 17 failed |

The reviewer confirmed **both halves** of the qf-eval fix are independently load-bearing, and that mutating `features.py` to swap the `cos` and `cos²` columns fails two tests — so the new tests pin column **order**, not merely width.

Callers checked, not assumed: `train.py`, `holdout_eval.py` and `ground_gate.py` produce identical output at 768 dims, `supported_dims()` is unchanged so the live gate's guard is untouched, and the new width-relative check is strictly stricter than the absolute one it replaces.