### PR TITLE
Let a failed or alarming step reach the exit code, and bound the run

### DIFF
--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -160,6 +161,16 @@ if str(REPO) not in sys.path:
 # spent 67 nights in.
 FAILED_STEPS: list[str] = []
 
+# A step that did its job and found something a human has to act on. Distinct
+# from FAILED_STEPS on purpose: "the canary recommends a rollback" is not a
+# broken step, and burying it in the failure list would make both mean less.
+ALERTS: list[str] = []
+
+# Whole-run wall clock. LOCI_MLOPS_STEP_TIMEOUT bounds each child; nothing
+# bounded the run, so one slow-but-not-hung step could push the nightly into the
+# next day and hold the lock the whole time.
+DEADLINE_SECONDS = float(os.environ.get("LOCI_MLOPS_DEADLINE", "10800"))
+
 
 
 def _last_error_line(stderr: str) -> str:
@@ -179,6 +190,29 @@ def _fail(step: str, line: str) -> None:
     key; the message stays whatever the call site already said."""
     FAILED_STEPS.append(step)
     print(f"[loop] {line}")
+
+
+def _over_deadline(started: float, next_step: str) -> bool:
+    """True once the run has used its whole wall clock.
+
+    Checked BETWEEN steps only. A step already running is bounded by its own
+    LOCI_MLOPS_STEP_TIMEOUT and by _run's drain-join bound; this stops the loop
+    from starting more work after the night is gone, and from holding the lock
+    into the next day's tick.
+    """
+    used = time.monotonic() - started
+    if used < DEADLINE_SECONDS:
+        return False
+    _fail("deadline", f"run deadline reached after {used / 60:.0f}m "
+                      f"(LOCI_MLOPS_DEADLINE={DEADLINE_SECONDS:.0f}s) — "
+                      f"stopping before {next_step}")
+    return True
+
+
+def _alert(step: str, line: str) -> None:
+    """The step worked and the answer needs someone. Reported, never silent."""
+    ALERTS.append(step)
+    print(f"[loop] ALERT: {line}")
 
 
 def _days_since(now: datetime, iso_ts, default: int = 999) -> int:
@@ -366,6 +400,9 @@ def _retrain(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
 
 # ── Canary evaluation ─────────────────────────────────────────────────────────
 
+# mlops/grounding/canary.py exit contract.
+CANARY_OK, CANARY_DRIFT, CANARY_ROLLBACK = 0, 1, 2
+
 def _run_canary(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
     if not CANDIDATE_MODEL.exists():
         print("[loop] no candidate model to evaluate")
@@ -381,9 +418,17 @@ def _run_canary(findings_glob: str, ollama: str, dry_run: bool) -> dict | None:
     if dry_run:
         cmd.append("--dry-run")
 
+    # canary.py's contract: 0 clean, 1 drift, 2 ROLLBACK RECOMMENDED. Only 1 was
+    # read, so a rollback recommendation -- the loudest thing it can say -- was
+    # discarded, and any other exit looked like a clean run.
     result = _run(cmd)
-    if result.returncode == 1:
-        print("[loop] ALERT: canary drift detected")
+    if result.returncode == CANARY_ROLLBACK:
+        _alert("canary", "canary recommends ROLLBACK — see canary output above")
+    elif result.returncode == CANARY_DRIFT:
+        _alert("canary", "canary drift detected")
+    elif result.returncode != CANARY_OK:
+        _fail("canary", f"canary exited {result.returncode}: "
+                        f"{_last_error_line(result.stderr)}")
     return {"exit_code": result.returncode, "stdout": result.stdout[-500:]}
 
 
@@ -494,21 +539,37 @@ def _run_embedding_drift(ollama: str, dry_run: bool) -> dict:
                "--dataset", str(DATASET), "--ollama", ollama,
                "--anchor", str(anchor), "--build-anchor"]
         result = _run(cmd)
+        if result.returncode != 0:
+            _fail("embedding drift", "anchor build failed: "
+                                     f"{_last_error_line(result.stderr)}")
+            return {"exit_code": result.returncode}
         return {"built_anchor": True}
+
     out_path = MLOPS / "embedding" / "drift_result.json"
+    # drift.py exits 1 for BOTH "drift exceeded" and "could not measure" (anchor
+    # unreadable, Ollama down). It writes --out only on the measuring path, so a
+    # file this run produced is the discriminator -- without it a down Ollama
+    # read as drift and scheduled a fine-tune.
+    before = out_path.stat().st_mtime if out_path.exists() else -1.0
     cmd = [sys.executable, str(drift_script),
            "--dataset", str(DATASET), "--ollama", ollama,
            "--anchor", str(anchor), "--out", str(out_path)]
     result = _run(cmd)
-    if result.returncode == 1:
-        print("[loop] ALERT: embedding drift detected — scheduling embedding fine-tune")
+    measured = out_path.exists() and out_path.stat().st_mtime > before
+
+    if result.returncode == 1 and measured:
+        _alert("embedding drift", "embedding drift detected — scheduling embedding fine-tune")
         if not dry_run:
             _emit_embedding_trigger()
-    if out_path.exists():
+    elif result.returncode != 0:
+        _fail("embedding drift", f"drift.py exited {result.returncode} without writing a "
+                                 f"result: {_last_error_line(result.stderr)}")
+
+    if measured:
         try:
             return json.loads(out_path.read_text())
-        except Exception:
-            pass
+        except Exception as exc:
+            _fail("embedding drift", f"drift.py wrote unreadable JSON: {exc}")
     return {"exit_code": result.returncode}
 
 
@@ -561,9 +622,15 @@ def _emit_embedding_trigger() -> None:
         f"  --out mlops/embedding/\n"
         f"echo 'Done. Load mlops/embedding/loci-embed-small/ as your embedding model.'\n"
     )
-    if not script.exists() or script.read_text() != body:
-        script.write_text(body)
-    script.chmod(0o755)
+    try:
+        if not script.exists() or script.read_text() != body:
+            script.write_text(body)
+        script.chmod(0o755)
+    except OSError as exc:
+        # The nag that follows tells the operator to run this file. If it was not
+        # written, that instruction is wrong and the tune can never happen.
+        _fail("embedding trigger", f"could not write {script}: {exc}")
+        return
     print(f"[loop] embedding trigger written to {script}")
 
 
@@ -640,6 +707,8 @@ def main() -> int:
     args = ap.parse_args()
 
     FAILED_STEPS.clear()  # module-global; a second main() in one process must start clean
+    ALERTS.clear()
+    started = time.monotonic()
     resolved = _resolve_backends()
     if args.ollama is None:
         args.ollama = (os.environ.get("OLLAMA_BASE_URL")
@@ -729,8 +798,12 @@ def main() -> int:
         # write as it went.
         state["runs_seen"] = (state["runs_seen"] + new_runs)[-RUNS_SEEN_MAX:]
 
-    # ── 7a. Weibull memory decay (runs every loop tick) ──────────────────────
     loop_count = state.get("total_loop_runs", 0) + 1
+    if _over_deadline(started, "decay"):
+        return _finish(state, args, now_iso, loop_count, new_runs, current_size,
+                       should_retrain, promoted, train_metrics)
+
+    # ── 7a. Weibull memory decay (runs every loop tick) ──────────────────────
     if loop_count % args.decay_every == 0:
         _run_decay(args.db, args.dry_run or not args.decay_apply)
     else:
@@ -745,6 +818,10 @@ def main() -> int:
     # ── 7d. Embedding drift detection ─────────────────────────────────────────
     if ollama_ok:
         _run_embedding_drift(args.ollama, args.dry_run)
+
+    if _over_deadline(started, "the SFT bake"):
+        return _finish(state, args, now_iso, loop_count, new_runs, current_size,
+                       should_retrain, promoted, train_metrics)
 
     # ── 7. SFT bake (cadence-gated) ───────────────────────────────────────────
     sft_days_ago = _days_since(now, state.get("last_sft_bake"))
@@ -772,6 +849,10 @@ def main() -> int:
     else:
         print(f"[loop] embedding trigger skipped ({emb_days_ago}d ago, cadence={args.embedding_every}d)")
 
+    if _over_deadline(started, "active learning"):
+        return _finish(state, args, now_iso, loop_count, new_runs, current_size,
+                       should_retrain, promoted, train_metrics)
+
     # ── 8a. Active learning candidates (cadence-gated) ────────────────────────
     al_days_ago = _days_since(now, state.get("last_active_learn"))
     if ollama_ok and al_days_ago >= args.active_learn_every:
@@ -783,6 +864,18 @@ def main() -> int:
         print(f"[loop] active_learn skipped — {_skip_reason(ollama_ok, al_days_ago, args.active_learn_every, args.ollama)}")
 
     # ── 9. Persist state + history ────────────────────────────────────────────
+    return _finish(state, args, now_iso, loop_count, new_runs, current_size,
+                   should_retrain, promoted, train_metrics)
+
+
+def _finish(state, args, now_iso, loop_count, new_runs, current_size,
+            should_retrain, promoted, train_metrics) -> int:
+    """Persist, report, and return the exit code.
+
+    Its own function because the deadline check returns here from the middle of
+    the run: a loop that stops early still has to write its state and say why,
+    or the early exit looks exactly like a clean one.
+    """
     state["last_run"] = now_iso
     state["total_loop_runs"] = loop_count
     if not args.dry_run:
@@ -797,10 +890,17 @@ def main() -> int:
         "train_metrics": train_metrics,
         "dry_run": args.dry_run,
         "failed_steps": list(FAILED_STEPS),
+        "alerts": list(ALERTS),
     })
 
-    status = "done" if not FAILED_STEPS else f"done with {len(FAILED_STEPS)} failed step(s): " + ", ".join(FAILED_STEPS)
-    print(f"[loop] {status}. promoted={promoted} dataset={state['last_dataset_size']} total_promotions={state['total_promotions']}")
+    parts = []
+    if FAILED_STEPS:
+        parts.append(f"{len(FAILED_STEPS)} failed step(s): " + ", ".join(FAILED_STEPS))
+    if ALERTS:
+        parts.append(f"{len(ALERTS)} alert(s): " + ", ".join(ALERTS))
+    status = "done" if not parts else "done with " + "; ".join(parts)
+    print(f"[loop] {status}. promoted={promoted} dataset={state['last_dataset_size']} "
+          f"total_promotions={state['total_promotions']}")
     return 1 if FAILED_STEPS else 0
 
 

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -102,6 +102,12 @@ def env(tmp_path, monkeypatch):
     # test_loop_timeouts.py and test_loop_streaming.py.
     monkeypatch.setattr(loop, "_run", runner)
 
+    # Module-level accumulators. main() clears them, but a test calling a single
+    # step does not, and a leaked entry makes the next test assert on the
+    # previous one's failure.
+    loop.FAILED_STEPS.clear()
+    loop.ALERTS.clear()
+
     saved_path = list(sys.path)
     yield types.SimpleNamespace(
         tmp=tmp_path, repo=repo, mlops=mlops, grounding=grounding, run=runner,
@@ -458,11 +464,23 @@ def test_run_canary_drift_exit_1_still_returns_dict_not_none(env, capsys):
     assert "ALERT: canary drift detected" in capsys.readouterr().out
 
 
-def test_run_canary_other_nonzero_exit_has_no_alert(env, capsys):
+def test_run_canary_exit_2_is_a_rollback_recommendation_not_silence(env, capsys):
+    """Was test_run_canary_other_nonzero_exit_has_no_alert, which characterised
+    the bug: canary.py exits 2 for ROLLBACK RECOMMENDED -- the loudest thing it
+    can say -- and only exit 1 was read, so it went nowhere."""
     (env.mlops / "grounding" / "candidate.joblib").write_text("m")
-    env.run.set("canary.py", FakeResult(2, stdout="crash"))
+    env.run.set("canary.py", FakeResult(2, stdout="rollback"))
     assert loop._run_canary("g", "o", False)["exit_code"] == 2
-    assert "ALERT" not in capsys.readouterr().out
+    assert "ROLLBACK" in capsys.readouterr().out
+    assert "canary" in loop.ALERTS
+    assert "canary" not in loop.FAILED_STEPS, "a rollback recommendation is not a broken step"
+
+
+def test_run_canary_an_unexpected_exit_is_a_failed_step(env):
+    (env.mlops / "grounding" / "candidate.joblib").write_text("m")
+    env.run.set("canary.py", FakeResult(3, stderr="Traceback\nValueError: x"))
+    loop._run_canary("g", "o", False)
+    assert "canary" in loop.FAILED_STEPS
 
 
 def test_run_canary_truncates_stored_stdout_to_500(env):
@@ -744,11 +762,13 @@ def test_embedding_drift_builds_anchor_when_absent(env, capsys):
     assert "no anchor — building anchor set" in capsys.readouterr().out
 
 
-def test_embedding_drift_reports_built_anchor_even_when_build_fails(env):
-    """The anchor-build branch never inspects the return code."""
+def test_embedding_drift_a_failed_anchor_build_is_not_reported_as_built(env):
+    """Was ..._reports_built_anchor_even_when_build_fails: the branch never
+    inspected the return code, so a failed build claimed an anchor exists."""
     _drift_script(env)
     env.run.set("drift.py", FakeResult(1, stderr="boom"))
-    assert loop._run_embedding_drift("o", False) == {"built_anchor": True}
+    assert loop._run_embedding_drift("o", False) == {"exit_code": 1}
+    assert "embedding drift" in loop.FAILED_STEPS
 
 
 def test_embedding_drift_clean_run_returns_exit_code(env):
@@ -765,13 +785,14 @@ def test_embedding_drift_prefers_result_json_over_exit_code(env):
     assert loop._run_embedding_drift("o", False) == {"drift": 0.4}
 
 
-def test_embedding_drift_returns_stale_result_json(env):
-    """A drift_result.json left by an earlier run is returned verbatim even when
-    this run's drift.py wrote nothing."""
+def test_embedding_drift_does_not_return_a_stale_result_json(env):
+    """Was ..._returns_stale_result_json. A file an earlier run left behind was
+    returned verbatim as this run's answer -- last week's drift score reported
+    as today's."""
     _drift_script(env)
     (env.mlops / "embedding" / "anchor.npz").write_text("a")
     (env.mlops / "embedding" / "drift_result.json").write_text('{"stale": true}')
