### PR TITLE
Close the fallback sqlite connection in read_recent_failures()

### DIFF
--- a/scripts/exif_skill_discovery.py
+++ b/scripts/exif_skill_discovery.py
@@ -55,17 +55,19 @@ def read_recent_failures():
         # Table or column may differ; try a fallback without bank filter
         try:
             conn = sqlite3.connect(MNEMOSYNE_DB)
-            fallback_query = """
-                SELECT content, importance
-                FROM memories
-                WHERE importance >= 5
-                  AND created_at >= ?
-                ORDER BY importance DESC, created_at DESC
-                LIMIT 20
-            """
-            rows = conn.execute(fallback_query, (cutoff,)).fetchall()
-            conn.close()
-            return [row[0] for row in rows]
+            try:
+                fallback_query = """
+                    SELECT content, importance
+                    FROM memories
+                    WHERE importance >= 5
+                      AND created_at >= ?
+                    ORDER BY importance DESC, created_at DESC
+                    LIMIT 20
+                """
+                rows = conn.execute(fallback_query, (cutoff,)).fetchall()
+                return [row[0] for row in rows]
+            finally:
+                conn.close()
         except Exception as exc2:
             print(f"[exif] db read error: {exc2}", file=sys.stderr)
             return []

--- a/scripts/tests/test_exif_skill_discovery_fallback_close.py
+++ b/scripts/tests/test_exif_skill_discovery_fallback_close.py
@@ -1,0 +1,59 @@
+"""read_recent_failures()'s fallback connection must close even when the
+fallback query itself raises (the same condition that triggered the
+fallback in the first place).
+"""
+import importlib.util
+import pathlib
+import sqlite3
+import unittest
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "_exif_skill_discovery", _SCRIPTS / "exif_skill_discovery.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeConn:
+    """Stand-in sqlite3 connection: every execute() raises OperationalError,
+    same as a locked/busy db. Records whether close() was ever called."""
+
+    def __init__(self, registry):
+        self.closed = False
+        registry.append(self)
+
+    def execute(self, *args, **kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    def close(self):
+        self.closed = True
+
+
+class TestFallbackConnectionCloses(unittest.TestCase):
+    def test_fallback_conn_closed_even_when_fallback_query_raises(self):
+        mod = _load()
+        created = []
+
+        with mock.patch.object(mod.os.path, "exists", return_value=True), \
+             mock.patch.object(
+                 mod.sqlite3, "connect", side_effect=lambda *a, **k: _FakeConn(created)
+             ):
+            result = mod.read_recent_failures()
+
+        self.assertEqual(result, [])
+        # Primary attempt opens one connection, fallback opens a second.
+        self.assertEqual(len(created), 2)
+        self.assertTrue(
+            all(c.closed for c in created),
+            "every sqlite3 connection opened by read_recent_failures() must be closed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was wrong

`read_recent_failures()` in `scripts/exif_skill_discovery.py` opens a sqlite
connection for its primary query inside a `try/finally` that always closes it.
The fallback path — reached when the primary query raises
`sqlite3.OperationalError` — opened a *second* connection with a bare `try`,
and `conn.close()` sat on the success path only:

```python
conn = sqlite3.connect(MNEMOSYNE_DB)
rows = conn.execute(fallback_query, (cutoff,)).fetchall()
conn.close()          # never reached if execute() raises
return [row[0] for row in rows]
```

If the fallback query also raised — the locked/busy database that caused the
fallback in the first place is the obvious way for that to happen — control
jumped to `except Exception as exc2` and the connection was dropped un-closed.

## Evidence it was real

Reproduced directly, not inferred: with the pre-fix source, a fake connection
whose `execute()` raises `sqlite3.OperationalError` leaves the fallback
connection with `closed == False` after `read_recent_failures()` returns.

Scope is honest about the blast radius: this is a per-invocation script
(`docs/OPERATIONS.md:222` runs it as `$LOCI_PY $LOCI/scripts/exif_skill_discovery.py`),
its only caller is `main()` at line 226, and nothing imports it into a
long-lived process — so the OS reclaims the handle seconds later at exit. It is
a genuine unguarded resource on a retry path with low operational consequence,
not an fd leak that accumulates in production.

## What changed

The fallback connect+query is wrapped in the same `try/finally` shape the
primary attempt already uses. Nothing else: the function's contract is
untouched — it still returns a list of memory strings on success and `[]` on
error, on every path it had before.

## The test

`scripts/tests/test_exif_skill_discovery_fallback_close.py` drives
`read_recent_failures()` with `sqlite3.connect` patched to hand back fake
connections that raise `OperationalError` from `execute()` and record whether
`close()` was called. It asserts two connections were opened (primary +
fallback) and that both were closed.

It fails without the fix. Confirmed by reverting `scripts/exif_skill_discovery.py`
to its `main` version in a clean worktree and rerunning the same test:

```
AssertionError: False is not true : every sqlite3 connection opened by
read_recent_failures() must be closed
```

With the fix restored: `scripts/tests` — 157 passed, 0 failed.

## Deliberately left alone

- The primary query path already had a correct `try/finally`; it was not
  rewritten to `contextlib.closing` or otherwise churned.
- No new defaults, fallback values, or swallowed errors were introduced — the
  `except Exception as exc2` handler still logs to stderr and returns `[]`
  exactly as before.
- No reformatting, renames, or refactors elsewhere in the file. The diff is one
  block plus one new test.
