### PR TITLE
Load backends.toml before qdrant_ops reads the environment

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -157,18 +157,19 @@ def _extract_entities(text: str) -> dict:
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 load_dotenv(Path(__file__).resolve().parent / ".env", override=True)
 
-# The .env files above are only two of the three places a backend endpoint lives; the
-# third is ~/.loci/backends.toml, deliberately outside the git tree so the Qdrant key is
-# never committable. Nothing here used to consult it, so a server launched without an
-# env block (the tracked .mcp.json registers loci as bare stdio) started with no
-# QDRANT_URL — and every RAG gate below reads os.environ directly. The failure is silent
-# and actively misleading: loci_health resolves through backends.qdrant(), which DOES read
-# backends.toml, so it reports qdrant_reachable=true while investigation_search returns
-# {"mode":"rag_required","qdrant_enabled":false,"results":[]}. Callers that treat an empty
-# result set as "nothing matched" then fail open — the codebase-ingest supersede step reads
-# it as "no prior doc to retire" and appends a duplicate. load_env() applies the same
-# precedence (existing env > .env > backends.toml) and must run before qdrant_ops is
-# imported, since that module reads os.environ at import time.
+# The .env files above are two of the three places a backend endpoint lives; the third
+# is ~/.loci/backends.toml, kept outside the tree so the Qdrant key is not committable.
+# Nothing here consulted it, so a server started without an env block (.mcp.json
+# registers loci as bare stdio) had no QDRANT_URL, while every RAG gate below reads
+# os.environ directly. That fails inverted: loci_health resolves through
+# backends.qdrant(), which DOES read backends.toml, so health reports reachable while
+# investigation_search returns qdrant_enabled=false with no results — and a caller
+# reading empty as "nothing matched" appends a duplicate instead of superseding.
+#
+# load_env() only fills what is still unset, so it ranks below both .env files. Note the
+# mcp/.env call above passes override=True and so beats even an exported variable:
+# measured effective order is mcp/.env > exported env > ../.env > backends.toml. Must run
+# before qdrant_ops is imported — that module reads os.environ at module level.
 import backends  # noqa: E402
 backends.load_env()
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -157,6 +157,21 @@ def _extract_entities(text: str) -> dict:
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 load_dotenv(Path(__file__).resolve().parent / ".env", override=True)
 
+# The .env files above are only two of the three places a backend endpoint lives; the
+# third is ~/.loci/backends.toml, deliberately outside the git tree so the Qdrant key is
+# never committable. Nothing here used to consult it, so a server launched without an
+# env block (the tracked .mcp.json registers loci as bare stdio) started with no
+# QDRANT_URL — and every RAG gate below reads os.environ directly. The failure is silent
+# and actively misleading: loci_health resolves through backends.qdrant(), which DOES read
+# backends.toml, so it reports qdrant_reachable=true while investigation_search returns
+# {"mode":"rag_required","qdrant_enabled":false,"results":[]}. Callers that treat an empty
+# result set as "nothing matched" then fail open — the codebase-ingest supersede step reads
+# it as "no prior doc to retire" and appends a duplicate. load_env() applies the same
+# precedence (existing env > .env > backends.toml) and must run before qdrant_ops is
+# imported, since that module reads os.environ at import time.
+import backends  # noqa: E402
+backends.load_env()
+
 import logging
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
Not originally my change — it was found uncommitted in the working tree, authored by a concurrent session. I verified every claim in it before landing rather than committing it blind.

**The asymmetry, measured under a bare environment:**
```
QDRANT_URL before load_env: None
backends.qdrant() resolves : True          <- health reads backends.toml
QDRANT_URL after  load_env: 'http://172.21.171.198:30633'
```
So `loci_health` reports `qdrant_reachable=true` while every RAG gate — which reads `os.environ` directly — sees nothing. An empty result set then reads as "nothing matched" rather than "never connected", and the codebase-ingest supersede step appends a duplicate instead of retiring the prior doc.

**The ordering requirement is real:** `qdrant_ops.py:25` reads `os.environ` at module level, so `load_env()` must precede the import. It does — line 173 vs 192.

**Checks:** the CI ruff gate (`--select E9,F401,F811,F821,F841 --ignore E402`) passes. The two errors a bare `ruff check` reports are default-rule E402/F402 and are present on the unmodified file too. Local pytest collection errors are missing `tree_sitter`/`qdrant_client` in this interpreter, not from this change.

Plausibly why the `qdrant` MCP server failed to connect in a session today.