-    assert loop._run_embedding_drift("o", False) == {"stale": True}
+    assert loop._run_embedding_drift("o", False) == {"exit_code": 0}
 
 
 def test_embedding_drift_malformed_result_json_falls_back_to_exit_code(env):
@@ -782,22 +803,44 @@ def test_embedding_drift_malformed_result_json_falls_back_to_exit_code(env):
     assert loop._run_embedding_drift("o", False) == {"exit_code": 1}
 
 
-def test_embedding_drift_exit_1_emits_contrastive_script(env, capsys):
+def _measured_drift(env, exceeded=True):
+    """drift.py writes --out only on the path where it actually measured."""
+    env.run.on_call("drift.py", lambda: (env.mlops / "embedding" / "drift_result.json")
+                    .write_text('{"exceeded": %s}' % ("true" if exceeded else "false")))
+
+
+def test_embedding_drift_exit_1_with_a_measurement_emits_contrastive_script(env, capsys):
     _drift_script(env)
     (env.mlops / "embedding" / "anchor.npz").write_text("a")
     env.run.set("drift.py", FakeResult(1))
+    _measured_drift(env)
     loop._run_embedding_drift("o", dry_run=False)
     assert (env.mlops / "run_contrastive.sh").exists()
-    assert "ALERT: embedding drift detected" in capsys.readouterr().out
+    assert "embedding drift detected" in capsys.readouterr().out
+
+
+def test_embedding_drift_exit_1_without_a_measurement_is_a_failure_not_drift(env, capsys):
+    """drift.py exits 1 for BOTH 'exceeded' and 'could not measure'. It writes
+    --out only when it measured, so a down Ollama used to read as drift and
+    schedule a fine-tune."""
+    _drift_script(env)
+    (env.mlops / "embedding" / "anchor.npz").write_text("a")
+    env.run.set("drift.py", FakeResult(1, stderr="[drift] ERROR: connection refused"))
+    loop._run_embedding_drift("o", dry_run=False)
+    out = capsys.readouterr().out
+    assert not (env.mlops / "run_contrastive.sh").exists(), "scheduled a tune for an error"
+    assert "embedding drift" in loop.FAILED_STEPS
+    assert "drift detected" not in out
 
 
 def test_embedding_drift_dry_run_alerts_but_emits_nothing(env, capsys):
     _drift_script(env)
     (env.mlops / "embedding" / "anchor.npz").write_text("a")
     env.run.set("drift.py", FakeResult(1))
