### PR TITLE
Make four cron scripts read the embedding config of the collection they touch

### DIFF
--- a/scripts/agentHER_relabeler.py
+++ b/scripts/agentHER_relabeler.py
@@ -23,7 +23,12 @@ MNEMOSYNE_DB = os.path.expanduser(
 )
 QDRANT_URL   = os.environ.get("QDRANT_URL")
 OLLAMA_URL   = os.environ.get("OLLAMA_URL")
-EMBED_MODEL  = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+# Follows the collection this writes (mnemosyne), not the script family: its only
+# reader, a2a_server, embeds with MNEMOSYNE_EMBEDDING_MODEL and drops every hit
+# under a hard 0.59 score floor, so a wrong-space positive is never returned.
+EMBED_MODEL  = (os.environ.get("MNEMOSYNE_EMBEDDING_MODEL")
+                or os.environ.get("EMBED_MODEL")
+                or "nomic-embed-text")
 GEN_MODEL    = os.environ.get("AGENTHER_GEN_MODEL", "llama3.2:latest")
 # Batch size. Own name, because the three consolidation scripts each had a
 # different budget under the shared MAX_PER_RUN; setting it for one silently

--- a/scripts/state_db_qdrant_sync.py
+++ b/scripts/state_db_qdrant_sync.py
@@ -8,7 +8,7 @@ Chunked at 4000 chars to keep embedding quality high and avoid
 Ollama stall on huge inputs.
 
 Uses embedding-worker (NodePort 30888) -> agent_core_chunks -> copy
-vector -> loci_sessions (named vector "dense", 768-dim Cosine).
+vector -> loci_sessions (named vector "dense", MNEMOSYNE_EMBEDDING_DIM Cosine).
 
 Incremental: tracks synced sessions by session_id in payload.
 Run standalone or from cron (no_agent=True).
@@ -23,6 +23,11 @@ COLLECTION   = "loci_sessions"
 SRC_COLL     = "agent_core_chunks"
 MAX_CHARS    = 4000   # per-session content cap before embedding
 BATCH_SIZE   = 4      # sessions per embed round-trip (keep under 32-chunk Ollama limit)
+
+# One source for the vector width. The validator below used a 768 literal while
+# the collection was created from this env, so a deployment on 1536-dim embeddings
+# dropped every chunk as "malformed" and still exited 0.
+VECTOR_DIM = int(os.environ.get("MNEMOSYNE_EMBEDDING_DIM", 768))
 
 AGENT_ID = os.environ.get("HERMES_AGENT_ID", "")
 PROFILE  = os.environ.get("HERMES_PROFILE", "")
