### PR TITLE
a2a_server: surface non-zero subprocess exits in docker_status and ua_search instead of returning an empty result

### DIFF
--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -1309,14 +1309,17 @@ async def skill_docker_status(task: dict) -> dict:
             ['docker', 'ps', '--format', '{{.Names}}\t{{.Status}}\t{{.Image}}'],
             capture_output=True, text=True, timeout=10
         )
-        containers = []
-        for line in r.stdout.strip().splitlines():
-            parts = line.split('\t')
-            if len(parts) >= 3:
-                entry = {'name': parts[0], 'status': parts[1], 'image': parts[2]}
-                if not flt or flt.lower() in parts[0].lower():
-                    containers.append(entry)
-        results['docker'] = containers
+        if r.returncode != 0:
+            results['docker_error'] = r.stderr.strip() or f'docker ps exited {r.returncode}'
+        else:
+            containers = []
+            for line in r.stdout.strip().splitlines():
+                parts = line.split('\t')
+                if len(parts) >= 3:
+                    entry = {'name': parts[0], 'status': parts[1], 'image': parts[2]}
+                    if not flt or flt.lower() in parts[0].lower():
+                        containers.append(entry)
+            results['docker'] = containers
     except Exception as e:
         results['docker_error'] = str(e)
 
@@ -1328,14 +1331,17 @@ async def skill_docker_status(task: dict) -> dict:
              '-o', 'custom-columns=NS:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,READY:.status.containerStatuses[0].ready'],
             capture_output=True, text=True, timeout=15
         )
-        pods = []
-        for line in r.stdout.strip().splitlines():
-            parts = line.split()
-            if len(parts) >= 3:
-                entry = {'namespace': parts[0], 'name': parts[1], 'status': parts[2], 'ready': parts[3] if len(parts) > 3 else '?'}
-                if not flt or flt.lower() in parts[1].lower():
-                    pods.append(entry)
-        results['k3s_pods'] = pods
+        if r.returncode != 0:
+            results['k3s_error'] = r.stderr.strip() or f'kubectl get pods exited {r.returncode}'
+        else:
+            pods = []
+            for line in r.stdout.strip().splitlines():
+                parts = line.split()
+                if len(parts) >= 3:
+                    entry = {'namespace': parts[0], 'name': parts[1], 'status': parts[2], 'ready': parts[3] if len(parts) > 3 else '?'}
+                    if not flt or flt.lower() in parts[1].lower():
+                        pods.append(entry)
+            results['k3s_pods'] = pods
     except Exception as e:
         results['k3s_error'] = str(e)
 
