### PR TITLE
Stop the index generator dropping its own previous output

### DIFF
--- a/scripts/generate_memory_index.py
+++ b/scripts/generate_memory_index.py
@@ -240,7 +240,10 @@ def build_sections(entries: list[Entry], source_order: list[str],
         by_type.setdefault(_type_section_name(e.mtype), []).append(e)
     for section in sorted(by_type):
         by_type[section].sort(key=lambda e: e.filename)
-        result[section] = by_type[section]
+        # Append: a type-derived name can collide with a section the source pass
+        # already filled, and assigning would drop everything that landed there
+        # on an earlier run — the generator eating its own output.
+        result.setdefault(section, []).extend(by_type[section])
 
     return result
 

--- a/scripts/tests/test_generate_memory_index.py
+++ b/scripts/tests/test_generate_memory_index.py
@@ -316,3 +316,30 @@ def test_cross_project_source_entry_survives(tmp_path, mod):
 
     assert "../other-project/memory/thing.md" in out
     assert "Elsewhere" in out
+
+
+def test_regenerating_from_own_output_keeps_every_entry(tmp_path, mod):
+    """Round-trip: files with no home in the source land in a type-derived
+    section, and that section becomes a real section of the next run's source.
+    If the type pass assigns rather than appends, run two silently drops
+    everything run one put there — the generator eating its own output."""
+    _write_mem(tmp_path, "listed.md", "listed", "in the curated index", mtype="project")
+    for i in range(3):
+        _write_mem(tmp_path, f"orphan-{i}.md", f"orphan-{i}", f"not in the index {i}",
+                   mtype="project")
+    source = "# Memory index\n\n## Curated\n- [Listed](listed.md) — in the curated index\n"
+
+    first = mod.render(mod.build_sections(
+        mod.load_entries(tmp_path)[0], *mod.parse_source_sections(source)[:2]))
+    assert all(f"orphan-{i}.md" in first for i in range(3))
+
+    # now a new file arrives and the previous output is the source
+    _write_mem(tmp_path, "newcomer.md", "newcomer", "arrived later", mtype="project")
+    order, secs, curated = mod.parse_source_sections(first)
+    entries = mod.apply_curated(mod.load_entries(tmp_path)[0], curated)
+    second = mod.render(mod.build_sections(entries, order, secs))
+
+    for i in range(3):
+        assert f"orphan-{i}.md" in second, f"orphan-{i}.md dropped on regeneration"
+    assert "newcomer.md" in second
+    assert "listed.md" in second


### PR DESCRIPTION
Found while regenerating the live index after adding one memory file: it went from **182 entries to 166**, silently losing all 17 memories that a previous run had placed in type-derived sections.

```python
for section in sorted(by_type):
    result[section] = by_type[section]      # assigns
```

Files not listed in the source index are grouped by `metadata.type`. Those type-derived section names (`Project`, `Reference`, …) are written into the output, so on the *next* run they arrive as real sections of the source and their files are consumed by the source pass. `remaining` then holds only newly-added files — and the assignment replaces the source-derived bucket instead of extending it. Every previously type-bucketed entry is dropped.

It is a slow-acting loop: each run keeps only the files added since the last one, so the index bleeds entries one regeneration at a time. Exactly the silent-drop failure the script exists to prevent, and now on a daily cron.

Fix is `result.setdefault(section, []).extend(...)`.

The existing round-trip test missed it because it regenerates with no new file, which leaves the type pass empty — the one condition under which assign and extend are identical. The new test adds a file between the two runs and fails on unfixed code with `AssertionError: orphan-0.md dropped on regeneration`.

Verified on the real 182-file corpus: 183 entries / 0 orphans, byte-identical on re-run, +1 file → 184 and stable, file removed → back to 183 exactly.