@@ -57,7 +62,7 @@ def ensure_collection(key, name=None, dim=None):
     curl_json returns {} rather than raising, so probe by response shape.
     """
     name = name or COLLECTION
-    dim  = int(dim or os.environ.get("MNEMOSYNE_EMBEDDING_DIM", 768))
+    dim  = int(dim or VECTOR_DIM)
     if curl_json("GET", f"{QDRANT}/collections/{name}", key=key).get("result"):
         return False
     curl_json("PUT", f"{QDRANT}/collections/{name}",
@@ -136,8 +141,6 @@ def get_synced_ids(key):
         if not offset:
             break
     return synced
-
-VECTOR_DIM = 768
 
 def embed_batch(chunks, key):
     """Embed via worker, return ({chunk_id: vector}, dropped_count) for successfully embedded chunks."""

--- a/scripts/swr_replay.py
+++ b/scripts/swr_replay.py
@@ -41,11 +41,20 @@ from datetime import datetime, timezone
 QDRANT_URL            = os.environ.get("QDRANT_URL")
 QDRANT_KEY            = os.environ.get("QDRANT_API_KEY",   "")
 OLLAMA_URL            = os.environ.get("OLLAMA_URL")
-EMBED_MODEL           = os.environ.get("MNEMOSYNE_EMBEDDING_MODEL", "nomic-embed-text")
+# This script reads and writes mcp's loci_memory, so it must embed with mcp's
+# knob (qdrant_ops.py:328), not the a2a server's. Under MNEMOSYNE_EMBEDDING_MODEL
+# alone, an operator following .env.example wrote consolidated abstractions into
+# loci_memory in a vector space no reader searches it with — silently unrankable.
+EMBED_MODEL           = (os.environ.get("EMBED_MODEL")
+                         or os.environ.get("MNEMOSYNE_EMBEDDING_MODEL")
+                         or "nomic-embed-text")
 _EMBED_API_KEY        = os.environ.get("EMBED_API_KEY", "")
 _EMBED_API_KEY_HEADER = os.environ.get("EMBED_API_KEY_HEADER", "Authorization")
 LLM_MODEL    = os.environ.get("SWR_LLM_MODEL",   "llama3.2:latest")
-COLLECTION   = os.environ.get("SWR_COLLECTION",  "loci_memory")
+# Same collection mcp owns: follow QDRANT_COLLECTION_PREFIX (qdrant_ops.py:25) so
+# renaming it there does not leave this script writing to the old name.
+COLLECTION   = (os.environ.get("SWR_COLLECTION")
+                or os.environ.get("QDRANT_COLLECTION_PREFIX", "loci_memory"))
 
 LOOKBACK_HOURS = float(os.environ.get("SWR_LOOKBACK_HOURS", "6"))
 REPLAY_K       = int(os.environ.get("SWR_REPLAY_K",        "7"))    # theta-gamma bound

--- a/scripts/tests/test_embedding_config_follows_the_collection.py
+++ b/scripts/tests/test_embedding_config_follows_the_collection.py
@@ -1,0 +1,157 @@
+"""A script's embedding config must follow the Qdrant collection it touches.
+
+Four standalone cron scripts each read an env var that no other participant in
+their own collection reads, so one setting had two names across two files:
+
+  * swr_replay reads and writes mcp's `loci_memory` but embedded with
+    MNEMOSYNE_EMBEDDING_MODEL, while qdrant_ops.py — which creates that
+    collection and searches it — uses EMBED_MODEL. Root .env.example ships only
+    the former, so an operator who followed it wrote consolidated abstractions
+    into loci_memory in a space nothing searches. Dims permitting, the upsert
+    succeeds and the memory is simply never retrievable again.
+  * agentHER_relabeler is the mirror image: it writes the `mnemosyne`
+    collection but embedded with EMBED_MODEL, while that collection's only
+    reader (a2a_server) uses MNEMOSYNE_EMBEDDING_MODEL and drops every hit
+    below a hard 0.59 score floor.
+  * state_db_qdrant_sync created loci_sessions from MNEMOSYNE_EMBEDDING_DIM but
+    validated returned vectors against a 768 literal, so a deployment on
+    1536-dim embeddings dropped every chunk as "malformed" and exited 0.
+  * ua-ingest read QDRANT_KEY, a name that appears in no .env.example, no doc
+    and no compose file.
+
+All of these look healthy from outside: they print progress and exit 0.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _fresh(mod: str):
+    """Re-import a script so its module-level env reads happen under patch."""
+    sys.modules.pop(mod, None)
+    return importlib.import_module(mod)
+
+
+def _load_dashed(modname: str, filename: str):
+    """ua-ingest.py is not an importable name. `requests` is stubbed because the
+    module pip-installs it on ImportError, and the CI test job has no network."""
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+    spec = importlib.util.spec_from_file_location(modname, SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def isolated_env(tmp_path):
+    """A clean environment with HOME pointed somewhere empty, so the scripts'
+    own ~/.hermes/.env and ~/.claude/settings.json loaders find nothing."""
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def apply(**overrides):
+        env = {"HOME": str(home),
+               "LOCI_ENV_FILE": str(tmp_path / "no-such.env"),
+               "QDRANT_URL": "http://qdrant.invalid:6333"}
+        env.update(overrides)
+        return mock.patch.dict(os.environ, env, clear=True)
+
+    return apply
+
+
+# ── swr_replay: loci_memory is mcp's collection, so mcp's knobs win ───────────
+
+def test_swr_replay_embeds_loci_memory_with_the_model_mcp_searches_it_with(isolated_env):
+    with isolated_env(EMBED_MODEL="mcp-space",
+                      MNEMOSYNE_EMBEDDING_MODEL="a2a-space"):
+        assert _fresh("swr_replay").EMBED_MODEL == "mcp-space"
+
+
+def test_swr_replay_still_honours_the_mnemosyne_name_alone(isolated_env):
+    """Existing deployments set only this one; they must not silently move."""
+    with isolated_env(MNEMOSYNE_EMBEDDING_MODEL="a2a-space"):
+        assert _fresh("swr_replay").EMBED_MODEL == "a2a-space"
+
+
+def test_swr_replay_follows_the_collection_prefix_mcp_owns(isolated_env):
+    with isolated_env(QDRANT_COLLECTION_PREFIX="loci_memory_v2"):
+        assert _fresh("swr_replay").COLLECTION == "loci_memory_v2"
+
+
+def test_an_explicit_swr_collection_still_overrides_the_prefix(isolated_env):
+    with isolated_env(SWR_COLLECTION="pinned",
+                      QDRANT_COLLECTION_PREFIX="loci_memory_v2"):
+        assert _fresh("swr_replay").COLLECTION == "pinned"
+
+
+# ── agentHER: the mirror case, mnemosyne is the a2a server's collection ──────
+
+def test_agenther_embeds_mnemosyne_with_the_model_its_reader_uses(isolated_env):
+    with isolated_env(EMBED_MODEL="mcp-space",
+                      MNEMOSYNE_EMBEDDING_MODEL="a2a-space"):
+        mod = _fresh("agentHER_relabeler")
+        assert mod.COLLECTION == "mnemosyne"
+        assert mod.EMBED_MODEL == "a2a-space"
+
+
+def test_agenther_still_honours_embed_model_alone(isolated_env):
+    with isolated_env(EMBED_MODEL="mcp-space"):
+        assert _fresh("agentHER_relabeler").EMBED_MODEL == "mcp-space"
+
+
+# ── state_db_qdrant_sync: one source for the vector width ───────────────────
+
+def test_the_validator_width_follows_the_same_env_the_collection_is_created_from(isolated_env):
+    with isolated_env(MNEMOSYNE_EMBEDDING_DIM="1536"):
+        assert _fresh("state_db_qdrant_sync").VECTOR_DIM == 1536
+
+
+def test_a_correctly_sized_vector_is_kept_rather_than_dropped(isolated_env):
+    """The defect in behavioural form: on a 1536-dim deployment every chunk the
+    embed worker returned was counted as malformed and discarded."""
+    with isolated_env(MNEMOSYNE_EMBEDDING_DIM="1536", EMBED_WORKER_URL="http://w.invalid"):
+        sd = _fresh("state_db_qdrant_sync")
+        vector = [0.1] * 1536
+        worker = mock.Mock(stdout='{"status": "ok", "vectors": {"c1": "u1"}}')
+        points = {"result": [{"id": "u1", "vector": {"dense": vector}}]}
+        with mock.patch.object(sd.subprocess, "run", return_value=worker), \
+             mock.patch.object(sd, "curl_json", return_value=points):
+            id_to_vec, dropped = sd.embed_batch([{"id": "c1", "text": "hi"}], key="")
+    assert dropped == 0
+    assert id_to_vec == {"c1": vector}
+
+
+def test_a_genuinely_wrong_width_is_still_dropped(isolated_env):
+    """The guard must keep guarding — it is what stops a mixed-space upsert."""
+    with isolated_env(MNEMOSYNE_EMBEDDING_DIM="1536", EMBED_WORKER_URL="http://w.invalid"):
+        sd = _fresh("state_db_qdrant_sync")
+        worker = mock.Mock(stdout='{"status": "ok", "vectors": {"c1": "u1"}}')
+        points = {"result": [{"id": "u1", "vector": {"dense": [0.1] * 768}}]}
+        with mock.patch.object(sd.subprocess, "run", return_value=worker), \
+             mock.patch.object(sd, "curl_json", return_value=points):
+            id_to_vec, dropped = sd.embed_batch([{"id": "c1", "text": "hi"}], key="")
+    assert (id_to_vec, dropped) == ({}, 1)
+
+
+# ── ua-ingest: the documented key name ──────────────────────────────────────
+
+def test_ua_ingest_reads_the_key_name_both_env_examples_actually_ship(isolated_env):
+    with isolated_env(QDRANT_API_KEY="documented"):
+        assert _load_dashed("ua_ingest_impl", "ua-ingest.py").QDRANT_KEY == "documented"
+
+
+def test_ua_ingest_keeps_the_undocumented_name_as_a_fallback(isolated_env):
+    with isolated_env(QDRANT_KEY="legacy"):
+        assert _load_dashed("ua_ingest_impl", "ua-ingest.py").QDRANT_KEY == "legacy"

--- a/scripts/ua-ingest.py
+++ b/scripts/ua-ingest.py
@@ -39,7 +39,7 @@ from datetime import datetime, timezone
 
 # ── Config from env or defaults ────────────────────────────────────────────
 QDRANT_URL  = os.environ.get("QDRANT_URL")
-QDRANT_KEY  = os.environ.get("QDRANT_KEY", "")
+QDRANT_KEY  = os.environ.get("QDRANT_API_KEY") or os.environ.get("QDRANT_KEY", "")
 OLLAMA_URL  = os.environ.get("OLLAMA_URL")
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "nomic-embed-text")
 COLLECTION  = os.environ.get("UA_COLLECTION", "understand_anything")


