### PR TITLE
Treat sqlite created_at as UTC, and stop the decay job from emptying the corpus when it starts working

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -388,7 +388,14 @@ def _run_decay(db_path: str, dry_run: bool) -> dict:
         from memory.decay import apply_decay
         stats = apply_decay(db_path=db_path, dry_run=dry_run)
         print(f"[loop] decay: n_rows={stats.get('n_rows')} n_decayed={stats.get('n_decayed')} "
-              f"mean_retention={stats.get('mean_retention', 0):.3f}")
+              f"mean_retention={stats.get('mean_retention', 0):.3f}"
+              f"{' (dry run)' if dry_run else ''}")
+        before = stats.get("n_grounding_visible_before")
+        after = stats.get("n_grounding_visible_after")
+        if before is not None:
+            print(f"[loop] decay: rows visible to the grounding hook "
+                  f"(importance >= {stats.get('grounding_min_importance')}): "
+                  f"{before} -> {after}")
         return stats
     except Exception as exc:
         _fail("decay", f"decay step failed: {exc}")
@@ -532,7 +539,12 @@ def main() -> int:
     ap.add_argument("--hook-state", default=DEFAULT_HOOK_STATE,
                     help="Directory containing guard_bash_*.log files for Live-Evo")
     ap.add_argument("--decay-every", type=int, default=1,
-                    help="Apply Weibull decay every N loop runs (default: every run)")
+                    help="Evaluate Weibull decay every N loop runs (default: every run)")
+    ap.add_argument("--decay-apply", action="store_true",
+                    help="Write the decayed importances back. Without this the decay step "
+                         "reports what it would do and changes nothing -- decay has never "
+                         "actually run against a real corpus, and the first write is large "
+                         "and not something a nightly cron should do unasked.")
     ap.add_argument("--active-learn-every", type=int, default=7,
                     help="Generate active learning candidates every N days (default: 7)")
     args = ap.parse_args()
@@ -630,7 +642,7 @@ def main() -> int:
     # ── 7a. Weibull memory decay (runs every loop tick) ──────────────────────
     loop_count = state.get("total_loop_runs", 0) + 1
     if loop_count % args.decay_every == 0:
-        _run_decay(args.db, args.dry_run)
+        _run_decay(args.db, args.dry_run or not args.decay_apply)
     else:
         print(f"[loop] decay skipped (run {loop_count}, cadence={args.decay_every})")
 

--- a/mlops/memory/decay.py
+++ b/mlops/memory/decay.py
@@ -9,6 +9,13 @@ With λ=30, k=0.8:
   30 days → 37% retention
   90 days → 10% retention
 
