### PR TITLE
Only stamp state when the work behind the stamp actually happened

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -3162,12 +3162,17 @@ def reflection_loop_tick(
         raw_warnings = {str(k): int(v) for k, v in (summary.get("warnings") or {}).items()}
         stats["errors_seen"] += sum(raw_errors.values())
         stats["warnings_seen"] += sum(raw_warnings.values())
-        processed[key] = {
-            "kind": kind,
-            "path_hash": _hash_path(path),
-            "processed_at": _now(),
-            "lines_scanned": summary.get("lines_scanned"),
-        }
+        if store_item_findings:
+            # Only a tick that could store findings may mark an item done:
+            # reflection_loop_seed permanently excludes every key in processed, so a
+            # preview tick (store_item_findings=False writes nothing) would otherwise
+            # retire the artifacts it only looked at, and no reseed brings them back.
+            processed[key] = {
+                "kind": kind,
+                "path_hash": _hash_path(path),
+                "processed_at": _now(),
+                "lines_scanned": summary.get("lines_scanned"),
+            }
         batch_error_signatures.update(raw_errors)
         batch_warning_signatures.update(raw_warnings)
 

--- a/mcp/tests/test_reflection_loop.py
+++ b/mcp/tests/test_reflection_loop.py
@@ -121,6 +121,46 @@ class ReflectionLoopTests(unittest.TestCase):
         self.assertEqual(processed_kinds[0], "process_log")
         self.assertEqual(processed_kinds[1], "session_event")
 
+    def _tick_with(self, store_item_findings):
+        state = server._reflection_default_state()
+        state["investigation_id"] = "test-inv"
+        state["queue"] = [{"kind": "process_log", "path": "/tmp/a.log"}]
+        summary = {
+            "status": "processed",
+            "kind": "process_log",
+            "path": "/tmp/a.log",
+            "lines_scanned": 10,
+            "bytes_scanned": 100,
+            "sampling_mode": "full",
+            "events": {},
+            "tools": {},
+            "errors": {},
+            "warnings": {},
+        }
+        with patch.object(server, "_load_reflection_state", side_effect=lambda: state), patch.object(
+            server, "_save_reflection_state", side_effect=lambda new_state: state.update(new_state)
+        ), patch.object(
+            server, "_ensure_investigation_exists", side_effect=lambda *args, **kwargs: None
+        ), patch.object(
+            server, "_process_reflection_item", side_effect=[summary]
+        ), patch.object(
+            server, "investigation_store", return_value=json.dumps({"stored": True})
+        ):
+            server.reflection_loop_tick(max_items=1, max_lines_per_file=100,
+                                        store_item_findings=store_item_findings)
+        return state
+
+    def test_preview_tick_does_not_retire_the_item_it_stored_nothing_for(self):
+        """reflection_loop_seed drops every key in processed and only reset_queue=True
+        clears it, so an item marked processed by a tick that wrote no finding is out of
+        the reflection corpus for good."""
+        state = self._tick_with(store_item_findings=False)
+        self.assertEqual(state["processed"], {})
+
+    def test_storing_tick_still_marks_the_item_processed(self):
+        state = self._tick_with(store_item_findings=True)
+        self.assertEqual(list(state["processed"]), ["process_log|/tmp/a.log"])
+
     def test_tick_batches_low_signal_session_events_into_one_observed(self):
         state = server._reflection_default_state()
         state["investigation_id"] = "test-inv"

--- a/mlops/loop.py
+++ b/mlops/loop.py
@@ -291,12 +291,18 @@ def _discover_runs(findings_glob: str, seen: list[str]) -> list[str]:
 
 # ── Dataset rebuild ───────────────────────────────────────────────────────────
 
-def _rebuild_dataset(findings_glob: str, ollama: str) -> int:
-    """Run build_grounding_dataset.py to refresh the dataset. Returns new pair count."""
+def _rebuild_dataset(findings_glob: str, ollama: str) -> int | None:
+    """Run build_grounding_dataset.py to refresh the dataset. Returns new pair count.
+
+    Returns None when the rebuild did not run to completion. The size on disk is the
+    same shape on both paths, so returning it for a failed build tells the caller
+    nothing happened while looking exactly like a build that produced that count —
+    and the caller uses the return to mark the runs it was supposed to ingest as seen.
+    """
     builder = REPO / "deep_think_loci" / "grounding" / "build_grounding_dataset.py"
     if not builder.exists():
         print("[loop] build_grounding_dataset.py not found — skipping rebuild")
-        return _current_dataset_size()
+        return None
 
     result = _run(
         [sys.executable, str(builder),
@@ -306,7 +312,7 @@ def _rebuild_dataset(findings_glob: str, ollama: str) -> int:
     )
     if result.returncode != 0:
         _fail("dataset rebuild", f"dataset rebuild failed: {_last_error_line(result.stderr)}")
-        return _current_dataset_size()
+        return None
 
     size = _current_dataset_size()
     print(f"[loop] dataset rebuilt → {size} pairs")
@@ -674,7 +680,9 @@ def main() -> int:
     should_retrain = should_rebuild
     if should_rebuild:
         # ── 4. Rebuild dataset ────────────────────────────────────────────────
-        new_size = _rebuild_dataset(args.findings, args.ollama)
+        rebuilt = _rebuild_dataset(args.findings, args.ollama)
+        rebuild_ok = rebuilt is not None
+        new_size = rebuilt if rebuild_ok else _current_dataset_size()
         new_pairs = new_size - state["last_dataset_size"]
         print(f"[loop] dataset after rebuild: {new_size} pairs ({new_pairs:+d})")
 
@@ -704,12 +712,20 @@ def main() -> int:
                 else:
                     print("[loop] canary held back or drift detected — keeping current model")
 
-        state["last_dataset_size"] = new_size
-        # Truncate: runs_seen only exists to skip runs already ingested, so the
-        # tail is what matters. It appended forever and was rewritten in full on
-        # every tick, so the state file grew without bound and got slower to
-        # write as it went.
-        state["runs_seen"] = (state["runs_seen"] + new_runs)[-RUNS_SEEN_MAX:]
+        # Only a rebuild that completed may mark these runs seen: _discover_runs
+        # excludes anything in runs_seen, so stamping them after a failed build
+        # hides them from every later tick and the next rebuild waits for
+        # --min-new-runs FRESH investigations instead of retrying these.
+        if rebuild_ok:
+            state["last_dataset_size"] = new_size
+            # Truncate: runs_seen only exists to skip runs already ingested, so the
+            # tail is what matters. It appended forever and was rewritten in full on
+            # every tick, so the state file grew without bound and got slower to
+            # write as it went.
+            state["runs_seen"] = (state["runs_seen"] + new_runs)[-RUNS_SEEN_MAX:]
+        else:
+            print(f"[loop] holding {len(new_runs)} new run(s) unseen — the rebuild that "
+                  "was supposed to ingest them did not complete")
 
     # ── 7a. Weibull memory decay (runs every loop tick) ──────────────────────
     loop_count = state.get("total_loop_runs", 0) + 1

--- a/mlops/tests/test_loop.py
+++ b/mlops/tests/test_loop.py
@@ -309,9 +309,12 @@ def test_current_dataset_size_counts_final_line_without_newline(env):
 # _rebuild_dataset
 # ══════════════════════════════════════════════════════════════════════════════
 
-def test_rebuild_dataset_missing_builder_returns_current_size_without_subprocess(env, capsys):
+def test_rebuild_dataset_missing_builder_reports_no_rebuild_without_subprocess(env, capsys):
+    """No builder means nothing was ingested. Returning the size on disk made that
+    indistinguishable from a build that produced it, and the caller marks the runs
+    it was supposed to ingest as seen on the strength of that return."""
     write_dataset(env, 4)
-    assert loop._rebuild_dataset("g", "http://o") == 4
+    assert loop._rebuild_dataset("g", "http://o") is None
     assert env.run.calls == []
     assert "build_grounding_dataset.py not found" in capsys.readouterr().out
 
@@ -329,7 +332,7 @@ def test_rebuild_dataset_argv_appends_v1_embeddings_to_ollama(env):
                        "--ollama", "http://o:1/v1/embeddings"]
 
 
-def test_rebuild_dataset_failure_returns_current_size_and_prints_the_exception(env, capsys):
+def test_rebuild_dataset_failure_reports_no_rebuild_and_prints_the_exception(env, capsys):
     """The last 500 chars of a traceback land mid-frame, so the log used to read
     "dataset rebuild failed: ^^^^^^^^^^". Report the exception line instead."""
     (env.repo / "deep_think_loci" / "grounding" / "build_grounding_dataset.py").write_text("")
@@ -340,7 +343,7 @@ def test_rebuild_dataset_failure_returns_current_size_and_prints_the_exception(e
           "    ^^^^^^^^^^^^^^^^^^^\n"
           "urllib.error.URLError: <urlopen error [Errno 111] Connection refused>\n")
     env.run.set("build_grounding_dataset.py", FakeResult(2, stderr=tb))
-    assert loop._rebuild_dataset("g", "http://o") == 7
+    assert loop._rebuild_dataset("g", "http://o") is None
     out = capsys.readouterr().out
     assert "dataset rebuild failed" in out
     assert "urllib.error.URLError" in out
@@ -1163,6 +1166,44 @@ def test_main_consumes_new_data_signal_even_when_training_failed(mainenv):
     e.rv["rebuild"] = 900
     e.main("--force")
     assert state_of(e)["last_dataset_size"] == 900
+
+
+# Captured at import, before the mainenv fixture stubs it out: the two tests below
+# drive the REAL rebuild step so the failure they assert on is the one the nightly
+# actually hits (builder exits non-zero), not a hand-written return value.
+_REAL_REBUILD = loop._rebuild_dataset
+
+
+def _failing_rebuild(e, monkeypatch):
+    (e.repo / "deep_think_loci" / "grounding" / "build_grounding_dataset.py").write_text("")
+    e.run.set("build_grounding_dataset.py",
+              FakeResult(2, stderr="urllib.error.URLError: connection refused\n"))
+    monkeypatch.setattr(loop, "_rebuild_dataset", _REAL_REBUILD)
+
+
+def test_main_runs_seen_held_when_the_rebuild_failed(mainenv, monkeypatch):
+    """_discover_runs excludes anything already in runs_seen, so a run marked seen
+    by a build that never ingested it is never offered to a later tick: the loop
+    then reports "new investigation runs: 0" and waits for --min-new-runs fresh
+    investigations before it tries again."""
+    e = mainenv
+    write_dataset(e, 11)
+    seed_state(e, runs_seen=["old"], last_dataset_size=11)
+    e.rv["new_runs"] = ["n1", "n2"]
+    _failing_rebuild(e, monkeypatch)
+    e.main("--force")
+    s = state_of(e)
+    assert s["runs_seen"] == ["old"]
+    assert s["last_dataset_size"] == 11
+
+
+def test_main_says_which_runs_it_held(mainenv, monkeypatch, capsys):
+    e = mainenv
+    seed_state(e)
+    e.rv["new_runs"] = ["n1", "n2"]
+    _failing_rebuild(e, monkeypatch)
+    e.main("--force")
+    assert "holding 2 new run(s) unseen" in capsys.readouterr().out
 
 
 def test_main_total_loop_runs_increments_and_persists(mainenv):

--- a/scripts/a2a_context_bridge.py
+++ b/scripts/a2a_context_bridge.py
@@ -110,10 +110,15 @@ ECHO_SOURCE_PREFIXES = [
 ]
 
 
-def _fetch_recent_memories(since: str, min_importance: float, max_items: int) -> list[dict]:
+def _fetch_recent_memories(since: str, min_importance: float, max_items: int) -> list[dict] | None:
     """
     Fetch memories newer than `since` (ISO timestamp) with importance >= min_importance,
     excluding anything that arrived through the mesh (see ECHO_SOURCE_PREFIXES).
+
+    Returns None -- NOT [] -- when the DB could not be read at all (file absent, or no
+    queryable table). An empty list means "the window really was quiet" and lets the
+    caller advance its watermark; None must not, because everything written during the
+    outage would fall behind the new watermark and never be bridged.
 
     Reads BOTH tiers. This used to read working_memory and fall back to `memories` only on
     OperationalError -- i.e. only if the table did not exist. working_memory does exist, and
@@ -128,7 +133,7 @@ def _fetch_recent_memories(since: str, min_importance: float, max_items: int) ->
     """
     if not os.path.exists(MNEMOSYNE_DB):
         log.warning("Mnemosyne DB not found: %s", MNEMOSYNE_DB)
-        return []
+        return None
 
     echo_clause = ""
     params_tail: list = []
@@ -143,6 +148,7 @@ def _fetch_recent_memories(since: str, min_importance: float, max_items: int) ->
     conn.row_factory = sqlite3.Row
     out: list[dict] = []
     seen: set = set()
+    tables_read = 0
     since_norm = (since or "").replace(" ", "T")
     _ALLOWED_TABLES = {"memories", "working_memory"}
     try:
@@ -161,6 +167,7 @@ def _fetch_recent_memories(since: str, min_importance: float, max_items: int) ->
             except sqlite3.OperationalError as e:
                 log.debug("skipping %s: %s", table, e)
                 continue
+            tables_read += 1
             for r in rows:
                 d = dict(r)
                 if d["id"] in seen:
@@ -169,6 +176,11 @@ def _fetch_recent_memories(since: str, min_importance: float, max_items: int) ->
                 out.append(d)
     finally:
         conn.close()
+
+    if not tables_read:
+        log.warning("No queryable memory table in %s — treating as unreadable, not as empty",
+                    MNEMOSYNE_DB)
+        return None
 
     out.sort(key=lambda m: (m.get("created_at") or "").replace(" ", "T"), reverse=True)
     return out[:max_items]
@@ -236,10 +248,21 @@ async def _broadcast_memory(session: aiohttp.ClientSession, mem: dict, dry_run: 
             data = await r.json()
             if r.status == 200:
                 out = data.get("result", {}).get("output", {})
-                ok_peers = sum(
-                    1 for p in out.get("broadcast", []) if p.get("status") == "ok"
-                )
-                return {"status": "ok", "id": mem["id"], "peers_ok": ok_peers}
+                peers = out.get("broadcast") or []
+                ok_peers = sum(1 for p in peers if p.get("status") == "ok")
+                peers_count = int(out.get("peers_count") or 0)
+                if ok_peers:
+                    return {"status": "ok", "id": mem["id"],
+                            "peers_ok": ok_peers, "peers_count": peers_count}
+                # 200 from our OWN server means the request parsed, not that the memory
+                # left the node: store_local is False above, so a run where every peer
+                # was skipped (no PEER_A2A_URLS, no token, bad TOTP seed) or 401'd
+                # delivered it nowhere. Reporting that as ok stamps the id into sent_ids
+                # and advances the watermark, and no later tick ever retries it.
+                reasons = ", ".join(sorted({str(p.get("status")) for p in peers})) or "no result"
+                return {"status": "no_peers" if peers_count == 0 else "peers_failed",
+                        "id": mem["id"], "peers_ok": 0, "peers_count": peers_count,
+                        "error": reasons}
             return {"status": f"http_{r.status}", "id": mem["id"]}
     except Exception as e:
         return {"status": "error", "id": mem["id"], "error": str(e)}
@@ -265,6 +288,13 @@ async def run(dry_run: bool, verbose: bool):
         log.info("First run — looking back %d min (since %s)", LOOKBACK_MIN, since)
 
     mems = _fetch_recent_memories(since, MIN_IMP, MAX_ITEMS)
+    if mems is None:
+        log.error(
+            "Could not read %s — holding the watermark at %s. Advancing it on a failed "
+            "read would put every memory written during the outage permanently behind it.",
+            MNEMOSYNE_DB, since,
+        )
+        return
     log.info("Found %d memories to bridge (imp>=%.1f)", len(mems), MIN_IMP)
 
     if not mems:

--- a/scripts/tests/test_context_bridge_delivery.py
+++ b/scripts/tests/test_context_bridge_delivery.py
@@ -1,0 +1,202 @@
+"""The bridge's watermark must attest to delivery, not to an HTTP code.
+
+Two ways the bridge used to record work it had not done, both of which are permanent:
+
+1. `_broadcast_memory` returned status 'ok' on any 200 from the LOCAL server. The local
+   server answers 200 with per-peer status 'skipped' when PEER_A2A_URLS is unset or a
+   peer has no token / a bad TOTP seed, and 'http_401' when a peer rejects the code.
+   store_local is False, so in every one of those cases the memory reached nobody — yet
+   the id went into sent_ids and the watermark advanced past it, and no later tick
+   retries a memory that is behind both gates.
+
+2. `_fetch_recent_memories` returned [] for "could not read the DB" exactly as it does
+   for "the window was quiet", and run() advances the watermark on []. One tick with a
+   missing/unreadable MNEMOSYNE_DB drops every memory written during the outage.
+
+These pin the failure direction (no delivery => no stamp) and the success direction
+(a genuinely quiet window still advances, or the bridge would re-scan forever).
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("LOCI_ENV_FILE", "/nonexistent-env-file-for-tests")
+os.environ.setdefault("LOCI_A2A_TOKEN", "t")
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "bridge_delivery_impl", _SCRIPTS / "a2a_context_bridge.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bridge = _load()
+
+MEM = {"id": "m1", "content": "hello", "importance": 0.9}
+
+
+class _FakeResp:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Stands in for aiohttp.ClientSession; .post() is an async context manager."""
+
+    def __init__(self, status, payload):
+        self._status = status
+        self._payload = payload
+
+    def post(self, *a, **kw):
+        return _FakeResp(self._status, self._payload)
+
+
+def _reply(broadcast, peers_count):
+    return {"result": {"output": {"broadcast": broadcast,
+                                  "peers_count": peers_count,
+                                  "stored_locally": False}}}
+
+
+def _send(broadcast, peers_count, status=200):
+    session = _FakeSession(status, _reply(broadcast, peers_count))
+    return asyncio.run(bridge._broadcast_memory(session, MEM, dry_run=False))
+
+
+class TestBroadcastOutcome(unittest.TestCase):
+    def test_a_peer_that_accepted_is_ok(self):
+        r = _send([{"peer": "p1", "status": "ok"}], 1)
+        self.assertEqual(r["status"], "ok")
+        self.assertEqual(r["peers_ok"], 1)
+
+    def test_one_ok_among_failures_is_still_ok(self):
+        r = _send([{"peer": "p1", "status": "ok"},
+                   {"peer": "p2", "status": "http_401"}], 2)
+        self.assertEqual(r["status"], "ok")
+
+    def test_no_peers_configured_is_not_ok(self):
+        # The server's own shape when PEER_A2A_URLS is unset.
+        r = _send([{"peer": "none", "status": "skipped",
+                    "error": "PEER_A2A_URLS not set"}], 0)
+        self.assertNotEqual(r["status"], "ok")
+        self.assertEqual(r["status"], "no_peers")
+
+    def test_every_peer_skipped_is_not_ok(self):
+        r = _send([{"peer": "p1", "status": "skipped", "error": "no token configured"},
+                   {"peer": "p2", "status": "skipped", "error": "invalid TOTP seed"}], 2)
+        self.assertNotEqual(r["status"], "ok")
+        self.assertEqual(r["peers_ok"], 0)
+
+    def test_every_peer_401_is_not_ok(self):
+        # The recorded mesh failure: a drifted TOTP seed 401s every hop.
+        r = _send([{"peer": "p1", "status": "http_401"}], 1)
+        self.assertNotEqual(r["status"], "ok")
+
+    def test_the_skip_reason_is_reported(self):
+        r = _send([{"peer": "p1", "status": "http_401"}], 1)
+        self.assertIn("http_401", r.get("error", ""))
+
+    def test_non_200_is_still_a_failure(self):
+        r = _send([], 0, status=503)
+        self.assertEqual(r["status"], "http_503")
+
+
+class TestWatermarkHeldWhenNothingLanded(unittest.TestCase):
+    def _run_with(self, result):
+        saved = {}
+        state = {"last_run": "2026-07-01T00:00:00", "sent_ids": []}
+
+        async def fake_broadcast(session, mem, dry_run):
+            return dict(result, id=mem["id"])
+
+        with mock.patch.object(bridge, "_load_state", return_value=state), \
+                mock.patch.object(bridge, "_save_state", side_effect=saved.update), \
+                mock.patch.object(bridge, "_fetch_recent_memories", return_value=[dict(MEM)]), \
+                mock.patch.object(bridge, "_broadcast_memory", side_effect=fake_broadcast):
+            asyncio.run(bridge.run(dry_run=False, verbose=False))
+        return saved
+
+    def test_undelivered_memory_does_not_advance_the_watermark(self):
+        saved = self._run_with({"status": "no_peers", "peers_ok": 0})
+        self.assertEqual(saved["last_run"], "2026-07-01T00:00:00")
+
+    def test_undelivered_memory_is_not_marked_sent(self):
+        saved = self._run_with({"status": "no_peers", "peers_ok": 0})
+        self.assertEqual(saved["sent_ids"], [])
+        self.assertEqual(saved["last_fail"], 1)
+
+    def test_delivered_memory_does_advance_the_watermark(self):
+        saved = self._run_with({"status": "ok", "peers_ok": 1})
+        self.assertNotEqual(saved["last_run"], "2026-07-01T00:00:00")
+        self.assertEqual(saved["sent_ids"], ["m1"])
+
+
+SCHEMA = ("CREATE TABLE {t} (id TEXT, content TEXT, importance REAL, "
+          "created_at TEXT, source TEXT)")
+
+
+class TestUnreadableDbIsNotAnEmptyWindow(unittest.TestCase):
+    def _db(self, tables=("memories", "working_memory")):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.addCleanup(os.unlink, path)
+        con = sqlite3.connect(path)
+        for t in tables:
+            con.execute(SCHEMA.format(t=t))
+        con.commit()
+        con.close()
+        return path
+
+    def _fetch(self, path):
+        with mock.patch.object(bridge, "MNEMOSYNE_DB", path):
+            return bridge._fetch_recent_memories("2026-07-01T00:00:00", 0.5, 20)
+
+    def test_quiet_window_is_an_empty_list(self):
+        self.assertEqual(self._fetch(self._db()), [])
+
+    def test_missing_db_is_none(self):
+        self.assertIsNone(self._fetch("/nonexistent/mnemosyne.db"))
+
+    def test_db_with_no_memory_table_is_none(self):
+        # Both per-table queries raise OperationalError and are skipped; the old code
+        # returned [] from here, which reads as "nothing new" and moves the watermark.
+        self.assertIsNone(self._fetch(self._db(tables=("something_else",))))
+
+    def _run_with_fetch(self, value):
+        saved = {}
+        state = {"last_run": "2026-07-01T00:00:00", "sent_ids": []}
+        with mock.patch.object(bridge, "_load_state", return_value=state), \
+                mock.patch.object(bridge, "_save_state", side_effect=saved.update), \
+                mock.patch.object(bridge, "_fetch_recent_memories", return_value=value):
+            asyncio.run(bridge.run(dry_run=False, verbose=False))
+        return saved
+
+    def test_run_writes_no_state_when_the_db_could_not_be_read(self):
+        self.assertEqual(self._run_with_fetch(None), {})
+
+    def test_run_still_advances_on_a_genuinely_quiet_window(self):
+        saved = self._run_with_fetch([])
+        self.assertNotEqual(saved.get("last_run"), "2026-07-01T00:00:00")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ua_watch_skip_gate.py
+++ b/scripts/tests/test_ua_watch_skip_gate.py
@@ -1,0 +1,111 @@
+"""ua-watch's stamp has to attest to the graph, not to the commit.
+
+run_ingest returns True on `returncode == 0`, and ua-ingest.py exits 0 after upserting
+zero points (flush_batch is a no-op on an empty batch, so an empty final-graph.json
+prints "Done. 0 points upserted" and exits clean). ua-watch then writes {git_hash,
+fg_mtime} for that project.
+
+The git gate used to be evaluated first and on its own, so once that hash was stamped
+the project was skipped at that commit no matter what happened to the graph afterwards.
+Regenerating the graph — the one repair that fixes an empty ingest — could not bring the
+project back into the collection until someone committed to the repo. These pin that a
+changed graph always re-ingests, while everything that was legitimately skipped before
+is still skipped.
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "ua_watch_impl", _SCRIPTS / "ua-watch.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ua = _load()
+HASH = "a" * 40
+OTHER = "b" * 40
+
+
+class TestSkipGate(unittest.TestCase):
+    def test_regenerated_graph_re_ingests_at_the_same_commit(self):
+        # The repair path: the graph was rewritten after a 0-point ingest.
+        self.assertEqual(ua.skip_reason(HASH, HASH, fg_mtime=200, last_mtime=100), "")
+
+    def test_nothing_changed_is_skipped(self):
+        self.assertNotEqual(ua.skip_reason(HASH, HASH, fg_mtime=100, last_mtime=100), "")
+
+    def test_new_commit_re_ingests_even_with_an_older_graph(self):
+        self.assertEqual(ua.skip_reason(OTHER, HASH, fg_mtime=100, last_mtime=100), "")
+
+    def test_never_ingested_is_not_skipped(self):
+        self.assertEqual(ua.skip_reason(HASH, "", fg_mtime=100, last_mtime=0), "")
+
+    def test_non_git_project_still_uses_the_graph_mtime(self):
+        self.assertNotEqual(ua.skip_reason("", "", fg_mtime=100, last_mtime=100), "")
+        self.assertEqual(ua.skip_reason("", "", fg_mtime=200, last_mtime=100), "")
+
+    def test_skip_reason_names_the_gate_that_fired(self):
+        self.assertIn(HASH[:8], ua.skip_reason(HASH, HASH, 100, 100))
+        self.assertEqual(ua.skip_reason("", "", 100, 100), "graph unchanged")
+
+
+class TestMainReIngests(unittest.TestCase):
+    """End-to-end through main(), which is where the two gates are actually applied."""
+
+    def _project(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = pathlib.Path(tmp.name) / "proj"
+        fg = root / ".understand-anything" / "intermediate" / "final-graph.json"
+        fg.parent.mkdir(parents=True)
+        fg.write_text(json.dumps({"nodes": [], "edges": []}))
+        return root, fg
+
+    def _run(self, root, ingested, git_hash=HASH):
+        state_file = pathlib.Path(self.state_dir.name) / "state.json"
+        with mock.patch.object(ua, "STATE_FILE", state_file), \
+                mock.patch.object(ua, "get_git_hash", lambda p: git_hash), \
+                mock.patch.object(ua, "run_ingest",
+                                  lambda p: (ingested.append(str(p)), True)[1]), \
+                mock.patch.object(sys, "argv", ["ua-watch.py", str(root)]):
+            ua.main()
+
+    def setUp(self):
+        self.state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.state_dir.cleanup)
+
+    def test_regenerated_graph_is_ingested_again(self):
+        # The 0-point ingest is stamped as done (ua-ingest exits 0 either way), so the
+        # only repair is to regenerate the graph. That has to be enough on its own.
+        root, fg = self._project()
+        ingested = []
+        self._run(root, ingested)
+        self.assertEqual(len(ingested), 1)
+
+        newer = fg.stat().st_mtime + 60
+        os.utime(fg, (newer, newer))
+        self._run(root, ingested)
+        self.assertEqual(len(ingested), 2)
+
+    def test_untouched_graph_is_not_ingested_again(self):
+        root, _ = self._project()
+        ingested = []
+        self._run(root, ingested)
+        self._run(root, ingested)
+        self.assertEqual(len(ingested), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ua-watch.py
+++ b/scripts/ua-watch.py
@@ -52,6 +52,24 @@ def get_git_hash(project_root):
         return ""
 
 
+def skip_reason(git_hash, last_hash, fg_mtime, last_mtime):
+    """Why this project needs no re-ingest, or "" if it does.
+
+    BOTH stamps have to be unchanged. The git gate used to be checked first and on its
+    own, which made the git hash a claim about the graph: ua-ingest.py exits 0 after
+    upserting zero points from an empty final-graph.json, ua-watch stamps the current
+    HEAD anyway, and re-running understand-anything to produce a real graph could not
+    get the project back into the collection — the git gate fired before the mtime gate
+    and printed "SKIP (git unchanged)" until someone happened to commit to that repo.
+    """
+    graph_unchanged = last_mtime > 0 and fg_mtime <= last_mtime
+    if not graph_unchanged:
+        return ""
+    if git_hash and git_hash != last_hash:
+        return ""
+    return f"git unchanged: {git_hash[:8]}" if git_hash else "graph unchanged"
+
+
 def find_ua_projects(roots):
     """Find directories with a completed understand-anything pipeline."""
     found = []
@@ -122,14 +140,10 @@ def main():
         fg_mtime = fg_path.stat().st_mtime
         last_mtime = state.get(key, {}).get("fg_mtime", 0)
 
-        if git_hash and git_hash == last:
+        reason = skip_reason(git_hash, last, fg_mtime, last_mtime)
+        if reason:
             skipped += 1
-            print(f"  SKIP {project.name} (git unchanged: {git_hash[:8]})")
-            continue
-
-        if fg_mtime <= last_mtime and last_mtime > 0:
-            skipped += 1
-            print(f"  SKIP {project.name} (graph unchanged)")
+            print(f"  SKIP {project.name} ({reason})")
             continue
 
         print(f"\n  INGEST {project.name} (git: {git_hash[:8] or 'unknown'})")


### PR DESCRIPTION
Four places wrote a "done" marker on a path where the work behind it had not
happened, and in every case that marker is the gate the *next* run reads — so
the work is never retried and the loss is silent.

## What was wrong, and the evidence it was real

**`scripts/a2a_context_bridge.py` — a broadcast that reached nobody reported `ok`**

`_broadcast_memory` returned `{"status": "ok"}` for any 200 from the **local**
server. It computed `ok_peers` and then discarded it. `a2a_server/server.py`
answers 200 with per-peer `status: 'skipped'` when `PEER_A2A_URLS` is unset
(`:1157`) or a peer has no token / an invalid TOTP seed (`_peer_headers`,
`:1033`/`:1042`), and `http_401` when a peer rejects the code. `store_local` is
`False` on this path, so in every one of those cases the memory left the node
nowhere — yet `run()` counted it `ok`, appended the id to `sent_ids`, and with
`fail == 0` advanced `last_run`. Both stamps then gate the next tick: the id is
skipped by `sent_set`, and the memory falls behind the
`REPLACE(created_at,' ','T') > ?` watermark. Recovery required hand-editing
`~/.hermes/bridge_state.json`. This is the failure mode already recorded for
this mesh — a TOTP-drift 401 on an A2A hop, silent at rc=0.

`_fetch_recent_memories` returned `[]` for "could not read the DB" exactly as it
does for "the window was quiet" — the DB file absent (`:127`) and every
per-table `sqlite3.OperationalError` skipped (`:154`) both fall through to an
empty list — and `run()` advances the watermark on `[]`. One tick under a unit
whose `MNEMOSYNE_DATA_DIR` does not resolve puts every memory written during the
outage permanently behind the new watermark.

**`mlops/loop.py` — runs marked ingested by a build that never ran**

`state["runs_seen"]` was extended with `new_runs` inside `if should_rebuild:`
with no check that the rebuild succeeded. `_rebuild_dataset` does not raise: a
missing builder returned `_current_dataset_size()` and a non-zero exit called
`_fail()` and returned the same. `_discover_runs` excludes anything in
`runs_seen`, so the loop then reports `new investigation runs: 0` —
indistinguishable from a quiet night — and waits for `--min-new-runs` **fresh**
investigations before trying again. The one failed night shows in that night's
exit code; the suppression it buys shows nowhere.

**`scripts/ua-watch.py` — a git hash stamped as a claim about the graph**

`run_ingest` returns True on `returncode == 0` alone, and `ua-ingest.py` exits 0
after upserting zero points (`flush_batch` is a no-op on an empty batch, so an
empty `final-graph.json` prints "Done. 0 points upserted" and exits clean). The
git gate was checked **before** the mtime gate and on its own, so once that hash
was stamped, regenerating the graph — the one repair for an empty ingest — could
not get the project back into the collection until someone happened to commit to
that repo. The watcher reported a healthy "Ingested: n Skipped: m" throughout.

**`mcp/server.py` — a preview tick retired the artifacts it only looked at**

`reflection_loop_tick` wrote `processed[key]` for every item that parsed,
including under `store_item_findings=False`, which stores nothing.
`reflection_loop_seed` does `existing_keys.update(processed.keys())` and only
`reset_queue=True` clears it, so a preview run permanently excluded those
artifacts from the reflection corpus while `processed_count` said they were
mined.

## What changed

- `_broadcast_memory` now decides on the transport result it already parses:
  `ok` only when `ok_peers > 0`, otherwise `no_peers`/`peers_failed` carrying the
  per-peer reasons. That increments `fail`, which engages the watermark hold
  `run()` already had.
- `_fetch_recent_memories` returns `None` — not `[]` — for DB-absent and
  no-queryable-table, and `run()` writes no state at all in that case. A
  genuinely empty window still returns `[]` and still advances.
- `_rebuild_dataset` returns `None` on both failure paths; `main()` only stamps
  `runs_seen` and `last_dataset_size` when the build completed, and says how many
  runs it held. The value fed to the `min_new_pairs` gate is unchanged
  (`_current_dataset_size()`, exactly what the old failure path returned), so
  nothing downstream of the rebuild moves.
- `ua-watch` gains `skip_reason()`: **both** stamps must be unchanged to skip. A
  plain reorder would not have fixed this — with the git gate second it still
  fires on the regenerated-graph path.
- `reflection_loop_tick` marks an item processed only when the tick could store
  findings.

## What proves it, and that it fails without the fix

Verified independently by checking out `origin/main`'s source into a separate
worktree, copying the branch's test files onto it, and running:

- `scripts/tests/test_context_bridge_delivery.py` + `test_ua_watch_skip_gate.py`:
  **14 failed, 9 passed** on main. `'ok' == 'ok'` for every-peer-skipped,
  every-peer-401 and no-peers-configured; `'http_401' not in ''`; `[] is not
  None` for the missing DB and the DB with no memory table; `TypeError` in
  `run()` for the unreadable case; the six `skip_reason` units error
  (`AttributeError`); and the end-to-end `main()` test fails `1 != 2` with the
  log showing `SKIP proj (git unchanged: aaaaaaaa)` after the graph was
  regenerated. All 23 pass on the branch.
- `mlops/tests/test_loop.py` + `mcp/tests/test_reflection_loop.py`: **5 failed**
  on main — `assert 4 is None` and `assert 7 is None` for the two
  `_rebuild_dataset` failure paths; `assert ['old','n1','n2'] == ['old']` and the
  missing "holding 2 new run(s) unseen" line, both driven end-to-end through
  `main()` with the **real** rebuild step and a builder exiting non-zero; and the
  preview tick leaving `{'process_log|/tmp/a.log': {...}}` in `processed`.
- Negative twins pass on main and still pass: an untouched graph is not
  re-ingested, a storing tick still marks the item processed, a genuinely quiet
  window still advances the watermark.
- Full combined `pytest mcp/tests scripts/tests mlops/tests`: **1274 passed, 3
  failed** on the branch; **1247 passed, the same 3 failed** on pristine main —
  `test_code_graph_ingest_and_query` (known) and two `test_loop.py` ollama-URL
  tests that only fail when `mcp/tests` is collected in the same process
  (`OLLAMA_BASE_URL` cross-suite pollution). No new failures.
- `scripts/callgraph/tests`: 425 passed, corpus file count still 126 — every
  added file is under a `tests/` dir. `vulture` (CI's exact invocation) clean on
  both branch and main; `check_vulture_whitelist.py` passes.
- `scripts/tests` was run both with the real `$HOME` and under `env -i` with an
  empty HOME (a clean runner has no `~/.hermes/.env` for the bridge module to
  read at import): 228 passed either way. The two new script tests need only
  `aiohttp`, which the `test-scripts` job already installs; neither imports
  `mcp/server.py`.

## Behaviour changes a reader should know about

- **A bridge on a node with no peers configured** now warns and holds its
  watermark every tick instead of silently advancing. Checked against this
  machine: the live `mrpink-context-bridge` has one peer, it is reachable, and
  the A2A server logs `context_broadcast: pushed to 1 peers — 1 ok`, so this
  node keeps returning `ok`. `_fetch_recent_memories` was also run against a copy
  of the live `mnemosyne.db` and returns a list (0 for today's window, 20 for a
  wide one), never `None`. Note the deployed bridge is a copy under
  `~/.hermes/profiles/mrpink/scripts/`, so merging does not deploy it.
- **A loop whose builder is permanently absent** re-reports the same new runs
  every night instead of consuming them. Merging *is* the deploy here —
  `~/.loci/bin/mlops-cron` resolves the script from `origin/main` and the 02:00
  crontab passes no `--dry-run` — so this was worked out against the live state:
  tonight `new_runs` = 3 and `should_rebuild` is True. If the rebuild succeeds,
  behaviour is byte-identical to today. If it fails, the runs are held and
  `new_pairs` = 5418 (the committed dataset the wrapper resets to) − 12684 (state)
  = −7266, under the 200 needed to retrain, so no retrain, canary or promotion is
  armed by the retry.
- **ua-watch** re-ingests when the commit moves even if the graph did not. That
  is the cost of the AND; it is idempotent (points are upserted under a
  deterministic UUID from `repo_name + node.id`) and it refreshes the `git_hash`
  payload field the collection indexes. Not scheduled anywhere — it is run by
  hand — and the state file holds one project.

## Deliberately left alone

`scripts/mnem_fix.py:124`, the sixth and most literal instance of the class:
every unresolved row is stamped `resolution='AUTO: ... Manual review recommended.'`
plus `resolved_at`, which closes the `WHERE resolution IS NULL OR resolution=''`
query it selects on. Its fix shape needs a schema change (record the auto-triage
in a new column so the row keeps surfacing) — an `ALTER TABLE` against two live
Mnemosyne SQLite banks, a much larger blast radius than anything else here. The
script is also untestable as written: top-level code with no main guard that
imports `sentence_transformers` and loads a model at import, so proving a fix
would mean restructuring the file. Per the finding, nothing automated reads that
stamp, which is why it was rated low.

`reflection_loop_tick` still increments `stats["files_processed"]` on a preview
tick. The load-bearing consumer — `seed`'s permanent exclusion — is fixed; the
counter is a scan count and the file was in fact scanned.
