### PR TITLE
Resolve the warm-keeper's generation model instead of hardcoding it

### DIFF
--- a/mcp/tests/test_gpu_warm.py
+++ b/mcp/tests/test_gpu_warm.py
@@ -75,7 +75,17 @@ def test_pin_embed_hits_embed_with_keep_alive():
     assert call["json"]["model"] == "nomic-embed-text"
 
 
-def test_warm_once_pins_both_models():
+def test_warm_once_pins_both_models(monkeypatch):
+    """The generation model is resolved, not hardcoded, so this test must fix it
+    rather than inherit whatever the machine has configured.
+
+    WARM_GEN_MODEL is the highest-precedence source; without pinning it, the
+    assertion below reads ~/.loci/backends.toml and passes on a runner (no config,
+    so the qwen default) while failing on an operator box that has one. A test
+    that is green in CI and red on the machine that matters is the read-but-never
+    -set trap in the test layer."""
+    monkeypatch.setenv("WARM_GEN_MODEL", "qwen2.5:3b")
+    monkeypatch.setattr(G, "_GEN_MODEL", G._resolve_gen_model())
     poster = _RecordingPoster()
     report = G.warm_once(keep_alive="-1", post_fn=poster, include_gpu=False)
     assert report["degraded"] is False

--- a/scripts/gpu_warm.py
+++ b/scripts/gpu_warm.py
@@ -47,8 +47,31 @@ from typing import Callable, Optional
 # Same base-URL convention as embed_ops.py / llm_local.py.
 _OLLAMA = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_URL") or ""
 
-# The two hot models to keep resident. [gen] qwen2.5:3b, [retrieval] nomic-embed-text.
-_GEN_MODEL = os.environ.get("WARM_GEN_MODEL", "qwen2.5:3b")
+
+def _resolve_gen_model() -> str:
+    """WARM_GEN_MODEL env -> backends.ollama_gen_model() -> the qwen2.5:3b default.
+
+    Same resolution chain mcp/memcheck/llm.py._llm_model() already uses, so the
+    model this script pins resident can't silently diverge from the model
+    mcp/llm_local.py actually generates with.
+    """
+    explicit = os.environ.get("WARM_GEN_MODEL")
+    if explicit:
+        return explicit
+    try:
+        sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, "mcp"))
+        import backends
+        m = backends.ollama_gen_model()
+        if m:
+            return m
+    except Exception:
+        pass
+    return "qwen2.5:3b"
+
+
+# The two hot models to keep resident. [gen] resolved via backends (see
+# _resolve_gen_model); [retrieval] nomic-embed-text.
+_GEN_MODEL = _resolve_gen_model()
 _EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 
 # Generous timeout: a cold load is ~70s [substrate]; 120s covers cold-load + tiny gen.

--- a/scripts/tests/test_gpu_warm_gen_model.py
+++ b/scripts/tests/test_gpu_warm_gen_model.py
@@ -1,0 +1,48 @@
+"""gpu_warm.py's default gen model must track backends.ollama_gen_model(),
+not a hardcoded "qwen2.5:3b" that can silently diverge from the model
+mcp/llm_local.py actually generates with (mcp/memcheck/llm.py._llm_model()
+already resolves through backends the same way).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+from unittest import mock
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO / "mcp"))
+
+
+def _fresh_gpu_warm():
+    sys.modules.pop("gpu_warm", None)
+    sys.modules.pop("backends", None)
+    return importlib.import_module("gpu_warm")
+
+
+def test_gen_model_follows_backends_config(tmp_path):
+    """No WARM_GEN_MODEL override -> resolve via backends.ollama_gen_model(),
+    which itself reads [ollama].gen_model from ~/.loci/backends.toml."""
+    cfg = tmp_path / "backends.toml"
+    cfg.write_text('[ollama]\ngen_model = "heretic-llama31-8b-instruct:latest"\n')
+    env = dict(os.environ)
+    env.pop("WARM_GEN_MODEL", None)
+    env["LOCI_CONFIG"] = str(cfg)
+    with mock.patch.dict(os.environ, env, clear=True):
+        mod = _fresh_gpu_warm()
+        assert mod._GEN_MODEL == "heretic-llama31-8b-instruct:latest"
+
+
+def test_explicit_warm_gen_model_env_still_wins(tmp_path):
+    cfg = tmp_path / "backends.toml"
+    cfg.write_text('[ollama]\ngen_model = "heretic-llama31-8b-instruct:latest"\n')
+    env = dict(os.environ)
+    env["LOCI_CONFIG"] = str(cfg)
+    env["WARM_GEN_MODEL"] = "explicit-override:latest"
+    with mock.patch.dict(os.environ, env, clear=True):
+        mod = _fresh_gpu_warm()
+        assert mod._GEN_MODEL == "explicit-override:latest"

--- a/scripts/tests/test_gpu_warm_gen_model.py
+++ b/scripts/tests/test_gpu_warm_gen_model.py
@@ -11,7 +11,6 @@ import pathlib
 import sys
 from unittest import mock
 
-import pytest
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "scripts"))


### PR DESCRIPTION
`scripts/gpu_warm.py` pinned `qwen2.5:3b` as a module constant. This host's `~/.loci/backends.toml` sets `gen_model = "heretic-llama31-8b-instruct:latest"`, and `backends.ollama_gen_model()` has existed to resolve exactly that since the vLLM/Ollama split.

So the warm-keeper has been holding the wrong model resident — keeping a 3B warm while generation actually runs on the 8B, which is the model that benefits from being pinned. A setting that looks configurable and is not, with its default quietly load-bearing.

`_resolve_gen_model()` is `WARM_GEN_MODEL` env → `backends.ollama_gen_model()` → the `qwen2.5:3b` default, matching the precedence every other resolver in the repo uses.

```
without the fix:  AssertionError: assert 'qwen2.5:3b' == 'heretic-llam...struct:latest'
with the fix:     2 passed
```

## Held once, for the right reason

The review caught that the fix broke `mcp/tests/test_gpu_warm.py` — **in a way CI could not see**:

```
operator box : 1 failed, 5 passed
CI runner    : 6 passed        (no backends.toml, so the qwen default)
```

That test asserts the literal `qwen2.5:3b`; once `_GEN_MODEL` resolves through `backends`, it reads whatever the machine has configured. **Green where nobody runs it, red where it matters** — the read-but-never-set trap this branch exists to close, reproduced one layer up in the test layer. I reproduced both halves before believing it.

The test's subject is *"both hot models get pinned with keep_alive set"*, not which model is hot, so it now fixes `WARM_GEN_MODEL` and re-resolves. Verified both ways on this machine:

```
real ~/.loci/backends.toml     8 passed
LOCI_CONFIG=/nonexistent.toml  8 passed
```

Also drops an unused `import pytest` the lint job would have gone red on — the review caught that too.

## Scope

Only the generation model. `nomic-embed-text` stays literal: `embed_model()` resolves it elsewhere and changing both at once would make the failure ambiguous if either is wrong.