### PR TITLE
Exclude tool cache directories from the corpus

### DIFF
--- a/scripts/callgraph/config.py
+++ b/scripts/callgraph/config.py
@@ -20,7 +20,11 @@ REPO_ROOT = PACKAGE_ROOT.parent.parent
 CORPUS_ROOTS: tuple[str, ...] = ("mcp", "scripts", "a2a_server", "mlops", "eval")
 
 # Directory (path-component) names excluded anywhere they occur under a
-# corpus root.
+# corpus root. Dot-directories are excluded as a class by is_excluded_rel --
+# naming them one at a time is how .pytest_cache got in (213 fixture files
+# under mcp/.pytest_cache/tmp, 2.7x the real corpus, on a machine that had run
+# the test suite). The explicit names below are the non-dot ones plus the two
+# that predate the class rule.
 EXCLUDE_DIR_NAMES: frozenset[str] = frozenset({
     "tests",
     "__pycache__",
@@ -47,6 +51,10 @@ def is_excluded_rel(rel_posix: str) -> bool:
     parts = rel_posix.split("/")
     for part in parts:
         if part in EXCLUDE_DIR_NAMES:
+            return True
+        # Any dot-directory: .pytest_cache, .mypy_cache, .ruff_cache, .tox,
+        # .venv, .git. Tool state, never analyzed source.
+        if len(part) > 1 and part.startswith("."):
             return True
         if part.endswith(EXCLUDE_DIR_SUFFIXES):
             return True
@@ -95,10 +103,13 @@ def iter_test_files_worktree(repo_root: Path = REPO_ROOT) -> list[str]:
         for dirpath, dirnames, filenames in os.walk(base):
             rel_dir = Path(dirpath).relative_to(repo_root).as_posix()
             parts = [] if rel_dir == "." else rel_dir.split("/")
+            # Same exclusions as the corpus walk minus `tests`, which this
+            # function exists to collect. Derived from is_excluded_rel rather
+            # than restated -- the restated copy had already drifted (it was
+            # missing .cache, and every dot-directory).
             dirnames[:] = [
                 d for d in dirnames
-                if d not in {"__pycache__", ".venv", "venv", ".git", "node_modules"}
-                and not d.endswith(".egg-info")
+                if d == "tests" or not is_excluded_rel(f"{rel_dir}/{d}" if rel_dir != "." else d)
             ]
             if "tests" not in parts:
                 continue

--- a/scripts/callgraph/tests/test_config.py
+++ b/scripts/callgraph/tests/test_config.py
@@ -50,3 +50,50 @@ def test_stdlib_module_names_contains_known_stdlib():
 def test_third_party_names_finds_installed_packages():
     names = config.third_party_top_level_names()
     assert "dotenv" in names or "starlette" in names
+
+
+# ── tool caches are not corpus ────────────────────────────────────────────────
+# Found by running the suite on a developer machine: pytest's tmp_path fixtures
+# leave .py files under mcp/.pytest_cache/tmp, and the corpus walk counted 339
+# files instead of 126. CI never saw it because it checks out clean and runs the
+# callgraph job in its own job, before anything populates the cache.
+
+def test_dot_directories_are_excluded_as_a_class():
+    for d in (".pytest_cache", ".mypy_cache", ".ruff_cache", ".tox", ".venv", ".git"):
+        assert config.is_excluded_rel(f"mcp/{d}/tmp/x.py"), d
+        assert config.is_excluded_rel(f"mcp/{d}"), d
+
+
+def test_a_leading_dot_does_not_exclude_a_corpus_root_relative_path():
+    assert not config.is_excluded_rel("mcp/server.py")
+    assert not config.is_excluded_rel("scripts/hunt_to_corpus.py")
+
+
+def _tree(root, rel_paths):
+    for rel in rel_paths:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x = 1\n")
+
+
+def test_corpus_walk_skips_tool_cache_directories(tmp_path):
+    _tree(tmp_path, [
+        "mcp/server.py",
+        "mcp/.pytest_cache/tmp/test_thing0/fixture.py",
+        "mcp/.mypy_cache/3.11/mod.py",
+        "mcp/__pycache__/server.cpython-311.py",
+    ])
+    assert config.iter_corpus_files_worktree(tmp_path) == ["mcp/server.py"]
+
+
+def test_the_two_walkers_share_one_exclusion_rule(tmp_path):
+    """iter_test_files_worktree is the complement of the corpus walk, so it must
+    differ on `tests` and nothing else."""
+    _tree(tmp_path, [
+        "mcp/server.py",
+        "mcp/tests/test_server.py",
+        "mcp/.pytest_cache/tmp/test_thing0/fixture.py",
+        "mcp/tests/.pytest_cache/junk.py",
+    ])
+    assert config.iter_corpus_files_worktree(tmp_path) == ["mcp/server.py"]
+    assert config.iter_test_files_worktree(tmp_path) == ["mcp/tests/test_server.py"]


### PR DESCRIPTION
The callgraph suite is green in CI and red on this machine:

```
CI      126 files
here    339 files      assert 339 == 126
```

The 213 extra are `.py` fixtures pytest's `tmp_path` leaves under `mcp/.pytest_cache/tmp`. `EXCLUDE_DIR_NAMES` lists `.venv`, `.git` and `.cache` — but not `.pytest_cache`, so every throwaway fixture was walked as production source. **2.7× the real corpus**, and every count `cg` prints is defined relative to that number: dead-code candidates, subsystem reports, the census gate.

CI never sees it. It checks out clean, and the callgraph job runs on its own runner before anything populates a cache. The tool is only wrong on a machine where someone has actually run the tests — which is every machine where anyone uses it.

## Two fixes

**Dot-directories are excluded as a class.** Naming caches one at a time is what produced the gap; this also covers `.mypy_cache`, `.ruff_cache` and `.tox` without another round.

**`iter_test_files_worktree` derives the rule instead of restating it.** It had its own literal copy of the exclusion set, and the copy had already drifted — missing `.cache` and every dot-directory. It now calls `is_excluded_rel` with `tests` added back, which is the one rule it is meant to differ on. Its docstring already called itself "the deliberate COMPLEMENT" of the corpus walk; now it is one.

## Verification

```
corpus 126   (matches CI exactly)
tests  109
scripts/callgraph/tests   257 passed
```

Four new tests, all red against `origin/main`: `4 failed, 8 passed` there, `12 passed` here. The two walk tests build a synthetic tree via `repo_root=tmp_path` rather than touching the real repo.