### PR TITLE
Fix NameError in the embedding cadence gate

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -743,7 +743,7 @@ def main() -> int:
     if emb_days_ago >= args.embedding_every:
         print(f"[loop] embedding trigger (last was {emb_days_ago}d ago)")
         _emit_embedding_trigger()
-        if _embedding_tune_ran(last_emb):
+        if _embedding_tune_ran(state.get("last_embedding_tune")):
             if not args.dry_run:
                 state["last_embedding_tune"] = now_iso
         else:


### PR DESCRIPTION
`main` is red: **55 failed, 560 passed** in the MLOps job, every failure `NameError: name 'last_emb' is not defined`.

#276 replaced the inline `last_emb = state.get("last_embedding_tune")` with `_days_since(...)`. #277 added a call to `_embedding_tune_ran(last_emb)`. Neither diff touched the other's line, so git merged both without a conflict and produced a call to a name that no longer exists. A textual merge cannot see this; only running the tests can.

The fix reads the state key directly, which is exactly what `_days_since` does on the line above it.

```
mlops   615 passed
```

## Why it landed

`MLOps tests` is not one of `main`'s three required checks:

```
required:  MCP server tests, A2A server tests, Lint (ruff)
not:       MLOps tests, Eval tests, Callgraph tool tests, Dead code (vulture),
           Type check (mypy), Sync script tests, Schema consistency, MCP tool integration
```

Auto-merge waits on the required three, so 55 red tests did not hold it. My merge driver has been hardened to refuse any PR with a failing check regardless of whether it is required — that is the half I control. Making `MLOps tests` required is a branch-protection change and yours to make; on today's evidence I'd suggest it.