### PR TITLE
Stop the nightly from hanging forever, and from skipping in silence

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -60,6 +60,12 @@ def _child_label(cmd) -> str:
     return Path(str(cmd[0])).stem
 
 
+# How long to wait for a child's output readers after the child itself has gone.
+# Only reached when a grandchild inherited the pipe; the drains are daemons and
+# a hung loop is far worse than a truncated log.
+DRAIN_JOIN_SECONDS = float(os.environ.get("LOCI_MLOPS_DRAIN_JOIN", "10"))
+
+
 def _run(cmd, timeout: int | None = None, stream: bool = True):
     """Run a child with a bound, resolved backends, and its output echoed live.
 
@@ -118,13 +124,24 @@ def _run(cmd, timeout: int | None = None, stream: bool = True):
         proc.kill()
         proc.wait()
         code = 124
+    # Bounded. Joining without a timeout assumed reaping the child closes the
+    # pipes, and that is only true if the child had no grandchild: a grandchild
+    # inherits the pipe fds and holds the write end open after its parent dies,
+    # so `for line in pipe` never returns and this join never comes back.
+    # Measured 2026-09-01: a loop.py sat in futex_wait_queue for 19h07m with two
+    # threads in pipe_read, holding /tmp/loci-mlops.lock, which made every
+    # subsequent `flock -n` nightly exit silently. The threads are daemons, so
+    # abandoning them costs nothing but a few interleaved log lines.
     for t in threads:
-        # No timeout. Returning while a drain thread still holds a pipe means log
-        # lines land after the caller has moved on, interleaved into the next
-        # step's output. The pipes are closed once the process is reaped, so
-        # these threads end on their own.
-        t.join()
+        t.join(timeout=DRAIN_JOIN_SECONDS)
+    stuck = [t for t in threads if t.is_alive()]
     err = "".join(captured["err"])
+    if stuck:
+        msg = (f"{len(stuck)} output reader(s) still blocked {DRAIN_JOIN_SECONDS}s after "
+               f"{label} exited — a grandchild is holding the pipe open. "
+               "Output past this point is lost; the step's result is not.")
+        print(f"  [{label}] {msg}", flush=True)
+        err = (err + "\n" + msg).strip()
     if code == 124:
         err = (err + f"\ntimed out after {limit}s").strip()
     return subprocess.CompletedProcess(cmd, code, "".join(captured["out"]), err)
@@ -142,6 +159,7 @@ if str(REPO) not in sys.path:
 # that reports "done" after every step errored is the failure mode this loop
 # spent 67 nights in.
 FAILED_STEPS: list[str] = []
+
 
 
 def _last_error_line(stderr: str) -> str:

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import stat
+import time
 import sys
 import types
 import urllib.error
@@ -1671,3 +1672,44 @@ def test_the_emitted_command_can_actually_import_its_dependencies(env):
         f"the emitted script runs {interp}, which cannot import sentence_transformers:\n"
         + out.stderr.strip()
     )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# _run must not be able to hang
+#
+# Measured 2026-09-01: a loop.py sat in futex_wait_queue for 19h07m with its two
+# drain threads in pipe_read, holding /tmp/loci-mlops.lock. The join had no
+# timeout on the assumption that reaping the child closes the pipes -- true only
+# when the child had no grandchild. A grandchild inherits the pipe fds and holds
+# the write end open after its parent dies, so `for line in pipe` never returns.
+# ══════════════════════════════════════════════════════════════════════════════
+
+def test_run_returns_even_when_a_grandchild_holds_the_pipe_open(monkeypatch):
+    """The child exits immediately; a grandchild keeps stdout open past it."""
+    monkeypatch.setattr(loop, "DRAIN_JOIN_SECONDS", 1.0, raising=False)
+    started = time.monotonic()
+    result = loop._run([
+        sys.executable, "-c",
+        # spawn a grandchild that inherits stdout and outlives us, then exit
+        "import subprocess,sys;"
+        "print('parent line', flush=True);"
+        "subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']);"
+        "sys.exit(0)",
+    ])
+    elapsed = time.monotonic() - started
+    assert elapsed < 20, f"_run took {elapsed:.1f}s — it is waiting on the grandchild"
+    assert result.returncode == 0
+    assert "parent line" in result.stdout
+
+
+def test_run_says_so_when_it_abandons_a_blocked_reader(monkeypatch, capsys):
+    monkeypatch.setattr(loop, "DRAIN_JOIN_SECONDS", 0.5, raising=False)
+    result = loop._run([
+        sys.executable, "-c",
+        "import subprocess,sys;"
+        "subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']);"
+        "sys.exit(0)",
+    ])
+    out = capsys.readouterr().out
+    assert "still blocked" in out, out
+    assert "still blocked" in result.stderr, result.stderr

--- a/scripts/mlops-cron
+++ b/scripts/mlops-cron
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Branch-independent launcher for the MLOps nightly.
+#
+# The crontab used to invoke scripts/mlops_loop_cron.sh straight out of the
+# working tree. 38 of the repo's 39 branches do not contain that file, so the
+# job silently no-opped for two nights with nothing in the log but an ENOENT
+# from flock — indistinguishable from "ran and found nothing to do".
+#
+# This resolves the script from origin/main instead, so it does not matter what
+# the working tree is checked out on, and it is loud about every way it can fail.
+set -uo pipefail
+
+LOCK="${LOCI_MLOPS_LOCK:-/tmp/loci-mlops.lock}"
+REPO="${LOCI_REPO:-/home/rjmendez/development/loci}"
+STAGE="${LOCI_MLOPS_STAGE:-$HOME/.loci/mlops/stage}"
+SCRIPT="scripts/mlops_loop_cron.sh"
+stamp() { date -Is; }
+
+# Take the lock HERE rather than in the crontab. `flock -n` in the crontab exits
+# 1 with no output, so a stuck run makes every following night a silent no-op --
+# indistinguishable from "ran and found nothing to do". On 2026-09-01 a loop.py
+# deadlocked for 19h holding this lock and two nightlies vanished without a line.
+# Who holds it, asked BEFORE we open our own descriptor -- otherwise fuser
+# reports this process too and the age below is our own.
+holders="$(fuser "$LOCK" 2>/dev/null | tr -s ' ' | sed 's/^ *//')"
+exec 9>"$LOCK" || { echo "$(stamp) mlops-cron: cannot open $LOCK" >&2; exit 1; }
+if ! flock -n 9; then
+  oldest="${holders%% *}"
+  age="$(ps -o etime= -p "${oldest:-0}" 2>/dev/null | tr -d ' ')"
+  what="$(ps -o args= -p "${oldest:-0}" 2>/dev/null | cut -c1-70)"
+  echo "$(stamp) mlops-cron: SKIPPED — another run holds $LOCK" >&2
+  echo "$(stamp) mlops-cron:   pid ${oldest:-?} running for ${age:-unknown}: ${what:-unknown}" >&2
+  echo "$(stamp) mlops-cron:   a run older than a day is stuck; kill it and the next tick recovers" >&2
+  exit 75   # EX_TEMPFAIL: not an error in this run, but not a run either
+fi
+
+[ -d "$REPO/.git" ] || { echo "$(stamp) mlops-cron: no git repo at $REPO" >&2; exit 1; }
+
+git -C "$REPO" fetch -q origin main 2>/dev/null \
+  || echo "$(stamp) mlops-cron: fetch failed, using the last known origin/main" >&2
+
+mkdir -p "$STAGE"
+if ! git -C "$REPO" show "origin/main:$SCRIPT" > "$STAGE/mlops_loop_cron.sh" 2>/dev/null; then
+  echo "$(stamp) mlops-cron: origin/main has no $SCRIPT — nothing ran" >&2
+  exit 1
+fi
+[ -s "$STAGE/mlops_loop_cron.sh" ] || { echo "$(stamp) mlops-cron: extracted an empty $SCRIPT" >&2; exit 1; }
+chmod +x "$STAGE/mlops_loop_cron.sh"
+
+echo "$(stamp) mlops-cron: running $SCRIPT from origin/main $(git -C "$REPO" rev-parse --short origin/main)"
+exec "$STAGE/mlops_loop_cron.sh" "$@"


### PR DESCRIPTION
I went looking for what else could be hardened in mlops and found the nightly **had not run for two nights**. A `loop.py` was sitting in `futex_wait_queue`, 19h07m elapsed, holding `/tmp/loci-mlops.lock`:

```
tid 2477520 (main)  futex_wait_queue   ← t.join(), no timeout
tid 2481092         pipe_read          ← drain thread
tid 2481093         pipe_read          ← drain thread
fd 4 -> pipe:[312028717]   fd 6 -> pipe:[312028718]
```

## The hang

`_run` joined its drain threads with no timeout, on a stated assumption:

> The pipes are closed once the process is reaped, so these threads end on their own.

That is true only when the child had no grandchild. **A grandchild inherits the pipe fds** and holds the write end open after its parent dies, so `for line in pipe` never returns and the join never comes back — even after `proc.kill()`.

The join is now bounded by `DRAIN_JOIN_SECONDS` (10s, `LOCI_MLOPS_DRAIN_JOIN`) and reports what it abandoned, to both the log and the step's stderr. The drains are daemon threads, so the cost is a few lost log lines against a nightly that cannot wedge.

## Why one hang cost three nights

The crontab ran the launcher under `flock -n`, which exits 1 with **no output at all** when the lock is held. In a log, that is indistinguishable from *"ran and found nothing to do"* — and it is exactly the failure this launcher was written to fix in the first place, one layer up. `mlops-cron` now takes the lock itself:

```
held:  mlops-cron: SKIPPED — another run holds /tmp/loci-mlops.lock
       mlops-cron:   pid 3060655 running for 00:02: flock ... sleep 25
       mlops-cron:   a run older than a day is stuck; kill it and the next tick recovers
       exit 75
free:  runs through unchanged
```

Both paths verified by test. The crontab's own `flock -n` had to go — the launcher's `exec 9>` creates a separate open file description, so leaving both would make it skip every night forever.

## The launcher is now in the repo

`scripts/mlops-cron` existed only at `~/.loci/bin/mlops-cron`: untracked, unreviewed, unbacked-up, and the single thing that actually starts the nightly.

## Tests

Red against main **by hanging**, which is the whole point:

```
main    _run took 30.0s — the grandchild's entire sleep      2 failed in 60.4s
here                                                          2 passed in 3.2s
mlops                                                        617 passed
```

## Still open, not in this PR

- `_run_canary`, `_run_embedding_drift` and `_emit_embedding_trigger` never call `_fail`, so their failures do not reach `FAILED_STEPS` or the exit code. `_run_embedding_drift` also swallows.
- **Nothing consumes the loop's exit code or `loop.log`.** `main()` returns 1 and maintains `FAILED_STEPS` carefully; the crontab appends to a file no one reads. `loop_history.jsonl` already records a `failed_steps: ["train.py"]` from 2026-08-31 that nobody saw.
- No wall-clock bound on the loop as a whole — `LOCI_MLOPS_STEP_TIMEOUT` bounds each child step, not the run.