### PR TITLE
Stop four state writes from destroying the file they replace

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -259,7 +259,13 @@ def _load_state() -> dict:
 
 
 def _save_state(state: dict) -> None:
-    STATE_FILE.write_text(json.dumps(state, indent=2))
+    """Same-directory temp + os.replace. Truncate-in-place loses the loop's only
+    cross-run state if the process dies mid-write, and _load_state cannot tell an
+    empty file from a first run: it returns the defaults, which re-discovers every
+    historical run as new and opens every cadence gate at once."""
+    tmp = STATE_FILE.parent / (STATE_FILE.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    os.replace(tmp, STATE_FILE)
 
 
 def _append_history(record: dict) -> None:

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -176,6 +176,38 @@ def test_save_state_writes_indent_2_json(env):
     assert "\n  " in text
 
 
+def test_save_state_keeps_the_old_state_when_the_write_dies(env):
+    """A crash part-way through the save must not leave the state file empty.
+
+    _load_state cannot tell a truncated file from a first run: it swallows the
+    JSONDecodeError and returns the defaults, so runs_seen=[] re-discovers every
+    historical run as new, last_dataset_size=0 disarms the --min-new-pairs veto,
+    and every cadence gate opens at once. The state is written once, at the end
+    of the run, so losing it costs the whole night's bookkeeping.
+    """
+    committed = {"last_dataset_size": 4200, "runs_seen": ["r1", "r2"],
+                 "total_promotions": 3}
+    loop._save_state(committed)
+    assert loop._load_state() == committed
+
+    def half_write_text(self, data, *args, **kwargs):
+        with open(self, "w") as fh:
+            fh.write(data[: len(data) // 2])
+        raise OSError("simulated crash mid-write")
+
+    # Its own context: the `env` fixture holds the function-scoped monkeypatch,
+    # so undoing that one would put STATE_FILE back to the real repo path.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(Path, "write_text", half_write_text)
+        with pytest.raises(OSError):
+            loop._save_state({"last_dataset_size": 5300,
+                              "runs_seen": ["r1", "r2", "r3"],
+                              "total_promotions": 4})
+
+    assert loop._load_state() == committed
+    assert (env.mlops / "loop_state.json").read_text() == json.dumps(committed, indent=2)
+
+
 def test_save_state_overwrites_previous_content(env):
     loop._save_state({"a": 1})
     loop._save_state({"b": 2})

--- a/scripts/a2a_context_bridge.py
+++ b/scripts/a2a_context_bridge.py
@@ -97,8 +97,14 @@ def _load_state() -> dict:
 
 
 def _save_state(state: dict):
-    Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)
-    Path(STATE_FILE).write_text(json.dumps(state, indent=2))
+    """Same-directory temp + os.replace. This runs on a 10-minute timer, and a
+    truncated state file reads back as {}: sent_ids empty re-broadcasts the whole
+    lookback window to every peer, and a lost last_run drops the held watermark."""
+    p = Path(STATE_FILE)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.parent / (p.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    os.replace(tmp, p)
 
 
 # ── Mnemosyne query ───────────────────────────────────────────────────────────────

--- a/scripts/event_log.py
+++ b/scripts/event_log.py
@@ -165,10 +165,17 @@ def compact(
         for ev in old_events:
             gz.write(json.dumps(ev) + "\n")
 
-    # Rewrite live log with only recent events
-    with open(path, "w") as fh:
+    # Rewrite live log with only recent events, via a same-directory temp +
+    # os.replace: truncate-in-place loses the entire log if the process dies
+    # part-way, and this file is the only record independent of the live store.
+    # This closes the crash half only. Events appended by another process between
+    # the read above and the replace are still dropped, because the snapshot is
+    # already stale by then; closing that needs a lock shared with append().
+    tmp = path.parent / (path.name + ".tmp")
+    with open(tmp, "w") as fh:
         for ev in new_events:
             fh.write(json.dumps(ev) + "\n")
+    os.replace(tmp, path)
 
     return {
         "archived": len(old_events),

--- a/scripts/tests/test_state_writes_are_atomic.py
+++ b/scripts/tests/test_state_writes_are_atomic.py
@@ -1,0 +1,133 @@
+"""A write that dies part-way must not destroy the file it was replacing.
+
+Three scripts persisted state by truncating the live file and writing into it:
+the A2A context bridge (~/.hermes/bridge_state.json, rewritten by a 10-minute
+systemd timer), ua-watch (~/.ua-watch-state.json, rewritten once per project
+inside the scan loop) and event_log.compact (the append-only audit log itself).
+Every one of their readers treats a truncated file as "nothing here yet" and
+returns an empty default without a word, so the loss is silent and the next run
+redoes work it had already done — re-broadcasting to peers, re-ingesting into
+Qdrant, or reporting that no memory mutation was ever recorded.
+
+Each test kills the write half-way and asserts the previous contents survived.
+Against truncate-in-place they fail; against temp + os.replace they pass.
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import time
+
+import pytest
+
+os.environ.setdefault("LOCI_ENV_FILE", "/nonexistent-env-file-for-tests")
+os.environ.setdefault("LOCI_A2A_TOKEN", "t")
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load(modname, filename):
+    spec = importlib.util.spec_from_file_location(modname, _SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _half_write_text(self, data, *args, **kwargs):
+    """Path.write_text that truncates, writes half the payload and then dies."""
+    with open(self, "w") as fh:
+        fh.write(data[: len(data) // 2])
+    raise OSError("simulated crash mid-write")
+
+
+class _DiesAfterFirstLine:
+    """File object that lets one write() through, then raises."""
+
+    def __init__(self, fh):
+        self._fh = fh
+        self._writes = 0
+
+    def write(self, s):
+        self._writes += 1
+        if self._writes > 1:
+            raise OSError("simulated crash mid-write")
+        return self._fh.write(s)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self._fh.close()
+        return False
+
+
+# ── scripts/a2a_context_bridge.py ────────────────────────────────────────────
+
+def test_bridge_state_survives_a_crash_mid_save(tmp_path, monkeypatch):
+    bridge = _load("bridge_atomic_uut", "a2a_context_bridge.py")
+    state_file = tmp_path / "bridge_state.json"
+    monkeypatch.setattr(bridge, "STATE_FILE", str(state_file))
+
+    good = {"last_run": "2026-08-30T12:00:00+00:00", "sent_ids": ["a", "b", "c"]}
+    bridge._save_state(good)
+    assert bridge._load_state() == good
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(pathlib.Path, "write_text", _half_write_text)
+        with pytest.raises(OSError):
+            bridge._save_state({"last_run": "2026-08-30T12:10:00+00:00",
+                                "sent_ids": ["a", "b", "c", "d", "e"]})
+
+    # The watermark and the dedup list are still the ones that were committed.
+    assert bridge._load_state() == good
+
+
+# ── scripts/ua-watch.py ──────────────────────────────────────────────────────
+
+def test_ua_watch_state_survives_a_crash_mid_save(tmp_path, monkeypatch):
+    ua = _load("ua_watch_atomic_uut", "ua-watch.py")
+    state_file = tmp_path / "ua-watch-state.json"
+    monkeypatch.setattr(ua, "STATE_FILE", state_file)
+
+    good = {"/repo/one": {"git_hash": "abc123", "fg_mtime": 1.0}}
+    ua.save_state(good)
+    assert ua.load_state() == good
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(pathlib.Path, "write_text", _half_write_text)
+        with pytest.raises(OSError):
+            ua.save_state({"/repo/one": {"git_hash": "abc123", "fg_mtime": 1.0},
+                           "/repo/two": {"git_hash": "def456", "fg_mtime": 2.0}})
+
+    # Both skip gates still see the recorded hash, so /repo/one is not re-ingested.
+    assert ua.load_state() == good
+
+
+# ── scripts/event_log.py ─────────────────────────────────────────────────────
+
+def test_compact_leaves_the_log_intact_when_the_rewrite_dies(tmp_path, monkeypatch):
+    ev = _load("event_log_atomic_uut", "event_log.py")
+    log = tmp_path / "event_log.jsonl"
+    now = time.time()
+    old = {"ts": now - 200 * 86400, "op": "store", "id": "old"}
+    recent = [{"ts": now - i, "op": "store", "id": f"r{i}"} for i in range(3)]
+    log.write_text("".join(json.dumps(e) + "\n" for e in [old] + recent))
+    before = log.read_text()
+
+    real_open = open
+
+    def crashing_open(file, mode="r", *args, **kwargs):
+        fh = real_open(file, mode, *args, **kwargs)
+        return _DiesAfterFirstLine(fh) if "w" in mode else fh
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ev, "open", crashing_open, raising=False)
+        with pytest.raises(OSError):
+            ev.compact(before_ts=now - 86400,
+                       archive_dir=str(tmp_path / "archive"),
+                       log_path=str(log))
+
+    # Every event is still there — including the three the rewrite meant to keep.
+    assert log.read_text() == before
+    assert len(ev.replay(log_path=str(log))) == 4

--- a/scripts/ua-watch.py
+++ b/scripts/ua-watch.py
@@ -38,7 +38,12 @@ def load_state():
 
 
 def save_state(state):
-    STATE_FILE.write_text(json.dumps(state, indent=2))
+    """Same-directory temp + os.replace. Called once per project inside the scan
+    loop, so a run over N projects opens the truncate window N times; a lost file
+    re-ingests every project into Qdrant."""
+    tmp = STATE_FILE.parent / (STATE_FILE.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    os.replace(tmp, STATE_FILE)
 
 
 def get_git_hash(project_root):


### PR DESCRIPTION
## What was wrong

Four places persisted state by truncating the live file and writing into it — no temp, no `os.replace`:

| | file | written by |
|---|---|---|
| HIGH | `mlops/loop.py:262` `_save_state` | once at the end of the ~20-minute 02:00 loop |
| MEDIUM | `scripts/a2a_context_bridge.py:101` `_save_state` | a 10-minute systemd timer, 144×/day |
| MEDIUM | `scripts/event_log.py:169` `compact` | operator, from the CLI |
| LOW | `scripts/ua-watch.py:41` `save_state` | once **per project** inside the scan loop |

None of these payloads fits in one `write()`. `runs_seen` is capped at 1000 run ids and `sent_ids` at 1000 — tens of KB each. A crash between the truncate and the last write leaves an empty or half-written file.

Every reader takes that for "nothing here yet" and returns a default without a word:

- `loop.py:245 _load_state` swallows the `JSONDecodeError` and returns its hardcoded dict. `runs_seen=[]` re-discovers every historical run as new so `should_rebuild` is True on a night with nothing new; `last_dataset_size=0` makes `new_pairs` a large positive so the `--min-new-pairs` veto can never trip and a retrain can reach the canary and **promote** on a re-ingested corpus; `last_sft_bake`/`last_embedding_tune`/`last_active_learn` all go None so every cadence gate opens on the same tick. The comment at `loop.py:650-657` already records this class of misfire in production with the sign flipped (a stale `last_dataset_size` of -7,266 that "vetoed everything on the night three new investigations carrying 1,139 findings had just been found").
- `a2a_context_bridge.py:93` returns `{}`. `sent_ids=[]` destroys the delivery dedup and re-broadcasts the whole lookback window to every peer; a lost `last_run` drops the held watermark that `:306-313` exists to maintain.
- `event_log.replay` skips undecodable lines by design, so a truncated audit log reads back as "no memory mutation was ever recorded" — and this file is the only record independent of the live store.
- `ua-watch.load_state` returns `{}`, so both skip gates miss and every project is re-ingested into Qdrant.

## Evidence it was real

Not a mock, and not theoretical. Hammering `_save_state` with a realistic 49 KB state (1000 run ids) in a child process and sending it a real `SIGKILL` at a random moment, 40 trials per arm:

```
origin/main : intact=17  CORRUPT=23
this branch : intact=40  CORRUPT=0
```

57% of kills landed inside the write window and left a file that no longer parses.

## What changed

Each write becomes a same-directory temp plus `os.replace` — the same shape already used by `mcp/inv_store.py:145` and `scripts/quorum_gate.py:68`. 24 insertions across the four production files. No reader, no default, no return value changed.

## What proves it

- `scripts/tests/test_state_writes_are_atomic.py` (new, 3 tests) and `mlops/tests/test_loop.py::test_save_state_keeps_the_old_state_when_the_write_dies`. Each kills the write half-way — a `Path.write_text` that truncates, writes half the payload and raises `OSError`; for `event_log`, a file object that lets one line through then raises — and asserts the previous contents survived.
- Verified red independently, restoring **only** the one file under test to its `origin/main` version each time:
  - `test_bridge_state_survives_a_crash_mid_save` → `assert {} == {'last_run': ..., 'sent_ids': ['a','b','c']}`
  - `test_ua_watch_state_survives_a_crash_mid_save` → `assert {} == {'/repo/one': {...}}`
  - `test_compact_leaves_the_log_intact_when_the_rewrite_dies` → the log lost 3 of its 4 lines; only `r0` survived, so the truncate destroyed two events `compact` had itself just decided to KEEP
  - `test_save_state_keeps_the_old_state_when_the_write_dies` → `_load_state()` returned the hardcoded defaults instead of the committed state

  4/4 green with the fixes.
- `scripts/`: 803 passed + 3 subtests, run the way CI runs it (`cd scripts && pytest tests/ hooks/tests/ --timeout=30`) in a venv holding only pytest, pytest-timeout and aiohttp — and run twice, once with the operator's real `$HOME` and once with an empty one, since `a2a_context_bridge` reads `~/.hermes/.env` at import. Identical both ways; no real state file was touched and nothing was created in the fresh `$HOME`.
- `mlops`: 616 collected, `mlops/tests` 190 passed. `scripts/callgraph/tests`: 257 passed, including the corpus file-count test (both new test files live under `tests/` dirs, which the corpus walk excludes). ruff and vulture clean.

## Deliberately left alone

- **The concurrent-append race in `event_log.compact`.** `compact` reads the whole log at `:145` and swaps at `:169`; events that `mcp/server.py:113 _event_log_append` writes between those two points are still lost, because the in-memory snapshot is already stale and `os.replace` does not help with that. Closing it needs the read and the swap under a lock shared with `append()`, or the tail past the last consumed offset re-read into the temp — both real changes to a fail-open audit path. `compact` is operator-invoked from the CLI only (absent from `cron/jobs.json` and every `scripts/*.sh`), so the window is opened rarely and deliberately. The commit message and an in-code comment both say this is the crash half only.
- **`loop.py:245 _load_state` still returns defaults on garbage.** `mlops/tests/test_loop.py:151-168` pins that in three separate tests, so it is a deliberate choice; with the write atomic the file should not become garbage in the first place.
- **No `fsync`.** This closes the process-crash and torn-read halves, which is what was reported. Surviving a machine-level power loss would additionally need the temp fsync'd before the replace and the directory fsync'd after. Neither existing house implementation does that either, so this stays consistent with them rather than diverging in one place.

## Notes for later, not in this change

- `.gitignore:89` covers `mlops/loop_state.json` exactly, so a crash-leftover `loop_state.json.tmp` is untracked. Harmless in practice — the state lives in `~/.loci/mlops/worktree`, and `scripts/mlops_loop_cron.sh` runs `git clean -qfd` before every run — but it would show up in `git status` in an interactive checkout.
- `scripts/a2a_watchdog.py:44` is a fifth instance of the same shape that this pass did not cover.