### PR DESCRIPTION
Four standalone cron scripts each read an env var that no other participant in
their own Qdrant collection reads. One setting — which vector space a collection
is in — had two names across two files. None of them fail loudly: they print
progress and exit 0.

## What was wrong, and the evidence it was real

**`swr_replay.py` (HIGH).** It reads and writes `loci_memory`, which mcp owns —
`mcp/qdrant_ops.py:265` creates it (`col = QDRANT_COLLECTION_PREFIX`, used as the
collection name directly, not as a prefix), `:328` embeds every query against it
with `EMBED_MODEL`, `:25` names it from `QDRANT_COLLECTION_PREFIX`. swr_replay
embedded with `MNEMOSYNE_EMBEDDING_MODEL` and took its name from
`SWR_COLLECTION`. It then writes the consolidated abstraction permanently into
that collection (`:316`), and `qdrant_ops` searches it unfiltered by
`record_type`, so every `rag_context_search` / `memory_route` /
`investigation_search` ranking includes those points. If the dims match the
upsert succeeds and the consolidated memory is unretrievable forever; if they
differ the nightly cron prints one stderr line. `docker-compose.yml:57` already
treats `EMBED_MODEL` as the master knob (it derives `MNEMOSYNE_EMBEDDING_MODEL`
from it), and `mcp/memcheck/llm.py:84` already resolves the pair in exactly the
order adopted here.

