### PR TITLE
Close two deployed-vs-repo drifts where the repo copy is the broken one

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -314,6 +314,14 @@ silently before — a hand-edited `pre_tool_grounding.py` accepting `PreToolUse`
 against a repo copy that only accepted the Hermes name, where a fresh install
 would have disabled the hook.
 
+`--check` also reads `~/.claude/settings.json` (`$CLAUDE_SETTINGS`) and prints
+`UNMANAGED` for any hook an event invokes out of the hooks dir that this repo does
+not ship — on the reference host, the `Stop` wrapper `session_end_sync.sh`, which
+supplies `QDRANT_URL` and the embedding endpoint and exists in no commit. Those
+lines do not affect the exit status; only file drift does. Grading the shipped
+files alone meant `--check` said "hooks in sync" without ever looking at the file
+the `Stop` hook actually runs.
+
 Two payload shapes to get right when writing a new hook; both were wrong until
 #228, and all three hooks ran, exited 0, and did nothing:
 

--- a/scripts/a2a_context_bridge.py
+++ b/scripts/a2a_context_bridge.py
@@ -9,6 +9,7 @@ and peer fanout happen atomically server-side.
 Env vars (from ~/.hermes/.env or ~/.hermes/profiles/{HERMES_PROFILE}/.env):
   LOCI_A2A_URL      Local A2A server endpoint (default: http://127.0.0.1:8201)
   LOCI_A2A_TOKEN    Bearer token for the local server
+                    (the legacy HERMES_* spelling is still accepted for both)
   BRIDGE_LOOKBACK_MIN How many minutes back to look for new memories (default: 30)
   BRIDGE_MIN_IMP      Minimum importance to bridge (default: 0.5)
   BRIDGE_MAX_ITEMS    Max memories to push per run (default: 20)
@@ -55,9 +56,16 @@ if os.path.exists(_ENV):
             os.environ.setdefault(_k.strip(), _v.strip())
 
 # ── config ───────────────────────────────────────────────────────────────────────
-LOCAL_A2A_URL  = os.environ.get("LOCI_A2A_URL", "http://127.0.0.1:8201")
+# The legacy spelling is read directly rather than through legacy_env.apply(): this
+# script runs standalone from systemd and has no import path to mcp/. The unit this
+# repo ships points EnvironmentFile= at a profile that supplies only HERMES_A2A_*,
+# so reading the new name alone silently produced an empty token and no TOTP header.
+LOCAL_A2A_URL  = (os.environ.get("LOCI_A2A_URL")
+                  or os.environ.get("HERMES_A2A_URL")
+                  or "http://127.0.0.1:8201")
 # Empty, not "changeme": the server defaults the same variable to '' so an unset token fails closed.
-LOCAL_A2A_TOKEN = os.environ.get("LOCI_A2A_TOKEN", "")
+LOCAL_A2A_TOKEN = (os.environ.get("LOCI_A2A_TOKEN")
+                   or os.environ.get("HERMES_A2A_TOKEN") or "")
 if not LOCAL_A2A_TOKEN:
     print('WARNING: LOCI_A2A_TOKEN is not set. The bridge will be rejected by any '
           'server that enforces bearer auth. Generate one with: '
@@ -68,7 +76,8 @@ MAX_ITEMS      = int(os.environ.get("BRIDGE_MAX_ITEMS", "20"))
 AGENT_ID       = os.environ.get("HERMES_AGENT_ID", "hermes")
 
 # The local server may enforce TOTP on /a2a, where the bearer alone 401s; empty seed sends no header.
-LOCAL_A2A_TOTP_SEED = os.environ.get("LOCI_A2A_TOTP_SEED", "").strip()
+LOCAL_A2A_TOTP_SEED = (os.environ.get("LOCI_A2A_TOTP_SEED")
+                       or os.environ.get("HERMES_A2A_TOTP_SEED") or "").strip()
 
 _mnem_dir   = os.path.expanduser(os.environ.get("MNEMOSYNE_DATA_DIR", "~/.hermes/mnemosyne/data"))
 MNEMOSYNE_DB= os.path.join(_mnem_dir, "mnemosyne.db")

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -15,6 +15,7 @@ HOOKS=(pre_llm_grounding.py pre_tool_grounding.py session_end_sync.py legacy_env
        workflow_balanced_models.py)
 SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEST="${CLAUDE_HOOKS_DIR:-$HOME/.claude/hooks}"
+SETTINGS="${CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
 
 if [[ "${1:-}" == "--check" ]]; then
   drift=0
@@ -25,7 +26,34 @@ if [[ "${1:-}" == "--check" ]]; then
       echo "DRIFTED  $h"; diff -u "$SRC/$h" "$DEST/$h" | sed -n '3,$p' | head -20; drift=1
     fi
   done
-  [[ $drift -eq 0 ]] && echo "hooks in sync"
+
+  # HOOKS is what this repo ships, not what Claude Code runs. settings.json can
+  # point an event at a file in the hooks dir that HOOKS does not name -- the Stop
+  # hook on the reference host runs session_end_sync.sh, a wrapper that exports the
+  # Qdrant and embedding endpoints and exists in no commit. Checking HOOKS alone
+  # examined every file except the entry point and still said "hooks in sync".
+  unmanaged=()
+  if [[ -f "$SETTINGS" ]]; then
+    while IFS= read -r path; do
+      name="${path##*/}"
+      known=0
+      for h in "${HOOKS[@]}"; do [[ "$h" == "$name" ]] && { known=1; break; }; done
+      [[ $known -eq 1 ]] || unmanaged+=("$name")
+    done < <(tr -s '[:space:],"' '\n' < "$SETTINGS" | grep -F "$DEST/" | sort -u)
+  fi
+  if [[ ${#unmanaged[@]} -gt 0 ]]; then
+    for u in "${unmanaged[@]}"; do
+      echo "UNMANAGED $u  (invoked from $SETTINGS, not managed by this script)"
+    done
+  fi
+
+  if [[ $drift -eq 0 ]]; then
+    if [[ ${#unmanaged[@]} -gt 0 ]]; then
+      echo "${#HOOKS[@]} hooks in sync; ${#unmanaged[@]} invoked but not managed here"
+    else
+      echo "hooks in sync"
+    fi
+  fi
   exit $drift
 fi
 

--- a/scripts/systemd/mrpink-context-bridge.service
+++ b/scripts/systemd/mrpink-context-bridge.service
@@ -13,7 +13,8 @@ Wants=network-online.target mrpink-a2a.service
 Type=oneshot
 WorkingDirectory=/home/rjmendez/.hermes/profiles/mrpink
 
-# Order is load-bearing: .bridge.env overrides LOCI_A2A_URL from .env. Do NOT reorder,
+# Order is load-bearing: .bridge.env overrides the A2A URL from .env (that profile
+# spells it HERMES_A2A_URL; the bridge accepts either). Do NOT reorder,
 # and do NOT move these values into a drop-in — on this box a drop-in Environment= loses
 # to the main unit's EnvironmentFile=, silently.
 EnvironmentFile=/home/rjmendez/.hermes/profiles/mrpink/.env

--- a/scripts/tests/test_install_check_sees_the_entry_point.py
+++ b/scripts/tests/test_install_check_sees_the_entry_point.py
@@ -1,0 +1,92 @@
+"""`install.sh --check` graded the files this repo ships, not the ones Claude Code runs.
+
+~/.claude/settings.json points the Stop event at ~/.claude/hooks/session_end_sync.sh,
+a wrapper that exports QDRANT_URL, the embedding endpoint and five other variables
+before exec'ing session_end_sync.py. That wrapper exists in no commit, so the HOOKS
+array does not name it, so --check never looked at it -- and printed "hooks in sync"
+over the one file the Stop hook actually executes. The drift detector was blind to
+the entry point.
+
+--check must not claim sync over a hook it did not examine.
+"""
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+INSTALL = REPO / "scripts" / "hooks" / "install.sh"
+MANAGED = "pre_llm_grounding.py"      # named in HOOKS
+UNMANAGED = "session_end_sync.sh"     # invoked by settings.json, in no commit
+
+
+def _hooks_named_by_install() -> list:
+    """The HOOKS array, read out of the script itself rather than duplicated here."""
+    src = INSTALL.read_text()
+    body = src.split("HOOKS=(", 1)[1].split(")", 1)[0]
+    return body.split()
+
+
+def _stage(tmp_path, settings_hooks):
+    """A deployed hooks dir with no file drift, plus a settings.json invoking it."""
+    dest = tmp_path / "hooks"
+    dest.mkdir()
+    for name in _hooks_named_by_install():
+        shutil.copy(REPO / "scripts" / "hooks" / name, dest / name)
+    (dest / UNMANAGED).write_text("#!/usr/bin/env bash\nexec true\n")
+
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"hooks": {
+        "Stop": [{"hooks": [{"type": "command", "command": str(dest / h)}
+                            for h in settings_hooks]}],
+    }}))
+    return dest, settings
+
+
+def _check(dest, settings):
+    return subprocess.run(
+        ["bash", str(INSTALL), "--check"],
+        capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(dest.parent),
+             "CLAUDE_HOOKS_DIR": str(dest), "CLAUDE_SETTINGS": str(settings)},
+    )
+
+
+def test_check_names_a_hook_settings_json_runs_that_the_repo_does_not_ship(tmp_path):
+    dest, settings = _stage(tmp_path, [UNMANAGED])
+    run = _check(dest, settings)
+    assert f"UNMANAGED {UNMANAGED}" in run.stdout, (
+        f"--check examined none of settings.json's own hook commands:\n{run.stdout}")
+    assert "hooks in sync\n" not in run.stdout, (
+        "claimed a clean bill over a hook it never compared:\n" + run.stdout)
+
+
+def test_check_still_says_in_sync_when_settings_runs_only_managed_hooks(tmp_path):
+    dest, settings = _stage(tmp_path, [MANAGED])
+    run = _check(dest, settings)
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "hooks in sync" in run.stdout
+    assert "UNMANAGED" not in run.stdout
+
+
+@pytest.mark.parametrize("missing", ["absent settings.json"])
+def test_check_survives_a_settings_file_that_is_not_there(tmp_path, missing):
+    """A fresh machine has no settings.json yet; --check must still grade the files."""
+    dest, settings = _stage(tmp_path, [UNMANAGED])
+    settings.unlink()
+    run = _check(dest, settings)
+    assert run.returncode == 0, f"{missing}: {run.stdout}{run.stderr}"
+    assert "hooks in sync" in run.stdout
+
+
+def test_unmanaged_hooks_do_not_change_the_exit_status(tmp_path):
+    """Exit 1 means file drift. An unmanaged entry point is reported, not graded --
+    resolving it is a decision about what this repo ships, not a sync action."""
+    dest, settings = _stage(tmp_path, [UNMANAGED])
+    assert _check(dest, settings).returncode == 0
+    (dest / MANAGED).write_text("# hand-edited on the box\n")
+    drifted = _check(dest, settings)
+    assert drifted.returncode == 1
+    assert f"DRIFTED  {MANAGED}" in drifted.stdout

--- a/scripts/tests/test_legacy_env_fallbacks.py
+++ b/scripts/tests/test_legacy_env_fallbacks.py
@@ -62,6 +62,33 @@ def test_the_settings_json_legacy_registration_name_is_hermes_memory():
             f"{f} looks up a legacy MCP registration name that never existed")
 
 
+@pytest.mark.parametrize("attr, legacy", [
+    ("LOCAL_A2A_URL",       "HERMES_A2A_URL"),
+    ("LOCAL_A2A_TOKEN",     "HERMES_A2A_TOKEN"),
+    ("LOCAL_A2A_TOTP_SEED", "HERMES_A2A_TOTP_SEED"),
+])
+def test_the_context_bridge_honours_the_legacy_a2a_names(attr, legacy, tmp_path):
+    """scripts/systemd/mrpink-context-bridge.service points EnvironmentFile= at a
+    profile that supplies only HERMES_A2A_*. Reading the new name alone left the
+    bridge with an empty token and no TOTP header, so every send 401'd."""
+    home = tmp_path / "no-hermes-here"          # keep the module's .env loader a no-op
+    env = {"HERMES_HOME": str(home), legacy: "from-legacy"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        assert getattr(_fresh("a2a_context_bridge"), attr) == "from-legacy"
+
+
+@pytest.mark.parametrize("attr, legacy, current", [
+    ("LOCAL_A2A_URL",       "HERMES_A2A_URL",       "LOCI_A2A_URL"),
+    ("LOCAL_A2A_TOKEN",     "HERMES_A2A_TOKEN",     "LOCI_A2A_TOKEN"),
+    ("LOCAL_A2A_TOTP_SEED", "HERMES_A2A_TOTP_SEED", "LOCI_A2A_TOTP_SEED"),
+])
+def test_the_context_bridge_prefers_the_current_a2a_names(attr, legacy, current, tmp_path):
+    home = tmp_path / "no-hermes-here"
+    env = {"HERMES_HOME": str(home), legacy: "from-legacy", current: "from-current"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        assert getattr(_fresh("a2a_context_bridge"), attr) == "from-current"
+
+
 def test_the_contract_hook_falls_back_too():
     src = (REPO / "scripts" / "hooks" / "post-commit-contract-extract.sh").read_text()
     assert "HERMES_ACTIVE_INVESTIGATION" in src


### PR DESCRIPTION
Two independent instances of the same class: an installed copy that drifted from
the repo it came from, where the repo side is the one that is wrong and a fresh
install would therefore break something that works on the box.

## 1. The context bridge reads only the new env spelling

`scripts/a2a_context_bridge.py` read `LOCI_A2A_URL` / `LOCI_A2A_TOKEN` /
`LOCI_A2A_TOTP_SEED` with no `HERMES_*` fallback. It runs standalone from systemd,
so it never picks up `mcp/legacy_env.py` the way the servers and hooks do — the
`LOCI_*` rename covered those and missed the scripts.

`scripts/systemd/mrpink-context-bridge.service`, the unit **this repo ships**,
points both `EnvironmentFile=` lines at `~/.hermes/profiles/mrpink`, which supplies
`HERMES_A2A_TOKEN`, `HERMES_A2A_URL` and `HERMES_A2A_TOTP_SEED` and no `LOCI_*`
spelling at all.

Evidence it was real, on the reference host:

- Importing the repo copy under that profile (`env -i HOME=... HERMES_PROFILE=mrpink`)
  gave an empty token and an empty TOTP seed while both legacy names were sitting
  in `os.environ`. After the change the same command gives
  `url=http://172.21.171.198:8201`, token set, seed set, and a 6-digit code.
- `_broadcast_memory()` would then POST `Authorization: Bearer ` with no `X-TOTP`
  to a local server whose `/health` reports `"totp_enabled":true` — every send 401s,
  the tick logs `Bridge complete — ok=0 fail=N`, and the oneshot still exits 0.
- The copy actually running on the box,
  `~/.hermes/profiles/mrpink/scripts/a2a_context_bridge.py` (Aug 14), predates the
  rename and still reads the old names, which is why nobody saw it. Deploying the
  repo copy over it — what `scripts/systemd/README.md` tells you to do — would have
  silently disabled the oxalis→jetson half of the mesh.

The fix reads the legacy name directly (`LOCI_* or HERMES_* or default`), matching
the shape `scripts/state_db_qdrant_sync.py` and `scripts/mnemosyne_qdrant_sync.py`
already use for the same reason. No new default is introduced: the URL default and
the empty-token fail-closed default are both unchanged from `main`. The unit comment
that claimed `.bridge.env` overrides `LOCI_A2A_URL` is corrected — that profile
spells it `HERMES_A2A_URL`.

**Test:** three new cases in `scripts/tests/test_legacy_env_fallbacks.py`, the suite
that already asserts exactly this for the two sibling scripts. Reverting only
`scripts/a2a_context_bridge.py` to `origin/main` and keeping the tests:

```
3 failed, 10 passed
  assert 'http://127.0.0.1:8201' == 'from-legacy'   (LOCAL_A2A_URL)
  assert ''                      == 'from-legacy'   (LOCAL_A2A_TOKEN)
  assert ''                      == 'from-legacy'   (LOCAL_A2A_TOTP_SEED)
```

Restored: 13 passed. Three companion cases assert the current spelling still wins;
those are guards and pass either way.

## 2. `install.sh --check` graded the files this repo ships, not the ones that run

The `HOOKS` array is what the repo ships. `~/.claude/settings.json` does not invoke
`session_end_sync.py` directly — its `Stop` hook runs
`~/.claude/hooks/session_end_sync.sh`, a wrapper that exports `QDRANT_URL`,
`QDRANT_API_KEY`, `LOCI_STATE_DB`, `LOCI_SYNC_CACHE` and the embedding endpoint
before exec'ing the Python. That wrapper appears in no commit, so `HOOKS` does not
name it, so `--check` never looked at it — and printed `hooks in sync`. The drift
detector that exists specifically to catch a divergent deployed copy was blind to
the entry point, and said so in the affirmative.

`--check` now also reads `~/.claude/settings.json` (overridable with
`$CLAUDE_SETTINGS`) and prints `UNMANAGED` for every hook an event invokes out of
the hooks dir that `HOOKS` does not name. Live on the reference host it now prints:

```
DRIFTED  pre_llm_grounding.py
DRIFTED  session_end_sync.py
UNMANAGED session_end_learn.sh  (invoked from .../settings.json, not managed by this script)
UNMANAGED session_end_sync.sh   (invoked from .../settings.json, not managed by this script)
```

Reporting only. The exit status still means file drift and nothing else — whether
the wrapper should be committed de-personalised, or `session_end_sync.py` should
read `backends.toml` instead, is a decision about what this repo ships, and failing
the check would force it. What is fixed here is the claim of coverage.

**Test:** `scripts/tests/test_install_check_sees_the_entry_point.py`, four cases
against a staged hooks dir and settings.json in `tmp_path` (`HOME`,
`CLAUDE_HOOKS_DIR` and `CLAUDE_SETTINGS` are all pinned there, so it reads no host
state). Replacing `scripts/hooks/install.sh` with the `origin/main` version and
keeping the test:

```
1 failed, 3 passed
  assert 'UNMANAGED session_end_sync.sh' in 'hooks in sync\n'
```

Restored: 4 passed. The other three are guards so the new reporting cannot become a
new false alarm: still says `hooks in sync` when settings.json names only managed
hooks, survives an absent settings.json, and an unmanaged entry point does not
change the exit status while real file drift still exits 1.

## Verification

- `scripts/tests` + `scripts/hooks/tests`: **766 passed** (762 on `origin/main` + 4 new).
- Re-run in the shape CI uses — `working-directory: scripts`, `env -i`, a `HOME`
  with no `~/.claude`, and only `pytest pytest-timeout aiohttp` installed:
  **766 passed**. Nothing here reads the real `~/.claude` or `~/.hermes`.
- `scripts/callgraph/tests/test_config.py`: 12 passed. The corpus file-count pin is
  unaffected — the one new `.py` file is under `scripts/tests/`, and `tests` is in
  `EXCLUDE_DIR_NAMES`.
- CI's exact ruff selection (`E9,F401,F811,F821,F841`) over the same paths: clean.
- vulture at `--min-confidence 60` over the changed files: only the pre-existing
  `row_factory` attribute, which is already in `.vulture_whitelist.py`.

Merging deploys nothing. The live
`~/.config/systemd/user/mrpink-context-bridge.service` runs
`~/.hermes/profiles/mrpink/scripts/a2a_context_bridge.py`, not the repo copy, and
differs from the shipped unit only in the comment corrected here. `install.sh
--check` writes nothing, its exit status is unchanged, and no crontab entry, hook
or launcher on the box invokes it or the repo bridge. What this unblocks is the
manual `cp` that was previously unsafe.

## Deliberately left alone

- **`~/.claude/hooks/pre_llm_grounding.py` (HIGH) and `session_end_sync.py` (MED)** —
  both stale against `c1c2178`; the repo is already correct and the drift is host
  state. The operator's action is one command: `scripts/hooks/install.sh`. `--check`
  now reports both.
- **The `session_end_sync.sh` wrapper itself (MED)** — commit a de-personalised
  wrapper, or make `session_end_sync.py` read `backends.toml`? Only the separable
  half is fixed here: the check no longer claims sync over a file it did not examine.
- **`.git/hooks/post-commit` (MED)** — a merge of two divergent copies, not a sync.
  The deployed copy is ahead in three ways and regressed in one: it resolves its log
  dir to `$repo_root/.git`, which is a *file* in a linked worktree, so the redirect
  is `ENOTDIR` and the code-graph re-ingest is skipped for every worktree commit.
  Reproduced twice while preparing this branch. Fixing it needs `git rev-parse
  --git-common-dir` **and** a re-run of `scripts/install_hooks.sh` in the live
  checkout, so a repo-side change alone would sit dark.
- **`docs/OPERATIONS.md` mlops schedule (MED)** — commit `~/.loci/bin/mlops-cron` as
  `scripts/mlops_cron` vs document the constraint is the operator's call, and
  `feat/mlops-cron-entrypoint` already carries edits to that exact section.

Known limit of the new scan: it matches hook commands by literal path prefix against
the resolved hooks dir, so a command written with `~` or `$HOME` instead of an
absolute path would not be matched. Claude Code writes absolute paths; the live
settings.json on the reference host is fully covered.
