### PR TITLE
Stop four failure paths from returning the success-shaped value

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1570,7 +1570,7 @@ def _compute_aggregate_confidence(
     finding_id: str,
     findings_by_id: dict,
     max_depth: int = 5,
-) -> float:
+) -> float | None:
     """Walk the derived_from chain for a finding and return the product of
     numeric_confidence values along the chain (up to max_depth nodes).
 
@@ -1578,6 +1578,11 @@ def _compute_aggregate_confidence(
     (_node_numeric_confidence), not scored 1.0 — absence is not perfect certainty,
     and in a product a 1.0 node silently stops constraining the aggregate.
     Returns 1.0 if the finding_id is not found or the chain is empty.
+    Returns None if the walk itself failed: for the same reason a node is not
+    worth 1.0, a crash is not worth 1.0 either — it is the top of the scale AND
+    the identity element of the product, so it would report perfect certainty
+    over a chain that was never read. investigation_finding_provenance already
+    returns None here (investigation_tools.py).
     """
     try:
         product = 1.0
@@ -1598,8 +1603,9 @@ def _compute_aggregate_confidence(
             current_id = str(parents[0]) if parents else None
             depth += 1
         return round(product, 6)
-    except Exception:
-        return 1.0
+    except Exception as exc:
+        logger.debug("_compute_aggregate_confidence: chain walk failed: %r", exc)
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -3516,6 +3522,11 @@ def _pre_answer_chain_confidence(
         for ev_id in matched_ids:
             if ev_id and ev_id in findings_by_id_for_conf:
                 agg = _compute_aggregate_confidence(ev_id, findings_by_id_for_conf)
+                if agg is None:
+                    # The chain walk failed: no measurement. It must not enter the
+                    # min() as 1.0, which cannot lower the bucket and so renders an
+                    # unread chain as 'high'.
+                    continue
                 chain_confidences.append(agg)
         if chain_confidences:
             min_chain_confidence = round(min(chain_confidences), 6)

--- a/mcp/tests/test_mcp_integration.py
+++ b/mcp/tests/test_mcp_integration.py
@@ -852,6 +852,44 @@ class TestNumericConfidence(unittest.TestCase):
         self.assertAlmostEqual(agg, 0.36, places=5,
                                msg="two unstamped 'medium' nodes are 0.6*0.6, not 1.0")
 
+    def test_aggregate_confidence_of_a_chain_it_could_not_walk_is_none(self):
+        """A crash in the walk must not render as 1.0 either. 1.0 is the top of
+        the scale AND the identity of the product, so it claims perfect certainty
+        over a chain that was never read, and is indistinguishable from the
+        legitimate 'no chain' answer."""
+        # A truthy non-subscriptable derived_from (an externally-imported or
+        # hand-edited findings.jsonl row) raises TypeError on parents[0].
+        findings_by_id = {"a": {"id": "a", "confidence": "high", "derived_from": 7}}
+        self.assertIsNone(
+            server._compute_aggregate_confidence("a", findings_by_id),
+            msg="an unwalkable chain is 'no measurement', not perfect certainty")
+        # The genuinely empty chain keeps its documented 1.0.
+        self.assertAlmostEqual(
+            server._compute_aggregate_confidence("missing", {}), 1.0, places=5)
+
+    def test_pre_answer_chain_confidence_does_not_report_high_for_unwalkable_chains(self):
+        """investigation_pre_answer_check emits min_chain_confidence /
+        confidence_summary as the agent's go/no-go on evidence quality. When every
+        chain walk failed there is no measurement, so it must report none rather
+        than min([1.0]) -> 'high'."""
+        inv_id = _new_id("chainconf")
+        server.investigation_start(investigation_id=inv_id, title="Chain confidence test")
+        (server._inv_dir(inv_id) / "findings.jsonl").write_text(
+            json.dumps({"id": "f1", "confidence": "high", "derived_from": 7}) + "\n"
+        )
+
+        conf, summary = server._pre_answer_chain_confidence(inv_id, {"f1"})
+        self.assertIsNone(conf, msg="a failed walk must not become a confidence value")
+        self.assertIsNone(summary)
+
+        # A walkable chain still measures, so the lane is not simply switched off.
+        (server._inv_dir(inv_id) / "findings.jsonl").write_text(
+            json.dumps({"id": "f1", "confidence": "medium", "derived_from": []}) + "\n"
+        )
+        conf, summary = server._pre_answer_chain_confidence(inv_id, {"f1"})
+        self.assertAlmostEqual(conf, 0.6, places=5)
+        self.assertEqual(summary, "medium (0.5-0.8)")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/a2a_watchdog.py
+++ b/scripts/a2a_watchdog.py
@@ -53,29 +53,44 @@ def check_health():
 
 
 def get_wsl_ip():
+    """Current eth0 IPv4. Returns (ip, None) or (None, reason).
+
+    A reason is not the same answer as "no rule": both drift branches below key
+    off this value, and returning a bare None for a probe that never ran skipped
+    them both — leaving the watchdog silent, which the contract above reads as
+    healthy while the portproxy drifts.
+    """
     try:
         result = subprocess.run(
             ["ip", "addr", "show", "eth0"],
             capture_output=True, text=True, timeout=5
         )
-        m = re.search(r"inet (\d+\.\d+\.\d+\.\d+)/", result.stdout)
-        return m.group(1) if m else None
-    except Exception:
-        return None
+    except Exception as exc:
+        return None, f"`ip addr show eth0` failed: {exc!r}"
+    m = re.search(r"inet (\d+\.\d+\.\d+\.\d+)/", result.stdout)
+    if not m:
+        return None, "`ip addr show eth0` printed no inet address"
+    return m.group(1), None
 
 
 def get_portproxy_wsl_ip():
-    """Read current portproxy rule for our port from Windows via PowerShell."""
+    """Read current portproxy rule for our port from Windows via PowerShell.
+
+    Returns (ip, None) when the rule was read, (None, None) when the read
+    succeeded and there is genuinely no rule, and (None, reason) when the read
+    could not be made — those last two are opposite findings, and collapsing them
+    turned "I could not ask Windows" into "there is no rule, go run netsh".
+    """
     try:
         result = subprocess.run(
             ["powershell.exe", "-Command",
              f"netsh interface portproxy show v4tov4 | Select-String '{A2A_PORT}'"],
             capture_output=True, text=True, timeout=10
         )
-        m = re.search(rf"{re.escape(TAILSCALE_IP)}\s+{A2A_PORT}\s+(\d+\.\d+\.\d+\.\d+)", result.stdout)
-        return m.group(1) if m else None
-    except Exception:
-        return None
+    except Exception as exc:
+        return None, f"netsh portproxy read failed: {exc!r}"
+    m = re.search(rf"{re.escape(TAILSCALE_IP)}\s+{A2A_PORT}\s+(\d+\.\d+\.\d+\.\d+)", result.stdout)
+    return (m.group(1) if m else None), None
 
 
 def write_portproxy_script(wsl_ip):
@@ -136,8 +151,18 @@ if not check_health():
         alerts.append(f"  Logs:  journalctl --user -u {SERVICE} -n 50")
 
 # ── 2. Portproxy IP drift check ──────────────────────────────────────────────
-wsl_ip = get_wsl_ip()
-proxy_ip = get_portproxy_wsl_ip()
+wsl_ip, wsl_err = get_wsl_ip()
+proxy_ip, proxy_err = get_portproxy_wsl_ip()
+
+# A probe that could not run is not a reading, and both failures are silent by
+# default: no output is no cron delivery. Say so instead.
+if wsl_err:
+    alerts.append(f"Could not read the WSL eth0 IP — portproxy drift NOT checked. {wsl_err}")
+if proxy_err:
+    alerts.append(
+        f"Could not read the Windows portproxy rule for port {A2A_PORT} — drift NOT "
+        f"checked. {proxy_err}"
+    )
 
 # write_portproxy_script returns False when the write failed (read-only FS, bad
 # permissions). Reporting "script written" regardless told the operator to go run a
@@ -151,8 +176,8 @@ if wsl_ip and proxy_ip and wsl_ip != proxy_ip:
         alerts.append(f"Run elevated: powershell -ExecutionPolicy Bypass -File {PORTPROXY_PS1}")
     else:
         alerts.append(f"Portproxy rule is stale, and {PORTPROXY_PS1} could NOT be written.")
-elif wsl_ip and not proxy_ip:
-    # No portproxy rule at all
+elif wsl_ip and not proxy_ip and not proxy_err:
+    # The read succeeded and returned no rule: there really is no portproxy rule.
     alerts.append(f"No portproxy rule found for port {A2A_PORT}.")
     if write_portproxy_script(wsl_ip):
         alerts.append(f"Script written to {PORTPROXY_PS1} — run elevated to apply.")

--- a/scripts/hooks/pre_llm_grounding.py
+++ b/scripts/hooks/pre_llm_grounding.py
@@ -484,10 +484,13 @@ def _clean_content(content: str) -> str:
 
 
 def _format_results(hits: list[dict], query: str, used_fallback: bool,
-                    unreachable: int = 0) -> str:
+                    unreachable: int = 0, searched: int | None = None) -> str:
     """Render the recall block. ``unreachable`` is the number of collections whose
     search failed this turn; the header states real coverage, because the model is
-    asked to trust it as "this is what memory holds"."""
+    asked to trust it as "this is what memory holds". ``searched`` overrides
+    len(COLLECTIONS) for a caller that queries a subset — the subagent path below
+    searches loci_memory only, and claiming all of COLLECTIONS answered is the same
+    kind of over-statement as hiding an outage."""
     lines = []
     seen = set()
     for h in hits:
@@ -509,14 +512,15 @@ def _format_results(hits: list[dict], query: str, used_fallback: bool,
     if not lines:
         return GROUNDING_DIRECTIVE
 
+    total = len(COLLECTIONS) if searched is None else searched
     if used_fallback:
         src = "BeamMemory fallback"
     elif unreachable:
-        reached = max(len(COLLECTIONS) - unreachable, 0)
-        src = (f"{reached} of {len(COLLECTIONS)} Qdrant collections "
+        reached = max(total - unreachable, 0)
+        src = (f"{reached} of {total} Qdrant collections "
                f"({unreachable} unreachable)")
     else:
-        src = f"{len(COLLECTIONS)} Qdrant collections"
+        src = f"{total} Qdrant collection" + ("" if total == 1 else "s")
     header = f'MEMORY MATCH ({len(lines)} results from {src}) for "{query}":'
     body = "\n".join(lines)
     footer = (
@@ -568,6 +572,7 @@ def main() -> None:
     # loci_memory only: the collection most relevant to code generation mid-investigation.
     if is_subagent:
         sub_hits: list[dict] = []
+        sub_used_fallback = False
         if QDRANT_URL:
             sub_vec = _embed(intent)
             if sub_vec is not None:
@@ -578,6 +583,7 @@ def main() -> None:
                     )
                 except _SearchFailed:
                     sub_hits = _beam_fallback(intent)
+                    sub_used_fallback = True
                 sub_hits = [h for h in sub_hits if h["importance"] >= MIN_IMPORTANCE]
                 _sub_ts = time.time()
                 for h in sub_hits:
@@ -585,9 +591,11 @@ def main() -> None:
                 sub_hits = sorted(sub_hits, key=lambda h: h["_ms_score"], reverse=True)[:2]
             else:
                 sub_hits = _beam_fallback(intent)
+                sub_used_fallback = True
 
         if sub_hits:
-            recall_block = _format_results(sub_hits, intent, False)
+            recall_block = _format_results(sub_hits, intent, sub_used_fallback,
+                                           searched=1)
         else:
             recall_block = (
                 "[WARNING: memory grounding unavailable in subagent context — "

--- a/scripts/hooks/tests/test_pre_llm_grounding.py
+++ b/scripts/hooks/tests/test_pre_llm_grounding.py
@@ -889,12 +889,22 @@ def test_format_results_fallback_source_label(hook):
     assert "from BeamMemory fallback" in hook._format_results(hits, "q", True)
 
 
-def test_format_results_source_label_counts_all_collections_even_when_unused(hook):
-    """Note: the label reports len(COLLECTIONS), not how many were searched --
-    the subagent path searches one collection but still claims three."""
+def test_format_results_source_label_defaults_to_every_configured_collection(hook):
+    """With no `searched` override the label reports len(COLLECTIONS) -- correct
+    for the main-session fan-out, which queries all of them."""
     hits = [{"collection": "loci_memory", "score": 0.5, "content": "x"}]
     hook.COLLECTIONS = hook.COLLECTIONS + [("extra", "text", None, True)]
     assert "from 4 Qdrant collections" in hook._format_results(hits, "q", False)
+
+
+def test_format_results_searched_override_states_the_real_collection_count(hook):
+    """A caller that queried a subset says so; the header is a coverage claim."""
+    hits = [{"collection": "loci_memory", "score": 0.5, "content": "x"}]
+    out = hook._format_results(hits, "q", False, searched=1)
+    assert out.splitlines()[0] == (
+        'MEMORY MATCH (1 results from 1 Qdrant collection) for "q":'
+    )
+    assert "3 Qdrant collections" not in out
 
 
 def test_format_results_dedupes_on_first_80_chars(hook):
@@ -1407,8 +1417,44 @@ def test_subagent_falls_back_to_beam_when_embedding_fails(hook):
     _, out = run_main(hook, _prompt(task_id="subagent-1"))
     ctx = context_of(out)
     assert "[mnemosyne-beam|0.60] beam says hi" in ctx
-    # used_fallback is hard-coded False on this path -> label is wrong
-    assert "Qdrant collections" in ctx and "BeamMemory fallback" not in ctx
+    # These are BeamMemory rows: the header must not attribute them to Qdrant.
+    assert "from BeamMemory fallback" in ctx
+    assert "Qdrant collection" not in ctx
+
+
+def test_subagent_search_failure_labels_the_beam_fallback_as_such(hook):
+    """A _SearchFailed on the one collection this path queries must not still
+    render as 'from N Qdrant collections' -- the header is a provenance claim the
+    subagent is told to trust as 'this is what memory holds'."""
+    def _boom(*a, **k):
+        raise hook._SearchFailed("qdrant down")
+
+    hook._embed = lambda t: [0.1]
+    hook._search_collection = _boom
+    hook._beam_fallback = lambda q: [{"collection": "mnemosyne_beam", "score": 0.6,
+                                      "importance": 0.9, "fused": 0.5,
+                                      "content": "beam says hi", "payload": {}}]
+    hook._load_rules_summary = lambda: ""
+    _, out = run_main(hook, _prompt(task_id="subagent-1"))
+    ctx = context_of(out)
+    assert "beam says hi" in ctx
+    assert "from BeamMemory fallback" in ctx
+    assert "Qdrant collection" not in ctx
+
+
+def test_subagent_healthy_header_counts_the_one_collection_it_searched(hook):
+    """The subagent path searches loci_memory only; it must not report that all
+    of COLLECTIONS answered."""
+    hook._embed = lambda t: [0.1]
+    hook._search_collection = lambda *a, **k: [
+        {"collection": "loci_memory", "point_id": None, "score": 0.9,
+         "importance": 0.9, "fused": 0.81, "content": "a finding", "payload": {}}]
+    hook._load_rules_summary = lambda: ""
+    _, out = run_main(hook, _prompt(task_id="subagent-1"))
+    ctx = context_of(out)
+    assert ctx.splitlines()[0].startswith(
+        "MEMORY MATCH (1 results from 1 Qdrant collection) for "
+    )
 
 
 def test_subagent_filters_importance_and_caps_at_two(hook):

--- a/scripts/mnemosyne_activity_check.py
+++ b/scripts/mnemosyne_activity_check.py
@@ -4,6 +4,11 @@ Mnemosyne activity watchdog — multi-bank.
 Checks default bank (via mnemosyne CLI) and dama-gotchi bank (via SQLite).
 Outputs a line only if working_memory has grown in any bank since last check.
 Silent when idle — prevents agent cron from burning tokens.
+
+A probe that could not run says so instead of reporting 0. 0 is a real
+working_memory count, and it can never exceed the stored high-water mark, so a
+broken probe reporting 0 makes this watchdog permanently silent — and silence is
+the contract above for "nothing to do".
 """
 import os
 import re
@@ -34,29 +39,38 @@ def _write_state(path: str, count: int) -> None:
         f.write(str(count))
 
 
-def get_default_wm_count() -> int:
-    """Get working_memory count from default bank via mnemosyne CLI."""
+def get_default_wm_count() -> "tuple[int | None, str | None]":
+    """working_memory count from the default bank via the mnemosyne CLI.
+
+    Returns (count, None) or (None, reason). MNEM is an absolute path into
+    another project's venv; check_output hides every symptom of it going stale.
+    """
     try:
         out = subprocess.check_output(
             [MNEM, "stats"], stderr=subprocess.DEVNULL, text=True, timeout=8
         )
-        m = re.search(r"Working memory:\s*(\d+)", out)
-        return int(m.group(1)) if m else 0
-    except Exception:
-        return 0
+    except Exception as exc:
+        return None, f"{MNEM} stats failed: {exc!r}"
+    m = re.search(r"Working memory:\s*(\d+)", out)
+    if not m:
+        return None, f"{MNEM} stats printed no 'Working memory:' line"
+    return int(m.group(1)), None
 
 
-def get_damagotchi_wm_count() -> int:
-    """Get working_memory count from dama-gotchi bank via SQLite."""
+def get_damagotchi_wm_count() -> "tuple[int | None, str | None]":
+    """working_memory count from the dama-gotchi bank via SQLite.
+
+    A missing DB is 'the bank moved', not 'the bank is empty'.
+    """
     if not os.path.exists(DAMA_DB):
-        return 0
+        return None, f"bank DB not found: {DAMA_DB}"
     try:
         conn = sqlite3.connect(DAMA_DB)
         count = conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
         conn.close()
-        return int(count)
-    except Exception:
-        return 0
+    except Exception as exc:
+        return None, f"{DAMA_DB} query failed: {exc!r}"
+    return int(count), None
 
 
 # ── check both banks ──────────────────────────────────────────────────────────
@@ -67,16 +81,29 @@ BANKS = [
 ]
 
 grew_parts = []
+blind_parts = []
 
 for bank_name, count_fn, state_file in BANKS:
-    current = count_fn()
+    current, err = count_fn()
+    if current is None:
+        blind_parts.append(f"{bank_name} ({err})")
+        continue
     last = _read_state(state_file)
 
     if current > last:
         _write_state(state_file, current)
         grew_parts.append(f"{bank_name}: {last}->{current} (+{current - last})")
 
+lines = []
 if grew_parts:
     detail = ", ".join(grew_parts)
-    print(f"working_memory grew: {detail}. Run mnemosyne_sleep now.")
+    lines.append(f"working_memory grew: {detail}. Run mnemosyne_sleep now.")
+if blind_parts:
+    lines.append(
+        "WARNING: working_memory could not be read for " + ", ".join(blind_parts)
+        + ". This is NOT idle — that bank is unmonitored until the probe is fixed."
+    )
+
+if lines:
+    print("\n".join(lines))
 # else: silent — cron agent won't fire tokens

--- a/scripts/tests/test_a2a_watchdog.py
+++ b/scripts/tests/test_a2a_watchdog.py
@@ -1,0 +1,134 @@
+"""scripts/a2a_watchdog.py — a probe that could not run must not read as healthy.
+
+The file's contract is 'silent on healthy; prints only on problems', so silence
+is what the operator (and cron) reads as 'the portproxy is fine'. Both read
+probes used to collapse an exception into the same None a successful read with
+no match returns, producing two opposite wrong answers:
+
+  * get_wsl_ip failing skipped BOTH drift branches -> total silence while the
+    A2A server was unreachable over Tailscale.
+  * get_portproxy_wsl_ip failing rendered as 'No portproxy rule found', and sent
+    the operator to run an elevated netsh command on a read that never happened.
+
+The module runs at import, so each test execs a fresh copy with subprocess.run
+and urlopen patched. Stdlib only: the test-scripts CI job installs pytest,
+pytest-timeout and aiohttp and nothing else.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import pathlib
+import subprocess
+import sys
+import urllib.request
+from unittest import mock
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "a2a_watchdog.py"
+
+TAILSCALE_IP = "100.64.0.1"
+PORT = "8201"
+
+
+class _Healthy:
+    """What urlopen returns for a live health endpoint."""
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _Proc:
+    """What subprocess.run returns; the watchdog reads .stdout only."""
+
+    def __init__(self, stdout=""):
+        self.stdout = stdout
+
+
+def run_script(tmp_path, ip_result, netsh_result):
+    """Exec a fresh copy of the watchdog; return its stdout.
+
+    ``ip_result`` / ``netsh_result`` are either a _Proc or an Exception to raise
+    from subprocess.run for that command.
+    """
+    def fake_run(argv, **kw):
+        out = ip_result if argv[0] == "ip" else netsh_result
+        if isinstance(out, Exception):
+            raise out
+        return out
+
+    env = {
+        "HOME": str(tmp_path),
+        "LOCI_TAILSCALE_IP": TAILSCALE_IP,
+        "LOCI_A2A_PORT": PORT,
+        "LOCI_PORTPROXY_PS1": str(tmp_path / "portproxy.ps1"),
+    }
+    out = io.StringIO()
+    with mock.patch.dict(os.environ, env, clear=False), \
+            mock.patch.object(subprocess, "run", fake_run), \
+            mock.patch.object(urllib.request, "urlopen",
+                              lambda *a, **k: _Healthy()):
+        spec = importlib.util.spec_from_file_location("_a2a_watchdog_uut", SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        with contextlib.redirect_stdout(out):
+            spec.loader.exec_module(mod)
+    sys.modules.pop("_a2a_watchdog_uut", None)
+    return out.getvalue()
+
+
+def _ip_addr(ip="172.28.1.5"):
+    return _Proc(f"    inet {ip}/20 brd 172.28.15.255 scope global eth0\n")
+
+
+def _netsh(ip="172.28.1.5"):
+    return _Proc(f"{TAILSCALE_IP}     {PORT}     {ip}     {PORT}\n")
+
+
+def test_healthy_and_matching_stays_silent(tmp_path):
+    """The contract this all rests on: nothing to say means no output."""
+    assert run_script(tmp_path, _ip_addr(), _netsh()) == ""
+
+
+def test_real_drift_is_still_reported(tmp_path):
+    out = run_script(tmp_path, _ip_addr("172.28.9.9"), _netsh("172.28.1.5"))
+    assert "WSL IP changed: 172.28.1.5 -> 172.28.9.9" in out
+    assert (tmp_path / "portproxy.ps1").exists()
+
+
+def test_a_genuinely_absent_rule_is_still_reported(tmp_path):
+    """netsh answered and listed no rule for our port: that IS 'no rule'."""
+    out = run_script(tmp_path, _ip_addr(), _Proc(""))
+    assert f"No portproxy rule found for port {PORT}." in out
+    assert "run elevated to apply" in out
+
+
+def test_unreadable_wsl_ip_breaks_the_silence(tmp_path):
+    """`ip` missing from PATH under cron skipped both drift branches, and this
+    file defines silence as healthy."""
+    out = run_script(tmp_path, FileNotFoundError("no ip"), _netsh())
+    assert out.strip(), "a probe that never ran must not render as healthy"
+    assert "Could not read the WSL eth0 IP" in out
+    assert "drift NOT checked" in out
+
+
+def test_eth0_without_an_inet_address_breaks_the_silence(tmp_path):
+    """`ip` ran but eth0 has no IPv4 — also not a reading."""
+    out = run_script(tmp_path, _Proc("    link/ether 00:15:5d:00:00:01\n"), _netsh())
+    assert "printed no inet address" in out
+
+
+def test_unreadable_portproxy_does_not_claim_the_rule_is_missing(tmp_path):
+    """powershell.exe off PATH must not become the affirmative claim 'there is
+    no rule' plus an instruction to go run an elevated netsh command."""
+    out = run_script(tmp_path, _ip_addr(), FileNotFoundError("no powershell.exe"))
+    assert "Could not read the Windows portproxy rule" in out
+    assert f"No portproxy rule found for port {PORT}." not in out
+    assert "run elevated to apply" not in out
+    assert not (tmp_path / "portproxy.ps1").exists(), \
+        "no script should be written on the strength of a read that never happened"

--- a/scripts/tests/test_mnemosyne_activity_check.py
+++ b/scripts/tests/test_mnemosyne_activity_check.py
@@ -1,0 +1,116 @@
+"""scripts/mnemosyne_activity_check.py — a broken probe must break the silence.
+
+The script's contract is 'output only when working_memory grew; silent when
+idle', and a cron agent reads that silence as 'nothing to do'. Both probes used
+to return 0 on failure, which is a real count that can never exceed the stored
+high-water mark — so a dead mnemosyne CLI or a moved bank DB rendered as idle,
+forever, because the high-water mark is only refreshed inside the growth branch.
+
+The module does all of its work at import time, so each test execs a fresh copy
+under a controlled HOME. Stdlib only: the test-scripts CI job installs pytest,
+pytest-timeout and aiohttp and nothing else.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import pathlib
+import sqlite3
+import sys
+from unittest import mock
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "mnemosyne_activity_check.py"
+
+
+def run_script(home: pathlib.Path) -> str:
+    """Exec a fresh copy of the script with HOME redirected; return its stdout."""
+    out = io.StringIO()
+    with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+        spec = importlib.util.spec_from_file_location("_mnem_activity_uut", SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        with contextlib.redirect_stdout(out):
+            spec.loader.exec_module(mod)
+    sys.modules.pop("_mnem_activity_uut", None)
+    return out.getvalue()
+
+
+def _make_bank(home: pathlib.Path, rows: int) -> None:
+    """Create the dama-gotchi bank DB the script probes, with `rows` entries."""
+    db = home / ".hermes/mnemosyne/data/banks/dama-gotchi/mnemosyne.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE working_memory (id INTEGER PRIMARY KEY)")
+    conn.executemany("INSERT INTO working_memory (id) VALUES (?)",
+                     [(i,) for i in range(rows)])
+    conn.commit()
+    conn.close()
+
+
+def _state(home: pathlib.Path, name: str, value: int) -> None:
+    p = home / ".hermes/mnemosyne" / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(str(value))
+
+
+def test_unreadable_banks_warn_instead_of_reporting_idle(tmp_path):
+    """Neither probe can run (no mnemosyne CLI, no bank DB under this HOME) and
+    both high-water marks are positive. Reporting 0 for both left this silent."""
+    _state(tmp_path, "last_wm_count.txt", 1413)
+    _state(tmp_path, "last_wm_count_dama-gotchi.txt", 52)
+
+    out = run_script(tmp_path)
+
+    assert out.strip(), "a probe that could not run must not read as 'idle'"
+    assert "WARNING" in out
+    assert "default" in out and "dama-gotchi" in out
+    assert "NOT idle" in out
+
+
+def test_one_dead_probe_does_not_suppress_the_other_bank_growth(tmp_path):
+    """The mnemosyne CLI is missing but the dama-gotchi bank grew: the growth
+    line must still be emitted, alongside the warning for the dead probe."""
+    _make_bank(tmp_path, rows=60)
+    _state(tmp_path, "last_wm_count_dama-gotchi.txt", 52)
+
+    out = run_script(tmp_path)
+
+    assert "working_memory grew: dama-gotchi: 52->60 (+8)" in out
+    assert "Run mnemosyne_sleep now." in out
+    assert "WARNING" in out and "default" in out
+
+
+def test_a_measured_zero_is_still_silent(tmp_path):
+    """0 keeps meaning 'the bank really is empty'. The bank DB is present and
+    holds nothing, the mark is 0 — that is genuinely idle, and stays quiet."""
+    _make_bank(tmp_path, rows=0)
+    _state(tmp_path, "last_wm_count_dama-gotchi.txt", 0)
+    # Give the default bank a working CLI so it has nothing to say either.
+    cli = tmp_path / ".hermes/hermes-agent/venv/bin/mnemosyne"
+    cli.parent.mkdir(parents=True, exist_ok=True)
+    cli.write_text("#!/bin/sh\necho '  Working memory: 7'\n")
+    cli.chmod(0o755)
+    _state(tmp_path, "last_wm_count.txt", 7)
+
+    assert run_script(tmp_path) == ""
+
+
+def test_growth_is_reported_and_the_high_water_mark_is_advanced(tmp_path):
+    _make_bank(tmp_path, rows=99)
+    _state(tmp_path, "last_wm_count_dama-gotchi.txt", 90)
+    cli = tmp_path / ".hermes/hermes-agent/venv/bin/mnemosyne"
+    cli.parent.mkdir(parents=True, exist_ok=True)
+    cli.write_text("#!/bin/sh\necho '  Working memory: 2010'\n")
+    cli.chmod(0o755)
+    _state(tmp_path, "last_wm_count.txt", 1413)
+
+    out = run_script(tmp_path)
+
+    assert "default: 1413->2010 (+597)" in out
+    assert "dama-gotchi: 90->99 (+9)" in out
+    assert "WARNING" not in out
+    assert (tmp_path / ".hermes/mnemosyne/last_wm_count.txt").read_text() == "2010"
+    # Second run over the same state is idle again.
+    assert run_script(tmp_path) == ""


### PR DESCRIPTION
Four exception handlers that returned the value the healthy path returns, so the consumer read a failure as an affirmative result.

## What was wrong, and the evidence it was real

**1. `mcp/server.py:1602` — `_compute_aggregate_confidence` ended in `except Exception: return 1.0`.**
1.0 is the top of the confidence scale *and* the identity element of the product this function computes — the one value that asserts perfect certainty while constraining nothing. It is also the documented answer for "finding not found / chain empty", so a crash and a clean unconstrained chain were the same reading. `_pre_answer_chain_confidence` (3518) takes `min()` over these and buckets `>=0.8` as `high`; that pair is emitted as `min_chain_confidence` / `confidence_summary` by `investigation_pre_answer_check` — the tool an agent calls to decide whether its evidence is strong enough to answer. A walk that never ran produced the strongest possible claim about it.

The invariant was already the file's own: `_node_numeric_confidence` (`mcp/inv_store.py:53-69`) refuses to score an unstamped record 1.0 ("Absence is not certainty"), this function's docstring repeats the argument, `mcp/investigation_tools.py:681` returns `None` from the same product on exception, and `mcp/tests/test_mcp_integration.py:845` already pinned "aggregate over unstamped nodes must not be 1.0". The outer handler defeated exactly that.

Reachability is narrow and worth stating: the live path is `parents = node.get("derived_from") or []` then `parents[0]`, so a truthy non-subscriptable `derived_from` raises `TypeError`. Every shipped writer goes through `_normalize_derived_from`, so no current producer emits that shape — a hand-edited or externally imported `findings.jsonl` row can.

**2. `scripts/mnemosyne_activity_check.py:46` — both probes returned `0` on failure.**
0 is a real `working_memory` count. The module compares `current > last` against a stored high-water mark, so 0 can never exceed a positive `last`, and the mark is only rewritten inside the growth branch — once a probe breaks, nothing re-arms it. A dead mnemosyne CLI (`MNEM` is an absolute path into another project's venv) or a moved bank DB therefore rendered as permanent silence, and the file's own docstring defines silence as "nothing to do".

**3. `scripts/a2a_watchdog.py:64` — two opposite wrong answers from one handler class.**
`get_wsl_ip()` failing returned the same bare `None` as "no match", which skipped *both* drift branches: total silence, and the contract at line 11 is "silent on healthy". `get_portproxy_wsl_ip()` failing turned "I could not ask Windows" into the affirmative claim `No portproxy rule found for port 8201`, wrote a `.ps1`, and told the operator to go run an elevated `netsh` — on a read that never happened. The file already carried the corrected version of this reasoning at 142-145, for `write_portproxy_script`'s `False`, but not for the two read probes above it.

**4. `scripts/hooks/pre_llm_grounding.py:580` — the subagent recall header lied about provenance.**
Both fallback branches set `sub_hits = _beam_fallback(intent)` and then rendered with `_format_results(sub_hits, intent, False)` — `used_fallback=False`, i.e. "Qdrant answered". The header is a coverage and provenance claim the subagent is explicitly told to trust as "this is what memory holds" (docstring, 488-490). The count was wrong on the healthy path too: that path searches `loci_memory` alone (576) but reported `len(COLLECTIONS)` — 3 by default. The main-session path at 698 already gets both right.

## What changed

- `_compute_aggregate_confidence` returns `None` on a failed walk (matching `investigation_finding_provenance`), and `_pre_answer_chain_confidence` skips `None` rather than letting it enter the `min()`. The genuinely empty chain keeps its documented 1.0. No caller contract breaks: `_pre_answer_chain_confidence` was already typed `tuple[float | None, str | None]` and already returned `(None, None)` on its own fail-open path, so `min_chain_confidence` / `confidence_summary` were already nullable in the tool response, and nothing else in the repo reads those fields.
- Both mnemosyne probes return `(count, reason)`. An unreadable bank gets a distinct `WARNING:` line naming it; `0` keeps meaning "measured zero" and stays silent.
- Both a2a probes return `(value, reason)`. A failed read is alerted as a failed read, and the "no portproxy rule" branch now fires only when the read actually succeeded (`not proxy_err`) — so no `.ps1` is written and no elevated-netsh instruction is issued on a read that never happened.
- The subagent path tracks its fallback in a local and passes it, plus `searched=1` — a literal fact about the call, which queries one collection. `_format_results` gained an optional `searched` override; with it omitted the main-session fan-out still reports `len(COLLECTIONS)`, unchanged.

## Tests, and that they fail without the fix

Each was verified red by restoring only the production file to `origin/main` and re-running:

| reverted file | result |
|---|---|
| `mcp/server.py` | 2 failed, 5 passed — `AssertionError: 1.0 is not None : a failed walk must not become a confidence value` |
| `scripts/hooks/pre_llm_grounding.py` | 4 failed, 185 passed — `TypeError: _format_results() got an unexpected keyword argument 'searched'`; `assert 'from BeamMemory fallback' in 'MEMORY MATCH (1 results from 3 Qdrant...'` |
| `scripts/mnemosyne_activity_check.py` | 2 failed, 2 passed — `a probe that could not run must not read as 'idle'` (stdout empty) |
| `scripts/a2a_watchdog.py` | 3 failed, 3 passed — `assert 'Could not read the Windows portproxy rule' in 'No portproxy rule found for port 8201.\nScript written to .../portproxy.ps1 — run elevated to apply.\n'` |

Every suite pins **both** directions, so the distinction is what is tested rather than the new value: `test_a_measured_zero_is_still_silent`, `test_a_genuinely_absent_rule_is_still_reported`, `test_healthy_and_matching_stays_silent`, `test_real_drift_is_still_reported`, and the walkable-chain half of `test_pre_answer_chain_confidence_...` all pass in both states.

Green: `pytest mcp/tests scripts/tests scripts/hooks/tests -q` → 1611 passed, 1 failed, 10 subtests passed. The single failure is `mcp/tests/test_graph_integration.py::test_code_graph_ingest_and_query` (`KeyError: 'ingested'`), reproduced identically on a clean `origin/main` worktree; main's CI is green, so it is a local graph-backend condition, not this branch.

The two new files live under `scripts/tests/`, are stdlib + `unittest.mock` only, and import no repo module — they exec a fresh copy of the script under a redirected `HOME`. Reproduced the `test-scripts` CI job exactly (`working-directory: scripts`, a venv holding only pytest/pytest-timeout/aiohttp, `pytest tests/ hooks/tests/ --timeout=30`) → 769 passed. Also confirmed on this machine that they touch no real state: `~/.hermes/mnemosyne/last_wm_count*` unchanged, no `~/.hermes-a2a-watchdog-state.json`, nothing written to `/mnt/c/tmp/`.

Other gates run locally: `ruff check ... --select E9,F401,F811,F821,F841 --ignore E402` clean; `vulture` with the exact CI invocation exit 0; `scripts/check_vulture_whitelist.py` → "all 55 entries still suppress a live finding"; `scripts/callgraph/tests` passes, including `test_corpus_is_exactly_126_files` (both new files are under `scripts/tests/`, which the corpus excludes).

## Deliberately left alone

- **`cron/jobs.json`.** `mnemosyne-consolidation` (every 20m, enabled) runs `mnemosyne_activity_check.py`, and its agent prompt gates on "if the script output above is empty or blank — output nothing and stop", then only defines behaviour for output containing `working_memory grew`. The new `WARNING:` line is output that prompt has no instruction for. Not fixed here because `cron/jobs.json` carries live scheduler state (`last_run_at` / `state` / `next_run_at`) and editing it in a PR invites a conflict with the running scheduler. A one-line prompt addition — "if the output starts with WARNING, echo it verbatim and stop" — closes it.
- **`_read_state()` in `mnemosyne_activity_check.py`** still returns 0 for an unreadable state file. Same class, but the failure direction is loud (it over-reports growth once) rather than silent, and it was not in the findings.

Nothing dormant is armed by merging. Both cron jobs that run `mnemosyne_activity_check.py` have `last_run_at: null` — the repo's own crontab comment records that `cron/jobs.json`'s enabled jobs have never fired (loci #205) — and on this machine both probes currently succeed, so the new warning would not trigger even if they did. `a2a_watchdog.py` is referenced by nothing: not in the crontab, not a systemd timer, not by any other file in the repo. The live grounding hook is a separately deployed copy at `~/.claude/hooks/pre_llm_grounding.py` that has already drifted from the repo, so merging does not deploy it. No new writes, subprocess calls, or network calls are introduced on any path.
