### PR TITLE
Guard _cosine against ragged vectors in embedding drift detection

### DIFF
--- a/mlops/embedding/drift.py
+++ b/mlops/embedding/drift.py
@@ -44,6 +44,8 @@ def _embed(text: str, ollama_url: str, model: str) -> list[float]:
 
 
 def _cosine(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
     dot = sum(x * y for x, y in zip(a, b))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(x * x for x in b))

--- a/mlops/embedding/tests/test_embedding.py
+++ b/mlops/embedding/tests/test_embedding.py
@@ -10,7 +10,6 @@ or by replacing ``drift._embed``, and no sentence-transformers model is ever dow
 
 import importlib
 import json
-import math
 import os
 import random
 import sys
@@ -119,17 +118,15 @@ def test_cosine_empty_vectors_return_zero():
     assert D._cosine([], [1.0, 2.0]) == 0.0
 
 
-def test_cosine_silently_accepts_ragged_vectors():
-    """BUG-ish: zip() truncates the dot product but the norms use the FULL vectors.
-
-    No length check is performed, so mismatched dimensionality yields a plausible-looking
-    number instead of an error.
+def test_cosine_rejects_ragged_vectors():
+    """Mismatched dimensionality (e.g. anchor built under a different EMBED_MODEL)
+    must not silently truncate via zip() into a plausible-looking score. It now
+    matches the guard already used by mcp/embed_ops.py, mcp/memcheck/backend.py,
+    and mcp/memcheck/llm.py.
     """
-    # dot is over the 1-element overlap (=1.0), both norms are 1.0 -> "perfect similarity"
-    assert D._cosine([1.0, 0.0], [1.0]) == pytest.approx(1.0)
-    # here the longer vector's extra component inflates its norm and drags the score down
-    assert D._cosine([1.0, 1.0], [1.0]) == pytest.approx(1.0 / math.sqrt(2))
-    assert D._cosine([1.0], [1.0, 1.0]) == pytest.approx(1.0 / math.sqrt(2))
+    assert D._cosine([1.0, 0.0], [1.0]) == 0.0
+    assert D._cosine([1.0, 1.0], [1.0]) == 0.0
+    assert D._cosine([1.0], [1.0, 1.0]) == 0.0
 
 
 def test_cosine_result_is_a_plain_float():


### PR DESCRIPTION
## What was wrong

`mlops/embedding/drift.py::_cosine` computed the dot product with `zip(a, b)` and no length check, but took the norms over the **full** vectors:

```python
dot = sum(x * y for x, y in zip(a, b))   # truncates to the shorter vector
na = math.sqrt(sum(x * x for x in a))    # full length
nb = math.sqrt(sum(x * x for x in b))    # full length
```

`zip()` silently stops at the shorter input, so a dimension mismatch produced a plausible-looking similarity instead of any indication the comparison was meaningless.

This is reachable in normal operation. `anchor.npz` is built once under whatever `EMBED_MODEL` was set at build time; `measure_drift()` re-embeds with `DEFAULT_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")` read fresh at import. When those differ the dimensionality differs, and nothing on the path — `measure_drift`, `main()`, or `mlops/loop.py::_run_embedding_drift` — ever compares `len(anchor_embs[i])` to `len(live_vec)`. `result["error"]` is only set for a numpy import failure, a missing anchor, or zero successful embeds.

## Evidence it was real

Driving `measure_drift()` with a 4-dim anchor against a 2-dim live embedder, on `main`:

```
{'mean_cosine': 0.9999000150019693, 'drift_score': 9.99e-05,
 'n_drifted_095': 0, 'n_texts': 2, 'threshold': 0.02, 'exceeded': False}
-> drift.py exit code: 0
```

Two entirely different embedding models, reported as **99.99% similar**, `exceeded=False`, exit 0. `loop.py` sees no drift and never schedules a retrain — the failure mode is a silent false negative that masks genuine drift. With different tail magnitudes the same mismatch instead scores 0.62 and fires a spurious retrain; either way the caller cannot tell a degenerate comparison from a real one.

Same scenario after the fix:

```
{'mean_cosine': 0.0, 'drift_score': 1.0, 'n_drifted_095': 2, 'n_texts': 2,
 'threshold': 0.02, 'exceeded': True}
-> drift.py exit code: 1   (loop.py ALERTs)
```

## What changed

Two lines in `_cosine`:

```python
if len(a) != len(b):
    return 0.0
```

This is the guard every sibling cosine helper in the repo already has — `mcp/embed_ops.py:145`, `mcp/memcheck/backend.py:41`, `mcp/memcheck/llm.py:406` all do `if not a or not b or len(a) != len(b): return 0.0` before the same zip-based dot product. `0.0` is also already this function's own sentinel for a zero-norm vector, and `test_measure_drift_zero_anchor_vector_scores_as_total_drift` already pins that as "reads as 100% drift". A mismatch now fails loud (alert) rather than quiet (masked drift). `_emit_embedding_trigger()` only writes `run_contrastive.sh` for a human to run, so the conservative direction costs a generated script, not a surprise GPU job.

## What proves it, and that it fails without the fix

`mlops/embedding/tests/test_embedding.py` had a characterization test pinning the bug (`test_cosine_silently_accepts_ragged_vectors`). It is replaced by `test_cosine_rejects_ragged_vectors`, asserting `0.0` for all three ragged shapes.

Verified by removing **only** the two guard lines and re-running — the reverted `drift.py` hashes back to `ac735e2`, byte-identical to main's:

```
FAILED test_cosine_rejects_ragged_vectors - assert 1.0 == 0.0
 +  where 1.0 = _cosine([1.0, 0.0], [1.0])
1 failed, 66 passed
```

Exactly one test fails, and it fails on the fabricated "perfect similarity" itself. With the guard restored: 67 passed in `test_embedding.py`, 577 passed across `pytest mlops -q`. `ruff check` clean on both files.

`import math` is dropped from the test file because the removed assertions were its only users — zero `math` tokens remain, and it would otherwise be an unused import.

## Deliberately left alone

The finding also suggested surfacing a distinct `n_dim_mismatch` count in `measure_drift()`'s result dict so `loop.py` could tell a stale anchor from real drift. Not done here: it changes a dict shape asserted by name in `test_measure_drift_no_change_returns_full_result_shape` and consumed by `loop.py`'s ALERT/print path, and it needs real decisions about what counts as "drifted" versus "mismatched". After this change a dimension mismatch is still indistinguishable from genuine total drift in the result dict — but it now fails in the loud direction, which is the part that was actually dangerous. Worth a follow-up.

`_cosine` is module-private; `measure_drift()` at `drift.py:136` is its only production caller, and the only other references are in this test file. The identically-named helpers in `scripts/skillops_maintenance.py` and `scripts/glymphatic_sweep.py` are separate definitions and are untouched.
