### PR TITLE
Put a computed floor under the model-authored summaries

### DIFF
--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -111,6 +111,73 @@ def _only_findings(records: list) -> list:
             and (r.get("record_type") or r.get("type") or "") not in _NON_FINDING_RECORD_TYPES]
 
 
+# Structured, low-cardinality metadata only. Free text is deliberately excluded:
+# these are facts about the SET, and a prose field has no class to report.
+_INVARIANT_FIELDS = ("record_type", "confidence", "resolution", "tier",
+                     "authored_by", "agent_id", "source")
+# Past this many distinct values a field is an identifier, not a class. Listing it
+# restates the data instead of describing it, so only the count is reported.
+_INVARIANT_MAX_VALUES = 5
+_INVARIANT_ABSENT = "(absent)"
+
+
+def _field_invariants(findings: list) -> dict:
+    """Describe a finding SET by the structured fields its members share.
+
+    This is a deterministic floor under the summary ladder. summary_l1/summary_l2
+    are model-authored, so at fidelity="summary" or "brief" every word a caller
+    reads about a set of findings is generated — nothing states, from the data,
+    that all twenty were high-confidence or that one of them is a gap. These
+    counts cannot be invented and cost no tokens to produce.
+
+    Three shapes, borrowed from the way a log compressor describes an elided run:
+    a field the whole set agrees on is a constant; a field with a handful of
+    values is an enumeration with counts; a field with more values than that is an
+    identifier, reported as a distinct count only.
+
+    Nothing here is budget-trimmed. The output is bounded by construction —
+    len(_INVARIANT_FIELDS) entries of at most _INVARIANT_MAX_VALUES counts — so
+    there is never a shed to disclose. That is the point: a summary that silently
+    drops facts is worse than one that never had them, because a reader takes the
+    absence of a field as evidence the field did not hold.
+    """
+    n = len(findings)
+    out: dict = {"n": n, "constant": {}, "varies": {}, "distinct_only": {}}
+    if not n:
+        return out
+
+    for field in _INVARIANT_FIELDS:
+        counts: dict = {}
+        for f in findings:
+            raw = f.get(field)
+            # Older records carry "type" where newer ones carry "record_type".
+            if raw in (None, "") and field == "record_type":
+                raw = f.get("type")
+            value = _INVARIANT_ABSENT if raw in (None, "") else str(raw)
+            counts[value] = counts.get(value, 0) + 1
+        if not counts or list(counts) == [_INVARIANT_ABSENT]:
+            continue  # no finding carried it; say nothing rather than "(absent)×n"
+        if len(counts) == 1:
+            out["constant"][field] = next(iter(counts))
+        elif len(counts) <= _INVARIANT_MAX_VALUES:
+            out["varies"][field] = dict(
+                sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+        else:
+            out["distinct_only"][field] = len(counts)
+
+    # Tags are a list per finding, so they get set semantics rather than a class:
+    # which tags EVERY finding carries, and how many distinct ones exist at all.
+    tag_sets = [{str(t) for t in (f.get("tags") or [])} for f in findings]
+    universe: set = set()
+    for s in tag_sets:
+        universe |= s
+    if universe:
+        shared = set.intersection(*tag_sets) if all(tag_sets) else set()
+        out["tags_on_every_finding"] = sorted(shared)
+        out["tags_distinct"] = len(universe)
+    return out
+
+
 def investigation_load(
     investigation_id: str,
     last_n_findings: int = 20,
@@ -150,6 +217,16 @@ def investigation_load(
         ``excluded_retracted`` (count of findings filtered out).
         When fidelity is "summary" or "brief", the ``recent_findings`` key is
         omitted and replaced with ``summary_l1`` and/or ``summary_l2``.
+
+        "full" and "summary" also carry ``field_invariants``: what the structured
+        fields of the whole surviving finding set agree on, as
+        ``constant`` (one value across the set), ``varies`` (value counts, up to
+        five), ``distinct_only`` (a count, for fields with more values than that),
+        and the tags every finding shares. It is computed, not generated, so it
+        holds when the model-authored summaries are absent, stale, or wrong, and
+        it covers findings the ``last_n_findings`` slice leaves out. "brief" omits
+        it deliberately — it reads no findings at all, and the manifest's
+        ``finding_counts`` already carries the type breakdown.
     """
     manifest = _load_manifest(investigation_id)
     if not manifest:
@@ -184,6 +261,10 @@ def investigation_load(
             "total_findings": len(findings),
             "summary_l1": summary_l1,
             "summary_l2": summary_l2,
+            # summary_l1/l2 are model-authored; this is not. At this fidelity the
+            # findings themselves are withheld, so without it every word the
+            # caller reads about them is generated.
+            "field_invariants": _field_invariants(findings),
             "excluded_retracted": excluded_retracted,
             "total_retracted": total_retracted,
             "include_retracted": include_retracted,
@@ -217,6 +298,10 @@ def investigation_load(
         "fidelity": "full",
         "total_findings": len(findings),
         "recent_findings": recent,
+        # Computed over every finding that survived filtering, not over the
+        # last_n_findings slice: its job is to describe the set the caller is
+        # being given a count of, including the part the slice left out.
+        "field_invariants": _field_invariants(findings),
         "excluded_retracted": excluded_retracted,
         "total_retracted": total_retracted,
         "include_retracted": include_retracted,

--- a/mcp/tests/test_field_invariants.py
+++ b/mcp/tests/test_field_invariants.py
@@ -1,0 +1,115 @@
+"""investigation_load's summary fidelities are entirely model-authored.
+
+summary_l1/summary_l2 come from investigation_reflect, so at fidelity="summary"
+every word a caller reads about a set of findings is generated — nothing states,
+from the data, that all twenty were high-confidence or that one of them is a gap.
+_field_invariants is the deterministic floor under that: counts the model cannot
+invent, and which survive the summary being absent, stale, or wrong.
+
+The shapes are borrowed from how a log compressor describes an elided run
+(constant / enumeration / identifier), with one deliberate difference: nothing
+here is budget-trimmed, so there is never a shed to disclose. A summary that
+silently drops facts is worse than one that never had them, because a reader
+takes a field's absence as evidence the field did not hold.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from investigation_tools import (  # noqa: E402
+    _INVARIANT_MAX_VALUES,
+    _field_invariants,
+)
+
+
+def _f(**kw):
+    base = {"record_type": "observed", "text": "t", "confidence": "high"}
+    base.update(kw)
+    return base
+
+
+class FieldInvariantsTest(unittest.TestCase):
+    def test_empty_set_reports_nothing_rather_than_guessing(self):
+        got = _field_invariants([])
+        self.assertEqual(got["n"], 0)
+        self.assertEqual(got["constant"], {})
+        self.assertEqual(got["varies"], {})
+
+    def test_a_field_the_whole_set_agrees_on_is_a_constant(self):
+        got = _field_invariants([_f(), _f(), _f()])
+        self.assertEqual(got["n"], 3)
+        self.assertEqual(got["constant"]["confidence"], "high")
+        self.assertEqual(got["constant"]["record_type"], "observed")
+        self.assertNotIn("confidence", got["varies"])
+
+    def test_a_handful_of_values_is_an_enumeration_with_counts(self):
+        findings = [_f(record_type="observed")] * 4 + [_f(record_type="gap")]
+        got = _field_invariants(findings)
+        self.assertEqual(got["varies"]["record_type"], {"observed": 4, "gap": 1})
+        self.assertNotIn("record_type", got["constant"])
+
+    def test_enumeration_is_ordered_by_descending_count(self):
+        findings = [_f(confidence="low")] + [_f(confidence="high")] * 3
+        self.assertEqual(list(_field_invariants(findings)["varies"]["confidence"]),
+                         ["high", "low"])
+
+    def test_a_field_with_too_many_values_reports_only_a_count(self):
+        """Listing an identifier restates the data instead of describing it — and
+        reporting the count is itself the disclosure that values were not listed."""
+        findings = [_f(source=f"tool_{i}") for i in range(_INVARIANT_MAX_VALUES + 3)]
+        got = _field_invariants(findings)
+        self.assertEqual(got["distinct_only"]["source"], _INVARIANT_MAX_VALUES + 3)
+        self.assertNotIn("source", got["varies"])
+        self.assertNotIn("source", got["constant"])
+
+    def test_a_field_only_some_findings_carry_is_not_reported_as_constant(self):
+        """The dangerous read. Two of three findings resolved 'fixed' must never
+        render as `all resolution=fixed` — absence is counted, not ignored."""
+        findings = [_f(resolution="fixed"), _f(resolution="fixed"), _f()]
+        got = _field_invariants(findings)
+        self.assertNotIn("resolution", got["constant"])
+        self.assertEqual(got["varies"]["resolution"], {"fixed": 2, "(absent)": 1})
+
+    def test_a_field_no_finding_carries_is_silent(self):
+        got = _field_invariants([_f(), _f()])
+        self.assertNotIn("resolution", got["constant"])
+        self.assertNotIn("resolution", got["varies"])
+        self.assertNotIn("resolution", got["distinct_only"])
+
+    def test_legacy_type_key_counts_as_record_type(self):
+        """Older records carry "type" where newer ones carry "record_type"; a set
+        mixing them is one class, not two."""
+        findings = [{"record_type": "observed", "text": "a"}, {"type": "observed", "text": "b"}]
+        self.assertEqual(_field_invariants(findings)["constant"]["record_type"], "observed")
+
+    def test_tags_report_the_shared_set_and_the_universe(self):
+        findings = [_f(tags=["dama", "clock"]), _f(tags=["dama", "audio"])]
+        got = _field_invariants(findings)
+        self.assertEqual(got["tags_on_every_finding"], ["dama"])
+        self.assertEqual(got["tags_distinct"], 3)
+
+    def test_one_untagged_finding_empties_the_shared_tag_set(self):
+        findings = [_f(tags=["dama"]), _f(tags=[])]
+        got = _field_invariants(findings)
+        self.assertEqual(got["tags_on_every_finding"], [])
+        self.assertEqual(got["tags_distinct"], 1)
+
+    def test_output_is_bounded_so_there_is_never_a_shed_to_disclose(self):
+        """The property that makes this safe to trust: a big, wildly varied set
+        still renders a small fixed-shape object, so nothing is ever dropped to
+        fit. Any future budget added here would need a disclosure alongside it."""
+        findings = [_f(record_type=f"t{i}", confidence=f"c{i}", source=f"s{i}",
+                       tags=[f"tag{i}"]) for i in range(500)]
+        got = _field_invariants(findings)
+        self.assertEqual(got["n"], 500)
+        for bucket in ("constant", "varies", "distinct_only"):
+            for field, value in got[bucket].items():
+                if bucket == "varies":
+                    self.assertLessEqual(len(value), _INVARIANT_MAX_VALUES, field)
+        self.assertEqual(got["distinct_only"]["record_type"], 500)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

`investigation_load(fidelity="summary")` withholds the findings and returns `summary_l1`/`summary_l2` in their place. Both are written by `investigation_reflect`, so **every word a caller then reads about that set of findings is generated**. Nothing in the payload states, from the data, that all twenty were high-confidence or that one of them is a gap.

That matters more than usual here because the groom tier can fall back to a deterministic stub when the backend is down — `_has_llm_summary` exists precisely to detect that — and a stale summary looks exactly like a fresh one.

## The change

`field_invariants`: what the structured fields of the surviving finding set agree on, in three shapes borrowed from how a log compressor describes an elided run.

| shape | when | example |
|---|---|---|
| `constant` | one value across the whole set | `resolution: "open"` |
| `varies` | up to 5 distinct values | `record_type: {observed: 18, gap: 1, inferred: 1}` |
| `distinct_only` | more values than that | `source: 20` |

The third is the identifier rule: listing a field that is different in every finding restates the data instead of describing it, and reporting the count is itself the disclosure that values were not listed.

Computed over every finding that survived retraction and ACL filtering — **not** the `last_n_findings` slice — so at full fidelity it also describes the part the slice left out.

## Two properties are the point

**It cannot be invented.** It holds when the summaries are absent, stale, or wrong.

**It is bounded by construction** — seven fields, at most five counts each — so there is never a shed to disclose. A summary that silently drops facts is worse than one that never had them, because a reader takes a field's absence as evidence the field did not hold. `test_output_is_bounded_so_there_is_never_a_shed_to_disclose` pins that, and says in its docstring that any future budget added here needs a disclosure alongside it.

Absence is counted rather than ignored for the same reason: two of three findings resolved `fixed` reports `{"fixed": 2, "(absent)": 1}` and never a constant. That is `test_a_field_only_some_findings_carry_is_not_reported_as_constant`.

`brief` is deliberately untouched — it reads no findings at all, and the manifest's `finding_counts` already carries the type breakdown.

## Run against real investigations

```
dama-hear-2026-09-06   (20 findings)
  constant: resolution=open, tier=warm
  varies:   record_type {observed 18, gap 1, inferred 1}, confidence {high 19, medium 1}
  distinct_only: source 20

dama-gunshot-2026-08-25 (51 findings)
  constant: resolution=open, tier=warm
  varies:   record_type {observed 39, inferred 8, gap 4}, confidence {high 46, medium 5}
  distinct_only: source 38
```

The second one is a fact about that case no summary had surfaced: **all 51 findings are still `open`**, including ones whose fixes have since shipped.

## Testing

11 new tests, ruff clean, full `mcp/tests` suite otherwise unchanged. Four pre-existing failures locally (`test_gpu_warm` ×2, `test_graph_integration`, `test_mcp_integration::TestProceduralMemory`) all need live ollama/kuzu/Qdrant state and none touch this path.