@@ -1368,6 +1374,8 @@ async def skill_ua_search(task: dict) -> dict:
 
     try:
         r = subprocess.run(args, capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            return {'error': r.stderr.strip()[-500:] or f'ua_search exited {r.returncode}', 'query': query}
         results = json.loads(r.stdout) if r.stdout.strip() else []
         return {'results': results, 'count': len(results), 'query': query}
     except Exception as e:

--- a/a2a_server/tests/test_subprocess_error_handling.py
+++ b/a2a_server/tests/test_subprocess_error_handling.py
@@ -1,0 +1,85 @@
+"""Tests that skill_docker_status / skill_ua_search surface a non-zero
+subprocess exit as an error field, instead of silently returning an
+empty result indistinguishable from a genuine "nothing found" answer.
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import subprocess
+import unittest
+from unittest import mock
+
+os.environ.setdefault("LOCI_A2A_TOKEN", "test-token-abc123")
+os.environ.setdefault("LOCI_A2A_URL", "http://localhost:8201")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("MNEMOSYNE_EMBEDDING_API_URL", "http://localhost:11434/v1")
+
+_server_path = pathlib.Path(__file__).parent.parent / "server.py"
+_spec = importlib.util.spec_from_file_location("a2a_server_impl", _server_path)
+a2a_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(a2a_server)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _completed(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestDockerStatusSurfacesFailure(unittest.TestCase):
+    def test_docker_daemon_unreachable_is_an_error_not_an_empty_list(self):
+        # docker exits non-zero with empty stdout when the daemon is unreachable;
+        # kubectl succeeds with no pods, to isolate the docker branch.
+        def fake_run(args, **kwargs):
+            if args[0] == 'docker':
+                return _completed(1, stdout="", stderr="Cannot connect to the Docker daemon")
+            return _completed(0, stdout="", stderr="")
+
+        with mock.patch('subprocess.run', side_effect=fake_run):
+            result = _run(a2a_server.skill_docker_status({'input': {}}))
+
+        self.assertIn('docker_error', result)
+        self.assertNotIn('docker', result)
+
+    def test_kubectl_no_context_is_an_error_not_an_empty_list(self):
+        def fake_run(args, **kwargs):
+            if args[0] == 'kubectl':
+                return _completed(1, stdout="", stderr="error: no context set")
+            return _completed(0, stdout="", stderr="")
+
+        with mock.patch('subprocess.run', side_effect=fake_run):
+            result = _run(a2a_server.skill_docker_status({'input': {}}))
+
+        self.assertIn('k3s_error', result)
+        self.assertNotIn('k3s_pods', result)
+
+    def test_success_still_parses_normally(self):
+        def fake_run(args, **kwargs):
+            if args[0] == 'docker':
+                return _completed(0, stdout="web\tUp\tnginx\n", stderr="")
+            return _completed(0, stdout="", stderr="")
+
+        with mock.patch('subprocess.run', side_effect=fake_run):
+            result = _run(a2a_server.skill_docker_status({'input': {}}))
+
+        self.assertNotIn('docker_error', result)
+        self.assertEqual(result['docker'], [{'name': 'web', 'status': 'Up', 'image': 'nginx'}])
+
+
+class TestUaSearchSurfacesFailure(unittest.TestCase):
+    def test_script_crash_before_stdout_is_an_error_not_a_zero_hit_search(self):
+        with mock.patch('subprocess.run', return_value=_completed(1, stdout="", stderr="Traceback: ImportError")):
+            with mock.patch.object(os.path, 'exists', return_value=True):
+                with mock.patch.dict(os.environ, {'UA_SEARCH_SCRIPT': '/fake/ua_search.py'}):
+                    result = _run(a2a_server.skill_ua_search({'input': {'query': 'foo'}}))
+
+        self.assertIn('error', result)
+        self.assertNotIn('results', result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What was wrong

`skill_docker_status` and `skill_ua_search` in `a2a_server/server.py` each ran a
subprocess with `subprocess.run(..., capture_output=True)` — no `check=True`, no
inspection of `returncode` — and parsed `r.stdout` straight into a result.

Both parsers are empty-tolerant, so a non-zero exit with empty stdout became a
clean, successful, *empty* answer:

- `docker ps` against an unreachable daemon → `{'docker': []}`
- `kubectl get pods` with no context / unreachable cluster → `{'k3s_pods': []}`
- the `understand-anything` search script crashing before it prints JSON →
  `{'results': [], 'count': 0}`

The only failure paths that were ever surfaced (`docker_error` / `k3s_error`)
required an *exception* — e.g. the binary missing from `$PATH`. The far more
common real failure (binary present, daemon or cluster unreachable) exited
non-zero and was swallowed.

Both skills are in `_SKILL_MAP` and advertised on the agent card, so a remote
agent asking "is service X running?" or "search the knowledge graph for Y" gets
back an answer structurally identical to a genuine "nothing is running" /
"no matches" — with no error field — when in fact the query never ran.

## Evidence it was real

Reproduced end-to-end against the real binaries (not mocks), calling the skill
function with a poisoned `DOCKER_HOST` and `KUBECONFIG`:

```
main       -> {'docker': [], 'k3s_pods': []}
this branch-> {'docker_error': 'failed to connect to the docker API at unix:///nonexistent.sock ...',
               'k3s_error':    'The connection to the server localhost:8080 was refused ...'}
```

Both commands exit non-zero and write **0 bytes** to stdout in that state, which
is exactly the case the old code parsed into an empty list.

## What changed

Eight added lines in `a2a_server/server.py` (`git diff -w` confirms the rest of
the hunk is pure re-indentation under the new `else:`):

- `docker` branch: `returncode != 0` → `results['docker_error'] = r.stderr.strip() or 'docker ps exited N'`, and `results['docker']` is not set.
- `kubectl` branch: same shape → `results['k3s_error']`.
- `skill_ua_search`: `returncode != 0` → `return {'error': stderr[-500:] or 'ua_search exited N', 'query': query}`.

The error-shape is not new: it is exactly what the pre-existing `except`
branches already returned for these skills, so no result key or default was
invented to make anything pass.

## What proves it, and that it fails without the fix

New `a2a_server/tests/test_subprocess_error_handling.py` (4 tests), following
the existing `spec_from_file_location` convention in this directory and mocking
`subprocess.run` so it needs neither docker nor kubectl:

- docker daemon unreachable → `docker_error` present, `docker` absent
- kubectl no context → `k3s_error` present, `k3s_pods` absent
- ua_search script crashes before stdout → `error` present, `results` absent
- success path still parses normally (regression guard)

Verified red pre-fix by restoring `origin/main`'s `a2a_server/server.py` under
the new test file:

```
3 failed, 1 passed
  AssertionError: 'docker_error' not found in {'docker': [], 'k3s_pods': []}
  AssertionError: 'k3s_error'    not found in {'docker': [], 'k3s_pods': []}
  AssertionError: 'error'        not found in {'results': [], 'count': 0, 'query': 'foo'}
```

The 4th (success path) is unaffected by the fix and passes either way — it is a
guard, not proof. With the fix restored: `4 passed`. Full `a2a_server/tests/`
suite: **100 passed**. Also run under a stripped `env -i` with `kubectl` absent
from `$PATH` (4 passed), since CI runners have neither binary.

## What was deliberately left alone

- **No caller had to change.** Nothing in-repo consumes these two skills'
  responses (`a2a_context_bridge.py` only calls `context_broadcast`); the
  consumers are remote agents over A2A, for which an explicit error strictly
  beats a fabricated empty inventory. The on-error shape already matched the
  existing exception path, so there is no second shape to teach anyone.
- **Not a deploy.** The live `mrpink-a2a.service` runs a separate copy under
  `~/.hermes/profiles/mrpink/a2a_server/`, already diverged from main; merging
  does not update it. `UA_SEARCH_SCRIPT` is also unset in that process, so the
  `ua_search` change is dark there until it is configured.
- **stderr is truncated only in `ua_search`** (`[-500:]`), matching the
  finding's requested shape. `docker_error`/`k3s_error` pass stderr through
  untruncated, consistent with the existing `str(e)` branches; kubectl's stderr
  is bounded in practice (~1 KB of API-group errors).
- Other unchecked `subprocess.run` calls elsewhere in the repo were not touched;
  only the two verified findings are in scope.
- `mcp/tests/` was not run — out of scope, and `test_graph_integration.py` there
  is documented as pre-broken on main.