+Decay is computed from ``base_importance`` -- a snapshot of the authored value
+taken the first time this runs -- and NOT from the live ``importance``. Reading
+and writing the same column compounds: retention is a function of absolute age,
+so a second run multiplies an already-decayed value by (almost) the same factor
+again, and the corpus lands on the floor. It also destroys the authored value,
+which nothing else stores.
+
 Run as a step in the MLOps loop or standalone:
     python3 mlops/memory/decay.py --db ~/.hermes/mnemosyne/data/mnemosyne.db --dry-run
 """
@@ -29,11 +36,38 @@ DEFAULT_LAMBDA = 30.0
 DEFAULT_K = 0.8
 DEFAULT_MIN_IMPORTANCE = 0.05
 
+# scripts/hooks/pre_llm_grounding.py filters recall hits at this importance in
+# three places. Rows below it are still in the table and invisible to grounding,
+# so it is the number that says whether a decay run costs anything.
+GROUNDING_MIN_IMPORTANCE = float(os.environ.get("HOOK_RECALL_MIN_IMPORTANCE", "0.2"))
+
 
 def weibull_retention(age_days: float, lambda_days: float = DEFAULT_LAMBDA, k: float = DEFAULT_K) -> float:
     if age_days <= 0:
         return 1.0
     return math.exp(-((age_days / lambda_days) ** k))
+
+
+def _has_baseline(conn: sqlite3.Connection) -> bool:
+    return "base_importance" in {r[1] for r in conn.execute("PRAGMA table_info(working_memory)")}
+
+
+def _ensure_baseline(conn: sqlite3.Connection) -> None:
+    """Snapshot the authored importance once, so decay has a fixed input.
+
+    Idempotent: the column is added only if absent, and only rows with no
+    baseline yet are seeded. Existing baselines are never overwritten -- that is
+    what makes a decay run reversible (UPDATE importance = base_importance).
+
+    Never called under dry_run: a schema change is a write.
+    """
+    if not _has_baseline(conn):
+        conn.execute("ALTER TABLE working_memory ADD COLUMN base_importance REAL")
+    conn.execute(
+        "UPDATE working_memory SET base_importance = importance "
+        "WHERE base_importance IS NULL AND importance IS NOT NULL"
+    )
+    conn.commit()
 
 
 def apply_decay(
@@ -52,14 +86,19 @@ def apply_decay(
 
     try:
         try:
+            if not dry_run:
+                _ensure_baseline(conn)
+            base_col = "base_importance" if _has_baseline(conn) else "importance AS base_importance"
             rows = conn.execute(
-                "SELECT id, importance, created_at FROM working_memory WHERE importance IS NOT NULL"
+                f"SELECT id, importance, {base_col}, created_at FROM working_memory "
+                "WHERE importance IS NOT NULL"
             ).fetchall()
         except sqlite3.OperationalError as exc:
             return {"error": str(exc), "n_rows": 0, "n_decayed": 0}
 
         updates = []
         retentions = []
+        n_visible = n_visible_before = 0
         for row in rows:
             created_raw = row["created_at"] or ""
             try:
@@ -79,7 +118,14 @@ def apply_decay(
             retention = weibull_retention(age_days, lambda_days, k)
             retentions.append(retention)
             current = float(row["importance"] or 0.0)
-            decayed = max(min_importance, current * retention)
+            # From the baseline, never from `current` -- see the module docstring.
+            base = row["base_importance"]
+            base = float(base) if base is not None else current
+            decayed = max(min_importance, base * retention)
+            if decayed >= GROUNDING_MIN_IMPORTANCE:
+                n_visible += 1
+            if current >= GROUNDING_MIN_IMPORTANCE:
+                n_visible_before += 1
             if abs(decayed - current) > 1e-6:
                 updates.append((decayed, row["id"]))
 
@@ -94,6 +140,9 @@ def apply_decay(
         "n_decayed": len(updates),
         "mean_retention": sum(retentions) / len(retentions) if retentions else 1.0,
         "min_retention": min(retentions) if retentions else 1.0,
+        "n_grounding_visible_before": n_visible_before,
+        "n_grounding_visible_after": n_visible,
+        "grounding_min_importance": GROUNDING_MIN_IMPORTANCE,
         "lambda_days": lambda_days,
         "k": k,
         "dry_run": dry_run,
@@ -117,6 +166,9 @@ def main() -> None:
           f"mean_retention={stats.get('mean_retention', 0):.3f} "
           f"min_retention={stats.get('min_retention', 0):.3f} "
           f"lambda={a.lambda_days}d k={a.k} dry_run={a.dry_run}")
+    print(f"[decay] rows visible to grounding (importance >= "
+          f"{stats.get('grounding_min_importance')}): "
+          f"{stats.get('n_grounding_visible_before')} -> {stats.get('n_grounding_visible_after')}")
 
     if a.out:
         Path(a.out).parent.mkdir(parents=True, exist_ok=True)

--- a/mlops/memory/decay.py
+++ b/mlops/memory/decay.py
@@ -18,6 +18,7 @@ import json
 import math
 import os
 import sqlite3
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -63,8 +64,16 @@ def apply_decay(
             created_raw = row["created_at"] or ""
             try:
                 created_dt = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+                # SQLite CURRENT_TIMESTAMP writes naive UTC; stamp it so the
+                # subtraction against an aware `now` does not raise.
+                if created_dt.tzinfo is None:
+                    created_dt = created_dt.replace(tzinfo=timezone.utc)
                 age_days = (now - created_dt).total_seconds() / 86400.0
-            except Exception:
+            except (ValueError, TypeError) as exc:
+                print(
+                    f"[decay] skipping row {row['id']}: bad created_at {created_raw!r} ({exc})",
+                    file=sys.stderr,
+                )
                 continue
 
             retention = weibull_retention(age_days, lambda_days, k)

--- a/mlops/memory/tests/test_memory.py
+++ b/mlops/memory/tests/test_memory.py
@@ -177,6 +177,8 @@ def test_apply_decay_success_dict_shape(tmp_path):
     assert set(res) == {
         "n_rows", "n_decayed", "mean_retention", "min_retention",
         "lambda_days", "k", "dry_run",
+        "n_grounding_visible_before", "n_grounding_visible_after",
+        "grounding_min_importance",
     }
     assert res["lambda_days"] == 30.0 and res["k"] == 0.8
     assert res["dry_run"] is True
@@ -307,16 +309,53 @@ def test_apply_decay_custom_lambda_and_k_are_echoed_and_used(tmp_path):
     assert _read_importance(db)[1] == pytest.approx(math.exp(-1.0), rel=1e-3)
 
 
-def test_apply_decay_is_not_idempotent(tmp_path):
-    # Each run multiplies by retention again — importance is recomputed from the
-    # *current* value, never from an original baseline.
+def test_apply_decay_is_idempotent(tmp_path):
+    # Was test_apply_decay_is_not_idempotent, which characterised the compounding:
+    # retention is a function of absolute age, so recomputing from the *current*
+    # value multiplies it again on every run. Decay now reads base_importance.
     db = _make_db(tmp_path / "m.db", [(1, "a", 0.8, _ago(30), "s1")])
     D.apply_decay(db)
     first = _read_importance(db)[1]
     D.apply_decay(db)
     second = _read_importance(db)[1]
-    assert second < first
-    assert second == pytest.approx(first * math.exp(-1.0), rel=1e-3)
+    assert second == pytest.approx(first, abs=1e-9)
+    assert first == pytest.approx(0.8 * math.exp(-1.0), rel=1e-3)
+
+
+def _base_importance(db_path: str, rid: int):
+    conn = sqlite3.connect(db_path)
+    out = conn.execute("SELECT base_importance FROM working_memory WHERE id=?", (rid,)).fetchone()[0]
+    conn.close()
+    return out
+
+
+def test_apply_decay_preserves_the_authored_importance(tmp_path):
+    """Nothing else stores the authored value, so an in-place write is one-way."""
+    db = _make_db(tmp_path / "m.db", [(1, "a", 0.9, _ago(90), "s1")])
+    D.apply_decay(db)
+    assert _read_importance(db)[1] < 0.2
+    assert _base_importance(db, 1) == pytest.approx(0.9), "the authored 0.9 cannot be restored"
+
+
+def test_apply_decay_does_not_reseed_the_baseline_from_a_decayed_value(tmp_path):
+    """Seeding on every run would re-derive the baseline from decayed output --
+    idempotent-looking on run two, and still one-way."""
+    db = _make_db(tmp_path / "m.db", [(1, "a", 0.9, _ago(90), "s1")])
+    D.apply_decay(db)
+    D.apply_decay(db)
+    assert _base_importance(db, 1) == pytest.approx(0.9)
+
+
+def test_apply_decay_reports_what_it_costs_the_grounding_hook(tmp_path):
+    """A row under HOOK_RECALL_MIN_IMPORTANCE stays in the table and drops out of
+    recall, so n_decayed alone does not say what a run costs."""
+    db = _make_db(tmp_path / "m.db", [
+        (1, "old", 0.9, _ago(90), "s1"),
+        (2, "new", 0.9, _ago(1), "s1"),
+    ])
+    res = D.apply_decay(db, dry_run=True)
+    assert (res["n_grounding_visible_before"], res["n_grounding_visible_after"]) == (2, 1)
+    assert _read_importance(db) == {1: 0.9, 2: 0.9}, "dry_run wrote to the database"
 
 
 def test_apply_decay_retention_stats_cover_only_parseable_rows(tmp_path):
@@ -795,3 +834,13 @@ def test_live_evo_main_on_missing_db_prints_none_for_penalized(tmp_path, monkeyp
     with redirect_stdout(buf):
         L.main()
     assert buf.getvalue() == "[live_evo] failures=0 correlated=0 penalized=None dry_run=False\n"
+
+
+def test_apply_decay_dry_run_does_not_alter_the_schema(tmp_path):
+    """A dry run that adds a column has already written to the database."""
+    db = _make_db(tmp_path / "m.db", [(1, "a", 0.9, _ago(90), "s1")])
+    D.apply_decay(db, dry_run=True)
+    conn = sqlite3.connect(db)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(working_memory)")}
+    conn.close()
+    assert "base_importance" not in cols

--- a/mlops/memory/tests/test_memory.py
+++ b/mlops/memory/tests/test_memory.py
@@ -196,16 +196,32 @@ def test_apply_decay_ignores_null_importance_rows(tmp_path):
     assert _read_importance(db)[2] is None
 
 
-def test_apply_decay_silently_skips_naive_timestamps(tmp_path):
-    # BUG: created_at without a timezone offset makes `now - created_dt` raise
-    # TypeError, which the bare `except Exception: continue` swallows. Such rows
-    # are counted in n_rows but never decayed and never contribute a retention.
+def test_apply_decay_treats_naive_timestamps_as_utc(tmp_path):
+    # created_at without a timezone offset is what SQLite CURRENT_TIMESTAMP writes,
+    # i.e. every production row. It is naive UTC and must decay like any other row,
+    # not raise TypeError into the except and be skipped.
     db = _make_db(tmp_path / "m.db", [(1, "a", 0.9, "2020-01-01T00:00:00", "s1")])
     res = D.apply_decay(db)
     assert res["n_rows"] == 1
-    assert res["n_decayed"] == 0
-    assert res["mean_retention"] == 1.0
-    assert _read_importance(db)[1] == 0.9  # a 5-year-old row keeps full importance
+    assert res["n_decayed"] == 1
+    assert res["mean_retention"] < 0.01
+    assert _read_importance(db)[1] == D.DEFAULT_MIN_IMPORTANCE
+
+
+def test_apply_decay_naive_and_aware_created_at_agree(tmp_path):
+    # The sqlite "YYYY-MM-DD HH:MM:SS" form and the same instant written as
+    # offset-aware ISO-8601 must produce the same retention.
+    aware = (datetime.now(timezone.utc) - timedelta(days=200)).replace(microsecond=0)
+    naive_db = _make_db(tmp_path / "naive.db",
+                        [(1, "a", 0.9, aware.strftime("%Y-%m-%d %H:%M:%S"), "s1")])
+    aware_db = _make_db(tmp_path / "aware.db", [(1, "a", 0.9, aware.isoformat(), "s1")])
+
+    naive_res = D.apply_decay(naive_db, dry_run=True)
+    aware_res = D.apply_decay(aware_db, dry_run=True)
+
+    assert naive_res["n_decayed"] == aware_res["n_decayed"] == 1
+    assert naive_res["mean_retention"] < 1.0
+    assert naive_res["mean_retention"] == pytest.approx(aware_res["mean_retention"], abs=1e-6)
 
 
 def test_apply_decay_skips_unparseable_and_null_created_at(tmp_path):

--- a/scripts/glymphatic_sweep.py
+++ b/scripts/glymphatic_sweep.py
@@ -36,7 +36,7 @@ import sys
 import time
 import urllib.request
 import urllib.error
-from datetime import datetime
+from datetime import datetime, timezone
 
 # ── config ────────────────────────────────────────────────────────────────────
 
@@ -196,7 +196,12 @@ def sweep_orphans(dry_run: bool) -> int:
             continue
         created = row["created_at"]
         try:
-            ts = datetime.fromisoformat(str(created).replace("Z", "+00:00")).timestamp()
+            dt = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+            # SQLite CURRENT_TIMESTAMP is naive UTC; .timestamp() would otherwise
+            # read it as local wall-clock and skew the TTL by the UTC offset.
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            ts = dt.timestamp()
         except Exception:
             continue
         if ts < cutoff_ts:

--- a/tests/test_glymphatic_orphan_clock.py
+++ b/tests/test_glymphatic_orphan_clock.py
@@ -1,0 +1,124 @@
+"""glymphatic_sweep.sweep_orphans — the orphan TTL must not depend on host timezone.
+
+working_memory.created_at is naive UTC (SQLite CURRENT_TIMESTAMP), but it is
+compared against time.time(), a UTC epoch. Taking .timestamp() on the naive
+datetime reads it as local wall-clock, so the DELETE gate is wrong by the host's
+UTC offset: rows survive past their TTL west of UTC and are deleted early east
+of it. These tests force both signs of offset so a UTC CI host cannot hide it.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_sweep():
+    spec = importlib.util.spec_from_file_location(
+        "glymphatic_sweep_under_test", REPO / "scripts" / "glymphatic_sweep.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def sweep():
+    return _load_sweep()
+
+
+@pytest.fixture
+def host_tz():
+    """Pin the host timezone for one test, then restore it."""
+    original = os.environ.get("TZ")
+
+    def _set(posix_tz):
+        os.environ["TZ"] = posix_tz
+        time.tzset()
+
+    yield _set
+
+    if original is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = original
+    time.tzset()
+
+
+def _make_db(path, age_hours):
+    """One un-recalled, un-linked row created `age_hours` ago, in sqlite's format."""
+    created = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE working_memory ("
+        " id TEXT PRIMARY KEY, content TEXT, importance REAL,"
+        " created_at TEXT, recall_count INTEGER)"
+    )
+    conn.execute("CREATE TABLE graph_edges (source TEXT, target TEXT)")
+    conn.execute(
+        "INSERT INTO working_memory VALUES (?,?,?,?,?)",
+        ("row-1", "c", 0.5, created.strftime("%Y-%m-%d %H:%M:%S"), 0),
+    )
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+def _surviving_ids(db_path):
+    conn = sqlite3.connect(db_path)
+    ids = [r[0] for r in conn.execute("SELECT id FROM working_memory")]
+    conn.close()
+    return ids
+
+
+def test_row_inside_ttl_survives_east_of_utc(sweep, host_tz, tmp_path, monkeypatch):
+    # UTC+10. Reading naive UTC as local makes the row look 10h OLDER than it is,
+    # so a row 5h short of its TTL is deleted early -- silent data loss.
+    host_tz("XXX-10")
+    db = _make_db(tmp_path / "east.db", age_hours=7 * 24 - 5)
+    monkeypatch.setattr(sweep, "DB_PATH", db)
+    monkeypatch.setattr(sweep, "ORPHAN_TTL_DAYS", 7.0)
+
+    assert sweep.sweep_orphans(dry_run=False) == 0
+    assert _surviving_ids(db) == ["row-1"]
+
+
+def test_row_past_ttl_is_removed_west_of_utc(sweep, host_tz, tmp_path, monkeypatch):
+    # UTC-4. Reading naive UTC as local makes the row look 4h YOUNGER, so a row
+    # 2h past its TTL is kept and the sweep silently under-collects.
+    host_tz("XXX4")
+    db = _make_db(tmp_path / "west.db", age_hours=7 * 24 + 2)
+    monkeypatch.setattr(sweep, "DB_PATH", db)
+    monkeypatch.setattr(sweep, "ORPHAN_TTL_DAYS", 7.0)
+
+    assert sweep.sweep_orphans(dry_run=False) == 1
+    assert _surviving_ids(db) == []
+
+
+def test_offset_aware_created_at_still_parses(sweep, host_tz, tmp_path, monkeypatch):
+    # Rows written with an explicit offset must keep working unchanged.
+    host_tz("XXX-10")
+    created = datetime.now(timezone.utc) - timedelta(days=30)
+    db = tmp_path / "aware.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE working_memory ("
+        " id TEXT PRIMARY KEY, content TEXT, importance REAL,"
+        " created_at TEXT, recall_count INTEGER)"
+    )
+    conn.execute("CREATE TABLE graph_edges (source TEXT, target TEXT)")
+    conn.execute("INSERT INTO working_memory VALUES (?,?,?,?,?)",
+                 ("row-1", "c", 0.5, created.isoformat(), 0))
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(sweep, "DB_PATH", str(db))
+    monkeypatch.setattr(sweep, "ORPHAN_TTL_DAYS", 7.0)
+
+    assert sweep.sweep_orphans(dry_run=False) == 1


