### PR TITLE
Stop three loops from dropping every record they were meant to read

### DIFF
--- a/mlops/embedding/drift.py
+++ b/mlops/embedding/drift.py
@@ -94,20 +94,26 @@ def build_anchor(
         return {"error": "no texts found in dataset"}
 
     embeddings = []
+    # measure_drift() pairs anchor_embs[i] with texts[i], so the saved texts must
+    # be the ones that actually embedded. Slicing texts[:len(embeddings)] drops
+    # from the tail while the failure happened mid-list, which silently shifted
+    # every later text against a stranger's vector for the life of the anchor.
+    kept = []
     for i, text in enumerate(texts):
         try:
             vec = _embed(text, ollama_url, model)
-            embeddings.append(vec)
         except Exception as exc:
             print(f"[drift] embed failed for sample {i}: {exc}", file=sys.stderr)
             continue
+        embeddings.append(vec)
+        kept.append(text)
 
     if not embeddings:
         return {"error": "all embeddings failed"}
 
     arr = np.array(embeddings, dtype=np.float32)
     Path(anchor_path).parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(anchor_path, embeddings=arr, texts=texts[:len(embeddings)])
+    np.savez_compressed(anchor_path, embeddings=arr, texts=kept)
     print(f"[drift] anchor built: {len(embeddings)} embeddings → {anchor_path}")
     return {"n_anchored": len(embeddings), "anchor_path": anchor_path}
 

--- a/mlops/embedding/tests/test_embedding.py
+++ b/mlops/embedding/tests/test_embedding.py
@@ -381,13 +381,13 @@ def test_build_anchor_respects_n(tmp_path, monkeypatch):
     assert result["n_anchored"] == 2
 
 
-def test_build_anchor_partial_failure_misaligns_texts_and_embeddings(tmp_path, monkeypatch):
-    """BUG: on a mid-list embedding failure, texts are truncated with `texts[:len(embs)]`
-    instead of tracking which texts actually succeeded.
+def test_build_anchor_partial_failure_keeps_texts_aligned_with_embeddings(tmp_path, monkeypatch):
+    """A mid-list embedding failure must drop that text, not the tail.
 
-    Sampled order for this dataset is C, A, B. Failing on A drops row 1, so the saved
-    embeddings are [vec(C), vec(B)] while the saved texts are ["C...", "A..."]. Row 1 now
-    pairs text "A" with B's vector.
+    Sampled order for this dataset is C, A, B. Failing on A must leave ["C", "B"]
+    against [vec(C), vec(B)]; the old `texts[:len(embeddings)]` slice saved
+    ["C", "A"] instead, so measure_drift() compared A's live vector with B's
+    anchor vector for the life of the anchor file.
     """
     import numpy as np
 
@@ -404,9 +404,34 @@ def test_build_anchor_partial_failure_misaligns_texts_and_embeddings(tmp_path, m
     assert D.build_anchor(str(ds), anchor_path=str(anchor))["n_anchored"] == 2
 
     z = np.load(anchor, allow_pickle=True)
-    assert [t[0] for t in z["texts"].tolist()] == ["C", "A"]
-    assert z["embeddings"].tolist() == [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]]  # C's vec, then B's
-    # -> row 1 claims to be text "A" but holds the embedding of text "B"
+    assert [t[0] for t in z["texts"].tolist()] == ["C", "B"]
+    assert z["embeddings"].tolist() == [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]]
+
+
+def test_measure_drift_reads_back_a_partially_failed_anchor_as_no_drift(tmp_path, monkeypatch):
+    """End to end: build an anchor over a flaky embedder, then measure against the
+    same embedder. Every surviving text must meet its own vector, so cosine is 1.0
+    and nothing is reported as drifted. Under the tail-slice bug the second row met
+    a stranger's vector and reported drift the model had not undergone."""
+    ds = _write_jsonl(tmp_path / "d.jsonl", [{"text": _long(c)} for c in "ABC"])
+    vecs = {"A": [1.0, 0.0, 0.0], "B": [0.0, 1.0, 0.0], "C": [0.0, 0.0, 1.0]}
+
+    def flaky(text, url, model):
+        if text.startswith("A"):
+            raise RuntimeError("boom")
+        return vecs[text[0]]
+
+    monkeypatch.setattr(D, "_embed", flaky)
+    anchor = tmp_path / "a.npz"
+    D.build_anchor(str(ds), anchor_path=str(anchor))
+
+    # The transient failure is over by measurement time — the usual case, and the
+    # one where a misaligned anchor is invisible rather than merely skipped.
+    monkeypatch.setattr(D, "_embed", lambda text, url, model: vecs[text[0]])
+    result = D.measure_drift(anchor_path=str(anchor))
+    assert result["mean_cosine"] == pytest.approx(1.0)
+    assert result["n_drifted_095"] == 0
+    assert result["exceeded"] is False
 
 
 # ======================================================================================

--- a/mlops/grounding/active_learn.py
+++ b/mlops/grounding/active_learn.py
@@ -56,6 +56,28 @@ def _load_dataset(dataset_path: str) -> list[dict]:
     return records
 
 
+def _record_pair(rec: dict) -> tuple[str, str]:
+    """(claim, evidence) for one dataset row.
+
+    grounding_dataset.jsonl rows are {claim, evidence, label, signal, cos} — none
+    of text/content/query exists on any of them, so the old field chain measured
+    every row as too short and dropped the whole corpus before scoring.
+    """
+    claim = (rec.get("text") or rec.get("claim") or rec.get("content")
+             or rec.get("query", ""))
+    evidence = rec.get("evidence") or rec.get("context", "")
+    return claim, evidence
+
+
+def _feature_contract():
+    """deep_think_loci/grounding/features.py — the one grounding feature contract."""
+    grounding = Path(__file__).resolve().parents[2] / "deep_think_loci" / "grounding"
+    if str(grounding) not in sys.path:
+        sys.path.insert(0, str(grounding))
+    import features
+    return features
+
+
 def boundary_samples(
     model_path: str,
     dataset_path: str,
@@ -68,6 +90,8 @@ def boundary_samples(
         return []
     try:
         import joblib
+        import numpy as np
+        _feat = _feature_contract()
         clf = joblib.load(model_path)
     except Exception as exc:
         print(f"[active_learn] could not load model: {exc}", file=sys.stderr)
@@ -77,18 +101,65 @@ def boundary_samples(
     if not records:
         return []
 
-    scored = []
-    for rec in records:
-        text = rec.get("text") or rec.get("content") or rec.get("query", "")
-        if len(text) < 20:
-            continue
-        try:
-            vec = _embed(text, ollama_url, embed_model)
-            proba = clf.predict_proba([vec])[0][1]
-            uncertainty = abs(proba - 0.5)
-            scored.append({"rec": rec, "proba": float(proba), "uncertainty": float(uncertainty)})
-        except Exception:
-            continue
+    # The live classifier scores (claim, evidence) PAIRS at the width it was
+    # trained on. This handed it one raw 768-d embedding, so predict_proba raised
+    # on every record and the per-record `except: continue` ate it — a field-name
+    # fix alone would still have scored nothing, just slower.
+    dim = int(getattr(clf, "n_features_in_", _feat.LEGACY_DIM))
+    if dim not in _feat.supported_dims():
+        print(f"[active_learn] {model_path} expects {dim} features; this sampler "
+              f"builds {_feat.supported_dims()} — refusing to score with a model "
+              "whose feature contract is unknown.", file=sys.stderr)
+        return []
+
+    usable = [(rec, c, e) for rec, (c, e) in ((r, _record_pair(r)) for r in records)
+              if len(c) >= 20 and e]
+    if not usable:
+        print(f"[active_learn] examined {len(records)} rows, 0 carried a "
+              "(claim, evidence) pair this model can score", file=sys.stderr)
+        return []
+
+    # One embed per distinct string, not two per row: the corpus repeats its
+    # claims and evidences heavily (5418 rows over 143 of each).
+    cache: dict[str, list] = {}
+    failures = []
+    for _, claim, evidence in usable:
+        for text in (claim, evidence):
+            if text in cache:
+                continue
+            try:
+                cache[text] = _embed(text, ollama_url, embed_model)
+            except Exception as exc:
+                failures.append(exc)
+                cache[text] = None
+    if failures:
+        # One line, not one per string: with Ollama down this is every distinct
+        # text in the corpus and the nightly log is the only reader.
+        print(f"[active_learn] {len(failures)}/{len(cache)} embeds failed, first: "
+              f"{failures[0]}", file=sys.stderr)
+
+    rows = [(rec, c, e) for rec, c, e in usable if cache.get(c) and cache.get(e)]
+    if not rows:
+        print(f"[active_learn] {len(usable)} scorable rows, 0 embedded",
+              file=sys.stderr)
+        return []
+
+    def _unit(texts):
+        arr = np.asarray([cache[t] for t in texts], dtype=np.float32)
+        return arr / (np.linalg.norm(arr, axis=1, keepdims=True) + 1e-9)
+
+    claims = [c for _, c, _ in rows]
+    evidences = [e for _, _, e in rows]
+    try:
+        feats = _feat.make_features(claims, evidences, _unit(claims), _unit(evidences),
+                                    dim=dim)
+        probas = clf.predict_proba(feats)[:, 1]
+    except Exception as exc:
+        print(f"[active_learn] scoring {len(rows)} rows failed: {exc}", file=sys.stderr)
+        return []
+
+    scored = [{"rec": rec, "proba": float(p), "uncertainty": float(abs(p - 0.5))}
+              for (rec, _, _), p in zip(rows, probas)]
 
     boundary = [s for s in scored if s["uncertainty"] <= uncertainty_band / 2]
     boundary.sort(key=lambda x: x["uncertainty"])
@@ -106,6 +177,12 @@ def hard_negatives(
     dataset_path: str,
     n: int = DEFAULT_N_HARD_NEG,
 ) -> list[dict]:
+    # NOT fixed alongside boundary_samples, deliberately. This reads the same
+    # absent text/content fields and so returns [] on the live corpus, but
+    # teaching it `claim` would emit claim-vs-claim pairs under {text, context}
+    # keys — neither the negative this (claim, evidence) classifier needs nor a
+    # shape the dataset can ingest. Fixing it is a design decision about what a
+    # hard negative is here, not a field-name repair.
     records = _load_dataset(dataset_path)
     positives = [r for r in records if r.get("label", 0) == 1]
     if len(positives) < 2:

--- a/mlops/grounding/active_learn.py
+++ b/mlops/grounding/active_learn.py
@@ -78,6 +78,18 @@ def _feature_contract():
     return features
 
 
+def _say(msg: str) -> None:
+    """Print a "the lane is dark, and here is why" line where the nightly can see it.
+
+    mlops/loop.py runs this script through _run(), which drains the child's
+    stdout with echo=True and its stderr with echo=False, and _run_active_learn
+    returns only the exit code. A diagnostic on stderr is therefore invisible in
+    the one log that reads it -- the nightly would print "boundary=0" alone,
+    which is the defect this file was changed to fix.
+    """
+    print(f"[active_learn] {msg}", flush=True)
+
+
 def boundary_samples(
     model_path: str,
     dataset_path: str,
@@ -94,7 +106,7 @@ def boundary_samples(
         _feat = _feature_contract()
         clf = joblib.load(model_path)
     except Exception as exc:
-        print(f"[active_learn] could not load model: {exc}", file=sys.stderr)
+        _say(f"could not load model: {exc}")
         return []
 
     records = _load_dataset(dataset_path)
@@ -107,16 +119,16 @@ def boundary_samples(
     # fix alone would still have scored nothing, just slower.
     dim = int(getattr(clf, "n_features_in_", _feat.LEGACY_DIM))
     if dim not in _feat.supported_dims():
-        print(f"[active_learn] {model_path} expects {dim} features; this sampler "
-              f"builds {_feat.supported_dims()} — refusing to score with a model "
-              "whose feature contract is unknown.", file=sys.stderr)
+        _say(f"{model_path} expects {dim} features; this sampler builds "
+             f"{_feat.supported_dims()} — refusing to score with a model whose "
+             "feature contract is unknown.")
         return []
 
     usable = [(rec, c, e) for rec, (c, e) in ((r, _record_pair(r)) for r in records)
               if len(c) >= 20 and e]
     if not usable:
-        print(f"[active_learn] examined {len(records)} rows, 0 carried a "
-              "(claim, evidence) pair this model can score", file=sys.stderr)
+        _say(f"examined {len(records)} rows, 0 carried a (claim, evidence) "
+             "pair this model can score")
         return []
 
     # One embed per distinct string, not two per row: the corpus repeats its
@@ -135,13 +147,11 @@ def boundary_samples(
     if failures:
         # One line, not one per string: with Ollama down this is every distinct
         # text in the corpus and the nightly log is the only reader.
-        print(f"[active_learn] {len(failures)}/{len(cache)} embeds failed, first: "
-              f"{failures[0]}", file=sys.stderr)
+        _say(f"{len(failures)}/{len(cache)} embeds failed, first: {failures[0]}")
 
     rows = [(rec, c, e) for rec, c, e in usable if cache.get(c) and cache.get(e)]
     if not rows:
-        print(f"[active_learn] {len(usable)} scorable rows, 0 embedded",
-              file=sys.stderr)
+        _say(f"{len(usable)} scorable rows, 0 embedded")
         return []
 
     def _unit(texts):
@@ -155,7 +165,7 @@ def boundary_samples(
                                     dim=dim)
         probas = clf.predict_proba(feats)[:, 1]
     except Exception as exc:
-        print(f"[active_learn] scoring {len(rows)} rows failed: {exc}", file=sys.stderr)
+        _say(f"scoring {len(rows)} rows failed: {exc}")
         return []
 
     scored = [{"rec": rec, "proba": float(p), "uncertainty": float(abs(p - 0.5))}

--- a/mlops/grounding/tests/test_active_learn_diagnostic_reaches_the_loop.py
+++ b/mlops/grounding/tests/test_active_learn_diagnostic_reaches_the_loop.py
@@ -1,0 +1,94 @@
+"""The diagnostic has to survive the trip through mlops/loop.py, not just capsys.
+
+The in-process tests assert these lines with capsys, which reads the string
+wherever it is written. mlops/loop.py runs this script as a CHILD: _run drains
+its stdout with echo=True and its stderr with echo=False, and _run_active_learn
+returns only the exit code. A diagnostic on stderr is green in every capsys test
+and absent from the one log that reads it, so the nightly prints
+
+    [active_learn] boundary=0 hard_negatives=0 total=0 -> .../cands.jsonl
+
+and the operator sees an ordinary zero. That is the defect this file exists to
+catch, so this drives the real subprocess through the real _run.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "mlops" / "grounding" / "active_learn.py"
+
+joblib = pytest.importorskip("joblib")
+np = pytest.importorskip("numpy")
+sklearn = pytest.importorskip("sklearn")
+
+
+def _loop_module():
+    spec = importlib.util.spec_from_file_location("loop_under_test", REPO / "mlops" / "loop.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO / "mlops"))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _unscorable_corpus(tmp_path):
+    """Rows with no (claim, evidence) pair the sampler can build features from."""
+    ds = tmp_path / "grounding_dataset.jsonl"
+    ds.write_text("".join(
+        json.dumps({"id": f"r{i}", "text": "too short"}) + "\n" for i in range(3)
+    ))
+    return ds
+
+
+def _live_model(tmp_path):
+    from sklearn.linear_model import LogisticRegression
+    sys.path.insert(0, str(REPO / "deep_think_loci" / "grounding"))
+    import features as F
+    clf = LogisticRegression()
+    clf.fit(np.zeros((2, F.CURRENT_DIM), dtype=np.float32), [0, 1])
+    path = tmp_path / "clf.joblib"
+    joblib.dump(clf, path)
+    return path
+
+
+def test_the_reason_reaches_the_nightly_log(tmp_path, capfd):
+    """Run the sampler the way the loop runs it and read what the loop printed."""
+    loop = _loop_module()
+    out = tmp_path / "cands.jsonl"
+    result = loop._run([
+        sys.executable, str(SCRIPT),
+        "--model", str(_live_model(tmp_path)),
+        "--dataset", str(_unscorable_corpus(tmp_path)),
+        "--out", str(out),
+        "--ollama", "http://127.0.0.1:1",
+    ])
+    printed = capfd.readouterr().out
+
+    assert result.returncode == 0, "the sampler is supposed to exit clean on an empty result"
+    assert "0 carried a (claim, evidence) pair" in printed, (
+        "the loop printed no reason for the empty result:\n" + printed
+    )
+    assert "boundary=0" in printed, printed
+
+
+def test_the_diagnostic_is_not_written_where_the_loop_discards_it():
+    """Pins the mechanism rather than the wording: _run echoes stdout and drops
+    stderr, so a diagnostic on stderr is invisible however well it reads."""
+    src = SCRIPT.read_text()
+    assert "file=sys.stderr" not in src, (
+        "a diagnostic on stderr never reaches the nightly log; use _say()"
+    )
+
+
+def test_a_crashing_sampler_is_reported_rather_than_skipped(tmp_path):
+    """The other half: when it exits non-zero, _run_active_learn must say so."""
+    loop = _loop_module()
+    result = loop._run([sys.executable, "-c", "import sys; sys.exit(3)"])
+    assert result.returncode == 3
+    assert "_fail(\"active_learn\"" in (REPO / "mlops" / "loop.py").read_text(), (
+        "a non-zero exit from the sampler leaves the previous candidates file in "
+        "place; the step has to report it like dataset-rebuild and train.py do"
+    )

--- a/mlops/grounding/tests/test_grounding.py
+++ b/mlops/grounding/tests/test_grounding.py
@@ -1150,7 +1150,7 @@ def test_boundary_samples_unloadable_model_returns_empty(tmp_path, boundary_data
     bad = tmp_path / "bad.joblib"
     bad.write_bytes(b"garbage")
     assert al.boundary_samples(str(bad), ds) == []
-    assert "could not load model" in capsys.readouterr().err
+    assert "could not load model" in capsys.readouterr().out
 
 
 def test_boundary_samples_empty_dataset_returns_empty(graded_model, tmp_path):
@@ -1203,7 +1203,7 @@ def test_boundary_samples_reports_a_scoring_failure_instead_of_returning_a_bare_
     monkeypatch.setattr(joblib, "load", lambda p: model)
     monkeypatch.setattr(al, "_embed", lambda text, url, m: [0.1, 0.2, 0.3, 0.4])
     assert al.boundary_samples(str(path), ds) == []
-    assert "scoring 6 rows failed" in capsys.readouterr().err
+    assert "scoring 6 rows failed" in capsys.readouterr().out
 
 
 def test_boundary_samples_uses_text_claim_content_query_in_that_order(tmp_path, monkeypatch,
@@ -1298,7 +1298,7 @@ def test_boundary_samples_says_so_when_no_row_is_scorable(tmp_path, graded_model
         for i in range(3):
             fh.write(json.dumps({"summary": f"no field this sampler reads {i}"}) + "\n")
     assert al.boundary_samples(graded_model, str(ds)) == []
-    assert "examined 3 rows, 0 carried a (claim, evidence) pair" in capsys.readouterr().err
+    assert "examined 3 rows, 0 carried a (claim, evidence) pair" in capsys.readouterr().out
 
 
 def test_boundary_samples_refuses_a_model_of_unknown_feature_width(tmp_path, monkeypatch,
@@ -1316,7 +1316,7 @@ def test_boundary_samples_refuses_a_model_of_unknown_feature_width(tmp_path, mon
     path.write_bytes(b"stub")
     monkeypatch.setattr(joblib, "load", lambda p: Wrong())
     assert al.boundary_samples(str(path), ds) == []
-    assert "expects 12 features" in capsys.readouterr().err
+    assert "expects 12 features" in capsys.readouterr().out
 
 
 # ── hard_negatives ────────────────────────────────────────────────────────────
@@ -1431,7 +1431,7 @@ def test_boundary_samples_reports_embed_failures_once_not_once_per_string(
             fh.write(json.dumps({"claim": f"a claim long enough to survive it {i}",
                                  "evidence": f"evidence {i}"}) + "\n")
     assert al.boundary_samples(graded_model, str(ds)) == []
-    err = capsys.readouterr().err
-    assert err.count("embeds failed") == 1
-    assert "8/8 embeds failed, first: connection refused" in err
-    assert "4 scorable rows, 0 embedded" in err
+    out = capsys.readouterr().out
+    assert out.count("embeds failed") == 1
+    assert "8/8 embeds failed, first: connection refused" in out
+    assert "4 scorable rows, 0 embedded" in out

--- a/mlops/grounding/tests/test_grounding.py
+++ b/mlops/grounding/tests/test_grounding.py
@@ -1101,28 +1101,38 @@ def test_embed_posts_to_the_native_ollama_api(monkeypatch):
 
 # ── boundary_samples ──────────────────────────────────────────────────────────
 
+# The sampler scores (claim, evidence) pairs through the shared grounding feature
+# contract, so a fake model has to advertise one of the widths that contract
+# builds at the production embedding size.
+_EMBED_DIM = 768
+_LEGACY_DIM = 2 * _EMBED_DIM + 1
+
+
+def _stub_vec():
+    return [1.0] + [0.0] * (_EMBED_DIM - 1)
+
+
 @pytest.fixture
 def boundary_dataset(tmp_path):
     texts = [f"candidate text number {i} padded out to length" for i in range(6)]
     p = tmp_path / "ds.jsonl"
     with open(p, "w") as fh:
         for i, t in enumerate(texts):
-            fh.write(json.dumps({"text": t, "id": i}) + "\n")
-        fh.write(json.dumps({"text": "short", "id": 99}) + "\n")
+            fh.write(json.dumps({"text": t, "evidence": f"evidence {i}", "id": i}) + "\n")
+        fh.write(json.dumps({"text": "short", "evidence": "e", "id": 99}) + "\n")
     return str(p), texts
 
 
 @pytest.fixture
-def graded_model(tmp_path, monkeypatch, boundary_dataset):
-    """A model whose P(1) walks away from 0.5 as the record index grows."""
-    _, texts = boundary_dataset
-    index = {t: i for i, t in enumerate(texts)}
-    monkeypatch.setattr(al, "_embed", lambda text, url, model: [float(index[text])])
+def graded_model(tmp_path, monkeypatch):
+    """A model whose P(1) walks away from 0.5 as the record's row position grows."""
+    monkeypatch.setattr(al, "_embed", lambda text, url, model: _stub_vec())
 
     class Graded:
-        def predict_proba(self, vecs):
-            i = vecs[0][0]
-            return [[1.0 - (0.5 + 0.05 * i), 0.5 + 0.05 * i]]
+        n_features_in_ = _LEGACY_DIM
+
+        def predict_proba(self, feats):
+            return np.array([[0.5 - 0.05 * i, 0.5 + 0.05 * i] for i in range(len(feats))])
 
     path = tmp_path / "m.joblib"
     path.write_bytes(b"stub")
@@ -1157,7 +1167,7 @@ def test_boundary_samples_sorts_by_uncertainty_and_annotates(graded_model, bound
     assert out[0]["proba"] == pytest.approx(0.5)
     assert out[0]["uncertainty"] == pytest.approx(0.0)
     assert out[3]["uncertainty"] == pytest.approx(0.15)
-    assert set(out[0]) == {"text", "id", "candidate_type", "proba", "uncertainty"}
+    assert set(out[0]) == {"text", "evidence", "id", "candidate_type", "proba", "uncertainty"}
 
 
 def test_boundary_samples_band_is_halved(graded_model, boundary_dataset):
@@ -1177,42 +1187,136 @@ def test_boundary_samples_skips_records_shorter_than_twenty_chars(graded_model, 
     assert 99 not in [c["id"] for c in al.boundary_samples(graded_model, ds, uncertainty_band=2.0)]
 
 
-def test_boundary_samples_swallows_per_record_failures(tmp_path, monkeypatch, boundary_dataset):
-    """BUG PIN: it scores raw embeddings, so a real classifier raises and is silently skipped."""
+def test_boundary_samples_reports_a_scoring_failure_instead_of_returning_a_bare_empty(
+        tmp_path, monkeypatch, boundary_dataset, capsys):
+    """A model that raises at predict_proba must say so once, not be indistinguishable
+    from a corpus with no uncertain samples."""
     from sklearn.linear_model import LogisticRegression
     ds, _ = boundary_dataset
     rng = np.random.RandomState(0)
-    X = rng.rand(40, 12)
+    X = rng.rand(40, _LEGACY_DIM)
     y = (X[:, 0] > 0.5).astype(int)
-    model = LogisticRegression(max_iter=500).fit(X, y)
+    model = LogisticRegression(max_iter=50).fit(X, y)
+    model.n_features_in_ = _LEGACY_DIM
     path = tmp_path / "m.joblib"
     path.write_bytes(b"stub")
     monkeypatch.setattr(joblib, "load", lambda p: model)
     monkeypatch.setattr(al, "_embed", lambda text, url, m: [0.1, 0.2, 0.3, 0.4])
     assert al.boundary_samples(str(path), ds) == []
+    assert "scoring 6 rows failed" in capsys.readouterr().err
 
 
-def test_boundary_samples_uses_text_content_query_in_that_order(tmp_path, monkeypatch):
+def test_boundary_samples_uses_text_claim_content_query_in_that_order(tmp_path, monkeypatch,
+                                                                     graded_model):
+    """`claim` sits second in the chain: it is the key the live corpus actually uses,
+    and adding it must not displace the three that were already read."""
     seen = []
-    monkeypatch.setattr(al, "_embed", lambda text, url, m: seen.append(text) or [0.0])
+    real = al._embed
+    monkeypatch.setattr(al, "_embed", lambda text, url, m: seen.append(text) or real(text, url, m))
+    ds = tmp_path / "ds.jsonl"
+    with open(ds, "w") as fh:
+        fh.write(json.dumps({"text": "from the text field padded out", "claim": "ignored",
+                             "evidence": "e0"}) + "\n")
+        fh.write(json.dumps({"claim": "from the claim field padded ok", "content": "ignored",
+                             "evidence": "e1"}) + "\n")
+        fh.write(json.dumps({"content": "from the content field padded", "evidence": "e2"}) + "\n")
+        fh.write(json.dumps({"query": "from the query field padded ok", "evidence": "e3"}) + "\n")
+        fh.write(json.dumps({"other": "invisible field, no text at all", "evidence": "e4"}) + "\n")
+    al.boundary_samples(graded_model, str(ds), uncertainty_band=2.0)
+    assert [t for t in seen if not t.startswith("e")] == [
+        "from the text field padded out",
+        "from the claim field padded ok",
+        "from the content field padded",
+        "from the query field padded ok",
+    ]
 
-    class Half:
-        def predict_proba(self, vecs):
-            return [[0.5, 0.5]]
+
+def test_boundary_samples_scores_the_claim_evidence_schema_the_corpus_uses(tmp_path,
+                                                                          graded_model):
+    """The live grounding_dataset.jsonl rows carry only {claim, evidence, label, ...}.
+
+    Before the fix the field chain read text/content/query, so `len(text) < 20`
+    fired on all 5418 rows and boundary_samples() returned [] having consulted
+    nothing — while the loop logged 'boundary=0' as an ordinary result.
+    """
+    ds = tmp_path / "corpus.jsonl"
+    with open(ds, "w") as fh:
+        for i in range(4):
+            fh.write(json.dumps({"claim": f"a claim long enough to survive the gate {i}",
+                                 "evidence": f"supporting evidence {i}",
+                                 "label": i % 2, "signal": "topical"}) + "\n")
+    out = al.boundary_samples(graded_model, str(ds), uncertainty_band=2.0)
+    assert len(out) == 4
+    assert [c["claim"][-1] for c in out] == ["0", "1", "2", "3"]
+    assert out[0]["candidate_type"] == "boundary"
+    assert "signal" in out[0]  # the source row is carried through intact
+
+
+def test_boundary_samples_feeds_the_model_pair_features_at_its_own_width(tmp_path, monkeypatch,
+                                                                        boundary_dataset):
+    """It used to hand predict_proba one raw 768-d embedding per record. The live
+    classifier declares n_features_in_ = 1537, so that raised for every record and
+    the per-record `except: continue` swallowed it."""
+    ds, _ = boundary_dataset
+    monkeypatch.setattr(al, "_embed", lambda text, url, m: _stub_vec())
+    shapes = []
+
+    class Recorder:
+        n_features_in_ = _LEGACY_DIM
+
+        def predict_proba(self, feats):
+            shapes.append(np.asarray(feats).shape)
+            return np.array([[0.5, 0.5]] * len(feats))
 
     path = tmp_path / "m.joblib"
     path.write_bytes(b"stub")
-    monkeypatch.setattr(joblib, "load", lambda p: Half())
-    ds = tmp_path / "ds.jsonl"
+    monkeypatch.setattr(joblib, "load", lambda p: Recorder())
+    al.boundary_samples(str(path), ds)
+    assert shapes == [(6, _LEGACY_DIM)]
+
+
+def test_boundary_samples_embeds_each_distinct_string_once(tmp_path, monkeypatch, graded_model):
+    """The corpus repeats its claims and evidences (5418 rows over 143 of each), so
+    a naive two-embeds-per-row loop would be ~38x the Ollama traffic it needs."""
+    calls = []
+    monkeypatch.setattr(al, "_embed", lambda text, url, m: calls.append(text) or _stub_vec())
+    ds = tmp_path / "dupes.jsonl"
     with open(ds, "w") as fh:
-        fh.write(json.dumps({"text": "from the text field padded out", "content": "ignored"}) + "\n")
-        fh.write(json.dumps({"content": "from the content field padded"}) + "\n")
-        fh.write(json.dumps({"query": "from the query field padded ok"}) + "\n")
-        fh.write(json.dumps({"other": "invisible field, no text at all"}) + "\n")
-    al.boundary_samples(str(path), str(ds))
-    assert seen == ["from the text field padded out",
-                    "from the content field padded",
-                    "from the query field padded ok"]
+        for _ in range(5):
+            fh.write(json.dumps({"claim": "one claim repeated across every row here",
+                                 "evidence": "one evidence repeated too"}) + "\n")
+    al.boundary_samples(graded_model, str(ds), uncertainty_band=2.0)
+    assert sorted(calls) == ["one claim repeated across every row here",
+                             "one evidence repeated too"]
+
+
+def test_boundary_samples_says_so_when_no_row_is_scorable(tmp_path, graded_model, capsys):
+    """An all-dropped run must be distinguishable from a genuine 'no uncertain
+    samples', which is exactly what 'boundary=0' hid for the whole corpus."""
+    ds = tmp_path / "unscorable.jsonl"
+    with open(ds, "w") as fh:
+        for i in range(3):
+            fh.write(json.dumps({"summary": f"no field this sampler reads {i}"}) + "\n")
+    assert al.boundary_samples(graded_model, str(ds)) == []
+    assert "examined 3 rows, 0 carried a (claim, evidence) pair" in capsys.readouterr().err
+
+
+def test_boundary_samples_refuses_a_model_of_unknown_feature_width(tmp_path, monkeypatch,
+                                                                  boundary_dataset, capsys):
+    ds, _ = boundary_dataset
+    monkeypatch.setattr(al, "_embed", lambda text, url, m: _stub_vec())
+
+    class Wrong:
+        n_features_in_ = 12
+
+        def predict_proba(self, feats):  # pragma: no cover - must never be reached
+            raise AssertionError("scored with an unknown feature contract")
+
+    path = tmp_path / "m.joblib"
+    path.write_bytes(b"stub")
+    monkeypatch.setattr(joblib, "load", lambda p: Wrong())
+    assert al.boundary_samples(str(path), ds) == []
+    assert "expects 12 features" in capsys.readouterr().err
 
 
 # ── hard_negatives ────────────────────────────────────────────────────────────
@@ -1313,3 +1417,21 @@ def test_embed_model_is_read_at_call_time_not_import_time(monkeypatch):
     assert train._emb_model() == "some-other-embedder"
     monkeypatch.delenv("EMBED_MODEL")
     assert train._emb_model() == "nomic-embed-text"
+
+
+def test_boundary_samples_reports_embed_failures_once_not_once_per_string(
+        tmp_path, monkeypatch, graded_model, capsys):
+    """With Ollama down this is every distinct text in the corpus, and the nightly
+    log is the only reader."""
+    monkeypatch.setattr(al, "_embed", lambda text, url, m: (_ for _ in ()).throw(
+        RuntimeError("connection refused")))
+    ds = tmp_path / "ds.jsonl"
+    with open(ds, "w") as fh:
+        for i in range(4):
+            fh.write(json.dumps({"claim": f"a claim long enough to survive it {i}",
+                                 "evidence": f"evidence {i}"}) + "\n")
+    assert al.boundary_samples(graded_model, str(ds)) == []
+    err = capsys.readouterr().err
+    assert err.count("embeds failed") == 1
+    assert "8/8 embeds failed, first: connection refused" in err
+    assert "4 scorable rows, 0 embedded" in err

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -487,6 +487,11 @@ def _run_active_learn(ollama: str) -> dict:
          "--out", str(ACTIVE_CANDIDATES),
          "--ollama", ollama],
     )
+    if result.returncode != 0:
+        # _run drains child stderr with echo=False, so without this a crash in
+        # the sampler is a silent step that leaves the previous candidates file
+        # in place. Same treatment the dataset-rebuild and train.py steps get.
+        _fail("active_learn", f"active_learn failed: {_last_error_line(result.stderr)}")
     return {"exit_code": result.returncode}
 
 

--- a/scripts/ebbinghaus_consolidation.py
+++ b/scripts/ebbinghaus_consolidation.py
@@ -94,18 +94,19 @@ def days_since(ts_str: str) -> float:
     if not ts_str:
         return 0.0
     ts_str = ts_str.strip()
+    # fromisoformat, not a strptime menu: the three formats tried here all
+    # rejected fractional seconds, so every timestamp this script writes back
+    # itself (now_iso() -> '...T13:56:27.745013+00:00') came back unparseable.
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        print(f"[warn] unrecognised timestamp format: {ts_str!r}")
+        return -1.0
     # Normalise SQLite datetimes that lack timezone info.
-    for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
-        try:
-            dt = datetime.strptime(ts_str, fmt)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            delta = datetime.now(timezone.utc) - dt
-            return delta.total_seconds() / 86400.0
-        except ValueError:
-            continue
-    print(f"[warn] unrecognised timestamp format: {ts_str!r}")
-    return -1.0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - dt
+    return delta.total_seconds() / 86400.0
 
 
 def _init_difficulty(importance: float) -> float:

--- a/scripts/tests/test_ebbinghaus_timestamps.py
+++ b/scripts/tests/test_ebbinghaus_timestamps.py
@@ -1,0 +1,71 @@
+"""days_since() must parse the timestamps this script itself writes back.
+
+now_iso() emits datetime.now(timezone.utc).isoformat(), which carries microseconds
+('2026-09-01T13:56:27.745013+00:00'). The old three-format strptime menu had no
+format with fractional seconds, so every such row fell through to the -1.0
+sentinel; retention() maps that to 0.0, which sorts ahead of every genuinely
+computed retention and pins the same rows at the head of every batch. 246 of the
+2756 rows in the live mnemosyne DB carry that shape.
+"""
+import importlib.util
+import pathlib
+import unittest
+from datetime import datetime, timedelta, timezone
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "_ebb_ts", _SCRIPTS / "ebbinghaus_consolidation.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class DaysSinceTest(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def _one_day_ago(self):
+        return datetime.now(timezone.utc) - timedelta(days=1)
+
+    def test_parses_the_timestamp_now_iso_writes(self):
+        ts = self.mod.now_iso()
+        self.assertIn(".", ts.split("+")[0], "now_iso should carry microseconds")
+        self.assertAlmostEqual(self.mod.days_since(ts), 0.0, places=3)
+
+    def test_parses_fractional_seconds_with_offset(self):
+        ts = self._one_day_ago().isoformat()
+        self.assertAlmostEqual(self.mod.days_since(ts), 1.0, places=3)
+
+    def test_parses_naive_fractional_seconds_as_utc(self):
+        ts = self._one_day_ago().replace(tzinfo=None).isoformat()
+        self.assertAlmostEqual(self.mod.days_since(ts), 1.0, places=3)
+
+    def test_still_parses_the_three_shapes_that_already_worked(self):
+        dt = self._one_day_ago().replace(microsecond=0)
+        for ts in (dt.isoformat(),
+                   dt.strftime("%Y-%m-%d %H:%M:%S"),
+                   dt.replace(tzinfo=None).isoformat()):
+            with self.subTest(ts=ts):
+                self.assertAlmostEqual(self.mod.days_since(ts), 1.0, places=3)
+
+    def test_parses_a_trailing_z_as_utc(self):
+        dt = self._one_day_ago().replace(microsecond=0, tzinfo=None)
+        self.assertAlmostEqual(self.mod.days_since(dt.isoformat() + "Z"), 1.0, places=3)
+
+    def test_keeps_the_sentinel_for_genuinely_unparseable_input(self):
+        self.assertEqual(self.mod.days_since("last tuesday"), -1.0)
+
+    def test_empty_is_still_zero_not_the_sentinel(self):
+        self.assertEqual(self.mod.days_since(""), 0.0)
+
+    def test_retention_no_longer_pins_a_fractional_timestamp_at_zero(self):
+        """retention() forces 0.0 on the sentinel so the row is eligible for
+        consolidation; a fresh microsecond timestamp must not land there."""
+        self.assertGreater(self.mod.retention(1, self.mod.now_iso(), "", 5.0), 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three loops swallowed a per-record exception with `except: continue`, so the count each one returned was a count of what parsed, presented as a count of what exists.

The worst is the active-learning sampler. The live classifier scores `(claim, evidence)` **pairs** at the width it was trained on; the sampler handed it one raw 768-d embedding, so `predict_proba` raised on **every** record and the per-record `continue` ate it. Proven against real inputs rather than stubs — the live model (`n_features_in_=1537`), the real 5418-row `grounding_dataset.jsonl`, and real `nomic-embed-text` vectors out of `.emb_cache.npz`:

```
origin/main   []
this branch   100 boundary candidates, proba 0.4398 - 0.557
```

A field-name fix alone would still have scored nothing, just slower.

## Held once, on the thing its own tests could not see

The review caught that the diagnostics went to **stderr**, and `mlops/loop.py` drains a child's stderr with `echo=False` while `_run_active_learn` returns only the exit code. Driving the sampler through `loop._run` on an unscorable corpus, the whole nightly log was:

```
  [active_learn] [active_learn] boundary=0 hard_negatives=0 total=0 -> cands.jsonl
returncode 0
```

The line explaining *why* it was zero was captured and dropped. So the next time the lane goes dark for a different reason — Ollama down, corpus schema drift again, a promoted model at a width the sampler refuses — the nightly reports an ordinary zero. **That is the defect this branch was filed against.**

Every test asserting the diagnostic used `capsys`, which reads the string wherever it is written. All of them were green while production was silent.

The six lines now go to stdout through `_say()`, which carries the reason in a comment so the next edit doesn't undo it. `_run_active_learn` also reports a non-zero exit via `_last_error_line`, the way the dataset-rebuild and `train.py` steps already do — without it a crashed sampler is a silent step that leaves the previous candidates file in place.

The new test drives the real subprocess through the real `loop._run` and reads what the loop printed, because `capsys` is what let this through.

## Verification

Each source file was reverted individually against `origin/main` to confirm its tests are red without it: `active_learn 10 failed/119 passed`, `drift 2/68`, `ebbinghaus 4/4`. The three new out-of-process tests all fail against the previous commit on this branch.

```
pytest mlops                              601 passed
cd scripts && pytest tests/ hooks/tests/  764 passed + 3 subtests
pytest scripts/callgraph/tests            257 passed, corpus count unmoved
ruff (CI ruleset) / vulture               clean
```

## Blast radius

`active_candidates.jsonl` has no reader anywhere in the repo — `loop.py` writes it and stores a timestamp. Merging *is* the deploy (`mlops-cron` resolves from `origin/main`, the 02:00 crontab passes no `--dry-run`), so the first night the lane goes from 0 Ollama calls and an empty file to 143 embeds and 100 rows. It is cadence-gated at 7 days and gated on `ollama_ok`, and Ollama is currently down on this box, so it will not fire until Ollama is back.

`drift` arms nothing (`anchor.npz` is git-cleaned nightly, so `measure_drift` never runs; the fix only reduces false alarms). `ebbinghaus` is scheduled nowhere and the fix strictly narrows the selected batch.