### PR TITLE
Let a finding's age reach the checks that read it, and stop a naive loop_state stamp from throwing away the tick

### DIFF
--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -1037,6 +1037,7 @@ def investigation_import(
 
         # Re-index findings into Qdrant (fail-open).
         qdrant_indexed = 0
+        import_ts = int(datetime.now(timezone.utc).timestamp())
         for finding in findings:
             if not isinstance(finding, dict):
                 continue
@@ -1045,13 +1046,24 @@ def investigation_import(
             if not text or not finding_id:
                 continue
             try:
-                payload = {
+                # Index the whole finding, as the native store path does
+                # (server._store_finding). A hand-built payload dropped
+                # created_at_ts, and every age check reads that key: ranking
+                # decay skipped the row and the retention purge could not match
+                # it, so imported findings outranked native ones forever.
+                payload = dict(finding)
+                payload.update({
                     "investigation_id": new_id,
                     "type": finding.get("type") or finding.get("record_type") or "observed",
                     "source": finding.get("source") or "",
                     "confidence": finding.get("confidence") or "medium",
                     "tags": finding.get("tags") or [],
-                }
+                })
+                if not payload.get("created_at_ts"):
+                    # A bundle with no age at all: substitute import time and say so,
+                    # so a reader can tell a real age from a stand-in.
+                    payload["created_at_ts"] = import_ts
+                    payload["age_source"] = "imported"
                 _qdrant_upsert(finding_id, text, payload)
                 qdrant_indexed += 1
             except Exception as exc:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -6401,9 +6401,17 @@ def _rag_apply_decay(results: list[dict]) -> None:
             ts_val = r.get("created_at_ts") or r.get("ts")
             if ts_val is None:
                 continue
-            # ts may be an ISO string; created_at_ts is always an int epoch
+            # ts may be an ISO string (inv_store._now); created_at_ts is always an
+            # int epoch. float() alone raised on every ISO fallback, so any point
+            # carrying only ts — the corpus predating created_at_ts — escaped decay.
             try:
-                age_days = (now_ts - float(ts_val)) / 86400.0
+                ts_num = float(ts_val)
+            except (TypeError, ValueError):
+                ts_num = float(_coerce_ts(ts_val))
+            if ts_num <= 0:
+                continue
+            try:
+                age_days = (now_ts - ts_num) / 86400.0
                 if age_days < 0:
                     age_days = 0.0
                 raw_score = float(r.get("score") or 0.0)

--- a/mcp/tests/test_age_key_survives.py
+++ b/mcp/tests/test_age_key_survives.py
@@ -1,0 +1,117 @@
+"""Two age checks that could not answer the question they were asked.
+
+Both readers of a finding's age default a missing/unreadable timestamp to
+"fresh": _rag_apply_decay keeps the raw score, and the retention purge cannot
+match a point with no created_at_ts at all. So a row that loses its age does not
+degrade — it wins, and keeps winning as the corpus gets older.
+
+1. investigation_import re-indexed findings with a hand-built payload that
+   dropped created_at_ts, so every imported finding was un-ageable and
+   un-purgeable.
+2. _rag_apply_decay's ISO fallback ran float() on an ISO string, which always
+   raised, so any point carrying only `ts` escaped decay through a swallowed
+   exception.
+"""
+import json
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+import investigation_tools
+import server
+
+
+def _bundle(finding):
+    return json.dumps({
+        "schema_version": "1.0",
+        "manifest": {"id": "src-inv", "title": "Source"},
+        "findings": [finding],
+    })
+
+
+class TestImportKeepsFindingAge(unittest.TestCase):
+    """investigation_import must index the age it was given."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_dir = server.MEMORY_DIR
+        server.MEMORY_DIR = Path(self._tmp.name)
+        self._orig_upsert = investigation_tools._qdrant_upsert
+        self.upserts = []
+        investigation_tools._qdrant_upsert = lambda pid, text, payload: self.upserts.append(
+            (pid, text, dict(payload))
+        )
+
+    def tearDown(self):
+        investigation_tools._qdrant_upsert = self._orig_upsert
+        server.MEMORY_DIR = self._orig_dir
+        self._tmp.cleanup()
+
+    def test_imported_finding_carries_its_own_created_at_ts(self):
+        old_ts = int(time.time()) - 90 * 86400
+        result = json.loads(server.investigation_import(bundle_json=_bundle({
+            "id": "f-old",
+            "text": "A finding exported from another machine three months ago.",
+            "type": "observed",
+            "source": "test:bundle",
+            "confidence": "high",
+            "created_at_ts": old_ts,
+            "ts": datetime.fromtimestamp(old_ts, timezone.utc).isoformat(),
+        })))
+        self.assertNotIn("error", result)
+        self.assertEqual(result["qdrant_indexed"], 1)
+
+        payload = self.upserts[0][2]
+        self.assertEqual(payload["created_at_ts"], old_ts)
+        self.assertNotIn("age_source", payload)
+        # The import still owns the row: investigation_id is rewritten.
+        self.assertEqual(payload["investigation_id"], result["new_investigation_id"])
+
+    def test_ageless_finding_gets_import_time_and_says_so(self):
+        before = int(time.time())
+        result = json.loads(server.investigation_import(bundle_json=_bundle({
+            "id": "f-ageless",
+            "text": "A finding from a bundle that carried no timestamp at all.",
+            "type": "observed",
+        })))
+        self.assertNotIn("error", result)
+
+        payload = self.upserts[0][2]
+        self.assertGreaterEqual(payload["created_at_ts"], before)
+        self.assertEqual(payload["age_source"], "imported")
+
+
+class TestRagDecayReadsIsoTimestamps(unittest.TestCase):
+    """A point carrying only `ts` is not exempt from decay."""
+
+    def _row(self, **kw):
+        row = {"origin": server.QDRANT_COLLECTION_PREFIX, "score": 1.0}
+        row.update(kw)
+        return row
+
+    def test_iso_ts_fallback_is_decayed(self):
+        old = datetime.fromtimestamp(time.time() - 100 * 86400, timezone.utc)
+        rows = [self._row(ts=old.isoformat())]
+        server._rag_apply_decay(rows)
+        self.assertTrue(rows[0].get("decay_applied"))
+        self.assertLess(rows[0]["score"], 0.6)
+
+    def test_iso_and_epoch_rows_of_the_same_age_score_the_same(self):
+        old_epoch = int(time.time()) - 100 * 86400
+        old_iso = datetime.fromtimestamp(old_epoch, timezone.utc).isoformat()
+        rows = [self._row(created_at_ts=old_epoch), self._row(ts=old_iso)]
+        server._rag_apply_decay(rows)
+        self.assertEqual(rows[0]["score"], rows[1]["score"])
+
+    def test_unreadable_timestamp_still_keeps_the_raw_score(self):
+        rows = [self._row(ts="not a timestamp"), self._row()]
+        server._rag_apply_decay(rows)
+        for row in rows:
+            self.assertEqual(row["score"], 1.0)
+            self.assertNotIn("decay_applied", row)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -163,6 +163,28 @@ def _fail(step: str, line: str) -> None:
     print(f"[loop] {line}")
 
 
+def _days_since(now: datetime, iso_ts, default: int = 999) -> int:
+    """Whole days between a loop_state.json timestamp and ``now``.
+
+    Flooring is fine — for an integer cadence ``floor(x) >= n`` and ``x >= n``
+    agree. Raising is not: a naive or hand-edited timestamp threw out of the
+    cadence gate, which sits AFTER the retrain and canary and BEFORE _save_state,
+    so the tick did its work and then lost its state. A naive stamp is read as
+    UTC; an unreadable one falls back to the same ``default`` a missing key gets
+    (ancient, so run), and says so.
+    """
+    if not iso_ts:
+        return default
+    try:
+        then = datetime.fromisoformat(str(iso_ts))
+    except (TypeError, ValueError):
+        print(f"[loop] unreadable timestamp {iso_ts!r} in loop_state.json — treating as {default}d ago")
+        return default
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=timezone.utc)
+    return (now - then).days
+
+
 def _skip_reason(ollama_ok: bool, days_ago: int, cadence: int, ollama: str) -> str:
     """Why a cadence-gated step did not run. These gates are also Ollama-gated, so
     reciting only the cadence blames the schedule for an unreachable backend."""
@@ -662,10 +684,7 @@ def main() -> int:
         _run_embedding_drift(args.ollama, args.dry_run)
 
     # ── 7. SFT bake (cadence-gated) ───────────────────────────────────────────
-    last_sft = state.get("last_sft_bake")
-    sft_days_ago = (
-        (now - datetime.fromisoformat(last_sft)).days if last_sft else 999
-    )
+    sft_days_ago = _days_since(now, state.get("last_sft_bake"))
     if ollama_ok and sft_days_ago >= args.sft_every:
         print(f"[loop] SFT bake (last was {sft_days_ago}d ago)")
         ok = _run_sft_bake(args.ollama, args.dry_run)
@@ -675,10 +694,7 @@ def main() -> int:
         print(f"[loop] SFT bake skipped — {_skip_reason(ollama_ok, sft_days_ago, args.sft_every, args.ollama)}")
 
     # ── 8. Embedding trigger (cadence-gated) ──────────────────────────────────
-    last_emb = state.get("last_embedding_tune")
-    emb_days_ago = (
-        (now - datetime.fromisoformat(last_emb)).days if last_emb else 999
-    )
+    emb_days_ago = _days_since(now, state.get("last_embedding_tune"))
     if emb_days_ago >= args.embedding_every:
         print(f"[loop] embedding trigger (last was {emb_days_ago}d ago)")
         _emit_embedding_trigger()
@@ -688,8 +704,7 @@ def main() -> int:
         print(f"[loop] embedding trigger skipped ({emb_days_ago}d ago, cadence={args.embedding_every}d)")
 
     # ── 8a. Active learning candidates (cadence-gated) ────────────────────────
-    last_al = state.get("last_active_learn")
-    al_days_ago = (now - datetime.fromisoformat(last_al)).days if last_al else 999
+    al_days_ago = _days_since(now, state.get("last_active_learn"))
     if ollama_ok and al_days_ago >= args.active_learn_every:
         print(f"[loop] active_learn (last was {al_days_ago}d ago)")
         al_result = _run_active_learn(args.ollama)

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -1323,23 +1323,41 @@ def test_main_sft_bake_is_still_attempted_in_dry_run(mainenv):
     assert not (e.mlops / "loop_state.json").exists()
 
 
-def test_main_naive_sft_timestamp_crashes_the_loop(mainenv):
-    """BUG pinned: cadence arithmetic subtracts a state timestamp from an
-    aware ``now`` with no normalisation. A naive ISO string in loop_state.json
-    (hand-edited, or written by a pre-timezone version) raises TypeError and
-    the nightly never reaches state persist or history append."""
+def test_main_naive_sft_timestamp_is_read_as_utc(mainenv):
+    """A naive ISO string in loop_state.json (hand-edited, or written by a
+    pre-timezone version) used to raise TypeError out of the cadence gate — which
+    sits after the retrain and canary and before the state persist, so the tick
+    did its work and threw the result away. It is now read as UTC."""
     e = mainenv
     seed_state(e, last_sft_bake="2024-01-01T00:00:00")
-    with pytest.raises(TypeError):
-        e.main()
-    assert read_history(e) == []
+    e.main()
+    assert len(e.calls["sft"]) == 1
+    assert read_history(e) != []
 
 
-def test_main_unparseable_sft_timestamp_crashes_the_loop(mainenv):
+def test_main_unparseable_sft_timestamp_is_treated_as_ancient(mainenv, capsys):
+    """Same crash through ValueError. Unreadable age now falls back to the
+    missing-key default — ancient, so the step runs — and says which value it
+    could not read."""
     e = mainenv
     seed_state(e, last_sft_bake="never")
-    with pytest.raises(ValueError):
-        e.main()
+    e.main()
+    assert len(e.calls["sft"]) == 1
+    assert "unreadable timestamp 'never' in loop_state.json" in capsys.readouterr().out
+    assert read_history(e) != []
+
+
+def test_days_since_normalises_a_naive_stamp_instead_of_raising():
+    now = datetime(2026, 1, 11, tzinfo=timezone.utc)
+    assert loop._days_since(now, "2026-01-01T00:00:00") == 10
+    assert loop._days_since(now, "2026-01-01T00:00:00+00:00") == 10
+
+
+def test_days_since_falls_back_to_the_missing_key_default():
+    now = datetime(2026, 1, 11, tzinfo=timezone.utc)
+    assert loop._days_since(now, "never") == 999
+    assert loop._days_since(now, None) == 999
+    assert loop._days_since(now, "") == 999
 
 
 # --- embedding trigger cadence ------------------------------------------------


### PR DESCRIPTION
Three age checks that could not answer the question they were asked. Each one
resolved a missing or unreadable timestamp in the direction that hides the
problem: two treated a row with no usable age as *fresh* (so it wins the
ranking and keeps winning as the corpus ages), and one threw the whole nightly
tick away rather than degrade.

## 1. `investigation_import` dropped the age it was handed

`investigation_import` re-indexed every imported finding into Qdrant with a
hand-built five-key payload — `{investigation_id, type, source, confidence,
tags}` — dropping `created_at_ts` and `ts`, both of which the source finding
carries. Three readers act on the absent key:

- `server._rag_apply_decay` (`mcp/server.py:6401`): `ts_val = r.get("created_at_ts") or r.get("ts")` → `None` → `continue`. The row keeps its raw bi-encoder score while native findings are multiplied by `exp(-λ·age)`.
- `qdrant_ops._purge_old_records` (`mcp/qdrant_ops.py:205`): the TTL delete is `Range(lt=cutoff)` on `created_at_ts`, and a Qdrant range condition does not match a point missing the key — so the retention window silently did not apply to imported findings at all, contradicting that function's own docstring.
- `server._surface_apply_decay` (`mcp/server.py:6622`): `float(r.get("created_at_ts") or now_ts)` → age 0 → decay 1.0.

The JSONL copy was never affected — the import writes `dict(finding)` whole to
disk at `investigation_tools.py:1020`; only the search index lost the age.
`investigation_import` is the cross-machine share path, so this was exactly the
corpus most likely to be old.

**Change:** index the whole finding, as the native store path already does
(`server._store_index` passes the finding dict straight to `_qdrant_upsert`),
then rewrite `investigation_id` and the four normalised fields on top. A bundle
that genuinely carries no age gets import time plus `age_source: "imported"`,
so a reader can tell a real age from a stand-in rather than the substitution
being invisible.

## 2. `_rag_apply_decay`'s ISO fallback could never fire

`created_at_ts` is an int epoch; `ts` is an ISO-8601 string from
`inv_store._now()`. `float(ts_val)` therefore raised `ValueError` on *every*
fallback. The exception was caught and logged at DEBUG, so the row flowed into
the sort undecayed with nothing to show for it. The affected corpus is points
predating `created_at_ts` — the oldest part of the index, which is what the
decay exists for.

**Change:** try `float()` first so anything it already accepted is byte-for-byte
unchanged, then fall back to `ladybug_ops._coerce_ts` (already imported in this
module) to bridge the ISO string. `_coerce_ts` returns 0 for what it cannot
read, and `ts_num <= 0` skips — keeping the raw score exactly as the old
swallowed exception did.

## 3. A naive `loop_state.json` timestamp threw away the whole tick

The three cadence gates in `mlops/loop.py` parsed state timestamps with a bare
`datetime.fromisoformat` and subtracted them from an aware `now`. A naive ISO
string raises `TypeError`; an unparseable one raises `ValueError`. Either lands
at the SFT gate (`:669`), which sits **after** the dataset rebuild, retrain and
canary and **before** `_save_state` — so the tick did all of its expensive work
and then lost the record of it, and the next night started over.

**Change:** `_days_since` reads a naive stamp as UTC (the same one-liner already
used in `mlops/memory/decay.py:107` and `scripts/glymphatic_sweep.py:206`) and
falls back on an unreadable one to the same `999` a missing key already gets —
ancient, so the step runs — naming the value it could not read. That is the
direction these gates already resolve a missing key and the branch a first-ever
run takes.

The `.days` floor stays: every cadence is `argparse type=int`, and for integer
`n`, `floor(x) >= n` and `x >= n` are the same test.

## Tests, and that they fail without the fix

`mcp/tests/test_age_key_survives.py` (new, 5 tests) and four tests in
`mlops/tests/test_loop.py`. Red-then-green was verified by restoring each
`origin/main` source file over the branch's, per file:

| reverted file | result |
|---|---|
| `mcp/server.py` only | 2 failed (`AssertionError: None is not true`; `0.4966 != 1.0`), 3 passed |
| `mcp/investigation_tools.py` only | 2 failed (`KeyError: 'created_at_ts'` ×2), 3 passed |
| both | 4 failed, 1 passed |
| branch as-is | 5 passed |
| `mlops/loop.py` reverted | 4 failed — `TypeError: can't subtract offset-naive and offset-aware datetimes`, `ValueError: Invalid isoformat string: 'never'`, `AttributeError: no attribute '_days_since'` ×2 |

Each fix is independently load-bearing for its own two tests; neither is carried
by the other. The fifth test (`test_unreadable_timestamp_still_keeps_the_raw_score`)
passes both ways by design — it pins that the new path did not change what
happens to a genuinely unreadable stamp.

Full suites on the branch: `mcp/tests` 856 passed + 10 subtests; `mlops/tests`
179 passed; `mlops/grounding/tests` 132 passed; `scripts/callgraph/tests` 257
passed (corpus file count unmoved — the only new `.py` is under `mcp/tests/`,
which is excluded). `ruff` clean over the CI-scoped paths.

## What this does and does not arm, measured on the operator box

- **The TTL purge stays off.** `~/.loci/backends.toml` has `retention_days = 0` and the code default is 0, so `_purge_old_records` returns before building a filter. Where an operator *has* opted in, imported findings past the window now go — which is what that setting says, and the docstring already claimed. Nothing starts deleting on this change alone.
- **No ranking moves today.** A live count against `loci_memory` (3,966 points) returns **0** points missing `created_at_ts` and **0** carrying `ts` without it, so fix #2 changes the score of nothing currently indexed. It is hardening for legacy and future rows.
- **No imported corpus exists here.** No manifest under `~/.loci/memory-sessions` (154 investigations) carries `imported_from`, so there are no already-broken points. Note that this fix corrects the *write* path only: `loci_groom index --apply` upserts ids **missing** from the index, so an operator who already has imported findings would need a re-index to repair them. Nothing to repair on this machine.
- **The nightly is bit-identical.** `~/.loci/bin/mlops-cron` resolves the loop from `origin/main` and the 02:00 crontab passes no flags, so merging is the deploy. Ran the old expression and `_days_since` side by side over both real `loop_state.json` files: `last_sft_bake=None` → 999/999, `last_embedding_tune` → 3/3 and 1/1, `last_active_learn` → 999/999 and 1/1. Every gate decides the same thing. `--decay-apply` is not passed, so the destructive Weibull write remains off.

## Deliberately left alone

Three of the six findings in this class are a measurement or an operator
decision, not a diff:

1. **`mlops/memory/decay.py:41` (HIGH)** — Weibull `λ=30, k=0.8` copied from a paper fit to another corpus. With floor 0.2 that is a forget cliff at 26.9 / 39.8 / 50.0 days for importance 0.5 / 0.7 / 0.9. Setting it right means sweeping λ on a labelled query set through `eval/harness.py` — an experiment. The interim guard (refuse to commit when `n_grounding_visible_after/before` drops past a fraction) needs a threshold nobody has derived either, and it gates a job that writes destructively to `importance`.
2. **`scripts/glymphatic_sweep.py:191` (MEDIUM)** — `recall_count` gates a permanent DELETE but has exactly one writer (`ebbinghaus_consolidation.py:339`), so it records "consolidation picked this row", not "anyone read it"; NULL folds to 0, the deleting branch. Every fix is either broad (write a `last_read_ts` from `_mnemo_recall`, `rag_context_search`, `memory_surface` and `pre_llm_grounding` — four modules and a schema column) or a behaviour flip an operator has to choose (making `dry_run` default True silently stops a maintenance job that runs today).
3. **`scripts/hooks/pre_llm_grounding.py:126` (MEDIUM)** — three unreconciled half-lives on one corpus: 7 d in the hook, 99 d in `server._MEMORY_DECAY_LAMBDA`, 19 d in `decay.py`'s Weibull. A 30-day finding scores 0.0513 in the hook and 0.8106 in `rag_context_search`. Same as #1: the fix is picking one *measured* half-life. Changing any constant blind moves the ranking of every agent turn, and the diff would look tiny while being the largest behaviour change of the six.