### PR DESCRIPTION
`mlops/memory/decay.py` and `scripts/glymphatic_sweep.py` both compare a `created_at` read from sqlite against `datetime.now(timezone.utc)`. SQLite's `CURRENT_TIMESTAMP` writes a **naive** string:

```
sqlite> select created_at from working_memory limit 1;
2026-05-30 23:16:37
```

Subtracting a naive datetime from an aware one raises `TypeError`, and decay caught it with a bare `except Exception: continue`. So **the decay job has never decayed anything** — 1992 rows, every one skipped, silently, for as long as it has been in the loop. The tests missed it because the suite's `_ago()` helper builds *aware* isoformat strings; production writes naive ones.

Naive values are stamped UTC, and the handler narrows to `(ValueError, TypeError)` and says which row it skipped.

## Turning it on is the dangerous part

Fixing the clock makes all 1992 rows eligible at once — and the write on the other side of that `continue` has two problems that were dormant only because nothing ever reached it.

**It compounds.** Retention is a function of *absolute* age, but `decayed = max(floor, current * retention)` reads the value it wrote last time. Measured on a copy of the live corpus:

```
                          above grounding's 0.2 gate    on the 0.05 floor
today                             1991 / 1992                    0
after run 1                          9                           1
after run 2                          9                        1983
```

