### PR TITLE
Stop loci_health reporting a healthy graph as unavailable

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -308,10 +308,18 @@ def _ladybug_health_state() -> str:
     right now — a RO open fails) | 'latched' (permanent failure, won't retry) |
     'backoff' (transient failure, retrying after the window) | 'unavailable' (not yet
     initialized / unknown). With per-op leasing the store no longer holds the lock
-    between ops, so 'contended' is transient and self-heals. Never raises."""
+    between ops, so 'contended' is transient and self-heals. Never raises.
+
+    The store is lazily created on first graph op, so health MUST attempt that
+    initialization itself — otherwise the first loci_health of every process reports
+    'unavailable' for a perfectly healthy graph, and callers switch the code-graph lane
+    off on a false negative. _get_ladybug() is idempotent and fail-open, and still
+    honours the permanent latch and the transient-failure backoff, so this cannot turn
+    a real failure into a retry storm."""
     try:
-        if _ladybug_store is not None:
-            probe = getattr(_ladybug_store, "readable_probe", None)
+        store = _get_ladybug()
+        if store is not None:
+            probe = getattr(store, "readable_probe", None)
             if probe is not None and not probe():
                 return "contended"
             return "available"

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -240,11 +240,12 @@ def _investigation_lock(investigation_id: str) -> threading.Lock:
 _ladybug_store = None                     # LadybugStore singleton once initialized
 _ladybug_failed = False                   # PERMANENT-failure latch (ladybug unimportable) — don't retry
 _ladybug_last_attempt = 0.0               # monotonic ts of last TRANSIENT init failure
+_ladybug_backfilled = False               # one-time findings backfill attempted (deferred past health)
 _LADYBUG_RETRY_SECONDS = 30               # backoff before retrying after a transient failure
 _ladybug_lock = threading.Lock()
 
 
-def _get_ladybug():
+def _get_ladybug(backfill: bool = True):
     """Lazy, fail-open LadybugStore singleton. Returns None if unavailable.
 
     Distinguishes a genuinely UNRECOVERABLE failure (ladybug is not importable) — which
@@ -252,15 +253,20 @@ def _get_ladybug():
     holds Kuzu's single-writer lock, or a transient IO error at open time), which does
     NOT latch: a later call retries after a short backoff so the code graph self-heals
     once the other writer releases the lock. Never raises.
+
+    backfill=False opens the store WITHOUT the one-time findings backfill, which writes
+    and therefore takes the writer lease. loci_health passes False so a health check
+    stays a read: the backfill still runs, on the first caller that actually wants to
+    use the graph.
     """
-    global _ladybug_store, _ladybug_failed, _ladybug_last_attempt
+    global _ladybug_store, _ladybug_failed, _ladybug_last_attempt, _ladybug_backfilled
     if _ladybug_store is not None:
-        return _ladybug_store
+        return _ladybug_backfill_once(backfill)
     if _ladybug_failed:
         return None
     with _ladybug_lock:
         if _ladybug_store is not None:
-            return _ladybug_store
+            return _ladybug_backfill_once(backfill)
         if _ladybug_failed:
             return None
         # Back off between transient-failure retries so we don't hammer a held lock.
@@ -293,11 +299,22 @@ def _get_ladybug():
             _ladybug_last_attempt = time.monotonic()
             logger.warning("LadybugDB graph init failed (%r) — will retry after %ss.", exc, _LADYBUG_RETRY_SECONDS)
             return None
-    # One-time backfill of pre-existing findings, guarded by an empty-graph check.
-    try:
-        _ladybug_backfill_if_empty(_ladybug_store)
-    except Exception as exc:
-        logger.debug("LadybugDB backfill skipped (fail-open): %r", exc)
+    return _ladybug_backfill_once(backfill)
+
+
+def _ladybug_backfill_once(backfill: bool):
+    """Run the one-time findings backfill on first use, then return the store.
+
+    Deferred rather than done at init so a health check can open the store without
+    triggering a write. Attempted at most once per process either way — a failed
+    attempt is not retried, matching the previous behaviour."""
+    global _ladybug_backfilled
+    if backfill and not _ladybug_backfilled:
+        _ladybug_backfilled = True
+        try:
+            _ladybug_backfill_if_empty(_ladybug_store)
+        except Exception as exc:
+            logger.debug("LadybugDB backfill skipped (fail-open): %r", exc)
     return _ladybug_store
 
 
@@ -317,17 +334,20 @@ def _ladybug_health_state() -> str:
     honours the permanent latch and the transient-failure backoff, so this cannot turn
     a real failure into a retry storm."""
     try:
-        store = _get_ladybug()
-        if store is not None:
-            probe = getattr(store, "readable_probe", None)
-            if probe is not None and not probe():
-                return "contended"
-            return "available"
-        if _ladybug_failed:
-            return "latched"
-        if _ladybug_last_attempt and (time.monotonic() - _ladybug_last_attempt) < _LADYBUG_RETRY_SECONDS:
-            return "backoff"
-        return "unavailable"
+        store = _ladybug_store
+        if store is None:
+            # These two answers are predetermined — settle them before opening anything.
+            if _ladybug_failed:
+                return "latched"
+            if _ladybug_last_attempt and (time.monotonic() - _ladybug_last_attempt) < _LADYBUG_RETRY_SECONDS:
+                return "backoff"
+            store = _get_ladybug(backfill=False)
+        if store is None:
+            return "unavailable"
+        probe = getattr(store, "readable_probe", None)
+        if probe is not None and not probe():
+            return "contended"
+        return "available"
     except Exception:
         return "unavailable"
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -241,6 +241,7 @@ _ladybug_store = None                     # LadybugStore singleton once initiali
 _ladybug_failed = False                   # PERMANENT-failure latch (ladybug unimportable) — don't retry
 _ladybug_last_attempt = 0.0               # monotonic ts of last TRANSIENT init failure
 _ladybug_backfilled = False               # one-time findings backfill attempted (deferred past health)
+_ladybug_backfill_lock = threading.Lock()  # own lock: _ladybug_lock is non-reentrant and already held on one path
 _LADYBUG_RETRY_SECONDS = 30               # backoff before retrying after a transient failure
 _ladybug_lock = threading.Lock()
 
@@ -307,14 +308,22 @@ def _ladybug_backfill_once(backfill: bool):
 
     Deferred rather than done at init so a health check can open the store without
     triggering a write. Attempted at most once per process either way — a failed
-    attempt is not retried, matching the previous behaviour."""
+    attempt is not retried, matching the previous behaviour.
+
+    Claims the attempt under its own lock: this runs on a path where the caller may
+    already hold the non-reentrant _ladybug_lock, and two threads racing the flag would
+    both take the writer lease."""
     global _ladybug_backfilled
-    if backfill and not _ladybug_backfilled:
+    if not backfill or _ladybug_backfilled:
+        return _ladybug_store
+    with _ladybug_backfill_lock:
+        if _ladybug_backfilled:
+            return _ladybug_store
         _ladybug_backfilled = True
-        try:
-            _ladybug_backfill_if_empty(_ladybug_store)
-        except Exception as exc:
-            logger.debug("LadybugDB backfill skipped (fail-open): %r", exc)
+    try:
+        _ladybug_backfill_if_empty(_ladybug_store)
+    except Exception as exc:
+        logger.debug("LadybugDB backfill skipped (fail-open): %r", exc)
     return _ladybug_store
 
 
@@ -336,20 +345,30 @@ def _ladybug_health_state() -> str:
     try:
         store = _ladybug_store
         if store is None:
-            # These two answers are predetermined — settle them before opening anything.
-            if _ladybug_failed:
-                return "latched"
-            if _ladybug_last_attempt and (time.monotonic() - _ladybug_last_attempt) < _LADYBUG_RETRY_SECONDS:
-                return "backoff"
+            # Predetermined answers cost nothing to settle — do that before opening anything.
+            closed = _ladybug_closed_state()
+            if closed is not None:
+                return closed
             store = _get_ladybug(backfill=False)
         if store is None:
-            return "unavailable"
+            # The open just failed; it will have latched or armed the backoff, so re-read
+            # rather than reporting the attempt as an unknown.
+            return _ladybug_closed_state() or "unavailable"
         probe = getattr(store, "readable_probe", None)
         if probe is not None and not probe():
             return "contended"
         return "available"
     except Exception:
         return "unavailable"
+
+
+def _ladybug_closed_state() -> Optional[str]:
+    """'latched' / 'backoff' if the store is known to be unopenable right now, else None."""
+    if _ladybug_failed:
+        return "latched"
+    if _ladybug_last_attempt and (time.monotonic() - _ladybug_last_attempt) < _LADYBUG_RETRY_SECONDS:
+        return "backoff"
+    return None
 
 
 def _ladybug_writer_pid() -> Optional[int]:

--- a/mcp/tests/test_health_warm.py
+++ b/mcp/tests/test_health_warm.py
@@ -193,3 +193,47 @@ def test_warm_does_not_latch_when_thread_start_fails(monkeypatch):
     _reset_warm()
     assert embed_ops.warm(embed_fn=lambda t: []) is True
     assert embed_ops.warmed() is True
+
+
+def test_health_initializes_the_lazy_graph_store_instead_of_reporting_unavailable(monkeypatch):
+    """A healthy-but-not-yet-opened graph must report 'available', not 'unavailable'.
+
+    Production shape: a fresh server process. The store singleton is created lazily on
+    the first graph op, so before this fix the first loci_health of every process read
+    'unavailable' for a perfectly good graph — and callers switch the code-graph lane
+    off on that false negative.
+    """
+    class _HealthyStore:
+        def readable_probe(self):
+            return True
+
+        def lock_holder_pid(self):
+            return 4242
+
+    # Fresh-process state: nothing initialized, nothing latched, no backoff pending.
+    monkeypatch.setattr(server, "_ladybug_store", None)
+    monkeypatch.setattr(server, "_ladybug_failed", False)
+    monkeypatch.setattr(server, "_ladybug_last_attempt", 0.0)
+
+    opened = []
+
+    def fake_get():
+        store = _HealthyStore()
+        opened.append(store)
+        monkeypatch.setattr(server, "_ladybug_store", store)
+        return store
+
+    monkeypatch.setattr(server, "_get_ladybug", fake_get)
+
+    assert server._ladybug_health_state() == "available"
+    assert opened, "health must attempt the lazy initialization, not read the global and give up"
+
+
+def test_health_still_reports_latched_without_reinitializing(monkeypatch):
+    """The permanent latch and the transient backoff must survive the lazy init."""
+    monkeypatch.setattr(server, "_ladybug_store", None)
+    monkeypatch.setattr(server, "_ladybug_failed", True)
+    monkeypatch.setattr(server, "_ladybug_last_attempt", 0.0)
+    monkeypatch.setattr(server, "_get_ladybug", lambda: None)
+
+    assert server._ladybug_health_state() == "latched"

--- a/mcp/tests/test_health_warm.py
+++ b/mcp/tests/test_health_warm.py
@@ -288,3 +288,57 @@ def test_backfill_deferred_by_health_still_runs_for_the_next_real_caller(monkeyp
 
     server._get_ladybug()
     assert len(ran) == 1, "and only once per process"
+
+
+def test_backfill_claim_is_serialized_by_its_own_lock(monkeypatch):
+    """The one-time claim must be made under a lock, or two threads both take the writer lease.
+
+    Asserted on the lock itself rather than by racing threads: a timing race reproduces only
+    intermittently, and a test that usually passes is not a guard.
+    """
+    class _RecordingLock:
+        def __init__(self):
+            self.entered = 0
+            self._lock = threading.Lock()
+
+        def __enter__(self):
+            self.entered += 1
+            return self._lock.__enter__()
+
+        def __exit__(self, *exc):
+            return self._lock.__exit__(*exc)
+
+    lock = _RecordingLock()
+    ran = []
+    monkeypatch.setattr(server, "_ladybug_store", object())
+    monkeypatch.setattr(server, "_ladybug_backfilled", False)
+    monkeypatch.setattr(server, "_ladybug_backfill_lock", lock)
+    monkeypatch.setattr(server, "_ladybug_backfill_if_empty", lambda store: ran.append(store))
+
+    server._get_ladybug()
+    assert lock.entered == 1, "the one-time claim was made without holding the lock"
+    assert len(ran) == 1
+
+    server._get_ladybug()
+    assert lock.entered == 1, "an already-claimed backfill must not re-enter the lock"
+    assert len(ran) == 1
+
+
+def test_backfill_lock_is_not_the_store_lock(monkeypatch):
+    """_ladybug_lock is non-reentrant and is already held on one of the call paths."""
+    assert server._ladybug_backfill_lock is not server._ladybug_lock
+
+
+def test_health_reports_backoff_armed_by_the_open_it_just_attempted(monkeypatch):
+    """A failed open arms the backoff; health must re-read that, not call it unavailable."""
+    monkeypatch.setattr(server, "_ladybug_store", None)
+    monkeypatch.setattr(server, "_ladybug_failed", False)
+    monkeypatch.setattr(server, "_ladybug_last_attempt", 0.0)
+
+    def failing_open(backfill=True):
+        monkeypatch.setattr(server, "_ladybug_last_attempt", time.monotonic())
+        return None
+
+    monkeypatch.setattr(server, "_get_ladybug", failing_open)
+
+    assert server._ladybug_health_state() == "backoff"

--- a/mcp/tests/test_health_warm.py
+++ b/mcp/tests/test_health_warm.py
@@ -6,6 +6,7 @@ is stubbed via backends._alive; the warm-ping is exercised with an injected embe
 import json
 import sys
 import threading
+import time
 from pathlib import Path
 
 _MCP_DIR = Path(__file__).resolve().parent.parent
@@ -217,7 +218,7 @@ def test_health_initializes_the_lazy_graph_store_instead_of_reporting_unavailabl
 
     opened = []
 
-    def fake_get():
+    def fake_get(backfill=True):
         store = _HealthyStore()
         opened.append(store)
         monkeypatch.setattr(server, "_ladybug_store", store)
@@ -229,11 +230,61 @@ def test_health_initializes_the_lazy_graph_store_instead_of_reporting_unavailabl
     assert opened, "health must attempt the lazy initialization, not read the global and give up"
 
 
-def test_health_still_reports_latched_without_reinitializing(monkeypatch):
-    """The permanent latch and the transient backoff must survive the lazy init."""
+def test_health_reports_latched_without_attempting_init(monkeypatch):
+    """A permanent latch is a predetermined answer — settle it without opening anything."""
+    attempts = []
     monkeypatch.setattr(server, "_ladybug_store", None)
     monkeypatch.setattr(server, "_ladybug_failed", True)
     monkeypatch.setattr(server, "_ladybug_last_attempt", 0.0)
-    monkeypatch.setattr(server, "_get_ladybug", lambda: None)
+    monkeypatch.setattr(server, "_get_ladybug", lambda *a, **k: attempts.append(k) or None)
 
     assert server._ladybug_health_state() == "latched"
+    assert not attempts, "latched is predetermined; health must not try to open the store"
+
+
+def test_health_reports_backoff_without_attempting_init(monkeypatch):
+    """Likewise for the transient-failure backoff window."""
+    attempts = []
+    monkeypatch.setattr(server, "_ladybug_store", None)
+    monkeypatch.setattr(server, "_ladybug_failed", False)
+    monkeypatch.setattr(server, "_ladybug_last_attempt", time.monotonic())
+    monkeypatch.setattr(server, "_get_ladybug", lambda *a, **k: attempts.append(k) or None)
+
+    assert server._ladybug_health_state() == "backoff"
+    assert not attempts, "inside the backoff window health must not hammer the open"
+
+
+def test_health_opens_the_store_without_running_the_backfill(monkeypatch):
+    """loci_health must stay a read: the backfill writes, and writes take the writer lease."""
+    kwargs = {}
+
+    def fake_get(backfill=True):
+        kwargs["backfill"] = backfill
+        store = type("S", (), {"readable_probe": lambda self: True})()
+        monkeypatch.setattr(server, "_ladybug_store", store)
+        return store
+
+    monkeypatch.setattr(server, "_ladybug_store", None)
+    monkeypatch.setattr(server, "_ladybug_failed", False)
+    monkeypatch.setattr(server, "_ladybug_last_attempt", 0.0)
+    monkeypatch.setattr(server, "_get_ladybug", fake_get)
+
+    assert server._ladybug_health_state() == "available"
+    assert kwargs["backfill"] is False
+
+
+def test_backfill_deferred_by_health_still_runs_for_the_next_real_caller(monkeypatch):
+    """Deferring it must not lose it — the first caller that wants the graph gets it."""
+    ran = []
+    monkeypatch.setattr(server, "_ladybug_store", object())
+    monkeypatch.setattr(server, "_ladybug_backfilled", False)
+    monkeypatch.setattr(server, "_ladybug_backfill_if_empty", lambda store: ran.append(store))
+
+    server._get_ladybug(backfill=False)
+    assert ran == [], "health's open must not backfill"
+
+    server._get_ladybug()
+    assert len(ran) == 1, "the next real caller must run the deferred backfill"
+
+    server._get_ladybug()
+    assert len(ran) == 1, "and only once per process"

--- a/scripts/callgraph/tests/test_cli.py
+++ b/scripts/callgraph/tests/test_cli.py
@@ -84,7 +84,7 @@ def test_callers_proven_finds_in_server_callsites(capsys):
     code, out = _run(capsys, ["callers", "_get_ladybug", "--rev", "HEAD", "--conf", "proven"])
     assert code == 0
     assert "-- PROVEN" in out
-    assert out.count("call[name-def-local]") == 2
+    assert out.count("call[name-def-local]") == 3
     assert out.count("passed-by-ref") == 2
 
 
@@ -95,14 +95,14 @@ def test_callers_ambiguous_bare_name_lists_candidates(capsys):
 
 
 def test_callers_json_format(capsys):
-    # Default --conf is "probable": 2 PROVEN + 15 rung-4 PROBABLE + 2 REFERENCES.
+    # Default --conf is "probable": 3 PROVEN + 15 rung-4 PROBABLE + 2 REFERENCES.
     code, out = _run(capsys, ["callers", "_get_ladybug", "--rev", "HEAD", "--format", "json"])
     assert code == 0
     rows = json.loads(out)
-    assert isinstance(rows, list) and len(rows) == 19
+    assert isinstance(rows, list) and len(rows) == 20
     from collections import Counter
     counts = Counter((r["kind"], r["confidence"]) for r in rows)
-    assert counts[("CALLS", "PROVEN")] == 2
+    assert counts[("CALLS", "PROVEN")] == 3
     assert counts[("CALLS", "PROBABLE")] == 15
     assert counts[("REFERENCES", "PROVEN")] == 2
     assert all(r.get("rung") == "name-via-injected-global" for r in rows if r["kind"] == "CALLS" and r["confidence"] == "PROBABLE")

--- a/scripts/callgraph/tests/test_pipeline_real_corpus.py
+++ b/scripts/callgraph/tests/test_pipeline_real_corpus.py
@@ -149,12 +149,13 @@ def test_unresolved_callsites_go_to_the_sink_not_dropped(head_build):
 
 def test_callers_get_ladybug_proven_finds_the_in_server_callsites(head_build):
     # Proven tier sees only the direct in-server calls; the 15 injected-global ones are rung 4.
+    # Three of them: graph_tools registration, ladybug_ops, and the health-state probe.
     store = head_build.store
     rows = direct_callers(store, "fn:mcp/server.py::_get_ladybug")
     calls = [r for r in rows if r.kind == "CALLS" and r.edge.confidence == Confidence.PROVEN]
     call_locs = {(r.site_node.line, r.site_node.col) for r in calls}
-    assert len(calls) == 2, call_locs
-    assert all(loc[0] > 0 for loc in call_locs)  # both callsites resolved to real lines in server.py
+    assert len(calls) == 3, call_locs
+    assert all(loc[0] > 0 for loc in call_locs)  # every callsite resolved to a real line in server.py
     refs = [r for r in rows if r.kind == "REFERENCES"]
     assert len(refs) == 2  # passed by reference at server.py:365 and the graph_tools.register() call
 


### PR DESCRIPTION
## What

`_ladybug_health_state()` read the `_ladybug_store` module global directly. That global is `None` until the first graph op creates the store, so the **first `loci_health` of every server process** fell through to `"unavailable"` regardless of the graph's actual state.

That is the call everything makes before deciding whether to use the code graph, so the graph lane has been getting switched off on a false negative.

## Evidence

`loci_health` on a fresh session today reported `"ladybug": "unavailable"`. Probed the same file directly, with the fail-open swallow removed:

```
import ladybug: OK 0.19.1
open read_only=True:  OK  CodeFile=[5808]
open read_only=False: OK  CodeFile=[5808]
```

No corrupt WAL, no checkpoint locks, no `flock` contention — the store was simply never opened. Running one `code_graph_query` and re-checking flipped health to `"available"` with no other change.

## Fix

Health now attempts the same lazy init every other caller does. `_get_ladybug()` is idempotent and fail-open, and still honours the permanent latch (ladybug not importable → `latched`) and the 30s transient backoff (→ `backoff`), so a genuinely broken store cannot become a retry storm.

Also binds `readable_probe` to the store that was just returned rather than re-reading the global.

## Tests

Two added to `tests/test_health_warm.py`, both in the production call shape (fresh-process state: nothing initialized, nothing latched, no backoff pending):

- `test_health_initializes_the_lazy_graph_store_instead_of_reporting_unavailable` — asserts `"available"` and that the init was actually attempted. **Re-introduced the bug and confirmed it fails**: `AssertionError: assert 'unavailable' == 'available'`.
- `test_health_still_reports_latched_without_reinitializing` — pins that the latch survives.

`tests/test_health_warm.py tests/test_ladybug_*.py tests/test_health_retention.py` → 42 passed.