### PR TITLE
Stop the finding window dropping open gaps on age, silently

### DIFF
--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -184,6 +184,15 @@ def _field_invariants(findings: list) -> dict:
 # gap is, the more likely everyone has forgotten it is still open. Recency is the
 # wrong axis to drop them on.
 _PROTECTED_RECORD_TYPES = frozenset({"gap", "assumed"})
+# Promotion is off for windows below this. Two reasons. A caller asking for a
+# handful of findings wants a tight recent view, and spending half of it on
+# promotions distorts a small sample far more than a large one. And concretely:
+# grounding.py loads a case with last_n_findings=6 and then takes [:3], which —
+# since selection is chronological and promoted records are older than the window
+# — would have handed it three gaps and no recent findings at all. Measured on
+# dama-gunshot-2026-08-25, which has four gaps among 51 findings, that is exactly
+# what happened. The default window of 20 is unaffected.
+_MIN_WINDOW_FOR_PROMOTION = 10
 
 
 def _record_type(finding: dict) -> str:
@@ -206,7 +215,8 @@ def _select_findings(findings: list, limit: int) -> tuple:
 
     Protected findings take at most half the window, so an investigation that is
     mostly gaps cannot squeeze recency out entirely; a caller asking for the last
-    20 still gets at least 10 genuinely recent ones.
+    20 still gets at least 10 genuinely recent ones. Windows below
+    _MIN_WINDOW_FOR_PROMOTION do not promote at all — see the constant.
 
     Returns ``(selected, omitted)`` where selected stays in chronological order.
     """
@@ -216,7 +226,8 @@ def _select_findings(findings: list, limit: int) -> tuple:
 
     kept = list(range(total - limit, total))
     older = range(0, total - limit)
-    promotable = [i for i in older if _record_type(findings[i]) in _PROTECTED_RECORD_TYPES]
+    promotable = ([i for i in older if _record_type(findings[i]) in _PROTECTED_RECORD_TYPES]
+                  if limit >= _MIN_WINDOW_FOR_PROMOTION else [])
     max_promoted = max(1, limit // 2)
 
     promoted = 0

--- a/mcp/investigation_tools.py
+++ b/mcp/investigation_tools.py
@@ -178,6 +178,78 @@ def _field_invariants(findings: list) -> dict:
     return out
 
 
+# A gap is something that should be checked and has not been; an assumption is a
+# working hypothesis carrying no evidence. Both are open obligations, and both are
+# most dangerous exactly when they have aged out of the recent window — the older a
+# gap is, the more likely everyone has forgotten it is still open. Recency is the
+# wrong axis to drop them on.
+_PROTECTED_RECORD_TYPES = frozenset({"gap", "assumed"})
+
+
+def _record_type(finding: dict) -> str:
+    return str(finding.get("record_type") or finding.get("type") or "")
+
+
+def _select_findings(findings: list, limit: int) -> tuple:
+    """Pick which findings ``last_n_findings`` returns, and say what it dropped.
+
+    The slice was ``findings[-limit:]``: pure recency, silently. On a long
+    investigation that means an open gap recorded early is gone from every
+    full-fidelity load, with nothing in the payload indicating a selection
+    happened at all — the caller sees ``total_findings`` and a list, and no
+    statement that the list is not the whole of it.
+
+    Two changes. Protected record types older than the window may claim slots,
+    newest first, evicting the oldest unprotected finding in the window — the same
+    "shed the routine first" ordering a budgeted summariser uses. And the
+    remainder is reported rather than dropped in silence.
+
+    Protected findings take at most half the window, so an investigation that is
+    mostly gaps cannot squeeze recency out entirely; a caller asking for the last
+    20 still gets at least 10 genuinely recent ones.
+
+    Returns ``(selected, omitted)`` where selected stays in chronological order.
+    """
+    total = len(findings)
+    if limit <= 0 or total <= limit:
+        return list(findings), {}
+
+    kept = list(range(total - limit, total))
+    older = range(0, total - limit)
+    promotable = [i for i in older if _record_type(findings[i]) in _PROTECTED_RECORD_TYPES]
+    max_promoted = max(1, limit // 2)
+
+    promoted = 0
+    for i in reversed(promotable):  # newest-first: an older gap loses to a newer one
+        if promoted >= max_promoted:
+            break
+        victim = next((j for j in kept
+                       if _record_type(findings[j]) not in _PROTECTED_RECORD_TYPES), None)
+        if victim is None:
+            break  # every slot already holds a protected finding
+        kept.remove(victim)
+        kept.append(i)
+        promoted += 1
+    kept.sort()
+
+    keptset = set(kept)
+    by_type: dict = {}
+    for i in range(total):
+        if i in keptset:
+            continue
+        rt = _record_type(findings[i]) or "(untyped)"
+        by_type[rt] = by_type.get(rt, 0) + 1
+    omitted = {
+        "count": total - len(kept),
+        "by_record_type": dict(sorted(by_type.items(), key=lambda kv: (-kv[1], kv[0]))),
+        "promoted_past_the_window": promoted,
+        "note": ("Selection is recency plus protected types "
+                 f"({', '.join(sorted(_PROTECTED_RECORD_TYPES))}); raise "
+                 "last_n_findings or use investigation_search to see the rest."),
+    }
+    return [findings[i] for i in kept], omitted
+
+
 def investigation_load(
     investigation_id: str,
     last_n_findings: int = 20,
@@ -198,7 +270,12 @@ def investigation_load(
 
     Args:
         investigation_id: Investigation identifier.
-        last_n_findings: How many recent findings to include (default 20).
+        last_n_findings: Size of the finding window (default 20). The window is
+                         the most recent findings, except that older ``gap`` and
+                         ``assumed`` records may claim up to half of it — they are
+                         open obligations, and aging out of the window is when a
+                         forgotten one does the most damage. Whatever the window
+                         leaves out is reported as ``findings_omitted``.
         include_retracted: Include soft-retracted findings (default False).
         requesting_agent_id: Optional agent_id of the requesting agent. When
                              provided and the investigation has a non-empty ACL,
@@ -218,7 +295,7 @@ def investigation_load(
         When fidelity is "summary" or "brief", the ``recent_findings`` key is
         omitted and replaced with ``summary_l1`` and/or ``summary_l2``.
 
-        "full" and "summary" also carry ``field_invariants``: what the structured
+        "full" and "summary" carry ``field_invariants``: what the structured
         fields of the whole surviving finding set agree on, as
         ``constant`` (one value across the set), ``varies`` (value counts, up to
         five), ``distinct_only`` (a count, for fields with more values than that),
@@ -227,6 +304,11 @@ def investigation_load(
         it covers findings the ``last_n_findings`` slice leaves out. "brief" omits
         it deliberately — it reads no findings at all, and the manifest's
         ``finding_counts`` already carries the type breakdown.
+
+        "full" carries ``findings_omitted`` whenever the window left something
+        out: how many, broken down by record type, and how many protected records
+        were pulled in from outside it. The key is absent when nothing was
+        dropped, so its presence is the signal that the list is partial.
     """
     manifest = _load_manifest(investigation_id)
     if not manifest:
@@ -289,7 +371,7 @@ def investigation_load(
             or f.get("authored_by", "") in acl_set
         ]
 
-    recent = findings[-last_n_findings:]
+    recent, findings_omitted = _select_findings(findings, last_n_findings)
     # Append-log overrides win, else stored/default "open"; findings without these fields read open and not-stale.
     _apply_lifecycle(recent, investigation_id)
 
@@ -303,6 +385,9 @@ def investigation_load(
         # being given a count of, including the part the slice left out.
         "field_invariants": _field_invariants(findings),
         "excluded_retracted": excluded_retracted,
+        # Present only when the window actually left something out, so a load that
+        # returned everything does not carry a paragraph saying it dropped nothing.
+        **({"findings_omitted": findings_omitted} if findings_omitted else {}),
         "total_retracted": total_retracted,
         "include_retracted": include_retracted,
     }

--- a/mcp/tests/test_protected_finding_slice.py
+++ b/mcp/tests/test_protected_finding_slice.py
@@ -73,13 +73,26 @@ class SelectFindingsTest(unittest.TestCase):
         self.assertEqual(len(recent), 5)
 
     def test_newest_protected_wins_a_contested_slot(self):
-        findings = ([_f(0, rt="gap"), _f(1, rt="gap")]
-                    + [_f(i) for i in range(2, 30)])
-        selected, _ = _select_findings(findings, 2)
-        # limit 2 -> at most 1 promotion; the newer gap (f001) takes it.
+        # limit 10 -> at most 5 promotions, but six old gaps compete for them.
+        findings = [_f(i, rt="gap") for i in range(6)] + [_f(i) for i in range(6, 40)]
+        selected, omitted = _select_findings(findings, 10)
         ids = [f["id"] for f in selected]
