### PR TITLE
Report the reason, not a None, when the shift check has no drift score

### DIFF
--- a/scripts/glymphatic_sweep.py
+++ b/scripts/glymphatic_sweep.py
@@ -457,8 +457,11 @@ def main(
             print(f"[glym] shift check: {shift_result}")
             return
         if not shift_result.get("should_sweep", True):
-            print(f"[glym] content shift below threshold ({shift_result.get('drift_score'):.4f}) "
-                  "— skipping sweep")
+            # drift_score is None on every early return (db_not_found, table_not_found,
+            # too_few_rows, embed_failed); report the reason those carry instead.
+            drift = shift_result.get("drift_score")
+            detail = f"{drift:.4f}" if drift is not None else shift_result.get("reason", "unknown")
+            print(f"[glym] content shift below threshold ({detail}) — skipping sweep")
             return
         print(f"[glym] content shift triggered sweep (drift={shift_result.get('drift_score'):.4f})")
 

--- a/tests/test_glymphatic_shift_report.py
+++ b/tests/test_glymphatic_shift_report.py
@@ -1,0 +1,61 @@
+"""main(--check-shift) must survive a drift_score of None.
+
+check_content_shift documents and returns ``drift_score=None`` on four paths
+(db_not_found, table_not_found, too_few_rows, embed_failed), each paired with
+``should_sweep=False`` — which is exactly the branch main() reports on. Formatting
+that None with ``:.4f`` raised TypeError out of main(), so the one condition
+--check-shift exists to detect cheaply (embeddings unavailable) aborted the run
+before the mutex was taken and no sweep ran at all.
+"""
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "glymphatic_sweep.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("glymphatic_sweep_under_test", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ShiftReportTest(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def _run_main(self, shift_result):
+        self.mod.check_content_shift = lambda **_kw: shift_result
+        for step in ("sweep_verdicts", "sweep_orphans", "sweep_edges", "sweep_duplicates"):
+            setattr(self.mod, step, lambda *_a, **_kw: self.fail(f"{step} ran despite should_sweep=False"))
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.mod.main(check_shift=True)
+        return buf.getvalue()
+
+    def test_none_drift_score_reports_reason_instead_of_crashing(self):
+        for reason in ("db_not_found", "table_not_found", "too_few_rows", "embed_failed"):
+            with self.subTest(reason=reason):
+                out = self._run_main(
+                    {"drift_score": None, "should_sweep": False, "reason": reason}
+                )
+                self.assertIn("skipping sweep", out)
+                self.assertIn(reason, out)
+
+    def test_none_drift_score_without_reason_key(self):
+        out = self._run_main({"drift_score": None, "should_sweep": False})
+        self.assertIn("skipping sweep", out)
+
+    def test_real_drift_score_still_formatted(self):
+        out = self._run_main({"drift_score": 0.0123456, "should_sweep": False, "n_sampled": 50})
+        self.assertIn("0.0123", out)
+        self.assertIn("skipping sweep", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was wrong

`scripts/glymphatic_sweep.py::main()` formatted a documented-nullable value with `:.4f`:

```python
if not shift_result.get("should_sweep", True):
    print(f"[glym] content shift below threshold ({shift_result.get('drift_score'):.4f}) "
          "— skipping sweep")
```

`check_content_shift()` returns `drift_score=None` on all four of its early returns — `db_not_found` (343), `table_not_found` (354), `too_few_rows` (359), `embed_failed` (368) — and every one of them pairs that `None` with `should_sweep=False`. So the "below threshold" line is not merely reachable on the `None` paths, it is the **guaranteed** path when embeddings are unavailable. Its own docstring says so: *"If Ollama is unreachable, returns `{"drift_score": None, "should_sweep": False}`."*

The `TypeError` escaped `main()` before the mutex was taken, so none of the four sweeps (verdicts, orphans, edges, duplicates) ran. `--check-shift` exists to make the sweep cheap by skipping it when content has not drifted; instead the one condition it was built to detect aborted the whole job.

## Evidence it was real

This fires on this box today — Ollama is unreachable here, so `check_content_shift()` takes the `embed_failed` return for real. Running `scripts/glymphatic_sweep.py --check-shift --dry-run` against the live mnemosyne DB, with the snapshot and mutex paths redirected to scratch so nothing was mutated:

On `main`:

```
  File ".../scripts/glymphatic_sweep.py", line 460, in main
    print(f"[glym] content shift below threshold ({shift_result.get('drift_score'):.4f}) "
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported format string passed to NoneType.__format__
```

Run aborted before the mutex; zero sweeps executed.

With the fix, same command, same box:

```
[glym] content shift below threshold (embed_failed) — skipping sweep
```

Reachability caveat, stated plainly: `--check-shift` is opt-in argparse and is not wired to any cron unit or systemd timer in this repo, so it is operator-invoked rather than scheduled.

## What changed

Three lines in `main()`. No signature, no return value, no control flow:

```python
drift = shift_result.get("drift_score")
detail = f"{drift:.4f}" if drift is not None else shift_result.get("reason", "unknown")
print(f"[glym] content shift below threshold ({detail}) — skipping sweep")
```

`reason` is already populated on all four `None` paths and is the more useful thing to print — `embed_failed` tells the operator to check Ollama; a fabricated `0.0000` would have told them the content had not drifted, which is the exact lie this class of bug produces. **No default drift score is invented.** `check_content_shift()`'s contract is untouched: `None` still means "no score", and the run still skips the sweep, which was already correct for `should_sweep=False`.

The `should_sweep=True` line below it (466) keeps its `:.4f`. That path is only reachable from `should_sweep = drift >= SHIFT_THRESHOLD` at 382, where `drift` is a float; all four `None` returns set `should_sweep=False`, and the baseline return sets `drift_score=0.0`. Nothing to guard there.

Nothing else consumes the changed output: `grep` over `.py`/`.sh`/`.md`/`.yaml`/`.service`/`.timer` finds no parser of the `[glym]` prints, and `main()` returns `None` before and after.

## What proves it, and that it fails without the fix

New `tests/test_glymphatic_shift_report.py` drives the real `main(check_shift=True)` with `check_content_shift` stubbed to each documented return, and stubs the four sweep functions to fail the test if any of them runs.

Verified by writing the new test file into a clean worktree at `origin/main` with `scripts/glymphatic_sweep.py` **unmodified** — no stash, the script was never edited on that side:

```
5 failed, 2 passed in 0.11s
E  TypeError: unsupported format string passed to NoneType.__format__
scripts/glymphatic_sweep.py:460: TypeError
SUBFAILED(reason='db_not_found')     ... TypeError
SUBFAILED(reason='table_not_found')  ... TypeError
SUBFAILED(reason='too_few_rows')     ... TypeError
SUBFAILED(reason='embed_failed')     ... TypeError
```

Every failure is the bug itself, at the bug's line. `test_real_drift_score_still_formatted` is one of the two that **passes** before and after — it pins the `0.0123` formatting the fix must not break.

With the fix: `pytest tests/ -q` → `11 passed, 4 subtests passed`, against `8 passed` on main. Purely additive; no existing test changed.

## What was deliberately left alone

The hunt that found this reported four other sites. All four are predicated on the unmerged branch `fix/cosine-dimension-mismatch`, which is where cosine starts returning `None`. Verified rather than assumed — `git cat-file -p origin/main:mcp/vecmath.py` → *path does not exist in 'origin/main'*, and every cosine on main returns `0.0` on degenerate input:

1. **`mcp/server.py:7540`** (grounding gate, rated HIGH). `c >= ground_threshold` is genuinely unguarded, but on main `_llm.cosine` is the `llm.py:404` version that returns `0.0` and cannot return `None` — there is no failing test to write, and the guard would be a no-op. It also collides head-on with the branch that introduces the `None`: that merge has to guard this site anyway, and a speculative guard landing separately just makes the merge harder. This is the one worth pushing back on — it deserves fixing, in that branch.
2. **`mcp/memcheck/checks/contradiction_llm.py:158`** — same reason. `cosine_fn` is an injectable seam, so a test *could* force `None` through it, but the parameter is typed `Callable[..., float]`; such a test would pin a contract the code does not currently make.
3. **`scripts/glymphatic_sweep.py:381`** (`1.0 - _cosine_vecs(...)`) — branch-only. Main's `_cosine_vecs` has `or 1.0` on both magnitudes and returns a float even for an all-zero centroid. Adjacent to this PR: the proposed fix returns `{'drift_score': None, 'reason': 'centroid_not_comparable'}`, and this change is exactly what makes that return printable, so it gets cheaper once this lands.
4. **`mcp/memcheck/backend.py:178`** — the code as described does not exist on main. Line 178 is a plain `similarity=cosine_similarity(...)`; the `or -1.0` sentinel arrives with the same branch. Rated LOW by the finding itself, with no decision change at the default `block_threshold` of 0.92.

One real bug on main, fixed. The other four are one merge of `fix/cosine-dimension-mismatch` away from being real simultaneously, which is more useful to say than four no-op guards.