**It is one-way.** The authored importance is stored nowhere else. Newest backup of that database is `2026-06-13` — 2.5 months stale.

And merging *is* deploying: `~/.loci/bin/mlops-cron` resolves the loop script from `origin/main`, and the `0 2 * * *` crontab passes no `--dry-run` with `--decay-every` defaulting to 1.

## What this branch does about it

Decay reads `base_importance`, seeded once from the authored value and never overwritten. Today is the only free moment to take that snapshot — the values are still pristine. Same copy, run twice:

```
1st  n_decayed=1992   grounding-visible 1991 -> 9
2nd  n_decayed=9      grounding-visible    9 -> 9
     base_importance intact on 1992/1992
     UPDATE importance = base_importance  ->  1991 back
```

Seeding is a schema change, so `dry_run` no longer calls it — it reads `importance` as its own baseline instead. The 577 MB copy is **byte-identical** after a dry run.

The loop's decay step is now **dry-run unless `--decay-apply`**. Even idempotent and reversible, the first real write takes the grounding hook from 1991 candidates to 9; λ=30d against a 93-day corpus, against a consumer that gates at 0.2, is a parameter choice and yours to make. The step now prints that number every tick — `n_decayed` alone never said what a run costs.

## Verification

`749 passed` across `mlops/ scripts/tests tests/`; vulture clean. `test_apply_decay_is_not_idempotent` characterised the compounding and is now `test_apply_decay_is_idempotent`. Red-then-green on the clock fix was reproduced against `origin/main`: exactly the 4 claimed failures, `4 failed / 65 passed` on main, `69 passed` here.

To arm it later: `--decay-apply`, after deciding λ or the 0.2 gate. `sqlite3 db "UPDATE working_memory SET importance = base_importance"` undoes any run.