### PR TITLE
Make a dead grounding lane visible instead of silently empty

### DIFF
--- a/mcp/grounding.py
+++ b/mcp/grounding.py
@@ -113,6 +113,11 @@ _MEM_STOP = {"the", "and", "for", "with", "not", "via", "per", "any", "all", "ne
 
 _MEM_DISTINCTIVE = 7  # a shared token this long is topical, not incidental English
 
+# RAG lane budget: a proportional share of the caller's total ask, floored at the old
+# absolute cap so a small/default budgetChars keeps its pre-existing behaviour exactly.
+_RAG_BUDGET_FRACTION = 0.35  # matches the add() slice_frac already used for the "rag" tag
+_RAG_BUDGET_FLOOR = 2000
+
 
 def _select_memory_files(task: dict, memory_dir: str, limit: int = 2,
                          min_score: int = 2) -> list[tuple[str, str, str]]:
@@ -287,7 +292,8 @@ def ground(task: dict, opts: Optional[dict] = None) -> dict:
     if S and remaining[0] > 400:
         try:
             q = f"{task.get('title','')} {task.get('focus','')}".strip()
-            res = _jload(S.rag_context_search(q, budget_chars=min(remaining[0], 2000), limit=6))
+            rag_cap = max(_RAG_BUDGET_FLOOR, int(budget * _RAG_BUDGET_FRACTION))
+            res = _jload(S.rag_context_search(q, budget_chars=min(remaining[0], rag_cap), limit=6))
             ctx = (res or {}).get("context", "") if isinstance(res, dict) else ""
             if ctx and (res.get("result_count") or 0) > 0:
                 add("rag", ctx, 0.35)
@@ -299,6 +305,15 @@ def ground(task: dict, opts: Optional[dict] = None) -> dict:
 
     # Curated memory files — a SUPPLEMENT after the precise (case/RAG) lanes, so a
     # fuzzy-matched memory can never crowd them out. Capped + thresholded selection.
+    # The lane must be VISIBLE when it can't run at all: '' (never configured) and "configured
+    # but no MEMORY.md at that path" (broken deployment) are both requested-but-dead, so both
+    # degrade the result rather than looking identical to "configured, searched, no match".
+    if not memory_dir:
+        degraded = True
+        sources.append("memory:unconfigured")
+    elif not (Path(memory_dir) / "MEMORY.md").exists():
+        degraded = True
+        sources.append("memory:missing-index")
     for fname, line, body in _select_memory_files(task, memory_dir):
         add(f"memory:{fname[:-3]}", (body or line), 0.15)
 

--- a/mcp/grounding.py
+++ b/mcp/grounding.py
@@ -296,7 +296,7 @@ def ground(task: dict, opts: Optional[dict] = None) -> dict:
             res = _jload(S.rag_context_search(q, budget_chars=min(remaining[0], rag_cap), limit=6))
             ctx = (res or {}).get("context", "") if isinstance(res, dict) else ""
             if ctx and (res.get("result_count") or 0) > 0:
-                add("rag", ctx, 0.35)
+                add("rag", ctx, _RAG_BUDGET_FRACTION)
             elif isinstance(res, dict) and not res.get("qdrant_available", True):
                 degraded = True
         except Exception as exc:
@@ -305,17 +305,30 @@ def ground(task: dict, opts: Optional[dict] = None) -> dict:
 
     # Curated memory files — a SUPPLEMENT after the precise (case/RAG) lanes, so a
     # fuzzy-matched memory can never crowd them out. Capped + thresholded selection.
-    # The lane must be VISIBLE when it can't run at all: '' (never configured) and "configured
-    # but no MEMORY.md at that path" (broken deployment) are both requested-but-dead, so both
-    # degrade the result rather than looking identical to "configured, searched, no match".
+    # The lane must be VISIBLE when it can't run, but only a genuine deployment fault
+    # degrades: '' is _default_memory_dir()'s documented no-op default for a host that
+    # never configured curated memory, so marking it degraded would make the shipped
+    # default always-degraded. "configured but no MEMORY.md at that path" IS broken and
+    # degrades. Never build a Path from memory_dir before confirming it's configured —
+    # Path('') == Path('.') would silently read a MEMORY.md from the process CWD. The
+    # existence check stays fail-open (memory_dir can arrive as a non-str from a
+    # misconfigured caller) rather than raising straight out of ground(). Tags use the
+    # 'memory-lane:' namespace, distinct from add()'s 'memory:<slug>', so a consumer
+    # can't mistake a dead-lane marker for a real memory file named unconfigured.md.
+    has_index = False
+    if memory_dir:
+        try:
+            has_index = (Path(memory_dir) / "MEMORY.md").exists()
+        except Exception:
+            has_index = False
     if not memory_dir:
+        sources.append("memory-lane:unconfigured")
+    elif not has_index:
         degraded = True
-        sources.append("memory:unconfigured")
-    elif not (Path(memory_dir) / "MEMORY.md").exists():
-        degraded = True
-        sources.append("memory:missing-index")
-    for fname, line, body in _select_memory_files(task, memory_dir):
-        add(f"memory:{fname[:-3]}", (body or line), 0.15)
+        sources.append("memory-lane:missing-index")
+    else:
+        for fname, line, body in _select_memory_files(task, memory_dir):
+            add(f"memory:{fname[:-3]}", (body or line), 0.15)
 
     # 6. Keyword/FTS fallback (off by default; filtered) — only if structured yield was thin.
     if opts.get("allowKeyword") and S and sum(len(p) for p in parts) < 500:

--- a/mcp/tests/test_grounding.py
+++ b/mcp/tests/test_grounding.py
@@ -165,17 +165,24 @@ def _fake_healthy_server():
     return fake
 
 
-def test_ground_marks_degraded_when_memory_dir_unconfigured(monkeypatch):
-    """An unconfigured memory dir ('') must be visible to the caller, not silently healthy.
-
-    Regression: memory_dir='' made _select_memory_files() return [] with no trace anywhere
-    in the result -- indistinguishable from a configured lane that just found no match.
+def test_ground_marks_unconfigured_memory_dir_visible_but_not_degraded(monkeypatch):
+    """An unconfigured memory dir ('') must be visible to the caller via a distinct tag,
+    but must NOT count as a fault. '' is _default_memory_dir()'s documented no-op default
+    for a host that never set up curated memory -- marking it degraded would make the
+    SHIPPED DEFAULT of ground() always-degraded, so a healthy run could never signal
+    'coverage is partial' as a real outage. That's a materially different claim from the
+    old disjunctive test, which passed whether degraded was True OR False.
     """
     monkeypatch.setitem(sys.modules, "server", _fake_healthy_server())
     r = G.ground({"title": "why is auth failing", "focus": "auth"}, {"budgetChars": 500, "memoryDir": ""})
-    assert r["degraded"] is True or any("memory" in s for s in r["sources"]), (
-        "unconfigured memory dir left no trace: degraded=%r sources=%r" % (r["degraded"], r["sources"])
+    assert r["degraded"] is False, (
+        "unconfigured memory dir must not degrade an otherwise-healthy run: got degraded=%r"
+        % r["degraded"]
     )
+    assert "memory-lane:unconfigured" in r["sources"]
+    # Must not be shaped like a real memory:<slug> tag from add() -- a consumer can't
+    # otherwise tell it apart from a memory file literally named unconfigured.md.
+    assert not any(s.startswith("memory:") for s in r["sources"]), r["sources"]
 
 
 def test_ground_marks_degraded_when_memory_dir_missing_index(tmp_path, monkeypatch):
@@ -189,6 +196,42 @@ def test_ground_marks_degraded_when_memory_dir_missing_index(tmp_path, monkeypat
         "configured memory dir with missing MEMORY.md reported degraded=False -- "
         "indistinguishable from a healthy empty lane"
     )
+    assert "memory-lane:missing-index" in r["sources"]
+
+
+def test_ground_unconfigured_memory_dir_never_reads_cwd(tmp_path, monkeypatch):
+    """Path('') == Path('.') -- an unconfigured memory_dir must never be turned into a
+    Path and read from the process CWD.
+
+    Regression (#286 review, grounding.py:318): the unconfigured branch tagged the lane
+    dead but still fell into _select_memory_files(task, ''), which did Path('') / 'MEMORY.md'
+    and read whatever MEMORY.md happened to be sitting in the process's current directory --
+    a real content-injection path, and exactly what PR #287's index generator writes.
+    """
+    (tmp_path / "MEMORY.md").write_text(
+        "- [planted](planted.md) — dispatch referenced flag dead-code registry rules detection\n")
+    (tmp_path / "planted.md").write_text("PLANTED BODY: must never surface via memoryDir=''")
+    monkeypatch.setitem(sys.modules, "server", _fake_healthy_server())
+    monkeypatch.chdir(tmp_path)
+    r = G.ground({"title": "dead-code detection", "focus": "dispatch referenced flag registry rules"},
+                 {"budgetChars": 500, "memoryDir": ""})
+    assert "PLANTED BODY" not in r["block"]
+    assert not any(s.startswith("memory:planted") for s in r["sources"]), r["sources"]
+
+
+def test_ground_fail_open_on_non_string_memory_dir(monkeypatch):
+    """A misconfigured caller might pass a non-str memoryDir. The existence check must
+    stay fail-open like every other lane, not raise straight out of ground().
+
+    Regression: 'Path(memory_dir) / "MEMORY.md").exists()' sat outside any try, unlike
+    _select_memory_files() whose body is wrapped -- memoryDir=5 or b'/tmp' raised
+    TypeError out of ground() instead of degrading gracefully.
+    """
+    monkeypatch.setitem(sys.modules, "server", _fake_healthy_server())
+    for bad in (5, b"/tmp"):
+        r = G.ground({"title": "x"}, {"budgetChars": 500, "memoryDir": bad})
+        assert set(r) == {"block", "sources", "chars", "degraded"}
+        assert r["degraded"] is True
 
 
 def test_ground_rag_budget_scales_with_large_ask(monkeypatch):

--- a/mcp/tests/test_grounding.py
+++ b/mcp/tests/test_grounding.py
@@ -153,6 +153,84 @@ def test_ground_budget_respected(tmp_path, monkeypatch):
     assert r["chars"] <= 800 + 500
 
 
+def _fake_healthy_server():
+    """A server double where every OTHER lane is healthy/non-degraded, so a degraded=True
+    result can only be attributed to the memory lane under test."""
+    import types
+    fake = types.ModuleType("server")
+    fake.investigation_load = lambda cid, **k: {"manifest": {}, "recent_findings": []}
+    fake.investigation_entity_lookup = lambda ent, **k: {"total_findings": 0}
+    fake.rag_context_search = lambda q, **k: {"context": "", "result_count": 0, "qdrant_available": True}
+    fake.investigation_search = lambda q, **k: {"results": []}
+    return fake
+
+
+def test_ground_marks_degraded_when_memory_dir_unconfigured(monkeypatch):
+    """An unconfigured memory dir ('') must be visible to the caller, not silently healthy.
+
+    Regression: memory_dir='' made _select_memory_files() return [] with no trace anywhere
+    in the result -- indistinguishable from a configured lane that just found no match.
+    """
+    monkeypatch.setitem(sys.modules, "server", _fake_healthy_server())
+    r = G.ground({"title": "why is auth failing", "focus": "auth"}, {"budgetChars": 500, "memoryDir": ""})
+    assert r["degraded"] is True or any("memory" in s for s in r["sources"]), (
+        "unconfigured memory dir left no trace: degraded=%r sources=%r" % (r["degraded"], r["sources"])
+    )
+
+
+def test_ground_marks_degraded_when_memory_dir_missing_index(tmp_path, monkeypatch):
+    """A configured-but-broken memory dir (no MEMORY.md at the configured path) is a
+    stronger signal than 'unconfigured' -- a deployment that thinks it has curated memory
+    but doesn't. Must set degraded=True, not silently no-op like the unconfigured case."""
+    monkeypatch.setitem(sys.modules, "server", _fake_healthy_server())
+    r = G.ground({"title": "why is auth failing", "focus": "auth"},
+                 {"budgetChars": 500, "memoryDir": str(tmp_path / "nope")})
+    assert r["degraded"] is True, (
+        "configured memory dir with missing MEMORY.md reported degraded=False -- "
+        "indistinguishable from a healthy empty lane"
+    )
+
+
+def test_ground_rag_budget_scales_with_large_ask(monkeypatch):
+    """budget_chars passed to rag_context_search must scale with the caller's ask, not be
+    hard-capped at 2000 regardless of how much budget the caller actually has."""
+    import types
+    seen = {}
+    fake = types.ModuleType("server")
+
+    def _capture(q, budget_chars=None, limit=6):
+        seen["budget_chars"] = budget_chars
+        return {"context": "x" * 100, "result_count": 1}
+
+    fake.rag_context_search = _capture
+    monkeypatch.setitem(sys.modules, "server", fake)
+    G.ground({"title": "t", "focus": "f"}, {"budgetChars": 8000, "memoryDir": "/nonexistent"})
+    assert seen["budget_chars"] > 2000, (
+        "large caller budget (8000) still clamped the RAG lane to the old 2000 absolute cap: "
+        "got budget_chars=%r" % seen.get("budget_chars")
+    )
+
+
+def test_ground_rag_budget_floor_unchanged_for_small_ask(monkeypatch):
+    """A caller with the (small/default) old-style budget must see identical RAG behaviour
+    to before this fix -- the floor preserves it."""
+    import types
+    seen = {}
+    fake = types.ModuleType("server")
+
+    def _capture(q, budget_chars=None, limit=6):
+        seen["budget_chars"] = budget_chars
+        return {"context": "x" * 100, "result_count": 1}
+
+    fake.rag_context_search = _capture
+    monkeypatch.setitem(sys.modules, "server", fake)
+    G.ground({"title": "t", "focus": "f"}, {"budgetChars": 4000, "memoryDir": "/nonexistent"})
+    assert seen["budget_chars"] == 2000, (
+        "default-sized budget (4000) must keep the old 2000 cap unchanged: got budget_chars=%r"
+        % seen.get("budget_chars")
+    )
+
+
 def test_ground_marks_degraded_when_server_import_fails(monkeypatch):
     """A total grounding failure must be distinguishable from 'nothing stored'.
 


### PR DESCRIPTION
## Observed defects

Both were verified live against `mcp/grounding.py` before touching it (see grounding block m5-m7):

**1. Curated memory lane fails silently.** `backends.memory_dir()` legitimately returns `''` on this host (no machine-specific default anymore, deliberate for a public repo) and `~/.loci/backends.toml` has no `[memory]` section set. `_select_memory_files()` correctly no-ops on an empty/missing dir, but `ground()` still reported `degraded=False` with nothing in `sources` -- byte-identical to a healthy "searched, nothing relevant" result. Confirmed live: `ground()` returned `sources:["rag"], degraded:false` while the memory lane never ran at all.

**2. RAG lane ignores the caller's budget.** `budget_chars=min(remaining[0], 2000)` is an absolute cap regardless of what the caller asked for. Confirmed live: asking for `budget_chars=8000` still returned `chars:2167`, with the block itself printing `[33 more results omitted -- budget 2000 chars]`.

## Fix

**Memory lane** -- mirrors the existing code-graph pattern (`elif task.get("codeRefs"): degraded = True`): before running the lane, check whether it can run at all.
- `memory_dir == ''` (never configured) -> `degraded=True`, `sources` gets `memory:unconfigured`.
- `memory_dir` set but no `MEMORY.md` there (configured but broken) -> `degraded=True`, `sources` gets `memory:missing-index`.

Both are marked distinctly so a caller (or a log) can tell "nobody set this up" apart from "somebody set this up wrong" -- the second is the stronger signal of a broken deployment. No machine-specific default path is reintroduced; an unconfigured dir stays a functional no-op, it just stops being silent about it.

**RAG lane** -- replaced the hardcoded `2000` with `max(2000, int(budget * 0.35))`. 0.35 matches the slice fraction `add()` already uses for the `"rag"` tag internally, so the outer request cap and the inner truncation cap now agree instead of the outer one silently overriding the inner one for large budgets. 2000 stays as a floor, so a caller on the old default budget (4000) gets byte-identical behavior to before. Verified: `budgetChars=8000` -> `rag_context_search` is called with `budget_chars=2800`, up from a hard 2000; `budgetChars=4000` -> still exactly 2000.

## Tests

Added to `mcp/tests/test_grounding.py`, each proven to fail against the pre-fix code before the fix was applied (using a `server` double where every *other* lane is healthy, so degraded=True can only be attributed to the lane under test):

- `test_ground_marks_degraded_when_memory_dir_unconfigured`
- `test_ground_marks_degraded_when_memory_dir_missing_index`
- `test_ground_rag_budget_scales_with_large_ask`
- `test_ground_rag_budget_floor_unchanged_for_small_ask`

Full `mcp/tests/test_grounding.py` suite: 17/17 passing after the fix.

Not merging/enabling auto-merge -- opening for review only.