**`agentHER_relabeler.py` (MEDIUM).** The mirror image. It writes the
`mnemosyne` collection (`:36`, upsert at `:176`) but embedded with
`EMBED_MODEL`, while both other participants in that collection use
`MNEMOSYNE_EMBEDDING_MODEL`: `a2a_server/server.py:242`, its only reader, and
`scripts/mnemosyne_qdrant_sync.py:23`, the other writer. The reader drops every
hit scoring under 0.59 (`server.py:646`) — a hard floor, not a rank penalty — so
a wrong-space synthetic positive is discarded before it is ever ranked, which
defeats the script's stated purpose. `docs/DEPLOYMENT.md:311` scopes
`MNEMOSYNE_EMBEDDING_MODEL` to hermes-a2a, which owns this collection.

**`state_db_qdrant_sync.py` (MEDIUM).** It sized the `loci_sessions` collection
from `MNEMOSYNE_EMBEDDING_DIM` (`:60`) but validated every returned vector
against a `768` literal (`:140`). `docs/DEPLOYMENT.md:81` tells operators to set
that env to 1536 for OpenAI/Azure embeddings; on such a deployment the
collection is created at 1536, the embed worker returns 1536-dim vectors, and
every one is dropped as "malformed". `main()` counts them as errors, prints
"0 upserted", and returns 0; the reader (`server.py:788`) reports the empty
collection as `{"sessions": []}` — indistinguishable from "no matching
sessions". The cross-file partner writing the same collection,
`scripts/hooks/session_end_sync.py`, is env-driven everywhere (`:80` create,
`:434` validate).

**`ua-ingest.py` (LOW).** It read `QDRANT_KEY`. Every other Qdrant client in the
repo reads `QDRANT_API_KEY`, both shipped `.env.example` files name
`QDRANT_API_KEY`, and `QDRANT_KEY` appears in no doc, compose file or workflow.
This one does fail loudly — a 403 traceback out of `ua-watch.py:80` — hence the
smallest change.

## What changed

- `swr_replay.py`: `EMBED_MODEL` first, `MNEMOSYNE_EMBEDDING_MODEL` as fallback;
  `COLLECTION` defaults to `QDRANT_COLLECTION_PREFIX` when `SWR_COLLECTION` is
  unset.
- `agentHER_relabeler.py`: `MNEMOSYNE_EMBEDDING_MODEL` first, `EMBED_MODEL` as
  fallback — following the collection it writes rather than the script family it
  belongs to.