-        self.assertIn("f001", ids)
-        self.assertNotIn("f000", ids)
+        self.assertEqual(omitted["promoted_past_the_window"], 5)
+        self.assertNotIn("f000", ids, "the oldest gap is the one that loses")
+        for i in range(1, 6):
+            self.assertIn(f"f{i:03d}", ids)
+
+    def test_small_windows_do_not_promote_at_all(self):
+        """grounding.py loads a case with last_n_findings=6 and takes [:3]. Since
+        selection is chronological and promoted records are older than the window,
+        promoting into a 6-window would hand that lane three gaps and no recent
+        findings. Measured on a real 51-finding case before this guard existed."""
+        findings = [_f(i, rt="gap") for i in range(4)] + [_f(i) for i in range(4, 51)]
+        selected, omitted = _select_findings(findings, 6)
+        self.assertEqual(omitted["promoted_past_the_window"], 0)
+        self.assertEqual([f["id"] for f in selected],
+                         [f"f{i:03d}" for i in range(45, 51)])
+        self.assertNotIn("gap", [f["record_type"] for f in selected[:3]])
 
     def test_omission_report_breaks_down_by_record_type(self):
         findings = ([_f(i) for i in range(20)]
@@ -97,7 +110,7 @@ class SelectFindingsTest(unittest.TestCase):
 
     def test_legacy_type_key_is_honoured_for_protection(self):
         findings = [{"id": "f000", "type": "gap", "text": "t"}] + [_f(i) for i in range(1, 30)]
-        selected, _ = _select_findings(findings, 5)
+        selected, _ = _select_findings(findings, 10)
         self.assertIn("f000", [f["id"] for f in selected])
 
     def test_zero_or_negative_limit_returns_everything(self):

--- a/mcp/tests/test_protected_finding_slice.py
+++ b/mcp/tests/test_protected_finding_slice.py
@@ -1,0 +1,112 @@
+"""investigation_load's finding window was findings[-N:] — recency, silently.
+
+Two failures in one line. A `gap` recorded early in a long investigation is an
+open obligation that nobody has closed, and dropping it on age means the longer
+it stays open the less likely anyone sees it again. And the payload said nothing
+about having selected at all: a caller got `total_findings` and a list, with
+nothing stating the list was not the whole of it, which is the same shape as a
+compressor that trims its summary and does not say so.
+
+_select_findings lets protected types claim slots from the oldest routine ones,
+capped so recency cannot be squeezed out entirely, and reports the remainder.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from investigation_tools import _select_findings  # noqa: E402
+
+
+def _f(i, rt="observed"):
+    return {"id": f"f{i:03d}", "record_type": rt, "text": f"finding {i}"}
+
+
+class SelectFindingsTest(unittest.TestCase):
+    def test_short_investigation_returns_everything_and_reports_no_omission(self):
+        findings = [_f(i) for i in range(5)]
+        selected, omitted = _select_findings(findings, 20)
+        self.assertEqual(len(selected), 5)
+        self.assertEqual(omitted, {}, "nothing was dropped, so say nothing")
+
+    def test_plain_window_is_still_the_most_recent(self):
+        findings = [_f(i) for i in range(50)]
+        selected, omitted = _select_findings(findings, 10)
+        self.assertEqual([f["id"] for f in selected], [f"f{i:03d}" for i in range(40, 50)])
+        self.assertEqual(omitted["count"], 40)
+        self.assertEqual(omitted["by_record_type"], {"observed": 40})
+        self.assertEqual(omitted["promoted_past_the_window"], 0)
+
+    def test_an_old_gap_is_pulled_into_the_window(self):
+        """The case the change exists for: a gap at index 0 of a 50-finding
+        investigation must not vanish from every full-fidelity load."""
+        findings = [_f(0, rt="gap")] + [_f(i) for i in range(1, 50)]
+        selected, omitted = _select_findings(findings, 10)
+        self.assertIn("f000", [f["id"] for f in selected])
+        self.assertEqual(omitted["promoted_past_the_window"], 1)
+
+    def test_promotion_evicts_the_oldest_routine_finding_not_a_recent_one(self):
+        findings = [_f(0, rt="gap")] + [_f(i) for i in range(1, 50)]
+        selected, _ = _select_findings(findings, 10)
+        ids = [f["id"] for f in selected]
+        self.assertNotIn("f040", ids, "the oldest in-window routine finding is the victim")
+        self.assertIn("f049", ids, "the newest finding must always survive")
+
+    def test_selection_stays_in_chronological_order(self):
+        findings = [_f(0, rt="gap")] + [_f(i) for i in range(1, 30)]
+        selected, _ = _select_findings(findings, 10)
+        self.assertEqual([f["id"] for f in selected], sorted(f["id"] for f in selected))
+
+    def test_assumptions_are_protected_too(self):
+        findings = [_f(0, rt="assumed")] + [_f(i) for i in range(1, 40)]
+        selected, _ = _select_findings(findings, 10)
+        self.assertIn("f000", [f["id"] for f in selected])
+
+    def test_protected_records_take_at_most_half_the_window(self):
+        """An investigation that is mostly gaps must not squeeze recency out: a
+        caller asking for 10 still gets 5 genuinely recent findings."""
+        findings = [_f(i, rt="gap") for i in range(40)] + [_f(i) for i in range(40, 50)]
+        selected, omitted = _select_findings(findings, 10)
+        self.assertEqual(omitted["promoted_past_the_window"], 5)
+        recent = [f for f in selected if int(f["id"][1:]) >= 40]
+        self.assertEqual(len(recent), 5)
+
+    def test_newest_protected_wins_a_contested_slot(self):
+        findings = ([_f(0, rt="gap"), _f(1, rt="gap")]
+                    + [_f(i) for i in range(2, 30)])
+        selected, _ = _select_findings(findings, 2)
+        # limit 2 -> at most 1 promotion; the newer gap (f001) takes it.
+        ids = [f["id"] for f in selected]
+        self.assertIn("f001", ids)
+        self.assertNotIn("f000", ids)
+
+    def test_omission_report_breaks_down_by_record_type(self):
+        findings = ([_f(i) for i in range(20)]
+                    + [_f(i, rt="inferred") for i in range(20, 25)]
+                    + [_f(i) for i in range(25, 30)])
+        _, omitted = _select_findings(findings, 5)
+        self.assertEqual(omitted["count"], 25)
+        self.assertEqual(omitted["by_record_type"], {"observed": 20, "inferred": 5})
+        self.assertIn("investigation_search", omitted["note"])
+
+    def test_untyped_records_are_counted_not_skipped(self):
+        findings = [{"id": f"f{i}", "text": "t"} for i in range(30)]
+        _, omitted = _select_findings(findings, 5)
+        self.assertEqual(omitted["by_record_type"], {"(untyped)": 25})
+
+    def test_legacy_type_key_is_honoured_for_protection(self):
+        findings = [{"id": "f000", "type": "gap", "text": "t"}] + [_f(i) for i in range(1, 30)]
+        selected, _ = _select_findings(findings, 5)
+        self.assertIn("f000", [f["id"] for f in selected])
+
+    def test_zero_or_negative_limit_returns_everything(self):
+        findings = [_f(i) for i in range(5)]
+        for limit in (0, -1):
+            selected, omitted = _select_findings(findings, limit)
+            self.assertEqual(len(selected), 5)
+            self.assertEqual(omitted, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The line

```python
recent = findings[-last_n_findings:]
```

Two problems in it.

**Recency is the wrong axis for a gap.** A `gap` is something that should be checked and has not been; an `assumed` is a hypothesis carrying no evidence. Both are open obligations. Dropping them by age means *the longer one stays open, the less likely anyone sees it again* — which is backwards. On a 50-finding investigation, a gap recorded early is absent from every full-fidelity load.

**And the payload never said a selection had happened.** A caller got `total_findings` and a list, with nothing stating the list was not the whole of it. That is the same shape as a summariser that trims and doesn't disclose: a reader takes the absence of a thing as evidence the thing does not exist.

## The change

`_select_findings` keeps the window at `last_n_findings` and lets older `gap`/`assumed` records claim slots inside it, newest-first, evicting the **oldest unprotected** finding — the "shed the routine first" ordering, applied to selection rather than to rendering.

Promotion is capped at **half the window**, so an investigation that is mostly gaps cannot squeeze recency out: a caller asking for 20 still gets at least 10 genuinely recent ones. `test_protected_records_take_at_most_half_the_window` pins that.

Whatever is left out is now reported:

```json
"findings_omitted": {
  "count": 25,
  "by_record_type": {"observed": 20, "inferred": 5},
  "promoted_past_the_window": 1,
  "note": "Selection is recency plus protected types (assumed, gap); raise last_n_findings or use investigation_search to see the rest."
}
```

The key is **absent when nothing was dropped**, so its presence is itself the signal that the list is partial.

## Details

- Selection stays in chronological order.
- The legacy `type` key is honoured alongside `record_type` for protection, matching `_only_findings`.
- Untyped records are counted as `(untyped)` in the breakdown rather than skipped.
- `limit <= 0` returns everything and reports no omission.

## Testing

12 new tests, ruff clean. `test_finding_lifecycle`, `test_only_findings` and the other `investigation_load` consumers pass unchanged (35 total in that group).

## Note

This and #291 both touch `investigation_load`'s payload dict and docstring, so whichever lands second needs a trivial rebase. They are independent in substance — #291 describes the whole set, this one fixes which subset you get and discloses the rest.
