### PR TITLE
Bound the Ollama embed call in amem_consolidation.py so a silent server cannot hang the run

### DIFF
--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -52,8 +52,13 @@ CONFLICT_KEYWORD_PAIRS = [
 # Embedding
 # ---------------------------------------------------------------------------
 
-def embed(text: str) -> list[float]:
-    """Return the embedding vector for *text* via Ollama."""
+def embed(text: str) -> list[float] | None:
+    """Return the embedding vector for *text* via Ollama, or None on failure.
+
+    None (rather than raising) lets the caller treat this row as unanswerable
+    for cosine comparisons, same as vecmath.cosine already does for a length
+    mismatch — one unresponsive row degrades instead of hanging the run.
+    """
     payload = json.dumps({"model": EMBED_MODEL, "input": text}).encode()
     req = urllib.request.Request(
         f"{OLLAMA_URL}/v1/embeddings",
@@ -61,10 +66,14 @@ def embed(text: str) -> list[float]:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
-        body = json.loads(resp.read())
-    # Ollama returns {"data": [{"embedding": [...]}]}
-    return body["data"][0]["embedding"]
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read())
+        # Ollama returns {"data": [{"embedding": [...]}]}
+        return body["data"][0]["embedding"]
+    except Exception as e:
+        print(f"[amem] embed error: {e}", file=_sys.stderr)
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/amem_consolidation.py
+++ b/scripts/amem_consolidation.py
@@ -80,8 +80,11 @@ def embed(text: str) -> list[float] | None:
 # Cosine similarity
 # ---------------------------------------------------------------------------
 
-def cosine(a: list[float], b: list[float]):
-    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable."""
+def cosine(a: list[float] | None, b: list[float] | None):
+    """Delegates to mcp/vecmath.py. None when the comparison is unanswerable.
+
+    A missing vector (embed() returned None) is one such case: vecmath.cosine
+    already answers None for anything falsy, so it needs no guard here."""
     return _vecmath.cosine(a, b)
 
 
@@ -178,7 +181,7 @@ def main() -> None:
         # ------------------------------------------------------------------
         # Phase 1 — Embed all entries
         # ------------------------------------------------------------------
-        entries: list[tuple[str, str, list[float], str]] = []
+        entries: list[tuple[str, str, list[float] | None, str]] = []
         for row in rows:
             vec = embed(row["content"])
             entries.append((row["id"], row["content"], vec, row["created_at"] or ""))

--- a/scripts/tests/test_amem_consolidation_embed_timeout.py
+++ b/scripts/tests/test_amem_consolidation_embed_timeout.py
@@ -1,0 +1,48 @@
+"""embed() in amem_consolidation.py must bound the Ollama call and degrade, not hang.
+
+Every other Ollama/Qdrant HTTP call site in this repo passes a timeout to
+urlopen(); this one didn't, so a connected-but-silent Ollama server blocked
+the whole consolidation run forever. Fixed to pass timeout= and to catch the
+failure so one bad row degrades (returns None, same as vecmath.cosine's
+"unanswerable" convention) instead of crashing/hanging the run.
+"""
+
+import importlib.util
+import pathlib
+import urllib.request
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "amem_consolidation_impl", _SCRIPTS / "amem_consolidation.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+amem = _load()
+
+
+def test_embed_passes_a_timeout_to_urlopen():
+    with mock.patch.object(urllib.request, "urlopen") as m:
+        m.return_value.__enter__.return_value.read.return_value = (
+            b'{"data": [{"embedding": [0.1, 0.2]}]}'
+        )
+        amem.embed("hello")
+        assert m.call_args is not None
+        _, kwargs = m.call_args
+        assert kwargs.get("timeout") is not None, (
+            "embed() must pass a timeout to urlopen — a connected-but-silent "
+            "server would otherwise block forever"
+        )
+
+
+def test_embed_degrades_to_none_on_timeout_instead_of_raising():
+    with mock.patch.object(
+        urllib.request, "urlopen", side_effect=TimeoutError("timed out")
+    ):
+        assert amem.embed("hello") is None


### PR DESCRIPTION
## What was wrong

`embed()` in `scripts/amem_consolidation.py` POSTed to Ollama's `/v1/embeddings`
with `urllib.request.urlopen(req)` — no `timeout`. A server that accepts the TCP
connection and then never answers (GPU busy, model still loading, box wedged)
blocks that call forever. TCP connect has its own ceiling; a connected-but-silent
peer is not covered by it.

`main()` calls `embed()` once per row in a plain loop, up to `AMEM_MAX_PER_RUN=100`,
with no try/except and no wrapper timeout, so one silent row hangs the whole run —
no output, no error, no recovery, until someone kills it by hand.

## The evidence it was real

Against a socket that accepts and never answers, on a copy of the live
`~/.hermes/mnemosyne/data/mnemosyne.db`:

```
$ timeout 40 env OLLAMA_URL=http://127.0.0.1:18119 AMEM_MAX_PER_RUN=3 \
    python scripts/amem_consolidation.py     # origin/main
real  0m42.7s
exit=124        # still hanging when the ceiling killed it; zero output
```

This was the last unbounded `urlopen` in the repo. All 44 others already pass a
timeout (10–120s), including `scripts/mnemosyne_qdrant_sync.py:embed_via_ollama`,
which makes the byte-identical Ollama `/v1/embeddings` request with `timeout=15`.

## What changed

`urlopen(req, timeout=15)` — 15s to match the sibling that issues the same call —
plus a `try/except` so a failed embed returns `None` instead of propagating.

`None` is this file's existing convention for "unanswerable", not a new one:
`vecmath.cosine` already returns `None` for a falsy or mismatched vector, and
`main()` already has `if sim is None: continue` with the comment *"Not comparable
-> no edge. Linking two memories on a similarity computed from a prefix is worse
than not linking them."* A missing vector flows straight into that existing lane.

Nothing is invented to paper over the failure — no zero vector, no `0.0`
similarity, no default. A dropped row produces no edge and says so on stderr.

The second commit widens the two annotations the new return type outgrew
(`entries`, and the local `cosine` wrapper), which otherwise added a
None-safety mypy error to one of the four modules `mypy.ini` singles out for
exactly that check. mypy on this file is back to the three pre-existing
`importlib` errors main already has.

## The test, and that it fails without the fix

`scripts/tests/test_amem_consolidation_embed_timeout.py` — two tests: `urlopen`
is called with a `timeout`, and a raised `TimeoutError` degrades to `None`
rather than propagating.

Verified red independently of the author: `git show origin/main:scripts/amem_consolidation.py`
copied over the fixed file, same test run — **2 failed** (no `timeout` kwarg;
`TimeoutError` propagates). Restored — **2 passed**.

## Behaviour on real data

Measured before/after on a fresh copy of the live DB, not assumed:

| | before | after |
|---|---|---|
| every embed times out | `graph_edges=2395 conflicts=282` | `graph_edges=2395 conflicts=282`, exit 0 in 47s |
| real Ollama, 8 rows | `graph_edges=2395` | `graph_edges=2410`, 6 cross-links + 3 `updated_by` + 6 `caused_by` |

A fully-degraded run writes exactly nothing. The happy path is unchanged; warm
embeds measure 41–85 ms against the 15s ceiling (4.5s on a cold model load).

Nothing dormant is armed by merging this. `amem_consolidation.py` is invoked by
no cron, no systemd unit, no `mlops_loop_cron.sh` step and no other script in the
repo — it is on-demand only, as `docs/ARCHITECTURE.md` says. The one newly
reachable line is `gate.reset()`, which a crashing run used to skip; it is behind
`QUORUM_AMEM_THRESHOLD > 0`, which defaults to `0` and is set nowhere in the repo
or the environment.

## Verified green where it matters

Run in a venv holding only what the `test-scripts` job installs (pytest,
pytest-timeout, aiohttp), not the local dev venv:

- `scripts/tests` + `scripts/hooks/tests` — 758 passed
- `tests/test_schema_consistency.py` — 8 passed (it parses this file's SQL)
- vulture, CI's exact command with no `|| true` — exit 0; whitelist checker clean
- `scripts/callgraph/tests` in CI shape (`PYTHONPATH=scripts`) — 252 passed,
  5 skipped on this branch **and** on `origin/main`, identical. The new file is
  under `scripts/tests/`, which the corpus walk excludes, so the pinned file
  count does not move.

## Left alone deliberately

- **26 `subprocess.run`/`check_output` call sites with no `timeout`.** Same
  hang class, different surface, and not in this finding. They deserve their own
  pass rather than being swept in here.
- **The three pre-existing `importlib` mypy errors** at `_load_quorum_gate` —
  present on main, unrelated to this call site.
- **The 15s ceiling is per call, not per run.** With a silent server and the
  default `AMEM_MAX_PER_RUN=100`, a wedged run now takes ~25 minutes instead of
  forever. Bounded, loud on stderr every 15s, and recoverable — the point of the
  fix — but a whole-run budget is a separate change and is not made here.