- `state_db_qdrant_sync.py`: the `768` literal is hoisted to one env-driven
  `VECTOR_DIM`, which `ensure_collection` now defaults to. The guard still
  fires, but only on a genuine mismatch.
- `ua-ingest.py`: `QDRANT_API_KEY` first, `QDRANT_KEY` as fallback — the exact
  form already used at `state_db_qdrant_sync.py:33`.

No reformatting, no renames, nothing else touched. Five files, +182/-8.

## The test, and that it fails without the fix

`scripts/tests/test_embedding_config_follows_the_collection.py`, 11 tests.
Red-then-green verified per file by reverting one file at a time to `origin/main`
in a clean worktree:

| reverted | result |
|---|---|
| `swr_replay.py` | 2 failed, 9 passed |
| `agentHER_relabeler.py` | 1 failed, 10 passed |
| `state_db_qdrant_sync.py` | 3 failed, 8 passed |
| `ua-ingest.py` | 1 failed, 10 passed |
| all four | 7 failed, 4 passed |
| none (branch HEAD) | 11 passed |

The 4 that pass in both states are the deliberate fallback guards: they assert
the alternate env name still works alone, so a deployment setting only the old
name does not silently move. They are supposed to be green before and after.

Two of the state_db tests exercise `embed_batch` itself, since that defect is
only visible as behaviour — one asserts a correctly sized 1536-dim vector now
survives, the other that a genuinely wrong width is still dropped.

## Blast radius

All four are no-ops at the default configuration, which is why no existing test
moved. Verified concretely: importing all four modules on this branch and on
`origin/main` with the reference host's actual environment yields byte-identical
values (`nomic-embed-text` / `loci_memory` / `768` / `''`). None of the four env
vars is set on the reference host, and none of these scripts is invoked by the
crontab, the MLOps loop, or the grooming tier — `cron/jobs.json`, which declares
`state-db-qdrant-sync`, is read by nothing (#205). Merging arms nothing.

CI gates reproduced locally: the `test-scripts` job's exact shape (a venv with
only pytest, pytest-timeout and aiohttp, run from `scripts/`) gives 800 passed —
the new file imports only stdlib and stubs `requests` rather than importing it,
so it does not error at collection there. `vulture` with `ci.yml`'s argv exits 0
with no findings, and `check_vulture_whitelist.py` reports all 55 entries still
live. The callgraph corpus file count (`== 126`) is unmoved — the new file is
under `scripts/tests/`, which that walk excludes.

## Deliberately left alone

**`scripts/hooks/pre_llm_grounding.py:102`** has the same drift as swr_replay in
the opposite role: it searches `loci_memory` — mcp's collection — with
`MNEMOSYNE_EMBEDDING_MODEL`. It runs on every LLM call, so changing which model
grounds retrieval has a much larger blast radius than a nightly cron script and
belongs in its own reviewed change.

**swr_replay's dense-only upsert.** It writes a `dense` vector only, while
`qdrant_ops` writes dense+sparse and searches hybrid RRF (`:540`). A real
defect, but a different one.

## Known limit of the swr_replay fix

The fallback means this does **not** close the drift in the one configuration the
finding named as the motivating case. An operator who copies `.env.example` sets
`MNEMOSYNE_EMBEDDING_MODEL` and never sees `EMBED_MODEL` mentioned; with only
that var set, swr_replay still resolves to it while `qdrant_ops` resolves to
`nomic-embed-text`. Measured on this branch:

```
MNEMOSYNE_EMBEDDING_MODEL=text-embedding-3-small, EMBED_MODEL unset
  swr_replay writes loci_memory with:   text-embedding-3-small
  qdrant_ops searches loci_memory with: nomic-embed-text        -> still disagree

EMBED_MODEL=nomic-embed-text, MNEMOSYNE_EMBEDDING_MODEL=text-embedding-3-small
  swr_replay: nomic-embed-text   qdrant_ops: nomic-embed-text   -> agree
```

The change is never worse than `main` in any configuration, and it matches the
resolution order mcp itself already uses at `memcheck/llm.py:84` — but the
complete fix needs `.env.example` to document `EMBED_MODEL` as the knob that
owns `loci_memory`, or a single shared resolver both files call. Left out here
because it is a docs+contract change touching a different surface, and because
`qdrant_ops` has its own unaddressed split (it sizes from
`MNEMOSYNE_EMBEDDING_DIM` but picks the model from `EMBED_MODEL`), which should
be settled in the same change rather than piecemeal.
