### PR TITLE
Stop the test suite writing to the operator's memcheck audit log

### DIFF
--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -8,9 +8,31 @@ tests are collected in the same session.
 import sys
 from pathlib import Path
 
+import pytest
+
 _MCP_DIR = str(Path(__file__).resolve().parent.parent)
 
 
 def pytest_configure(config):  # noqa: ARG001
     if _MCP_DIR not in sys.path:
         sys.path.insert(0, _MCP_DIR)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_the_audit_log(tmp_path, monkeypatch):
+    """No test may touch ~/.hermes/memcheck-audit.jsonl.
+
+    memcheck's audit log defaults to the operator's real home, and
+    test_daemon.py drives process_action -> _append_audit_line with no
+    isolation. That was harmless while the writer only appended.
+
+    On 2026-09-01 a change adding size-based rotation to that writer turned it
+    destructive: running mcp/tests once took the real log from 9,588,755 bytes
+    and 49,412 records spanning 2026-06-22 to 2,102,181 bytes and 10,733
+    records from 2026-08-23. About 38,700 records over 62 days, with no backup.
+    A clean CI runner has no such file, so the rotation hits FileNotFoundError
+    and returns -- green on the runner, destructive on the machine in daily use.
+
+    autouse and unconditional: an opt-in fixture is one a new test file forgets.
+    """
+    monkeypatch.setenv("MEMCHECK_AUDIT_LOG", str(tmp_path / "memcheck-audit.jsonl"))

--- a/mcp/tests/test_audit_log_is_isolated.py
+++ b/mcp/tests/test_audit_log_is_isolated.py
@@ -1,0 +1,39 @@
+"""The audit log a test writes must never be the operator's.
+
+mcp/memcheck defaults its audit log to ~/.hermes/memcheck-audit.jsonl, and
+test_daemon.py drives the writer with no isolation of its own. Harmless while
+the writer only appended; a size-based rotation added to that writer on
+2026-09-01 made one `pytest mcp/tests` run take the real log from 9,588,755
+bytes / 49,412 records back to 2026-08-23 -- about 38,700 records over 62 days,
+with no backup, on a machine where that log is the only record of what memcheck
+has seen.
+
+A clean runner has no such file, so nothing about this is visible in CI.
+"""
+import os
+import pathlib
+
+from memcheck import cli as memcheck_cli  # noqa: E402  (conftest puts mcp/ on sys.path)
+
+
+def test_the_audit_path_is_not_the_operators():
+    home = pathlib.Path.home().resolve()
+    path = memcheck_cli.audit_log_path().resolve()
+    assert not str(path).startswith(str(home / ".hermes")), (
+        f"tests resolve the audit log to {path}, inside the operator's home"
+    )
+
+
+def test_the_isolation_is_an_env_override_not_a_monkeypatched_internal():
+    """Pins the mechanism: memcheck resolves the path per call from the
+    environment, so a subprocess or a re-import stays isolated too."""
+    assert os.environ.get("MEMCHECK_AUDIT_LOG"), (
+        "the autouse fixture in conftest.py is gone; every test that reaches "
+        "_append_audit_line is writing to ~/.hermes again"
+    )
+
+
+def test_writing_an_audit_line_lands_in_the_isolated_file():
+    memcheck_cli._append_audit_line({"ts": "x", "tool_name": "test"})
+    written = pathlib.Path(os.environ["MEMCHECK_AUDIT_LOG"])
+    assert written.exists() and "test" in written.read_text()


### PR DESCRIPTION
**I destroyed data with this and I want to lead with that.**

`mcp/memcheck` defaults its audit log to `~/.hermes/memcheck-audit.jsonl`. `test_cli_dispatch.py` points `MEMCHECK_AUDIT_LOG` at a temp path; **`test_daemon.py` does not**, and drives `process_action → _append_audit_line` straight into the real file. Harmless while the writer only appended — which is why it survived.

A branch in today's hunt added size-based rotation to that writer. One `pytest mcp/tests` run then did this:

```
before   9,588,755 bytes   49,412 records   oldest 2026-06-22
after    2,102,181 bytes   10,733 records   oldest 2026-08-23
```

**~38,700 records over 62 days, gone, with no backup.** That file is the only record of what memcheck has seen. I searched the whole filesystem: the one 9.5 MB copy that exists is synthetic padding the reviewer generated for its own experiment — 42,223 rows all stamped `2026-06-22T00:00:00`, not a copy of yours. The data is not recoverable. The conclusion drawn from it earlier (memcheck has never once set `would_flag`) is preserved in my notes; the raw rows are not.

A clean runner has no such file, so the rotation returns on `FileNotFoundError`. **Green in CI, destructive on the machine in daily use** — the same shape as three other bugs today, with the worst possible payload.

## The fix

An autouse fixture in `mcp/tests/conftest.py`. Autouse and unconditional, because an opt-in fixture is the one a new test file forgets — which is exactly how `test_daemon.py` came to differ from `test_cli_dispatch.py`. It sets the env var rather than patching an internal, so a subprocess or a re-import stays isolated too.

Measured on a fake `HOME` with a planted 3.58 MB log — same 9 tests, passing both times, noticing nothing either way:

```
without the fixture   3,580,000 -> 3,581,674 bytes
with the fixture      3,580,000 -> 3,580,000 bytes
```

Three tests pin it: the resolved path is not under `~/.hermes`, the env override is present (so deleting the fixture fails loudly), and a written line lands in the isolated file.

## What this unblocks

`fix/unbounded-growth` is held pending exactly this. Its rotation code is correct and well-tested; what made it unmergeable was that landing it armed this leak. With isolation in place that branch can be re-reviewed.

```
mcp/tests    859 passed
```

`test_graph_integration.py::test_code_graph_ingest_and_query` fails on this box from the Kuzu single-writer lock and is unrelated — it fails identically on a clean `main`.