+    _measured_drift(env)
     loop._run_embedding_drift("o", dry_run=True)
     assert not (env.mlops / "run_contrastive.sh").exists()
-    assert "ALERT: embedding drift detected" in capsys.readouterr().out
+    assert "embedding drift detected" in capsys.readouterr().out
 
 
 def test_embedding_drift_exit_2_does_not_emit(env):
@@ -968,7 +1011,7 @@ def mainenv(env, monkeypatch):
 
     def run(*extra):
         monkeypatch.setattr(sys, "argv", ["loop.py", *extra])
-        loop.main()
+        return loop.main()
 
     env.main = run
     return env
@@ -1215,8 +1258,10 @@ def test_main_history_record_shape(mainenv):
     e.main()
     rec = read_history(e)[0]
     assert set(rec) == {"run_at", "new_runs", "dataset_size", "retrained",
-                        "promoted", "train_metrics", "dry_run", "failed_steps"}
+                        "promoted", "train_metrics", "dry_run", "failed_steps",
+                        "alerts"}
     assert rec["failed_steps"] == []
+    assert rec["alerts"] == []
     assert rec["new_runs"] == 2
     assert rec["dataset_size"] == 42
     assert rec["retrained"] is False
@@ -1713,3 +1758,47 @@ def test_run_says_so_when_it_abandons_a_blocked_reader(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "still blocked" in out, out
     assert "still blocked" in result.stderr, result.stderr
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# the run has a wall clock
+# ══════════════════════════════════════════════════════════════════════════════
+
+def test_main_stops_at_the_deadline_and_still_persists(mainenv, monkeypatch, capsys):
+    """A run that stops early must write its state and say why. An early exit
+    that looks like a clean one is the whole problem."""
+    e = mainenv
+    write_dataset(e, 10)
+    monkeypatch.setattr(loop, "DEADLINE_SECONDS", 0.0)
+    rc = e.main()
+    out = capsys.readouterr().out
+    assert rc == 1, "a run cut short is not a clean run"
+    assert "run deadline reached" in out, out
+    assert "deadline" in loop.FAILED_STEPS
+    rec = read_history(e)[0]
+    assert rec["failed_steps"] == ["deadline"]
+    assert (e.mlops / "loop_state.json").exists(), "state was not persisted on the early exit"
+
+
+def test_main_does_not_stop_when_inside_the_deadline(mainenv, monkeypatch, capsys):
+    e = mainenv
+    write_dataset(e, 10)
+    monkeypatch.setattr(loop, "DEADLINE_SECONDS", 10_000.0)
+    assert e.main() == 0
+    assert "run deadline reached" not in capsys.readouterr().out
+
+
+def test_alerts_are_reported_separately_from_failures(mainenv, monkeypatch, capsys):
+    """A canary rollback recommendation is not a broken step, and must not be
+    filed as one -- nor swallowed. main() clears both lists at entry, so the
+    alert has to be raised by a step during the run."""
+    e = mainenv
+    write_dataset(e, 10)
+    monkeypatch.setattr(loop, "_run_monitor",
+                        lambda *a, **k: (loop._alert("canary", "recommends ROLLBACK"), {})[1])
+    rc = e.main()
+    rec = read_history(e)[0]
+    assert rec["alerts"] == ["canary"], rec
+    assert rec["failed_steps"] == [], "an alert is not a failure"
+    assert rc == 0, "an alert alone must not fail the run"
+    assert "1 alert(s): canary" in capsys.readouterr().out


### PR DESCRIPTION
Items 2 and 3 of the five. Three steps could not report failure at all, and one was discarding the loudest thing the pipeline can say.

## The canary's rollback recommendation went nowhere

`canary.py`'s contract is `0` clean / `1` drift / `2` **ROLLBACK RECOMMENDED**. The loop read only `1`:

```python
if result.returncode == 1:
    print("[loop] ALERT: canary drift detected")
```

So exit 2 — *"ROLLBACK RECOMMENDED: {reason}"* — was silently dropped, and every other exit looked like a clean run. Exit 2 is now an alert; an unexpected exit is a failure.

## A down Ollama read as embedding drift

`drift.py` exits `1` for **both** "drift exceeded" and "could not measure" (anchor unreadable, Ollama down). The loop treated `1` as drift and **scheduled an embedding fine-tune** for it.

It writes `--out` only on the path where it actually measured, so a file produced by *this* run is the discriminator. Without one, exit 1 is now a failed step and no tune is scheduled. The same mtime check closes an adjacent bug the suite had already characterised: a `drift_result.json` left by an earlier run was returned verbatim as this run's answer — last week's drift score reported as today's.

Also: a failed anchor build returned `{"built_anchor": True}`, and a trigger script that could not be written printed that it had been.

## Alerts are not failures

`ALERTS` is its own list. *"The canary recommends a rollback"* is not a broken step, and filing it under failures would make both mean less. Both reach `loop_history.jsonl` and the closing status line; only failures set the exit code.

## The run has a wall clock

`LOCI_MLOPS_DEADLINE`, default 3h, checked between steps. `LOCI_MLOPS_STEP_TIMEOUT` bounds each child and `_run`'s drain join is bounded as of #280, but nothing bounded the *run* — so a slow night could hold the lock into the next day's tick, which is how one hang cost three nights.

A run that stops early still persists its state and says why. `_finish` exists for that reason: **an early exit that reads like a clean one is the problem this entire change is about.**

## Tests

Five existing tests characterised the old behaviour and now assert the new. Their names said it out loud:

```
test_run_canary_other_nonzero_exit_has_no_alert
test_embedding_drift_reports_built_anchor_even_when_build_fails
test_embedding_drift_returns_stale_result_json
```

```
mlops                       622 passed
ruff (CI ruleset)           clean
corpus count                unmoved
```